### PR TITLE
feat: static-mode finishing — scored SEO report (SEO002–009, scoring, JSON, flags)

### DIFF
--- a/.changeset/static-mode-finishing.md
+++ b/.changeset/static-mode-finishing.md
@@ -1,0 +1,11 @@
+---
+'svelte-vitals': minor
+'@svelte-vitals/core': minor
+---
+
+Static-mode finishing: scored SEO report.
+
+- New rules SEO002–SEO009 (description, canonical, og:image, og:title, robots.txt, sitemap.xml, JSON-LD, `<html lang>`).
+- Scoring model (§12): per-route scores, route average, site penalty, and a critical cap, surfaced in the console header and JSON.
+- JSON reporter (`--json` / `--reporter json`) and `--by-route` per-route tree.
+- New flags: `--fail-on`/`--fail-on-warning`, `--rules`/`--ignore`. `treatDynamicAs: 'warn'` now reports dynamic values as warnings.

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
-import { readFileSync } from 'node:fs';
 import mri from 'mri';
-import { allRules } from '@svelte-vitals/core';
 import { run } from './index.js';
+import { readPackageVersion } from './version.js';
+import { buildRulesConfig, findUnknownRuleIds, knownRuleIds } from './rules-config.js';
 
 const HELP = `svelte-vitals — a SvelteKit SEO checker (static mode)
 
@@ -28,31 +28,7 @@ Exit codes:
   1  critical finding present (or --fail-on threshold reached)
   2  execution error (not a SvelteKit project / internal error)`;
 
-// Read the version from the package's own package.json at runtime so it never
-// drifts from the published version (dist/bin.js -> ../package.json).
-function readVersion(): string {
-  try {
-    const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as {
-      version?: string;
-    };
-    return pkg.version ?? '0.0.0';
-  } catch {
-    return '0.0.0';
-  }
-}
-
-const VERSION = readVersion();
-
-function buildRulesConfig(
-  allow: string[],
-  ignore: Record<string, 'off' | 'critical' | 'warning' | 'info'>
-): Record<string, 'off' | 'critical' | 'warning' | 'info'> {
-  const rules = { ...ignore };
-  if (allow.length > 0) {
-    for (const r of allRules) if (!allow.includes(r.id)) rules[r.id] = 'off';
-  }
-  return rules;
-}
+const VERSION = readPackageVersion();
 
 async function main(): Promise<void> {
   const argv = mri(process.argv.slice(2), {
@@ -89,9 +65,14 @@ async function main(): Promise<void> {
           .map((s) => s.trim())
           .filter(Boolean)
       : [];
-  const ignoreRules: Record<string, 'off' | 'critical' | 'warning' | 'info'> = {};
-  for (const id of toList(argv.ignore)) ignoreRules[id] = 'off';
   const allow = toList(argv.rules);
+  const ignore = toList(argv.ignore);
+  const unknown = findUnknownRuleIds([...allow, ...ignore]);
+  if (unknown.length > 0) {
+    console.error(`svelte-vitals: unknown rule id(s) in --rules/--ignore: ${unknown.join(', ')}`);
+    console.error(`Known rule ids: ${knownRuleIds().join(', ')}`);
+    process.exit(2);
+  }
   const reporter = argv.json || argv.reporter === 'json' ? 'json' : 'console';
   const failOnRaw = argv['fail-on'];
   const failOn = argv['fail-on-warning']
@@ -108,7 +89,7 @@ async function main(): Promise<void> {
     reporter,
     byRoute: Boolean(argv['by-route']),
     failOn,
-    rules: buildRulesConfig(allow, ignoreRules)
+    rules: buildRulesConfig(allow, ignore)
   });
   process.exit(code);
 }

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { readFileSync } from 'node:fs';
 import mri from 'mri';
+import { allRules } from '@svelte-vitals/core';
 import { run } from './index.js';
 
 const HELP = `svelte-vitals — a SvelteKit SEO checker (static mode)
@@ -12,12 +13,19 @@ Options:
   --meta-components <names>   Comma-separated component names that emit head metadata
   --treat-dynamic-as <mode>   pass | warn | fail (default: pass)
   --route <glob>              Only analyze routes matching this glob
+  --by-route                  Show per-route score breakdown in console output
+  --reporter <mode>           console | json (default: console)
+  --json                      Alias for --reporter=json
+  --fail-on <severity>        Fail (exit 1) when any finding reaches this severity: critical | warning | info
+  --fail-on-warning           Alias for --fail-on=warning
+  --rules <ids>               Comma-separated rule ids to enable (all others disabled)
+  --ignore <ids>              Comma-separated rule ids to disable
   -h, --help                  Show this help
   -v, --version               Show version
 
 Exit codes:
   0  no failing findings
-  1  critical finding present
+  1  critical finding present (or --fail-on threshold reached)
   2  execution error (not a SvelteKit project / internal error)`;
 
 // Read the version from the package's own package.json at runtime so it never
@@ -35,10 +43,22 @@ function readVersion(): string {
 
 const VERSION = readVersion();
 
+function buildRulesConfig(
+  allow: string[],
+  ignore: Record<string, 'off' | 'critical' | 'warning' | 'info'>
+): Record<string, 'off' | 'critical' | 'warning' | 'info'> {
+  const rules = { ...ignore };
+  if (allow.length > 0) {
+    for (const r of allRules) if (!allow.includes(r.id)) rules[r.id] = 'off';
+  }
+  return rules;
+}
+
 async function main(): Promise<void> {
   const argv = mri(process.argv.slice(2), {
     alias: { h: 'help', v: 'version' },
-    string: ['meta-components', 'treat-dynamic-as', 'route']
+    boolean: ['by-route', 'json', 'fail-on-warning'],
+    string: ['meta-components', 'treat-dynamic-as', 'route', 'fail-on', 'reporter', 'rules', 'ignore']
   });
 
   if (argv.help) {
@@ -62,11 +82,33 @@ async function main(): Promise<void> {
   const treatDynamicAs = treatRaw === 'warn' || treatRaw === 'fail' || treatRaw === 'pass' ? treatRaw : undefined;
   const route = typeof argv.route === 'string' ? argv.route : undefined;
 
+  const toList = (v: unknown) =>
+    typeof v === 'string'
+      ? v
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : [];
+  const ignoreRules: Record<string, 'off' | 'critical' | 'warning' | 'info'> = {};
+  for (const id of toList(argv.ignore)) ignoreRules[id] = 'off';
+  const allow = toList(argv.rules);
+  const reporter = argv.json || argv.reporter === 'json' ? 'json' : 'console';
+  const failOnRaw = argv['fail-on'];
+  const failOn = argv['fail-on-warning']
+    ? 'warning'
+    : failOnRaw === 'warning' || failOnRaw === 'info' || failOnRaw === 'critical'
+      ? failOnRaw
+      : undefined;
+
   const code = await run({
     cwd: positional ?? process.cwd(),
     metaComponents,
     treatDynamicAs,
-    route
+    route,
+    reporter,
+    byRoute: Boolean(argv['by-route']),
+    failOn,
+    rules: buildRulesConfig(allow, ignoreRules)
   });
   process.exit(code);
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,12 +2,16 @@ import {
   allRules,
   runRules,
   formatConsoleReport,
+  formatJsonReport,
   summarize,
   hasFailureAtOrAbove,
   defineConfig,
   selectRules,
-  applyRuleSeverities
+  applyRuleSeverities,
+  type Severity,
+  type RuleSetting
 } from '@svelte-vitals/core';
+import { readFileSync } from 'node:fs';
 import { createNodeRuntime } from './runtime/node.js';
 import { sourceHeadProvider } from './providers/source/routes.js';
 import { detectProject, ProjectError, collectProjectFacts } from './providers/source/project.js';
@@ -20,6 +24,19 @@ export interface RunOptions {
   treatDynamicAs?: 'pass' | 'warn' | 'fail';
   /** Restrict analysis to routes whose path matches this glob (matched against the route path without leading slash). */
   route?: string;
+  reporter?: 'console' | 'json';
+  byRoute?: boolean;
+  failOn?: Severity;
+  rules?: Record<string, RuleSetting>;
+}
+
+function cliVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as { version?: string };
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
 }
 
 export function routeMatcher(glob: string | undefined): (route: string) => boolean {
@@ -48,7 +65,9 @@ export async function run(opts: RunOptions = {}): Promise<number> {
   const rt = createNodeRuntime();
   const config = defineConfig({
     treatDynamicAs: opts.treatDynamicAs ?? 'pass',
-    metaComponents: opts.metaComponents ?? []
+    metaComponents: opts.metaComponents ?? [],
+    rules: opts.rules ?? {},
+    failOn: opts.failOn ?? 'critical'
   });
 
   try {
@@ -67,7 +86,11 @@ export async function run(opts: RunOptions = {}): Promise<number> {
     const project = await collectProjectFacts(rt, cwd);
     const rules = selectRules(allRules, config);
     const results = applyRuleSeverities(await runRules(rules, { heads, project, config }), config);
-    log(formatConsoleReport(results, config));
+    if (opts.reporter === 'json') {
+      log(formatJsonReport(results, config, { version: cliVersion() }));
+    } else {
+      log(formatConsoleReport(results, config, { byRoute: opts.byRoute ?? false }));
+    }
     const summary = summarize(results, config);
     return hasFailureAtOrAbove(summary, config.failOn) ? 1 : 0;
   } catch (err) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,11 +4,13 @@ import {
   formatConsoleReport,
   summarize,
   hasFailureAtOrAbove,
-  defineConfig
+  defineConfig,
+  selectRules,
+  applyRuleSeverities
 } from '@svelte-vitals/core';
 import { createNodeRuntime } from './runtime/node.js';
 import { sourceHeadProvider } from './providers/source/routes.js';
-import { detectProject, ProjectError } from './providers/source/project.js';
+import { detectProject, ProjectError, collectProjectFacts } from './providers/source/project.js';
 
 export interface RunOptions {
   cwd?: string;
@@ -62,10 +64,12 @@ export async function run(opts: RunOptions = {}): Promise<number> {
   try {
     const matches = routeMatcher(opts.route);
     const heads = (await sourceHeadProvider.collect(rt, cwd, config)).filter((h) => matches(h.route));
-    const results = await runRules(allRules, { heads, config });
+    const project = await collectProjectFacts(rt, cwd);
+    const rules = selectRules(allRules, config);
+    const results = applyRuleSeverities(await runRules(rules, { heads, project, config }), config);
     log(formatConsoleReport(results, config));
     const summary = summarize(results, config);
-    return hasFailureAtOrAbove(summary, 'critical') ? 1 : 0;
+    return hasFailureAtOrAbove(summary, config.failOn) ? 1 : 0;
   } catch (err) {
     errorLog(`svelte-vitals: ${err instanceof Error ? err.message : String(err)}`);
     return 2;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,10 +11,10 @@ import {
   type Severity,
   type RuleSetting
 } from '@svelte-vitals/core';
-import { readFileSync } from 'node:fs';
 import { createNodeRuntime } from './runtime/node.js';
 import { sourceHeadProvider } from './providers/source/routes.js';
 import { detectProject, ProjectError, collectProjectFacts } from './providers/source/project.js';
+import { readPackageVersion } from './version.js';
 
 export interface RunOptions {
   cwd?: string;
@@ -28,15 +28,6 @@ export interface RunOptions {
   byRoute?: boolean;
   failOn?: Severity;
   rules?: Record<string, RuleSetting>;
-}
-
-function cliVersion(): string {
-  try {
-    const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as { version?: string };
-    return pkg.version ?? '0.0.0';
-  } catch {
-    return '0.0.0';
-  }
 }
 
 export function routeMatcher(glob: string | undefined): (route: string) => boolean {
@@ -87,7 +78,7 @@ export async function run(opts: RunOptions = {}): Promise<number> {
     const rules = selectRules(allRules, config);
     const results = applyRuleSeverities(await runRules(rules, { heads, project, config }), config);
     if (opts.reporter === 'json') {
-      log(formatJsonReport(results, config, { version: cliVersion() }));
+      log(formatJsonReport(results, config, { version: readPackageVersion() }));
     } else {
       log(formatConsoleReport(results, config, { byRoute: opts.byRoute ?? false }));
     }

--- a/packages/cli/src/providers/source/project.ts
+++ b/packages/cli/src/providers/source/project.ts
@@ -1,4 +1,4 @@
-import type { Runtime } from '@svelte-vitals/core';
+import type { Project, Detection, Runtime } from '@svelte-vitals/core';
 
 /** Thrown when the target directory is not a SvelteKit project (CLI maps to exit 2). */
 export class ProjectError extends Error {
@@ -45,4 +45,37 @@ export async function detectProject(rt: Runtime, cwd: string): Promise<void> {
 export async function enumerateRoutePages(rt: Runtime, cwd: string): Promise<string[]> {
   const pages = await rt.glob(`${ROUTES_DIR}/**/+page.svelte`, cwd);
   return pages.sort();
+}
+
+async function existsAny(rt: Runtime, cwd: string, paths: string[]): Promise<boolean> {
+  for (const p of paths) {
+    if (await rt.exists(rt.join(cwd, p))) return true;
+  }
+  return false;
+}
+
+function detectHtmlLang(html: string): Detection {
+  const match = /<html[^>]*\slang\s*=\s*("([^"]*)"|'([^']*)')/i.exec(html);
+  if (!match) return { presence: 'none', value: 'absent' };
+  const value = match[2] ?? match[3] ?? '';
+  return { presence: 'own', value: value.trim().length > 0 ? 'static' : 'absent' };
+}
+
+/** Precompute project-wide facts for project-scope rules (design §10, §11, §17). */
+export async function collectProjectFacts(rt: Runtime, cwd: string): Promise<Project> {
+  const hasRobotsTxt = await existsAny(rt, cwd, [
+    'static/robots.txt',
+    'src/routes/robots.txt/+server.ts',
+    'src/routes/robots.txt/+server.js'
+  ]);
+  const hasSitemap = await existsAny(rt, cwd, [
+    'static/sitemap.xml',
+    'src/routes/sitemap.xml/+server.ts',
+    'src/routes/sitemap.xml/+server.js'
+  ]);
+  const appHtmlPath = rt.join(cwd, 'src/app.html');
+  const htmlLang = (await rt.exists(appHtmlPath))
+    ? detectHtmlLang(await rt.readFile(appHtmlPath))
+    : { presence: 'none' as const, value: 'absent' as const };
+  return { hasRobotsTxt, hasSitemap, htmlLang };
 }

--- a/packages/cli/src/providers/source/project.ts
+++ b/packages/cli/src/providers/source/project.ts
@@ -48,34 +48,34 @@ export async function enumerateRoutePages(rt: Runtime, cwd: string): Promise<str
 }
 
 async function existsAny(rt: Runtime, cwd: string, paths: string[]): Promise<boolean> {
-  for (const p of paths) {
-    if (await rt.exists(rt.join(cwd, p))) return true;
-  }
-  return false;
+  const found = await Promise.all(paths.map((p) => rt.exists(rt.join(cwd, p))));
+  return found.some(Boolean);
 }
 
 function detectHtmlLang(html: string): Detection {
-  const match = /<html[^>]*\slang\s*=\s*("([^"]*)"|'([^']*)')/i.exec(html);
+  // Match double-quoted, single-quoted, or unquoted lang values (e.g. <html lang=en>).
+  const match = /<html[^>]*\slang\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>]+))/i.exec(html);
   if (!match) return { presence: 'none', value: 'absent' };
-  const value = match[2] ?? match[3] ?? '';
+  const value = match[1] ?? match[2] ?? match[3] ?? '';
   return { presence: 'own', value: value.trim().length > 0 ? 'static' : 'absent' };
+}
+
+async function detectAppHtmlLang(rt: Runtime, cwd: string): Promise<Detection> {
+  const appHtmlPath = rt.join(cwd, 'src/app.html');
+  if (!(await rt.exists(appHtmlPath))) return { presence: 'none', value: 'absent' };
+  return detectHtmlLang(await rt.readFile(appHtmlPath));
 }
 
 /** Precompute project-wide facts for project-scope rules (design §10, §11, §17). */
 export async function collectProjectFacts(rt: Runtime, cwd: string): Promise<Project> {
-  const hasRobotsTxt = await existsAny(rt, cwd, [
-    'static/robots.txt',
-    'src/routes/robots.txt/+server.ts',
-    'src/routes/robots.txt/+server.js'
+  const [hasRobotsTxt, hasSitemap, htmlLang] = await Promise.all([
+    existsAny(rt, cwd, ['static/robots.txt', 'src/routes/robots.txt/+server.ts', 'src/routes/robots.txt/+server.js']),
+    existsAny(rt, cwd, [
+      'static/sitemap.xml',
+      'src/routes/sitemap.xml/+server.ts',
+      'src/routes/sitemap.xml/+server.js'
+    ]),
+    detectAppHtmlLang(rt, cwd)
   ]);
-  const hasSitemap = await existsAny(rt, cwd, [
-    'static/sitemap.xml',
-    'src/routes/sitemap.xml/+server.ts',
-    'src/routes/sitemap.xml/+server.js'
-  ]);
-  const appHtmlPath = rt.join(cwd, 'src/app.html');
-  const htmlLang = (await rt.exists(appHtmlPath))
-    ? detectHtmlLang(await rt.readFile(appHtmlPath))
-    : { presence: 'none' as const, value: 'absent' as const };
   return { hasRobotsTxt, hasSitemap, htmlLang };
 }

--- a/packages/cli/src/rules-config.ts
+++ b/packages/cli/src/rules-config.ts
@@ -1,0 +1,28 @@
+import { allRules, type RuleSetting } from '@svelte-vitals/core';
+
+const KNOWN_IDS = new Set(allRules.map((r) => r.id));
+
+/** Rule ids passed to --rules/--ignore that aren't part of the built-in registry. */
+export function findUnknownRuleIds(ids: string[]): string[] {
+  return [...new Set(ids.filter((id) => !KNOWN_IDS.has(id)))];
+}
+
+/** All built-in rule ids, sorted — for help and error messages. */
+export function knownRuleIds(): string[] {
+  return [...KNOWN_IDS].sort();
+}
+
+/**
+ * Build the per-rule config map from an allow-list (--rules) and a deny-list
+ * (--ignore). An allow-list disables every rule not listed; deny always wins.
+ * Callers should reject unknown ids first (see findUnknownRuleIds) so a typo in
+ * --rules can't silently disable every rule.
+ */
+export function buildRulesConfig(allow: string[], ignore: string[]): Record<string, RuleSetting> {
+  const rules: Record<string, RuleSetting> = {};
+  if (allow.length > 0) {
+    for (const r of allRules) if (!allow.includes(r.id)) rules[r.id] = 'off';
+  }
+  for (const id of ignore) rules[id] = 'off';
+  return rules;
+}

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+
+// Read the version from the package's own package.json at runtime so it never
+// drifts from the published version (dist/*.js -> ../package.json). tsup inlines
+// this module, so import.meta.url resolves to the bundling file's dist location.
+export function readPackageVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as {
+      version?: string;
+    };
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}

--- a/packages/cli/test/fixtures/basic-project/src/app.html
+++ b/packages/cli/test/fixtures/basic-project/src/app.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    %sveltekit.head%
+  </head>
+  <body>
+    %sveltekit.body%
+  </body>
+</html>

--- a/packages/cli/test/fixtures/basic-project/static/robots.txt
+++ b/packages/cli/test/fixtures/basic-project/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/packages/cli/test/fixtures/basic-project/static/sitemap.xml
+++ b/packages/cli/test/fixtures/basic-project/static/sitemap.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>

--- a/packages/cli/test/project-facts.test.ts
+++ b/packages/cli/test/project-facts.test.ts
@@ -25,5 +25,9 @@ describe('collectProjectFacts', () => {
     expect(empty.htmlLang).toEqual({ presence: 'own', value: 'absent' });
     const none = await collectProjectFacts(createMemoryRuntime({ 'src/app.html': '<html>' }), '');
     expect(none.htmlLang).toEqual({ presence: 'none', value: 'absent' });
+    const unquoted = await collectProjectFacts(createMemoryRuntime({ 'src/app.html': '<html lang=en>' }), '');
+    expect(unquoted.htmlLang).toEqual({ presence: 'own', value: 'static' });
+    const single = await collectProjectFacts(createMemoryRuntime({ 'src/app.html': "<html lang='ja'>" }), '');
+    expect(single.htmlLang).toEqual({ presence: 'own', value: 'static' });
   });
 });

--- a/packages/cli/test/project-facts.test.ts
+++ b/packages/cli/test/project-facts.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { collectProjectFacts } from '../src/providers/source/project.js';
+import { createMemoryRuntime } from './helpers/memory-runtime.js';
+
+describe('collectProjectFacts', () => {
+  it('detects static robots.txt and sitemap.xml', async () => {
+    const rt = createMemoryRuntime({ 'static/robots.txt': 'x', 'static/sitemap.xml': '<urlset/>' });
+    const p = await collectProjectFacts(rt, '');
+    expect(p.hasRobotsTxt).toBe(true);
+    expect(p.hasSitemap).toBe(true);
+  });
+  it('detects endpoint-based robots and sitemap', async () => {
+    const rt = createMemoryRuntime({
+      'src/routes/robots.txt/+server.ts': 'export function GET(){}',
+      'src/routes/sitemap.xml/+server.js': 'export function GET(){}'
+    });
+    const p = await collectProjectFacts(rt, '');
+    expect(p.hasRobotsTxt).toBe(true);
+    expect(p.hasSitemap).toBe(true);
+  });
+  it('parses <html lang> from app.html', async () => {
+    const present = await collectProjectFacts(createMemoryRuntime({ 'src/app.html': '<html lang="en">' }), '');
+    expect(present.htmlLang).toEqual({ presence: 'own', value: 'static' });
+    const empty = await collectProjectFacts(createMemoryRuntime({ 'src/app.html': '<html lang="">' }), '');
+    expect(empty.htmlLang).toEqual({ presence: 'own', value: 'absent' });
+    const none = await collectProjectFacts(createMemoryRuntime({ 'src/app.html': '<html>' }), '');
+    expect(none.htmlLang).toEqual({ presence: 'none', value: 'absent' });
+  });
+});

--- a/packages/cli/test/rules-config.test.ts
+++ b/packages/cli/test/rules-config.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { buildRulesConfig, findUnknownRuleIds, knownRuleIds } from '../src/rules-config.js';
+
+describe('buildRulesConfig', () => {
+  it('an allow-list disables every rule not listed', () => {
+    const cfg = buildRulesConfig(['SEO001'], []);
+    expect(cfg.SEO001).toBeUndefined();
+    expect(cfg.SEO002).toBe('off');
+    expect(cfg.SEO009).toBe('off');
+  });
+
+  it('an ignore-list disables only the listed rules', () => {
+    expect(buildRulesConfig([], ['SEO002', 'SEO003'])).toEqual({ SEO002: 'off', SEO003: 'off' });
+  });
+
+  it('deny wins over allow', () => {
+    const cfg = buildRulesConfig(['SEO001'], ['SEO001']);
+    expect(cfg.SEO001).toBe('off');
+  });
+
+  it('returns an empty config when no flags are given', () => {
+    expect(buildRulesConfig([], [])).toEqual({});
+  });
+});
+
+describe('findUnknownRuleIds', () => {
+  it('flags ids that are not part of the registry (typos)', () => {
+    expect(findUnknownRuleIds(['SEO001', 'SEO999', 'nope'])).toEqual(['SEO999', 'nope']);
+  });
+
+  it('returns nothing when all ids are known', () => {
+    expect(findUnknownRuleIds(['SEO001', 'SEO009'])).toEqual([]);
+  });
+
+  it('deduplicates repeated unknown ids', () => {
+    expect(findUnknownRuleIds(['SEO999', 'SEO999'])).toEqual(['SEO999']);
+  });
+});
+
+describe('knownRuleIds', () => {
+  it('lists the built-in ids sorted', () => {
+    const ids = knownRuleIds();
+    expect(ids).toContain('SEO001');
+    expect(ids).toEqual([...ids].sort());
+  });
+});

--- a/packages/cli/test/run.test.ts
+++ b/packages/cli/test/run.test.ts
@@ -60,3 +60,27 @@ describe('run() flags', () => {
     expect(cap.out.join('\n')).not.toContain('/none');
   });
 });
+
+describe('run() reporters and gating', () => {
+  it('emits JSON when reporter is json', async () => {
+    const cap = capture();
+    await run({ cwd: fixtureDir, log: cap.log, errorLog: cap.errorLog, reporter: 'json' });
+    const json = JSON.parse(cap.out.join('\n'));
+    expect(json).toHaveProperty('score');
+    expect(json).toHaveProperty('routes');
+  });
+
+  it('fails on warning when failOn=warning', async () => {
+    const cap = capture();
+    const code = await run({ cwd: fixtureDir, log: cap.log, errorLog: cap.errorLog, failOn: 'warning' });
+    expect(code).toBe(1); // fixture has warnings (robots/sitemap/og missing)
+  });
+
+  it('disabling a rule via rules:{id:off} removes its findings', async () => {
+    const cap = capture();
+    await run({ cwd: fixtureDir, log: cap.log, errorLog: cap.errorLog, reporter: 'json', rules: { SEO002: 'off' } });
+    const json = JSON.parse(cap.out.join('\n'));
+    const anySEO002 = json.routes.some((r: { issues: { id: string }[] }) => r.issues.some((i) => i.id === 'SEO002'));
+    expect(anySEO002).toBe(false);
+  });
+});

--- a/packages/cli/test/run.test.ts
+++ b/packages/cli/test/run.test.ts
@@ -70,10 +70,20 @@ describe('run() reporters and gating', () => {
     expect(json).toHaveProperty('routes');
   });
 
+  it('reports project facts: robots/sitemap/html lang all pass for the fixture', async () => {
+    const cap = capture();
+    await run({ cwd: fixtureDir, log: cap.log, errorLog: cap.errorLog, reporter: 'json' });
+    const json = JSON.parse(cap.out.join('\n'));
+    const siteIds = json.siteIssues.map((i: { id: string }) => i.id);
+    expect(siteIds).not.toContain('SEO006'); // robots.txt present
+    expect(siteIds).not.toContain('SEO007'); // sitemap present
+    expect(siteIds).not.toContain('SEO009'); // html lang present
+  });
+
   it('fails on warning when failOn=warning', async () => {
     const cap = capture();
     const code = await run({ cwd: fixtureDir, log: cap.log, errorLog: cap.errorLog, failOn: 'warning' });
-    expect(code).toBe(1); // fixture has warnings (robots/sitemap/og missing)
+    expect(code).toBe(1); // fixture has warnings (og:image, og:title, canonical missing)
   });
 
   it('disabling a rule via rules:{id:off} removes its findings', async () => {

--- a/packages/cli/test/run.test.ts
+++ b/packages/cli/test/run.test.ts
@@ -42,8 +42,14 @@ describe('run() flags', () => {
   it('suppresses a missing title for a metaComponents-declared component', async () => {
     const cap = capture();
     const code = await run({ cwd: fixtureDir, log: cap.log, errorLog: cap.errorLog, metaComponents: ['Widget'] });
-    const failures = cap.out.join('\n').split('Passed')[0];
-    expect(failures).not.toContain('/widget');
+    const report = cap.out.join('\n');
+    // The Critical section should list /none (SEO001 missing title) but NOT /widget —
+    // Widget suppression promotes /widget's title detection to dynamic/pass.
+    // Extract the Critical block (from header up to the next severity header or Passed).
+    const criticalBlock = report.split(/\n(?:Warnings|Info|Passed)\s*\(/)[0];
+    expect(criticalBlock).toContain('SEO001  Missing <title>');
+    expect(criticalBlock).toContain('/none');
+    expect(criticalBlock).not.toContain('/widget');
     expect(code).toBe(1); // /none is still a missing-title critical
   });
 

--- a/packages/cli/test/source-provider.test.ts
+++ b/packages/cli/test/source-provider.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { seo001Title, type Detection, type ResolvedHead, defaultConfig, defineConfig } from '@svelte-vitals/core';
+import {
+  seo001Title,
+  type Detection,
+  type ResolvedHead,
+  defaultConfig,
+  defaultProject,
+  defineConfig
+} from '@svelte-vitals/core';
 import { createNodeRuntime } from '../src/runtime/node.js';
 import { sourceHeadProvider } from '../src/providers/source/routes.js';
 import { createMemoryRuntime } from './helpers/memory-runtime.js';
@@ -40,7 +47,7 @@ describe('SourceHeadProvider (Node runtime, real fixture)', () => {
   it('feeds SEO001 to produce one critical failure (the missing title)', async () => {
     const rt = createNodeRuntime();
     const heads = await sourceHeadProvider.collect(rt, fixtureDir);
-    const results = await seo001Title.check({ heads, config: { treatDynamicAs: 'pass', metaComponents: [] } });
+    const results = await seo001Title.check({ heads, project: defaultProject, config: defineConfig({}) });
     const failing = results.filter((r) => r.detection.presence === 'none');
     expect(failing).toHaveLength(2);
     expect(failing.map((r) => r.route).sort()).toEqual(['/none', '/widget']);

--- a/packages/core/src/config-apply.ts
+++ b/packages/core/src/config-apply.ts
@@ -1,0 +1,15 @@
+import type { Config, Result } from './types.js';
+import type { Rule } from './rule.js';
+
+/** Drop rules disabled via config (design §6). */
+export function selectRules(rules: Rule[], config: Config): Rule[] {
+  return rules.filter((rule) => config.rules[rule.id] !== 'off');
+}
+
+/** Apply per-rule severity overrides to results (design §6). */
+export function applyRuleSeverities(results: Result[], config: Config): Result[] {
+  return results.map((result) => {
+    const setting = config.rules[result.id];
+    return setting && setting !== 'off' ? { ...result, severity: setting } : result;
+  });
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,6 @@ export { runRules } from './engine.js';
 export { allRules, seo001Title } from './rules/index.js';
 
 export type { Summary, Classification } from './summary.js';
-export { summarize, classify, hasFailureAtOrAbove } from './summary.js';
+export { summarize, classify, hasFailureAtOrAbove, effectiveSeverity } from './summary.js';
 
 export { formatConsoleReport } from './reporter/console.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,5 +45,5 @@ export { formatJsonReport } from './reporter/json.js';
 
 export { selectRules, applyRuleSeverities } from './config-apply.js';
 
-export type { ScoreModel, ScoreResult } from './scoring/score.js';
+export type { ScoreModel, ScoreResult, ScoreOptions } from './scoring/score.js';
 export { computeScore } from './scoring/score.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,3 +28,5 @@ export type { Summary, Classification } from './summary.js';
 export { summarize, classify, hasFailureAtOrAbove, effectiveSeverity } from './summary.js';
 
 export { formatConsoleReport } from './reporter/console.js';
+
+export { selectRules, applyRuleSeverities } from './config-apply.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,7 +22,16 @@ export type { Rule, RuleContext } from './rule.js';
 export { isPenalized } from './rule.js';
 
 export { runRules } from './engine.js';
-export { allRules, seo001Title } from './rules/index.js';
+export {
+  allRules,
+  seo001Title,
+  seo002Description,
+  seo003Canonical,
+  seo004OgImage,
+  seo005OgTitle,
+  seo008JsonLd
+} from './rules/index.js';
+export { headTagRule } from './rules/seo/head-tag-rule.js';
 
 export type { Summary, Classification } from './summary.js';
 export { summarize, classify, hasFailureAtOrAbove, effectiveSeverity } from './summary.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,6 +39,7 @@ export { headTagRule } from './rules/seo/head-tag-rule.js';
 export type { Summary, Classification } from './summary.js';
 export { summarize, classify, hasFailureAtOrAbove, effectiveSeverity } from './summary.js';
 
+export type { ConsoleReportOptions } from './reporter/console.js';
 export { formatConsoleReport } from './reporter/console.js';
 
 export { selectRules, applyRuleSeverities } from './config-apply.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,7 @@ export { summarize, classify, hasFailureAtOrAbove, effectiveSeverity } from './s
 
 export type { ConsoleReportOptions } from './reporter/console.js';
 export { formatConsoleReport } from './reporter/console.js';
+export { formatJsonReport } from './reporter/json.js';
 
 export { selectRules, applyRuleSeverities } from './config-apply.js';
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,3 +30,6 @@ export { summarize, classify, hasFailureAtOrAbove, effectiveSeverity } from './s
 export { formatConsoleReport } from './reporter/console.js';
 
 export { selectRules, applyRuleSeverities } from './config-apply.js';
+
+export type { ScoreModel, ScoreResult } from './scoring/score.js';
+export { computeScore } from './scoring/score.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,9 +29,9 @@ export {
   seo003Canonical,
   seo004OgImage,
   seo005OgTitle,
-  seo008JsonLd,
   seo006Robots,
   seo007Sitemap,
+  seo008JsonLd,
   seo009HtmlLang
 } from './rules/index.js';
 export { headTagRule } from './rules/seo/head-tag-rule.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,8 +1,20 @@
 // @svelte-vitals/core — runtime-agnostic core (design §8).
 // No `node:` imports, no I/O, no runtime-specific globals.
 
-export type { Severity, Presence, Value, Detection, Result, Scope, Category, TreatDynamicAs, Config } from './types.js';
-export { defaultConfig, defineConfig } from './types.js';
+export type {
+  Severity,
+  Presence,
+  Value,
+  Detection,
+  Project,
+  Result,
+  Scope,
+  Category,
+  TreatDynamicAs,
+  RuleSetting,
+  Config
+} from './types.js';
+export { defaultConfig, defineConfig, defaultProject } from './types.js';
 
 export type { HeadTag, ResolvedHead, HeadProvider } from './head.js';
 export type { Runtime } from './runtime.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,7 +29,10 @@ export {
   seo003Canonical,
   seo004OgImage,
   seo005OgTitle,
-  seo008JsonLd
+  seo008JsonLd,
+  seo006Robots,
+  seo007Sitemap,
+  seo009HtmlLang
 } from './rules/index.js';
 export { headTagRule } from './rules/seo/head-tag-rule.js';
 

--- a/packages/core/src/reporter/console.ts
+++ b/packages/core/src/reporter/console.ts
@@ -1,5 +1,7 @@
 import type { Config, Result, Severity } from '../types.js';
-import { classify, summarize } from '../summary.js';
+import { classify, summarize, effectiveSeverity } from '../summary.js';
+import { computeScore } from '../scoring/score.js';
+import { isPenalized } from '../rule.js';
 
 const RULE = '────────────────────────';
 const SEVERITY_TITLE: Record<Severity, string> = {
@@ -8,20 +10,49 @@ const SEVERITY_TITLE: Record<Severity, string> = {
   info: 'Info'
 };
 
+export interface ConsoleReportOptions {
+  byRoute?: boolean;
+}
+
+function scoreHeader(results: Result[], config: Config): string {
+  const { score, scoreModel } = computeScore(results, config);
+  const parts = [`route avg ${scoreModel.routeAverage}`];
+  if (scoreModel.sitePenalty > 0) parts.push(`site −${scoreModel.sitePenalty}`);
+  if (scoreModel.criticalCap !== null) parts.push(`capped at ${scoreModel.criticalCap}: critical present`);
+  return `SEO Score: ${score}/100   (${parts.join(' · ')})`;
+}
+
+function byRouteTree(results: Result[], config: Config): string[] {
+  const routes = new Map<string, Result[]>();
+  for (const r of results) {
+    if (r.route === undefined) continue;
+    if (!routes.has(r.route)) routes.set(r.route, []);
+    routes.get(r.route)!.push(r);
+  }
+  const lines: string[] = ['By route', RULE];
+  for (const [route, rs] of [...routes.entries()].sort()) {
+    const { score } = computeScore(rs, config);
+    lines.push(`${route.padEnd(28)} ${score}`);
+    for (const r of rs.filter((x) => isPenalized(x.detection, config.treatDynamicAs))) {
+      lines.push(`    ✗ ${r.id}  ${r.message}`);
+    }
+  }
+  lines.push('');
+  return lines;
+}
+
 /**
  * Render results as a console report string (design §7). Pure: returns a string,
- * the caller is responsible for printing. Slice 0 lists failures grouped by
- * severity, then passing routes (with a ↯ marker for dynamic values).
+ * the caller is responsible for printing. Prepends a score header; when byRoute is
+ * set, adds a per-route score tree.
  */
-export function formatConsoleReport(results: Result[], config: Config): string {
+export function formatConsoleReport(results: Result[], config: Config, options: ConsoleReportOptions = {}): string {
   const summary = summarize(results, config);
-  const lines: string[] = [];
-
-  lines.push('Svelte Vitals  ·  SEO (static mode)', '');
+  const lines: string[] = ['Svelte Vitals  ·  SEO (static mode)', '', scoreHeader(results, config), ''];
 
   const failures = results.filter((r) => classify(r, config) === 'fail');
   for (const severity of ['critical', 'warning', 'info'] as const) {
-    const bucket = failures.filter((r) => r.severity === severity);
+    const bucket = failures.filter((r) => effectiveSeverity(r, config) === severity);
     if (bucket.length === 0) continue;
     lines.push(`${SEVERITY_TITLE[severity]} (${bucket.length})`, RULE);
     for (const r of bucket) {
@@ -43,9 +74,8 @@ export function formatConsoleReport(results: Result[], config: Config): string {
     lines.push('');
   }
 
-  if (summary.dynamic > 0) {
-    lines.push('↯ = set dynamically (verified at runtime).');
-  }
+  if (options.byRoute) lines.push(...byRouteTree(results, config));
+  if (summary.dynamic > 0) lines.push('↯ = set dynamically (verified at runtime).');
 
   return lines.join('\n').replace(/\n+$/, '\n');
 }

--- a/packages/core/src/reporter/console.ts
+++ b/packages/core/src/reporter/console.ts
@@ -29,7 +29,7 @@ function byRouteTree(results: Result[], config: Config): string[] {
     routes.get(r.route)!.push(r);
   }
   const lines: string[] = ['By route', RULE];
-  for (const [route, rs] of [...routes.entries()].sort()) {
+  for (const [route, rs] of [...routes.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
     const { score } = computeScore(rs, config, { applyCriticalCap: false });
     lines.push(`${route.padEnd(28)} ${score}`);
     for (const r of rs.filter((x) => classify(x, config) === 'fail')) {

--- a/packages/core/src/reporter/console.ts
+++ b/packages/core/src/reporter/console.ts
@@ -1,7 +1,6 @@
 import type { Config, Result, Severity } from '../types.js';
 import { classify, summarize, effectiveSeverity } from '../summary.js';
 import { computeScore } from '../scoring/score.js';
-import { isPenalized } from '../rule.js';
 
 const RULE = '────────────────────────';
 const SEVERITY_TITLE: Record<Severity, string> = {
@@ -31,9 +30,9 @@ function byRouteTree(results: Result[], config: Config): string[] {
   }
   const lines: string[] = ['By route', RULE];
   for (const [route, rs] of [...routes.entries()].sort()) {
-    const { score } = computeScore(rs, config);
+    const { score } = computeScore(rs, config, { applyCriticalCap: false });
     lines.push(`${route.padEnd(28)} ${score}`);
-    for (const r of rs.filter((x) => isPenalized(x.detection, config.treatDynamicAs))) {
+    for (const r of rs.filter((x) => classify(x, config) === 'fail')) {
       lines.push(`    ✗ ${r.id}  ${r.message}`);
     }
   }

--- a/packages/core/src/reporter/json.ts
+++ b/packages/core/src/reporter/json.ts
@@ -1,0 +1,43 @@
+import type { Config, Result } from '../types.js';
+import { computeScore } from '../scoring/score.js';
+import { summarize, effectiveSeverity } from '../summary.js';
+import { isPenalized } from '../rule.js';
+
+function issueOf(result: Result) {
+  return {
+    id: result.id,
+    title: result.message,
+    detection: result.detection,
+    location: result.location,
+    recommendation: result.recommendation
+  };
+}
+
+/** Render results as the documented JSON report string (design §7). */
+export function formatJsonReport(results: Result[], config: Config, meta: { version: string }): string {
+  const { score, scoreModel } = computeScore(results, config);
+  const summary = summarize(results, config);
+
+  const routeMap = new Map<string, { route: string; results: Result[] }>();
+  for (const r of results) {
+    if (r.route === undefined) continue;
+    if (!routeMap.has(r.route)) routeMap.set(r.route, { route: r.route, results: [] });
+    routeMap.get(r.route)!.results.push(r);
+  }
+
+  const routes = [...routeMap.values()]
+    .sort((a, b) => a.route.localeCompare(b.route))
+    .map(({ route, results: rs }) => ({
+      route,
+      score: computeScore(rs, config).score,
+      issues: rs
+        .filter((r) => isPenalized(r.detection, config.treatDynamicAs))
+        .map((r) => ({ ...issueOf(r), severity: effectiveSeverity(r, config) }))
+    }));
+
+  const siteIssues = results
+    .filter((r) => r.route === undefined && isPenalized(r.detection, config.treatDynamicAs))
+    .map((r) => ({ ...issueOf(r), severity: effectiveSeverity(r, config) }));
+
+  return JSON.stringify({ version: meta.version, score, scoreModel, summary, routes, siteIssues }, null, 2);
+}

--- a/packages/core/src/reporter/json.ts
+++ b/packages/core/src/reporter/json.ts
@@ -29,7 +29,7 @@ export function formatJsonReport(results: Result[], config: Config, meta: { vers
     .sort((a, b) => a.route.localeCompare(b.route))
     .map(({ route, results: rs }) => ({
       route,
-      score: computeScore(rs, config).score,
+      score: computeScore(rs, config, { applyCriticalCap: false }).score,
       issues: rs
         .filter((r) => isPenalized(r.detection, config.treatDynamicAs))
         .map((r) => ({ ...issueOf(r), severity: effectiveSeverity(r, config) }))

--- a/packages/core/src/rule.ts
+++ b/packages/core/src/rule.ts
@@ -29,7 +29,7 @@ export interface Rule {
  *
  *   presence 'none'            → penalized (nothing set anywhere)
  *   value 'absent'             → penalized (tag present but empty)
- *   value 'dynamic'            → penalized only when treatDynamicAs is 'fail'
+ *   value 'dynamic'            → penalized when treatDynamicAs is not 'pass' (warn or fail)
  *   otherwise (static/inherited) → not penalized
  */
 export function isPenalized(detection: Detection, treatDynamicAs: TreatDynamicAs): boolean {

--- a/packages/core/src/rule.ts
+++ b/packages/core/src/rule.ts
@@ -35,6 +35,6 @@ export interface Rule {
 export function isPenalized(detection: Detection, treatDynamicAs: TreatDynamicAs): boolean {
   if (detection.presence === 'none') return true;
   if (detection.value === 'absent') return true;
-  if (detection.value === 'dynamic') return treatDynamicAs === 'fail';
+  if (detection.value === 'dynamic') return treatDynamicAs !== 'pass';
   return false;
 }

--- a/packages/core/src/rule.ts
+++ b/packages/core/src/rule.ts
@@ -1,9 +1,10 @@
-import type { Category, Config, Detection, Result, Scope, Severity, TreatDynamicAs } from './types.js';
+import type { Category, Config, Detection, Project, Result, Scope, Severity, TreatDynamicAs } from './types.js';
 import type { ResolvedHead } from './head.js';
 
 /** Input given to every rule. Mode-independent: rules see only ResolvedHead[] (design §8, §10). */
 export interface RuleContext {
   heads: ResolvedHead[];
+  project: Project;
   config: Config;
 }
 

--- a/packages/core/src/rules/index.ts
+++ b/packages/core/src/rules/index.ts
@@ -7,6 +7,7 @@ import {
   seo005OgTitle,
   seo008JsonLd
 } from './seo/seo002-005-008.js';
+import { seo006Robots, seo007Sitemap, seo009HtmlLang } from './seo/project-rules.js';
 
 export const allRules: Rule[] = [
   seo001Title,
@@ -14,7 +15,20 @@ export const allRules: Rule[] = [
   seo003Canonical,
   seo004OgImage,
   seo005OgTitle,
-  seo008JsonLd
+  seo008JsonLd,
+  seo006Robots,
+  seo007Sitemap,
+  seo009HtmlLang
 ];
 
-export { seo001Title, seo002Description, seo003Canonical, seo004OgImage, seo005OgTitle, seo008JsonLd };
+export {
+  seo001Title,
+  seo002Description,
+  seo003Canonical,
+  seo004OgImage,
+  seo005OgTitle,
+  seo008JsonLd,
+  seo006Robots,
+  seo007Sitemap,
+  seo009HtmlLang
+};

--- a/packages/core/src/rules/index.ts
+++ b/packages/core/src/rules/index.ts
@@ -1,7 +1,20 @@
 import type { Rule } from '../rule.js';
 import { seo001Title } from './seo/seo001-title.js';
+import {
+  seo002Description,
+  seo003Canonical,
+  seo004OgImage,
+  seo005OgTitle,
+  seo008JsonLd
+} from './seo/seo002-005-008.js';
 
-/** Rule registry. Slice 0 ships SEO001 only; later slices append here. */
-export const allRules: Rule[] = [seo001Title];
+export const allRules: Rule[] = [
+  seo001Title,
+  seo002Description,
+  seo003Canonical,
+  seo004OgImage,
+  seo005OgTitle,
+  seo008JsonLd
+];
 
-export { seo001Title };
+export { seo001Title, seo002Description, seo003Canonical, seo004OgImage, seo005OgTitle, seo008JsonLd };

--- a/packages/core/src/rules/index.ts
+++ b/packages/core/src/rules/index.ts
@@ -15,9 +15,9 @@ export const allRules: Rule[] = [
   seo003Canonical,
   seo004OgImage,
   seo005OgTitle,
-  seo008JsonLd,
   seo006Robots,
   seo007Sitemap,
+  seo008JsonLd,
   seo009HtmlLang
 ];
 
@@ -27,8 +27,8 @@ export {
   seo003Canonical,
   seo004OgImage,
   seo005OgTitle,
-  seo008JsonLd,
   seo006Robots,
   seo007Sitemap,
+  seo008JsonLd,
   seo009HtmlLang
 };

--- a/packages/core/src/rules/seo/head-tag-rule.ts
+++ b/packages/core/src/rules/seo/head-tag-rule.ts
@@ -1,0 +1,52 @@
+import type { Detection, Result, Severity } from '../../types.js';
+import type { HeadTag, ResolvedHead } from '../../head.js';
+import type { Rule, RuleContext } from '../../rule.js';
+
+export interface HeadTagRuleOptions {
+  id: string;
+  title: string;
+  severity: Severity;
+  /** Identifies the tag this rule looks for. */
+  match: (tag: HeadTag) => boolean;
+  /** Short human label, e.g. 'description'. */
+  label: string;
+  recommendation: string;
+}
+
+function detect(head: ResolvedHead, match: (t: HeadTag) => boolean): Detection {
+  const tag = head.tags.find(match);
+  return tag ? { presence: tag.presence, value: tag.value } : { presence: 'none', value: 'absent' };
+}
+
+/** Build a route-scope rule asserting the presence of a single head tag (design §11). */
+export function headTagRule(opts: HeadTagRuleOptions): Rule {
+  const docsUrl = `https://svelte-vitals.dev/rules/${opts.id}`;
+  return {
+    id: opts.id,
+    title: opts.title,
+    category: 'seo',
+    severity: opts.severity,
+    scope: 'route',
+    async check(ctx: RuleContext): Promise<Result[]> {
+      return ctx.heads.map((head) => {
+        const detection = detect(head, opts.match);
+        const message =
+          detection.presence === 'none'
+            ? `Missing ${opts.label}`
+            : detection.value === 'absent'
+              ? `Empty ${opts.label}`
+              : opts.label;
+        return {
+          id: opts.id,
+          severity: opts.severity,
+          detection,
+          route: head.route,
+          location: head.file,
+          message,
+          recommendation: opts.recommendation,
+          docsUrl
+        } satisfies Result;
+      });
+    }
+  };
+}

--- a/packages/core/src/rules/seo/project-rules.ts
+++ b/packages/core/src/rules/seo/project-rules.ts
@@ -1,0 +1,74 @@
+import type { Detection, Result } from '../../types.js';
+import type { Rule, RuleContext } from '../../rule.js';
+
+const present: Detection = { presence: 'own', value: 'static' };
+const absent: Detection = { presence: 'none', value: 'absent' };
+
+export const seo006Robots: Rule = {
+  id: 'SEO006',
+  title: 'robots.txt',
+  category: 'seo',
+  severity: 'warning',
+  scope: 'project',
+  async check(ctx: RuleContext): Promise<Result[]> {
+    const detection = ctx.project.hasRobotsTxt ? present : absent;
+    return [
+      {
+        id: 'SEO006',
+        severity: 'warning',
+        detection,
+        message: ctx.project.hasRobotsTxt ? 'robots.txt' : 'Missing robots.txt',
+        recommendation: 'Add static/robots.txt or a src/routes/robots.txt/+server endpoint.',
+        docsUrl: 'https://svelte-vitals.dev/rules/SEO006'
+      }
+    ];
+  }
+};
+
+export const seo007Sitemap: Rule = {
+  id: 'SEO007',
+  title: 'sitemap.xml',
+  category: 'seo',
+  severity: 'warning',
+  scope: 'project',
+  async check(ctx: RuleContext): Promise<Result[]> {
+    const detection = ctx.project.hasSitemap ? present : absent;
+    return [
+      {
+        id: 'SEO007',
+        severity: 'warning',
+        detection,
+        message: ctx.project.hasSitemap ? 'sitemap.xml' : 'Missing sitemap.xml',
+        recommendation: 'Add static/sitemap.xml or a src/routes/sitemap.xml/+server endpoint.',
+        docsUrl: 'https://svelte-vitals.dev/rules/SEO007'
+      }
+    ];
+  }
+};
+
+export const seo009HtmlLang: Rule = {
+  id: 'SEO009',
+  title: '<html lang>',
+  category: 'seo',
+  severity: 'warning',
+  scope: 'project',
+  async check(ctx: RuleContext): Promise<Result[]> {
+    const detection = ctx.project.htmlLang;
+    const message =
+      detection.presence === 'none'
+        ? 'Missing <html lang>'
+        : detection.value === 'absent'
+          ? 'Empty <html lang>'
+          : '<html lang>';
+    return [
+      {
+        id: 'SEO009',
+        severity: 'warning',
+        detection,
+        message,
+        recommendation: 'Set <html lang="..."> in src/app.html.',
+        docsUrl: 'https://svelte-vitals.dev/rules/SEO009'
+      }
+    ];
+  }
+};

--- a/packages/core/src/rules/seo/seo002-005-008.ts
+++ b/packages/core/src/rules/seo/seo002-005-008.ts
@@ -1,0 +1,47 @@
+import type { HeadTag } from '../../head.js';
+import { headTagRule } from './head-tag-rule.js';
+
+export const seo002Description = headTagRule({
+  id: 'SEO002',
+  title: 'Description presence',
+  severity: 'critical',
+  match: (t: HeadTag) => t.kind === 'meta' && t.name === 'description',
+  label: '<meta name="description">',
+  recommendation: 'Add a <meta name="description"> in <svelte:head>, or set the description on your meta component.'
+});
+
+export const seo003Canonical = headTagRule({
+  id: 'SEO003',
+  title: 'Canonical URL',
+  severity: 'warning',
+  match: (t: HeadTag) => t.kind === 'link' && t.rel === 'canonical',
+  label: '<link rel="canonical">',
+  recommendation: 'Add <link rel="canonical"> in <svelte:head>, or set the canonical prop on your meta component.'
+});
+
+export const seo004OgImage = headTagRule({
+  id: 'SEO004',
+  title: 'Open Graph image',
+  severity: 'warning',
+  match: (t: HeadTag) => t.kind === 'meta' && t.property === 'og:image',
+  label: '<meta property="og:image">',
+  recommendation: 'Add <meta property="og:image">, or set openGraph.images on your meta component.'
+});
+
+export const seo005OgTitle = headTagRule({
+  id: 'SEO005',
+  title: 'Open Graph title',
+  severity: 'warning',
+  match: (t: HeadTag) => t.kind === 'meta' && t.property === 'og:title',
+  label: '<meta property="og:title">',
+  recommendation: 'Add <meta property="og:title">, or set openGraph.title on your meta component.'
+});
+
+export const seo008JsonLd = headTagRule({
+  id: 'SEO008',
+  title: 'JSON-LD structured data',
+  severity: 'info',
+  match: (t: HeadTag) => t.kind === 'jsonld',
+  label: 'JSON-LD (<script type="application/ld+json">)',
+  recommendation: 'Add JSON-LD structured data, e.g. via <svelte:head> or a JsonLd component.'
+});

--- a/packages/core/src/scoring/score.ts
+++ b/packages/core/src/scoring/score.ts
@@ -35,23 +35,36 @@ export function computeScore(results: Result[], config: Config, options: ScoreOp
   for (const r of routeResults) if (!routeScores.has(r.route as string)) routeScores.set(r.route as string, 100);
 
   let anyCritical = false;
+
+  // One deduction per (route, rule id): take the max deduction among duplicates.
+  const routeRuleMax = new Map<string, number>();
   for (const r of routeResults) {
     if (!isPenalized(r.detection, config.treatDynamicAs)) continue;
     const sev = effectiveSeverity(r, config);
-    routeScores.set(r.route as string, (routeScores.get(r.route as string) as number) - DEDUCTION[sev]);
     if (sev === 'critical') anyCritical = true;
+    const key = `${r.route as string} ${r.id}`;
+    const prev = routeRuleMax.get(key) ?? 0;
+    if (DEDUCTION[sev] > prev) routeRuleMax.set(key, DEDUCTION[sev]);
+  }
+  for (const [key, deduction] of routeRuleMax) {
+    const route = key.slice(0, key.lastIndexOf(' '));
+    routeScores.set(route, (routeScores.get(route) as number) - deduction);
   }
 
   const scores = [...routeScores.values()].map(clamp);
   const routeAverage = scores.length ? Math.round(scores.reduce((a, b) => a + b, 0) / scores.length) : 100;
 
-  let sitePenalty = 0;
+  // One deduction per project rule id: take the max deduction among duplicates.
+  const projectRuleMax = new Map<string, number>();
   for (const r of projectResults) {
     if (!isPenalized(r.detection, config.treatDynamicAs)) continue;
     const sev = effectiveSeverity(r, config);
-    sitePenalty += DEDUCTION[sev];
     if (sev === 'critical') anyCritical = true;
+    const prev = projectRuleMax.get(r.id) ?? 0;
+    if (DEDUCTION[sev] > prev) projectRuleMax.set(r.id, DEDUCTION[sev]);
   }
+  let sitePenalty = 0;
+  for (const deduction of projectRuleMax.values()) sitePenalty += deduction;
 
   const applyCap = options.applyCriticalCap ?? true;
   const criticalCap = applyCap && anyCritical ? CRITICAL_CAP : null;

--- a/packages/core/src/scoring/score.ts
+++ b/packages/core/src/scoring/score.ts
@@ -8,7 +8,7 @@ const CRITICAL_CAP = 79;
 export interface ScoreModel {
   routeAverage: number;
   sitePenalty: number;
-  /** Headline cap applied when a critical finding exists, else null. */
+  /** Headline cap value when it actually lowered the score, else null. */
   criticalCap: number | null;
 }
 
@@ -36,18 +36,23 @@ export function computeScore(results: Result[], config: Config, options: ScoreOp
 
   let anyCritical = false;
 
-  // One deduction per (route, rule id): take the max deduction among duplicates.
-  const routeRuleMax = new Map<string, number>();
+  // One deduction per (route, rule id): take the max deduction among duplicates,
+  // then sum a route's per-rule deductions. Keyed by a nested map so route paths
+  // never need to be parsed back out of a composite string key.
+  const routeRuleMax = new Map<string, Map<string, number>>();
   for (const r of routeResults) {
     if (!isPenalized(r.detection, config.treatDynamicAs)) continue;
     const sev = effectiveSeverity(r, config);
     if (sev === 'critical') anyCritical = true;
-    const key = `${r.route as string} ${r.id}`;
-    const prev = routeRuleMax.get(key) ?? 0;
-    if (DEDUCTION[sev] > prev) routeRuleMax.set(key, DEDUCTION[sev]);
+    const route = r.route as string;
+    let perRule = routeRuleMax.get(route);
+    if (!perRule) routeRuleMax.set(route, (perRule = new Map()));
+    const prev = perRule.get(r.id) ?? 0;
+    if (DEDUCTION[sev] > prev) perRule.set(r.id, DEDUCTION[sev]);
   }
-  for (const [key, deduction] of routeRuleMax) {
-    const route = key.slice(0, key.lastIndexOf(' '));
+  for (const [route, perRule] of routeRuleMax) {
+    let deduction = 0;
+    for (const d of perRule.values()) deduction += d;
     routeScores.set(route, (routeScores.get(route) as number) - deduction);
   }
 
@@ -66,10 +71,13 @@ export function computeScore(results: Result[], config: Config, options: ScoreOp
   let sitePenalty = 0;
   for (const deduction of projectRuleMax.values()) sitePenalty += deduction;
 
+  // The cap is only meaningful when it actually lowers the score; reporting it
+  // otherwise reads as "rounded down to 79" even when the score is already below.
   const applyCap = options.applyCriticalCap ?? true;
-  const criticalCap = applyCap && anyCritical ? CRITICAL_CAP : null;
-  let score = routeAverage - sitePenalty;
-  if (criticalCap !== null) score = Math.min(score, criticalCap);
+  const uncapped = routeAverage - sitePenalty;
+  const capBinds = applyCap && anyCritical && uncapped > CRITICAL_CAP;
+  const criticalCap = capBinds ? CRITICAL_CAP : null;
+  const score = capBinds ? CRITICAL_CAP : uncapped;
 
   return { score: clamp(score), scoreModel: { routeAverage, sitePenalty, criticalCap } };
 }

--- a/packages/core/src/scoring/score.ts
+++ b/packages/core/src/scoring/score.ts
@@ -17,12 +17,16 @@ export interface ScoreResult {
   scoreModel: ScoreModel;
 }
 
+export interface ScoreOptions {
+  applyCriticalCap?: boolean;
+}
+
 function clamp(n: number): number {
   return Math.max(0, Math.min(100, n));
 }
 
 /** Compute the headline score and its breakdown (design §12). */
-export function computeScore(results: Result[], config: Config): ScoreResult {
+export function computeScore(results: Result[], config: Config, options: ScoreOptions = {}): ScoreResult {
   const routeResults = results.filter((r) => r.route !== undefined);
   const projectResults = results.filter((r) => r.route === undefined);
 
@@ -49,7 +53,8 @@ export function computeScore(results: Result[], config: Config): ScoreResult {
     if (sev === 'critical') anyCritical = true;
   }
 
-  const criticalCap = anyCritical ? CRITICAL_CAP : null;
+  const applyCap = options.applyCriticalCap ?? true;
+  const criticalCap = applyCap && anyCritical ? CRITICAL_CAP : null;
   let score = routeAverage - sitePenalty;
   if (criticalCap !== null) score = Math.min(score, criticalCap);
 

--- a/packages/core/src/scoring/score.ts
+++ b/packages/core/src/scoring/score.ts
@@ -1,0 +1,57 @@
+import type { Config, Result, Severity } from '../types.js';
+import { isPenalized } from '../rule.js';
+import { effectiveSeverity } from '../summary.js';
+
+const DEDUCTION: Record<Severity, number> = { critical: 15, warning: 5, info: 1 };
+const CRITICAL_CAP = 79;
+
+export interface ScoreModel {
+  routeAverage: number;
+  sitePenalty: number;
+  /** Headline cap applied when a critical finding exists, else null. */
+  criticalCap: number | null;
+}
+
+export interface ScoreResult {
+  score: number;
+  scoreModel: ScoreModel;
+}
+
+function clamp(n: number): number {
+  return Math.max(0, Math.min(100, n));
+}
+
+/** Compute the headline score and its breakdown (design §12). */
+export function computeScore(results: Result[], config: Config): ScoreResult {
+  const routeResults = results.filter((r) => r.route !== undefined);
+  const projectResults = results.filter((r) => r.route === undefined);
+
+  // Seed every route at 100 so passing routes count toward the average.
+  const routeScores = new Map<string, number>();
+  for (const r of routeResults) if (!routeScores.has(r.route as string)) routeScores.set(r.route as string, 100);
+
+  let anyCritical = false;
+  for (const r of routeResults) {
+    if (!isPenalized(r.detection, config.treatDynamicAs)) continue;
+    const sev = effectiveSeverity(r, config);
+    routeScores.set(r.route as string, (routeScores.get(r.route as string) as number) - DEDUCTION[sev]);
+    if (sev === 'critical') anyCritical = true;
+  }
+
+  const scores = [...routeScores.values()].map(clamp);
+  const routeAverage = scores.length ? Math.round(scores.reduce((a, b) => a + b, 0) / scores.length) : 100;
+
+  let sitePenalty = 0;
+  for (const r of projectResults) {
+    if (!isPenalized(r.detection, config.treatDynamicAs)) continue;
+    const sev = effectiveSeverity(r, config);
+    sitePenalty += DEDUCTION[sev];
+    if (sev === 'critical') anyCritical = true;
+  }
+
+  const criticalCap = anyCritical ? CRITICAL_CAP : null;
+  let score = routeAverage - sitePenalty;
+  if (criticalCap !== null) score = Math.min(score, criticalCap);
+
+  return { score: clamp(score), scoreModel: { routeAverage, sitePenalty, criticalCap } };
+}

--- a/packages/core/src/summary.ts
+++ b/packages/core/src/summary.ts
@@ -20,12 +20,18 @@ export function classify(result: Result, config: Config): Classification {
   return 'pass';
 }
 
+/** A penalized dynamic finding is a warning under treatDynamicAs 'warn'; otherwise the rule's severity. */
+export function effectiveSeverity(result: Result, config: Config): Severity {
+  if (result.detection.value === 'dynamic' && config.treatDynamicAs === 'warn') return 'warning';
+  return result.severity;
+}
+
 export function summarize(results: Result[], config: Config): Summary {
   const summary: Summary = { critical: 0, warning: 0, info: 0, passed: 0, dynamic: 0 };
   for (const result of results) {
     const cls = classify(result, config);
     if (cls === 'fail') {
-      summary[severityKey(result.severity)] += 1;
+      summary[effectiveSeverity(result, config)] += 1;
     } else {
       summary.passed += 1;
       if (cls === 'dynamic') summary.dynamic += 1;
@@ -38,9 +44,5 @@ export function summarize(results: Result[], config: Config): Summary {
 export function hasFailureAtOrAbove(summary: Summary, min: Severity): boolean {
   const order: Severity[] = ['info', 'warning', 'critical'];
   const threshold = order.indexOf(min);
-  return order.some((sev, idx) => idx >= threshold && summary[severityKey(sev)] > 0);
-}
-
-function severityKey(severity: Severity): 'critical' | 'warning' | 'info' {
-  return severity;
+  return order.some((sev, idx) => idx >= threshold && summary[sev] > 0);
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -42,15 +42,24 @@ export type Category = 'seo' | 'performance' | 'a11y' | 'maintainability';
 /** How dynamic (`{data.title}`) values are treated by scoring (design §4, §12). */
 export type TreatDynamicAs = 'pass' | 'warn' | 'fail';
 
+/** Per-rule override: disable, or change severity. */
+export type RuleSetting = 'off' | Severity;
+
 export interface Config {
   treatDynamicAs: TreatDynamicAs;
   /** Component names treated as meta sources of unknown content (design §11 layer 4). */
   metaComponents: string[];
+  /** Per-rule overrides keyed by rule id (design §6). */
+  rules: Record<string, RuleSetting>;
+  /** Minimum severity that fails the run / CI (design §6). */
+  failOn: Severity;
 }
 
 export const defaultConfig: Config = {
   treatDynamicAs: 'pass',
-  metaComponents: []
+  metaComponents: [],
+  rules: {},
+  failOn: 'critical'
 };
 
 /** Merge user config over defaults. Identity helper for config files (design §6). */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -24,7 +24,7 @@ export interface Detection {
 export interface Project {
   hasRobotsTxt: boolean;
   hasSitemap: boolean;
-  /** <html lang> from app.html: presence 'own' if the attribute exists, value reflects emptiness. */
+  /** <html lang> from app.html: presence 'own' when the attribute exists ('none' otherwise); value 'static' if non-empty, 'absent' if empty. */
   htmlLang: Detection;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -20,6 +20,20 @@ export interface Detection {
   value: Value;
 }
 
+/** Project-wide facts precomputed by the runtime layer for project-scope rules (design §10). */
+export interface Project {
+  hasRobotsTxt: boolean;
+  hasSitemap: boolean;
+  /** <html lang> from app.html: presence 'own' if the attribute exists, value reflects emptiness. */
+  htmlLang: Detection;
+}
+
+export const defaultProject: Project = {
+  hasRobotsTxt: false,
+  hasSitemap: false,
+  htmlLang: { presence: 'none', value: 'absent' }
+};
+
 /** A single rule finding for one route (or the whole project). */
 export interface Result {
   /** Rule id, e.g. 'SEO001'. */

--- a/packages/core/test/config-apply.test.ts
+++ b/packages/core/test/config-apply.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { selectRules, applyRuleSeverities, defineConfig, type Rule, type Result } from '../src/index.js';
+
+const ruleA = {
+  id: 'SEO001',
+  title: 't',
+  category: 'seo',
+  severity: 'critical',
+  scope: 'route',
+  check: async () => []
+} as Rule;
+const ruleB = {
+  id: 'SEO008',
+  title: 't',
+  category: 'seo',
+  severity: 'info',
+  scope: 'route',
+  check: async () => []
+} as Rule;
+
+describe('config application', () => {
+  it('drops rules set to off', () => {
+    const kept = selectRules([ruleA, ruleB], defineConfig({ rules: { SEO008: 'off' } }));
+    expect(kept.map((r) => r.id)).toEqual(['SEO001']);
+  });
+  it('overrides result severity', () => {
+    const results: Result[] = [
+      { id: 'SEO003', severity: 'warning', detection: { presence: 'none', value: 'absent' }, message: 'x' }
+    ];
+    const out = applyRuleSeverities(results, defineConfig({ rules: { SEO003: 'critical' } }));
+    expect(out[0]!.severity).toBe('critical');
+  });
+  it('leaves results unchanged when no override', () => {
+    const results: Result[] = [
+      { id: 'SEO003', severity: 'warning', detection: { presence: 'none', value: 'absent' }, message: 'x' }
+    ];
+    expect(applyRuleSeverities(results, defineConfig({}))[0]!.severity).toBe('warning');
+  });
+});

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -12,3 +12,17 @@ describe('Config.metaComponents', () => {
     expect(config.treatDynamicAs).toBe('pass');
   });
 });
+
+describe('Config.rules and failOn', () => {
+  it('defaults rules to {} and failOn to critical', () => {
+    expect(defaultConfig.rules).toEqual({});
+    expect(defaultConfig.failOn).toBe('critical');
+  });
+
+  it('merges rules and failOn via defineConfig', () => {
+    const config = defineConfig({ rules: { SEO008: 'off', SEO003: 'critical' }, failOn: 'warning' });
+    expect(config.rules).toEqual({ SEO008: 'off', SEO003: 'critical' });
+    expect(config.failOn).toBe('warning');
+    expect(config.metaComponents).toEqual([]);
+  });
+});

--- a/packages/core/test/console-report.test.ts
+++ b/packages/core/test/console-report.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { formatConsoleReport, defineConfig, type Result } from '../src/index.js';
+
+const config = defineConfig({});
+const results: Result[] = [
+  {
+    id: 'SEO001',
+    severity: 'critical',
+    detection: { presence: 'own', value: 'static' },
+    route: '/a',
+    message: '<title>'
+  },
+  {
+    id: 'SEO002',
+    severity: 'critical',
+    detection: { presence: 'none', value: 'absent' },
+    route: '/a',
+    location: 'src/routes/a/+page.svelte',
+    message: 'Missing <meta name="description">'
+  },
+  { id: 'SEO006', severity: 'warning', detection: { presence: 'none', value: 'absent' }, message: 'Missing robots.txt' }
+];
+
+describe('formatConsoleReport', () => {
+  it('shows a score header and groups findings', () => {
+    const out = formatConsoleReport(results, config);
+    expect(out).toMatch(/SEO Score: \d+\/100/);
+    expect(out).toContain('Critical (1)');
+    expect(out).toContain('Missing <meta name="description">');
+  });
+  it('renders a per-route tree under --by-route', () => {
+    const out = formatConsoleReport(results, config, { byRoute: true });
+    expect(out).toContain('By route');
+    expect(out).toMatch(/\/a\s+\d+/);
+  });
+});

--- a/packages/core/test/head-rules.test.ts
+++ b/packages/core/test/head-rules.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import {
+  seo002Description,
+  seo003Canonical,
+  seo004OgImage,
+  seo005OgTitle,
+  seo008JsonLd,
+  defaultProject,
+  defineConfig,
+  type ResolvedHead
+} from '../src/index.js';
+
+const config = defineConfig({});
+const ctx = (tags: ResolvedHead['tags']) => ({
+  heads: [{ route: '/x', source: 'static' as const, file: 'src/routes/x/+page.svelte', tags }],
+  project: defaultProject,
+  config
+});
+
+describe('head-tag rules', () => {
+  it('SEO002 flags a missing description', async () => {
+    const [r] = await seo002Description.check(ctx([]));
+    expect(r!.detection).toEqual({ presence: 'none', value: 'absent' });
+    expect(r!.severity).toBe('critical');
+  });
+  it('SEO002 passes a present description', async () => {
+    const [r] = await seo002Description.check(
+      ctx([{ kind: 'meta', name: 'description', presence: 'own', value: 'static' }])
+    );
+    expect(r!.detection).toEqual({ presence: 'own', value: 'static' });
+  });
+  it('SEO003 matches link rel=canonical', async () => {
+    const [r] = await seo003Canonical.check(
+      ctx([{ kind: 'link', rel: 'canonical', presence: 'own', value: 'dynamic' }])
+    );
+    expect(r!.detection.value).toBe('dynamic');
+    expect(r!.severity).toBe('warning');
+  });
+  it('SEO004/005 match og:image/og:title by property', async () => {
+    const [img] = await seo004OgImage.check(
+      ctx([{ kind: 'meta', property: 'og:image', presence: 'own', value: 'static' }])
+    );
+    expect(img!.detection.presence).toBe('own');
+    const [title] = await seo005OgTitle.check(ctx([]));
+    expect(title!.detection).toEqual({ presence: 'none', value: 'absent' });
+  });
+  it('SEO008 is info severity and matches jsonld', async () => {
+    const [r] = await seo008JsonLd.check(ctx([{ kind: 'jsonld', presence: 'own', value: 'static' }]));
+    expect(r!.severity).toBe('info');
+    expect(r!.detection.presence).toBe('own');
+  });
+});

--- a/packages/core/test/json-report.test.ts
+++ b/packages/core/test/json-report.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { formatJsonReport, defineConfig, type Result } from '../src/index.js';
+
+const config = defineConfig({});
+const results: Result[] = [
+  {
+    id: 'SEO001',
+    severity: 'critical',
+    detection: { presence: 'own', value: 'static' },
+    route: '/a',
+    message: '<title>'
+  },
+  {
+    id: 'SEO002',
+    severity: 'critical',
+    detection: { presence: 'none', value: 'absent' },
+    route: '/a',
+    location: 'src/routes/a/+page.svelte',
+    message: 'Missing description'
+  },
+  { id: 'SEO006', severity: 'warning', detection: { presence: 'none', value: 'absent' }, message: 'Missing robots.txt' }
+];
+
+describe('formatJsonReport', () => {
+  it('emits the documented shape with only penalized findings', () => {
+    const json = JSON.parse(formatJsonReport(results, config, { version: '0.1.0' }));
+    expect(json.version).toBe('0.1.0');
+    expect(typeof json.score).toBe('number');
+    expect(json.scoreModel).toHaveProperty('routeAverage');
+    expect(json.summary.critical).toBe(1);
+    const routeA = json.routes.find((r: { route: string }) => r.route === '/a');
+    expect(routeA.issues).toHaveLength(1); // only the missing description (SEO001 passed)
+    expect(routeA.issues[0].id).toBe('SEO002');
+    expect(routeA.issues[0].detection).toEqual({ presence: 'none', value: 'absent' });
+    expect(json.siteIssues).toHaveLength(1);
+    expect(json.siteIssues[0].id).toBe('SEO006');
+  });
+});

--- a/packages/core/test/project-rules.test.ts
+++ b/packages/core/test/project-rules.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import {
+  seo006Robots,
+  seo007Sitemap,
+  seo009HtmlLang,
+  defaultProject,
+  defineConfig,
+  type Project
+} from '../src/index.js';
+
+const config = defineConfig({});
+const ctx = (project: Project) => ({ heads: [], project, config });
+
+describe('project-scope rules', () => {
+  it('SEO006 fails when robots.txt is absent, passes when present', async () => {
+    const [absent] = await seo006Robots.check(ctx(defaultProject));
+    expect(absent!.detection).toEqual({ presence: 'none', value: 'absent' });
+    expect(absent!.route).toBeUndefined();
+    const [present] = await seo006Robots.check(ctx({ ...defaultProject, hasRobotsTxt: true }));
+    expect(present!.detection).toEqual({ presence: 'own', value: 'static' });
+  });
+  it('SEO007 reflects sitemap presence', async () => {
+    const [present] = await seo007Sitemap.check(ctx({ ...defaultProject, hasSitemap: true }));
+    expect(present!.detection.presence).toBe('own');
+  });
+  it('SEO009 reflects html lang detection', async () => {
+    const [absent] = await seo009HtmlLang.check(ctx(defaultProject));
+    expect(absent!.detection).toEqual({ presence: 'none', value: 'absent' });
+    const [present] = await seo009HtmlLang.check(
+      ctx({ ...defaultProject, htmlLang: { presence: 'own', value: 'static' } })
+    );
+    expect(present!.detection).toEqual({ presence: 'own', value: 'static' });
+  });
+});

--- a/packages/core/test/project.test.ts
+++ b/packages/core/test/project.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { defaultProject } from '../src/index.js';
+
+describe('defaultProject', () => {
+  it('is empty/none by default', () => {
+    expect(defaultProject).toEqual({
+      hasRobotsTxt: false,
+      hasSitemap: false,
+      htmlLang: { presence: 'none', value: 'absent' }
+    });
+  });
+});

--- a/packages/core/test/score.test.ts
+++ b/packages/core/test/score.test.ts
@@ -44,6 +44,21 @@ describe('computeScore (§12 worked example)', () => {
     expect(scoreModel.criticalCap).toBeNull();
   });
 
+  it('reports criticalCap null when the cap does not actually lower the score', () => {
+    // /x: critical (15) + 5 warnings (25) => 100-40 = 60, already below the 79 cap.
+    const results: Result[] = [
+      fail('SEO002', '/x', 'critical'),
+      fail('SEO003', '/x', 'warning'),
+      fail('SEO004', '/x', 'warning'),
+      fail('SEO005', '/x', 'warning'),
+      fail('SEO010', '/x', 'warning'),
+      fail('SEO011', '/x', 'warning')
+    ];
+    const { score, scoreModel } = computeScore(results, defineConfig({}));
+    expect(score).toBe(60);
+    expect(scoreModel.criticalCap).toBeNull();
+  });
+
   it('omits the critical cap for a single-route view when applyCriticalCap is false', () => {
     const results: Result[] = [
       {

--- a/packages/core/test/score.test.ts
+++ b/packages/core/test/score.test.ts
@@ -43,4 +43,18 @@ describe('computeScore (§12 worked example)', () => {
     expect(score).toBe(100);
     expect(scoreModel.criticalCap).toBeNull();
   });
+
+  it('omits the critical cap for a single-route view when applyCriticalCap is false', () => {
+    const results: Result[] = [
+      {
+        id: 'SEO002',
+        severity: 'critical',
+        detection: { presence: 'none', value: 'absent' },
+        route: '/x',
+        message: 'missing'
+      }
+    ];
+    expect(computeScore(results, defineConfig({})).score).toBe(79); // capped (default)
+    expect(computeScore(results, defineConfig({}), { applyCriticalCap: false }).score).toBe(85); // uncapped: 100-15
+  });
 });

--- a/packages/core/test/score.test.ts
+++ b/packages/core/test/score.test.ts
@@ -57,4 +57,35 @@ describe('computeScore (§12 worked example)', () => {
     expect(computeScore(results, defineConfig({})).score).toBe(79); // capped (default)
     expect(computeScore(results, defineConfig({}), { applyCriticalCap: false }).score).toBe(85); // uncapped: 100-15
   });
+
+  it('deducts once per (route, rule) even if a rule emits duplicate penalized results', () => {
+    const results: Result[] = [
+      {
+        id: 'SEO002',
+        severity: 'warning',
+        detection: { presence: 'none', value: 'absent' },
+        route: '/x',
+        message: 'a'
+      },
+      {
+        id: 'SEO002',
+        severity: 'critical',
+        detection: { presence: 'none', value: 'absent' },
+        route: '/x',
+        message: 'b'
+      }
+    ];
+    // one deduction per (route, rule), taking the max (critical = 15) -> 100-15 = 85, uncapped view
+    expect(computeScore(results, defineConfig({}), { applyCriticalCap: false }).score).toBe(85);
+  });
+
+  it('deducts once per project rule even if duplicated', () => {
+    const results: Result[] = [
+      { id: 'SEO006', severity: 'warning', detection: { presence: 'none', value: 'absent' }, message: 'a' },
+      { id: 'SEO006', severity: 'warning', detection: { presence: 'none', value: 'absent' }, message: 'b' }
+    ];
+    // single route seeded at 100 not present; routeAverage falls back to 100; site penalty counted once (5) -> 95
+    expect(computeScore(results, defineConfig({})).scoreModel.sitePenalty).toBe(5);
+    expect(computeScore(results, defineConfig({})).score).toBe(95);
+  });
 });

--- a/packages/core/test/score.test.ts
+++ b/packages/core/test/score.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { computeScore, defineConfig, type Result } from '../src/index.js';
+
+const pass = (id: string, route: string): Result => ({
+  id,
+  severity: 'critical',
+  detection: { presence: 'own', value: 'static' },
+  route,
+  message: 'ok'
+});
+const fail = (id: string, route: string, severity: 'critical' | 'warning' | 'info'): Result => ({
+  id,
+  severity,
+  detection: { presence: 'none', value: 'absent' },
+  route,
+  message: 'missing'
+});
+
+describe('computeScore (§12 worked example)', () => {
+  it('caps at 79 when a critical exists and applies site penalty', () => {
+    const results: Result[] = [
+      pass('SEO001', '/a'),
+      pass('SEO001', '/b'),
+      pass('SEO001', '/c'),
+      pass('SEO001', '/d'),
+      // route /blog: critical + 2 warnings + 1 info  => 100-15-5-5-1 = 74
+      fail('SEO002', '/blog', 'critical'),
+      fail('SEO003', '/blog', 'warning'),
+      fail('SEO004', '/blog', 'warning'),
+      fail('SEO008', '/blog', 'info'),
+      // project rule: robots.txt missing (warning) => site penalty 5
+      { id: 'SEO006', severity: 'warning', detection: { presence: 'none', value: 'absent' }, message: 'no robots' }
+    ];
+    const { score, scoreModel } = computeScore(results, defineConfig({}));
+    expect(scoreModel.routeAverage).toBe(95); // (100*4 + 74)/5 = 94.8 -> 95
+    expect(scoreModel.sitePenalty).toBe(5);
+    expect(scoreModel.criticalCap).toBe(79);
+    expect(score).toBe(79);
+  });
+
+  it('no cap and full marks when everything passes', () => {
+    const { score, scoreModel } = computeScore([pass('SEO001', '/a')], defineConfig({}));
+    expect(score).toBe(100);
+    expect(scoreModel.criticalCap).toBeNull();
+  });
+});

--- a/packages/core/test/seo001.test.ts
+++ b/packages/core/test/seo001.test.ts
@@ -6,6 +6,7 @@ import {
   classify,
   formatConsoleReport,
   defaultConfig,
+  defaultProject,
   type ResolvedHead,
   type Config
 } from '../src/index.js';
@@ -35,26 +36,26 @@ const inheritedHead = head('/child', 'src/routes/child/+page.svelte', {
 
 describe('SEO001 title detection', () => {
   it('detects a static title as present (own/static)', async () => {
-    const [result] = await seo001Title.check({ heads: [staticHead], config });
+    const [result] = await seo001Title.check({ heads: [staticHead], project: defaultProject, config });
     expect(result!.detection).toEqual({ presence: 'own', value: 'static' });
     expect(classify(result!, config)).toBe('pass');
   });
 
   it('treats a dynamic title as present and never penalizes it', async () => {
-    const [result] = await seo001Title.check({ heads: [dynamicHead], config });
+    const [result] = await seo001Title.check({ heads: [dynamicHead], project: defaultProject, config });
     expect(result!.detection).toEqual({ presence: 'own', value: 'dynamic' });
     expect(classify(result!, config)).toBe('dynamic');
   });
 
   it('flags a missing title as none/absent (fail)', async () => {
-    const [result] = await seo001Title.check({ heads: [noneHead], config });
+    const [result] = await seo001Title.check({ heads: [noneHead], project: defaultProject, config });
     expect(result!.detection).toEqual({ presence: 'none', value: 'absent' });
     expect(classify(result!, config)).toBe('fail');
     expect(result!.message).toBe('Missing <title>');
   });
 
   it('passes an inherited title', async () => {
-    const [result] = await seo001Title.check({ heads: [inheritedHead], config });
+    const [result] = await seo001Title.check({ heads: [inheritedHead], project: defaultProject, config });
     expect(result!.detection).toEqual({ presence: 'inherited', value: 'static' });
     expect(classify(result!, config)).toBe('pass');
   });
@@ -64,6 +65,7 @@ describe('summary + reporter', () => {
   it('summarizes a mixed project', async () => {
     const results = await runRules([seo001Title], {
       heads: [staticHead, dynamicHead, noneHead],
+      project: defaultProject,
       config
     });
     const summary = summarize(results, config);
@@ -73,6 +75,7 @@ describe('summary + reporter', () => {
   it('renders ✗ for missing and ↯ for dynamic', async () => {
     const results = await runRules([seo001Title], {
       heads: [staticHead, dynamicHead, noneHead],
+      project: defaultProject,
       config
     });
     const report = formatConsoleReport(results, config);

--- a/packages/core/test/severity.test.ts
+++ b/packages/core/test/severity.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { isPenalized, effectiveSeverity, summarize, defineConfig, type Result } from '../src/index.js';
+
+const dynResult: Result = {
+  id: 'SEO001',
+  severity: 'critical',
+  detection: { presence: 'own', value: 'dynamic' },
+  route: '/x',
+  message: '<title>'
+};
+
+describe('treatDynamicAs handling', () => {
+  it('does not penalize dynamic under pass', () => {
+    expect(isPenalized(dynResult.detection, 'pass')).toBe(false);
+  });
+  it('penalizes dynamic under warn and fail', () => {
+    expect(isPenalized(dynResult.detection, 'warn')).toBe(true);
+    expect(isPenalized(dynResult.detection, 'fail')).toBe(true);
+  });
+  it('effective severity downgrades dynamic to warning under warn', () => {
+    expect(effectiveSeverity(dynResult, defineConfig({ treatDynamicAs: 'warn' }))).toBe('warning');
+    expect(effectiveSeverity(dynResult, defineConfig({ treatDynamicAs: 'fail' }))).toBe('critical');
+  });
+  it('summarize buckets a warn-dynamic finding as a warning', () => {
+    const s = summarize([dynResult], defineConfig({ treatDynamicAs: 'warn' }));
+    expect(s.warning).toBe(1);
+    expect(s.critical).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Completes static mode (issues #4–#7): `npx svelte-vitals` now produces a real **scored** SEO report.

- **Rules SEO002–SEO009**: description, canonical, og:image, og:title (route-scope, via a shared `headTagRule` factory) + robots.txt, sitemap.xml, `<html lang>` (project-scope) + JSON-LD.
- **Scoring model (§12)**: per-route score (100 − deductions), route average, site penalty for project rules, and a 79 critical cap on the headline. Surfaced in the console header and JSON.
- **JSON reporter** (`--json` / `--reporter json`) matching the §7 shape; **`--by-route`** per-route tree (per-route scores are uncapped so they reconcile with the listed findings).
- **Flags**: `--fail-on=<critical|warning|info>` / `--fail-on-warning`, `--rules <ids>` (allow-list) / `--ignore <ids>` (deny-list, deny wins).
- `treatDynamicAs: 'warn'` now reports dynamic values as warnings (`effectiveSeverity`); default stays `pass` (no Slice-1 regression).

## Architecture

- `@svelte-vitals/core` stays runtime-agnostic. Project-scope rules read facts the **CLI precomputes** into `RuleContext.project` (`collectProjectFacts` via the `Runtime` abstraction) — no I/O in core.
- Same Provider→Rule→Scorer→Reporter boundary; `Config` gains `rules`/`failOn`; `selectRules`/`applyRuleSeverities` apply on/off + severity overrides.

## Verification

- 83 tests pass (core 32, cli 51); `pnpm -r build` / `typecheck` / `pnpm lint` green.
- CLI: console shows `SEO Score: NN/100` header; `--by-route` shows reconcilable per-route scores; `--json` valid §7 JSON; `--fail-on=warning` exits 1.
- Whole-branch review (Opus) caught and fixed: per-route/by-route scores were applying the site-wide 79 cap (now uncapped per route); stale JSDoc; filter consistency — all with regression tests.

## Release

Changeset bumps `svelte-vitals` and `@svelte-vitals/core` **minor** (→ 0.2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #4, #5, #6, #7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded SEO reporting with new checks for description, canonical, Open Graph fields, robots.txt, sitemap.xml, JSON-LD, and `<html lang>`.
  * Added JSON output reporting, including overall scoring and scoring breakdowns.
  * Added per-route reporting (`--by-route`) and configurable output (`--reporter` / `--json`).
  * Added rule selection/gating via `--rules` / `--ignore`, plus `--fail-on` / `--fail-on-warning`.
* **Changes**
  * Dynamic detections can now downgrade to warnings when configured, affecting severity-aware gating and exit codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->