### PR TITLE
feat: plugin mode — @svelte-vitals/vite (analyze prerendered HTML at build time)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@svelte-vitals/vite"]
+  "ignore": []
 }

--- a/.changeset/plugin-mode.md
+++ b/.changeset/plugin-mode.md
@@ -1,5 +1,6 @@
 ---
+'@svelte-vitals/core': minor
 '@svelte-vitals/vite': minor
 ---
 
-Plugin mode: `@svelte-vitals/vite` analyzes prerendered HTML during `vite build` and runs the full SEO rule set (library-agnostic), gating the build via `failOn`. Console/JSON reports with a per-route score; only prerendered routes are covered.
+Plugin mode: `@svelte-vitals/vite` analyzes prerendered HTML during `vite build` and runs the full SEO rule set (library-agnostic), gating the build via `failOn`. Console/JSON reports with a per-route score; only prerendered routes are covered. The core console reporter gained an optional `mode` label for the header line.

--- a/.changeset/plugin-mode.md
+++ b/.changeset/plugin-mode.md
@@ -1,0 +1,5 @@
+---
+'@svelte-vitals/vite': minor
+---
+
+Plugin mode: `@svelte-vitals/vite` analyzes prerendered HTML during `vite build` and runs the full SEO rule set (library-agnostic), gating the build via `failOn`. Console/JSON reports with a per-route score; only prerendered routes are covered.

--- a/.changeset/plugin-mode.md
+++ b/.changeset/plugin-mode.md
@@ -3,4 +3,4 @@
 '@svelte-vitals/vite': minor
 ---
 
-Plugin mode: `@svelte-vitals/vite` analyzes prerendered HTML during `vite build` and runs the full SEO rule set (library-agnostic), gating the build via `failOn`. Console/JSON reports with a per-route score; only prerendered routes are covered. The core console reporter gained an optional `mode` label for the header line.
+Plugin mode: `@svelte-vitals/vite` analyzes prerendered HTML during `vite build` and runs the full SEO rule set (library-agnostic), gating the build via `failOn`. Console/JSON reports with a per-route score; only prerendered routes are covered. `outFile` is resolved against the project root (parent directories are created), and an internal analysis failure is reported as a warning rather than failing the build (distinct from a real finding). The core console reporter gained an optional `mode` label for the header line, and now exports the shared `ROBOTS_SOURCE_PATHS` / `SITEMAP_SOURCE_PATHS` project-rule path lists used by both modes.

--- a/packages/cli/src/providers/source/project.ts
+++ b/packages/cli/src/providers/source/project.ts
@@ -1,4 +1,10 @@
-import type { Project, Detection, Runtime } from '@svelte-vitals/core';
+import {
+  ROBOTS_SOURCE_PATHS,
+  SITEMAP_SOURCE_PATHS,
+  type Project,
+  type Detection,
+  type Runtime
+} from '@svelte-vitals/core';
 
 /** Thrown when the target directory is not a SvelteKit project (CLI maps to exit 2). */
 export class ProjectError extends Error {
@@ -47,7 +53,7 @@ export async function enumerateRoutePages(rt: Runtime, cwd: string): Promise<str
   return pages.sort();
 }
 
-async function existsAny(rt: Runtime, cwd: string, paths: string[]): Promise<boolean> {
+async function existsAny(rt: Runtime, cwd: string, paths: readonly string[]): Promise<boolean> {
   const found = await Promise.all(paths.map((p) => rt.exists(rt.join(cwd, p))));
   return found.some(Boolean);
 }
@@ -69,12 +75,8 @@ async function detectAppHtmlLang(rt: Runtime, cwd: string): Promise<Detection> {
 /** Precompute project-wide facts for project-scope rules (design §10, §11, §17). */
 export async function collectProjectFacts(rt: Runtime, cwd: string): Promise<Project> {
   const [hasRobotsTxt, hasSitemap, htmlLang] = await Promise.all([
-    existsAny(rt, cwd, ['static/robots.txt', 'src/routes/robots.txt/+server.ts', 'src/routes/robots.txt/+server.js']),
-    existsAny(rt, cwd, [
-      'static/sitemap.xml',
-      'src/routes/sitemap.xml/+server.ts',
-      'src/routes/sitemap.xml/+server.js'
-    ]),
+    existsAny(rt, cwd, ROBOTS_SOURCE_PATHS),
+    existsAny(rt, cwd, SITEMAP_SOURCE_PATHS),
     detectAppHtmlLang(rt, cwd)
   ]);
   return { hasRobotsTxt, hasSitemap, htmlLang };

--- a/packages/core/src/head.ts
+++ b/packages/core/src/head.ts
@@ -2,9 +2,10 @@ import type { Presence, Value, Config } from './types.js';
 import type { Runtime } from './runtime.js';
 
 /**
- * A normalized head tag. The mode-independent boundary (design §8): both the
- * static SourceHeadProvider and the future RenderedHeadProvider emit these, so
- * rules never need to know which provider produced them.
+ * A normalized head tag. The mode-independent boundary (design §8): the static
+ * SourceHeadProvider (CLI, via the runtime-abstracted `HeadProvider` below) and
+ * the rendered collector (`@svelte-vitals/vite`, build-time Node) both emit
+ * these, so rules never need to know which mode produced them.
  */
 export interface HeadTag {
   kind: 'title' | 'meta' | 'link' | 'jsonld';
@@ -34,7 +35,11 @@ export interface ResolvedHead {
   file: string;
 }
 
-/** Supplies ResolvedHead[] for a project. The only piece that differs per mode. */
+/**
+ * Supplies ResolvedHead[] for a project through the runtime abstraction. The
+ * static (CLI) mode implements this; rendered mode reads prerendered HTML at
+ * build time and emits the same ResolvedHead[] without the runtime indirection.
+ */
 export interface HeadProvider {
   mode: 'static' | 'rendered';
   collect(rt: Runtime, cwd: string, config?: Config): Promise<ResolvedHead[]>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export type {
 export { defaultConfig, defineConfig, defaultProject } from './types.js';
 
 export type { HeadTag, ResolvedHead, HeadProvider } from './head.js';
+export { ROBOTS_SOURCE_PATHS, SITEMAP_SOURCE_PATHS } from './project-paths.js';
 export type { Runtime } from './runtime.js';
 export type { Rule, RuleContext } from './rule.js';
 export { isPenalized } from './rule.js';

--- a/packages/core/src/project-paths.ts
+++ b/packages/core/src/project-paths.ts
@@ -1,0 +1,19 @@
+/**
+ * Source-file locations that satisfy the project-scope rules, shared by every
+ * mode so the static (CLI) and rendered (plugin) collectors never drift. This
+ * module is pure data: no I/O, no `node:` imports (design §8).
+ */
+
+/** Locations that satisfy the robots.txt project rule (SEO006). */
+export const ROBOTS_SOURCE_PATHS = [
+  'static/robots.txt',
+  'src/routes/robots.txt/+server.ts',
+  'src/routes/robots.txt/+server.js'
+] as const;
+
+/** Locations that satisfy the sitemap.xml project rule (SEO007). */
+export const SITEMAP_SOURCE_PATHS = [
+  'static/sitemap.xml',
+  'src/routes/sitemap.xml/+server.ts',
+  'src/routes/sitemap.xml/+server.js'
+] as const;

--- a/packages/core/src/reporter/console.ts
+++ b/packages/core/src/reporter/console.ts
@@ -11,6 +11,8 @@ const SEVERITY_TITLE: Record<Severity, string> = {
 
 export interface ConsoleReportOptions {
   byRoute?: boolean;
+  /** Mode label shown in the header (default 'static mode'). */
+  mode?: string;
 }
 
 function scoreHeader(results: Result[], config: Config): string {
@@ -47,7 +49,12 @@ function byRouteTree(results: Result[], config: Config): string[] {
  */
 export function formatConsoleReport(results: Result[], config: Config, options: ConsoleReportOptions = {}): string {
   const summary = summarize(results, config);
-  const lines: string[] = ['Svelte Vitals  ·  SEO (static mode)', '', scoreHeader(results, config), ''];
+  const lines: string[] = [
+    `Svelte Vitals  ·  SEO (${options.mode ?? 'static mode'})`,
+    '',
+    scoreHeader(results, config),
+    ''
+  ];
 
   const failures = results.filter((r) => classify(r, config) === 'fail');
   for (const severity of ['critical', 'warning', 'info'] as const) {

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -1,0 +1,31 @@
+# @svelte-vitals/vite
+
+[![npm](https://img.shields.io/npm/v/@svelte-vitals/vite)](https://www.npmjs.com/package/@svelte-vitals/vite)
+
+Vite/SvelteKit plugin for [svelte-vitals](https://github.com/oekazuma/svelte-vitals). It piggybacks on `vite build`, parses the **prerendered HTML's `<head>`**, and runs the same SEO rules as the CLI — library-agnostic, because it inspects the real output. Fails the build when findings reach `failOn`.
+
+## Usage
+
+```ts
+// vite.config.ts
+import { sveltekit } from '@sveltejs/kit/vite';
+import { svelteVitals } from '@svelte-vitals/vite';
+
+export default {
+  plugins: [sveltekit(), svelteVitals({ failOn: 'critical', report: 'console' })]
+};
+```
+
+## Options
+
+- `failOn` — minimum severity that fails the build (default `critical`).
+- `report` — `'console' | 'json' | false` (default `console`).
+- `outFile` — write the JSON report to a path.
+- `rules` / `metaComponents` / `treatDynamicAs` — same as the CLI/core config.
+- `prerenderDir` — override the prerendered-pages directory.
+
+Only **prerendered** routes are analyzed; for SSR/dynamic routes use the `svelte-vitals` CLI.
+
+## License
+
+[MIT](https://github.com/oekazuma/svelte-vitals/blob/main/LICENSE.md) © [Kazuma Oe](https://github.com/oekazuma)

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,22 +1,52 @@
 {
   "name": "@svelte-vitals/vite",
   "version": "0.0.0",
-  "description": "Plugin mode for svelte-vitals — analyzes prerendered HTML during vite build. (stub; implemented in v0.2)",
+  "description": "Vite/SvelteKit plugin for svelte-vitals — analyzes prerendered HTML during vite build.",
   "type": "module",
   "license": "MIT",
-  "private": true,
+  "author": "Kazuma Oe (https://github.com/oekazuma)",
+  "keywords": [
+    "svelte",
+    "sveltekit",
+    "seo",
+    "vite-plugin",
+    "svelte-vitals"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/oekazuma/svelte-vitals.git",
+    "directory": "packages/vite"
+  },
+  "bugs": {
+    "url": "https://github.com/oekazuma/svelte-vitals/issues"
+  },
+  "homepage": "https://github.com/oekazuma/svelte-vitals#readme",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
-    "build": "echo \"@svelte-vitals/vite is a stub (v0.2)\" && exit 0",
+    "build": "tsup",
     "typecheck": "tsc --noEmit",
-    "test": "echo \"no tests yet\" && exit 0"
+    "test": "vitest run"
   },
   "dependencies": {
-    "@svelte-vitals/core": "workspace:*"
+    "@svelte-vitals/core": "workspace:*",
+    "node-html-parser": "catalog:",
+    "tinyglobby": "catalog:"
+  },
+  "peerDependencies": {
+    "vite": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "vite": "catalog:"
   }
 }

--- a/packages/vite/src/analyze.ts
+++ b/packages/vite/src/analyze.ts
@@ -1,0 +1,65 @@
+import { writeFile } from 'node:fs/promises';
+import {
+  allRules,
+  selectRules,
+  applyRuleSeverities,
+  runRules,
+  computeScore,
+  summarize,
+  hasFailureAtOrAbove,
+  formatConsoleReport,
+  formatJsonReport,
+  defineConfig,
+  type Result,
+  type Summary
+} from '@svelte-vitals/core';
+import type { SvelteVitalsOptions } from './plugin.js';
+import { collectRenderedHeads } from './providers/rendered/collect.js';
+import { collectRenderedProject } from './providers/rendered/project.js';
+
+export interface AnalyzeResult {
+  score: number;
+  summary: Summary;
+  results: Result[];
+  consoleReport: string;
+  jsonReport: string;
+  routeCount: number;
+  failed: boolean;
+}
+
+const PLUGIN_VERSION = '0.0.0';
+
+/** Collect prerendered heads + project facts, run the core pipeline, and format reports. */
+export async function analyze(
+  prerenderPagesDir: string,
+  cwd: string,
+  options: SvelteVitalsOptions
+): Promise<AnalyzeResult> {
+  const config = defineConfig({
+    treatDynamicAs: options.treatDynamicAs ?? 'pass',
+    metaComponents: options.metaComponents ?? [],
+    rules: options.rules ?? {},
+    failOn: options.failOn ?? 'critical'
+  });
+
+  const { heads, htmlLang } = await collectRenderedHeads(prerenderPagesDir);
+  const project = await collectRenderedProject(cwd, htmlLang);
+  const results = applyRuleSeverities(
+    await runRules(selectRules(allRules, config), { heads, project, config }),
+    config
+  );
+
+  const { score } = computeScore(results, config);
+  const summary = summarize(results, config);
+  const failed = hasFailureAtOrAbove(summary, config.failOn);
+
+  const header =
+    `Svelte Vitals  ·  SEO (rendered / plugin)\n` +
+    `Analyzed ${heads.length} prerendered route(s). SSR/dynamic routes are not covered — run \`npx svelte-vitals\` for those.\n`;
+  const consoleReport = header + '\n' + formatConsoleReport(results, config);
+  const jsonReport = formatJsonReport(results, config, { version: PLUGIN_VERSION });
+
+  if (options.outFile) await writeFile(options.outFile, jsonReport);
+
+  return { score, summary, results, consoleReport, jsonReport, routeCount: heads.length, failed };
+}

--- a/packages/vite/src/analyze.ts
+++ b/packages/vite/src/analyze.ts
@@ -1,4 +1,3 @@
-import { writeFile } from 'node:fs/promises';
 import {
   allRules,
   selectRules,
@@ -11,11 +10,13 @@ import {
   formatJsonReport,
   defineConfig,
   type Result,
-  type Summary
+  type Summary,
+  type Severity
 } from '@svelte-vitals/core';
 import type { SvelteVitalsOptions } from './plugin.js';
 import { collectRenderedHeads } from './providers/rendered/collect.js';
 import { collectRenderedProject } from './providers/rendered/project.js';
+import { readPackageVersion } from './version.js';
 
 export interface AnalyzeResult {
   score: number;
@@ -25,9 +26,8 @@ export interface AnalyzeResult {
   jsonReport: string;
   routeCount: number;
   failed: boolean;
+  failOn: Severity;
 }
-
-const PLUGIN_VERSION = '0.0.0';
 
 /** Collect prerendered heads + project facts, run the core pipeline, and format reports. */
 export async function analyze(
@@ -57,9 +57,16 @@ export async function analyze(
     `Svelte Vitals  ·  SEO (rendered / plugin)\n` +
     `Analyzed ${heads.length} prerendered route(s). SSR/dynamic routes are not covered — run \`npx svelte-vitals\` for those.\n`;
   const consoleReport = header + '\n' + formatConsoleReport(results, config);
-  const jsonReport = formatJsonReport(results, config, { version: PLUGIN_VERSION });
+  const jsonReport = formatJsonReport(results, config, { version: readPackageVersion() });
 
-  if (options.outFile) await writeFile(options.outFile, jsonReport);
-
-  return { score, summary, results, consoleReport, jsonReport, routeCount: heads.length, failed };
+  return {
+    score,
+    summary,
+    results,
+    consoleReport,
+    jsonReport,
+    routeCount: heads.length,
+    failed,
+    failOn: config.failOn
+  };
 }

--- a/packages/vite/src/analyze.ts
+++ b/packages/vite/src/analyze.ts
@@ -53,10 +53,11 @@ export async function analyze(
   const summary = summarize(results, config);
   const failed = hasFailureAtOrAbove(summary, config.failOn);
 
-  const header =
-    `Svelte Vitals  ·  SEO (rendered / plugin)\n` +
-    `Analyzed ${heads.length} prerendered route(s). SSR/dynamic routes are not covered — run \`npx svelte-vitals\` for those.\n`;
-  const consoleReport = header + '\n' + formatConsoleReport(results, config);
+  const coverageNote =
+    `Analyzed ${heads.length} prerendered route(s). ` +
+    'SSR/dynamic routes are not covered — run `npx svelte-vitals` for those.';
+  const consoleReport =
+    formatConsoleReport(results, config, { mode: 'rendered / plugin' }) + '\n' + coverageNote + '\n';
   const jsonReport = formatJsonReport(results, config, { version: readPackageVersion() });
 
   return {

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,8 +1,2 @@
-// @svelte-vitals/vite — plugin mode (stub).
-//
-// Implemented in v0.2 (design §9). This package will expose a Vite/SvelteKit
-// plugin that piggybacks on `vite build`, parses prerendered HTML's <head>
-// via a RenderedHeadProvider, and feeds the same core Rule Engine as the CLI.
-//
-// Intentionally empty for Slice 0.
-export {};
+export { svelteVitals } from './plugin.js';
+export type { SvelteVitalsOptions } from './plugin.js';

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
-import { writeFile } from 'node:fs/promises';
-import { join, isAbsolute } from 'node:path';
+import { writeFile, mkdir } from 'node:fs/promises';
+import { join, isAbsolute, dirname } from 'node:path';
 import type { Plugin } from 'vite';
 import type { RuleSetting, Severity, TreatDynamicAs } from '@svelte-vitals/core';
 import { analyze } from './analyze.js';
@@ -42,14 +42,28 @@ export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin {
       // prerendered HTML (Task 2 spike). Skip the early/empty invocation so we
       // don't emit a spurious "0 routes" report or gate on nothing.
       if (!existsSync(resolved)) return;
-      const result = await analyze(resolved, root, options);
+
+      let result;
+      try {
+        result = await analyze(resolved, root, options);
+      } catch (err) {
+        // The analysis itself failed (unreadable/malformed output, glob error,
+        // …). That's our problem, not a real SEO finding, so warn and skip the
+        // gate instead of failing the whole build — distinct from `result.failed`.
+        console.warn(`svelte-vitals: skipped — analysis failed: ${err instanceof Error ? err.message : String(err)}`);
+        return;
+      }
       if (result.routeCount === 0) return;
 
       if (options.report !== false) {
         const out = options.report === 'json' ? result.jsonReport : result.consoleReport;
         console.log(out);
       }
-      if (options.outFile) await writeFile(options.outFile, result.jsonReport);
+      if (options.outFile) {
+        const outPath = isAbsolute(options.outFile) ? options.outFile : join(root, options.outFile);
+        await mkdir(dirname(outPath), { recursive: true });
+        await writeFile(outPath, result.jsonReport);
+      }
       if (result.failed) {
         throw new Error(`svelte-vitals: build failed — findings at or above "${result.failOn}".`);
       }

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -1,4 +1,5 @@
 import { existsSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
 import { join, isAbsolute } from 'node:path';
 import type { Plugin } from 'vite';
 import type { RuleSetting, Severity, TreatDynamicAs } from '@svelte-vitals/core';
@@ -46,11 +47,11 @@ export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin {
 
       if (options.report !== false) {
         const out = options.report === 'json' ? result.jsonReport : result.consoleReport;
-        // eslint-disable-next-line no-console
         console.log(out);
       }
+      if (options.outFile) await writeFile(options.outFile, result.jsonReport);
       if (result.failed) {
-        throw new Error(`svelte-vitals: build failed — findings at or above "${options.failOn ?? 'critical'}".`);
+        throw new Error(`svelte-vitals: build failed — findings at or above "${result.failOn}".`);
       }
     }
   };

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -1,5 +1,8 @@
+import { existsSync } from 'node:fs';
+import { join, isAbsolute } from 'node:path';
 import type { Plugin } from 'vite';
 import type { RuleSetting, Severity, TreatDynamicAs } from '@svelte-vitals/core';
+import { analyze } from './analyze.js';
 
 export interface SvelteVitalsOptions {
   /** Project root (defaults to the Vite config root / cwd). */
@@ -17,11 +20,38 @@ export interface SvelteVitalsOptions {
   prerenderDir?: string;
 }
 
-/** svelte-vitals Vite/SvelteKit plugin (skeleton — analysis added in Task 5). */
+const DEFAULT_PRERENDER_DIR = '.svelte-kit/output/prerendered/pages';
+
+/** svelte-vitals Vite/SvelteKit plugin. */
 export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin {
-  void options;
+  let root = options.cwd ?? process.cwd();
   return {
     name: 'svelte-vitals',
-    apply: 'build'
+    apply: 'build',
+    enforce: 'post',
+    configResolved(config) {
+      if (!options.cwd) root = config.root;
+    },
+    async closeBundle() {
+      const pagesDir = options.prerenderDir ? options.prerenderDir : join(root, DEFAULT_PRERENDER_DIR);
+      const resolved = isAbsolute(pagesDir) ? pagesDir : join(root, pagesDir);
+
+      // SvelteKit calls closeBundle TWICE: once during the JS bundle phase
+      // (before prerendering, dir absent) and once after the adapter writes
+      // prerendered HTML (Task 2 spike). Skip the early/empty invocation so we
+      // don't emit a spurious "0 routes" report or gate on nothing.
+      if (!existsSync(resolved)) return;
+      const result = await analyze(resolved, root, options);
+      if (result.routeCount === 0) return;
+
+      if (options.report !== false) {
+        const out = options.report === 'json' ? result.jsonReport : result.consoleReport;
+        // eslint-disable-next-line no-console
+        console.log(out);
+      }
+      if (result.failed) {
+        throw new Error(`svelte-vitals: build failed — findings at or above "${options.failOn ?? 'critical'}".`);
+      }
+    }
   };
 }

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -1,0 +1,27 @@
+import type { Plugin } from 'vite';
+import type { RuleSetting, Severity, TreatDynamicAs } from '@svelte-vitals/core';
+
+export interface SvelteVitalsOptions {
+  /** Project root (defaults to the Vite config root / cwd). */
+  cwd?: string;
+  treatDynamicAs?: TreatDynamicAs;
+  metaComponents?: string[];
+  rules?: Record<string, RuleSetting>;
+  /** Minimum severity that fails the build (default: 'critical'). */
+  failOn?: Severity;
+  /** Report output (default: 'console'). */
+  report?: 'console' | 'json' | false;
+  /** Write the JSON report to this path. */
+  outFile?: string;
+  /** Override the prerendered-pages directory (default: .svelte-kit/output/prerendered/pages). */
+  prerenderDir?: string;
+}
+
+/** svelte-vitals Vite/SvelteKit plugin (skeleton — analysis added in Task 5). */
+export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin {
+  void options;
+  return {
+    name: 'svelte-vitals',
+    apply: 'build'
+  };
+}

--- a/packages/vite/src/providers/rendered/collect.ts
+++ b/packages/vite/src/providers/rendered/collect.ts
@@ -1,0 +1,39 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { glob } from 'tinyglobby';
+import type { ResolvedHead, Value } from '@svelte-vitals/core';
+import { parseHtmlHead } from './parse-html.js';
+
+/** Map a prerendered HTML path (relative to pages/, POSIX) to its route. */
+export function deriveRouteFromHtmlPath(relPath: string): string {
+  let p = relPath.replace(/\\/g, '/').replace(/\.html$/, '');
+  if (p === 'index') return '/';
+  if (p.endsWith('/index')) p = p.slice(0, -'/index'.length);
+  return '/' + p;
+}
+
+export interface CollectedHeads {
+  heads: ResolvedHead[];
+  htmlLang: { presence: 'own' | 'none'; value: Value };
+}
+
+/** Read every prerendered HTML page under `prerenderPagesDir` into ResolvedHead[]. */
+export async function collectRenderedHeads(prerenderPagesDir: string): Promise<CollectedHeads> {
+  const files = (await glob('**/*.html', { cwd: prerenderPagesDir })).sort();
+  const heads: ResolvedHead[] = [];
+  let htmlLang: CollectedHeads['htmlLang'] = { presence: 'none', value: 'absent' };
+
+  for (const rel of files) {
+    const html = await readFile(join(prerenderPagesDir, rel), 'utf8');
+    const parsed = parseHtmlHead(html);
+    if (htmlLang.presence === 'none' && parsed.htmlLang.presence === 'own') htmlLang = parsed.htmlLang;
+    heads.push({
+      route: deriveRouteFromHtmlPath(rel),
+      source: 'rendered',
+      tags: parsed.tags,
+      file: rel
+    });
+  }
+
+  return { heads, htmlLang };
+}

--- a/packages/vite/src/providers/rendered/collect.ts
+++ b/packages/vite/src/providers/rendered/collect.ts
@@ -20,12 +20,16 @@ export interface CollectedHeads {
 /** Read every prerendered HTML page under `prerenderPagesDir` into ResolvedHead[]. */
 export async function collectRenderedHeads(prerenderPagesDir: string): Promise<CollectedHeads> {
   const files = (await glob('**/*.html', { cwd: prerenderPagesDir })).sort();
+  // Read + parse in parallel; Promise.all preserves the sorted order so the
+  // "first own <html lang>" pick below stays deterministic.
+  const parsedFiles = await Promise.all(
+    files.map(async (rel) => ({ rel, parsed: parseHtmlHead(await readFile(join(prerenderPagesDir, rel), 'utf8')) }))
+  );
+
   const heads: ResolvedHead[] = [];
   let htmlLang: CollectedHeads['htmlLang'] = { presence: 'none', value: 'absent' };
 
-  for (const rel of files) {
-    const html = await readFile(join(prerenderPagesDir, rel), 'utf8');
-    const parsed = parseHtmlHead(html);
+  for (const { rel, parsed } of parsedFiles) {
     if (htmlLang.presence === 'none' && parsed.htmlLang.presence === 'own') htmlLang = parsed.htmlLang;
     heads.push({
       route: deriveRouteFromHtmlPath(rel),

--- a/packages/vite/src/providers/rendered/parse-html.ts
+++ b/packages/vite/src/providers/rendered/parse-html.ts
@@ -1,0 +1,55 @@
+import { parse, type HTMLElement } from 'node-html-parser';
+import type { HeadTag, Value } from '@svelte-vitals/core';
+
+function attrValue(v: string | undefined): Value {
+  return v !== undefined && v.trim().length > 0 ? 'static' : 'absent';
+}
+
+export interface ParsedHtmlHead {
+  tags: HeadTag[];
+  htmlLang: { presence: 'own' | 'none'; value: Value };
+}
+
+/** Parse a fully-rendered HTML document's <head> into normalized head tags. */
+export function parseHtmlHead(html: string): ParsedHtmlHead {
+  const root = parse(html);
+  const head = root.querySelector('head') ?? root;
+  const tags: HeadTag[] = [];
+
+  const title = head.querySelector('title');
+  if (title) tags.push({ kind: 'title', presence: 'own', value: attrValue(title.text) });
+
+  for (const meta of head.querySelectorAll('meta')) {
+    const name = meta.getAttribute('name');
+    const property = meta.getAttribute('property');
+    if (!name && !property) continue;
+    tags.push({
+      kind: 'meta',
+      ...(name ? { name } : {}),
+      ...(property ? { property } : {}),
+      presence: 'own',
+      value: attrValue(meta.getAttribute('content'))
+    });
+  }
+
+  for (const link of head.querySelectorAll('link')) {
+    const rel = link.getAttribute('rel');
+    if (!rel) continue;
+    tags.push({ kind: 'link', rel, presence: 'own', value: attrValue(link.getAttribute('href')) });
+  }
+
+  for (const script of head.querySelectorAll('script')) {
+    if (script.getAttribute('type') === 'application/ld+json') {
+      tags.push({ kind: 'jsonld', presence: 'own', value: attrValue(script.text) });
+    }
+  }
+
+  const htmlEl: HTMLElement | null = root.querySelector('html');
+  const lang = htmlEl?.getAttribute('lang');
+  const htmlLang =
+    lang === undefined || lang === null
+      ? { presence: 'none' as const, value: 'absent' as const }
+      : { presence: 'own' as const, value: attrValue(lang) };
+
+  return { tags, htmlLang };
+}

--- a/packages/vite/src/providers/rendered/parse-html.ts
+++ b/packages/vite/src/providers/rendered/parse-html.ts
@@ -1,4 +1,4 @@
-import { parse, type HTMLElement } from 'node-html-parser';
+import { parse } from 'node-html-parser';
 import type { HeadTag, Value } from '@svelte-vitals/core';
 
 function attrValue(v: string | undefined): Value {
@@ -44,7 +44,7 @@ export function parseHtmlHead(html: string): ParsedHtmlHead {
     }
   }
 
-  const htmlEl: HTMLElement | null = root.querySelector('html');
+  const htmlEl = root.querySelector('html');
   const lang = htmlEl?.getAttribute('lang');
   const htmlLang =
     lang === undefined || lang === null

--- a/packages/vite/src/providers/rendered/project.ts
+++ b/packages/vite/src/providers/rendered/project.ts
@@ -1,6 +1,6 @@
 import { access } from 'node:fs/promises';
 import { join } from 'node:path';
-import type { Detection, Project } from '@svelte-vitals/core';
+import { ROBOTS_SOURCE_PATHS, SITEMAP_SOURCE_PATHS, type Detection, type Project } from '@svelte-vitals/core';
 
 async function exists(path: string): Promise<boolean> {
   try {
@@ -11,22 +11,16 @@ async function exists(path: string): Promise<boolean> {
   }
 }
 
-async function existsAny(cwd: string, paths: string[]): Promise<boolean> {
-  for (const p of paths) if (await exists(join(cwd, p))) return true;
-  return false;
+async function existsAny(cwd: string, paths: readonly string[]): Promise<boolean> {
+  const found = await Promise.all(paths.map((p) => exists(join(cwd, p))));
+  return found.some(Boolean);
 }
 
 /** Project facts for plugin mode: robots/sitemap from source, htmlLang from rendered HTML. */
 export async function collectRenderedProject(cwd: string, htmlLang: Detection): Promise<Project> {
-  const hasRobotsTxt = await existsAny(cwd, [
-    'static/robots.txt',
-    'src/routes/robots.txt/+server.ts',
-    'src/routes/robots.txt/+server.js'
-  ]);
-  const hasSitemap = await existsAny(cwd, [
-    'static/sitemap.xml',
-    'src/routes/sitemap.xml/+server.ts',
-    'src/routes/sitemap.xml/+server.js'
+  const [hasRobotsTxt, hasSitemap] = await Promise.all([
+    existsAny(cwd, ROBOTS_SOURCE_PATHS),
+    existsAny(cwd, SITEMAP_SOURCE_PATHS)
   ]);
   return { hasRobotsTxt, hasSitemap, htmlLang };
 }

--- a/packages/vite/src/providers/rendered/project.ts
+++ b/packages/vite/src/providers/rendered/project.ts
@@ -1,0 +1,32 @@
+import { access } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { Detection, Project } from '@svelte-vitals/core';
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function existsAny(cwd: string, paths: string[]): Promise<boolean> {
+  for (const p of paths) if (await exists(join(cwd, p))) return true;
+  return false;
+}
+
+/** Project facts for plugin mode: robots/sitemap from source, htmlLang from rendered HTML. */
+export async function collectRenderedProject(cwd: string, htmlLang: Detection): Promise<Project> {
+  const hasRobotsTxt = await existsAny(cwd, [
+    'static/robots.txt',
+    'src/routes/robots.txt/+server.ts',
+    'src/routes/robots.txt/+server.js'
+  ]);
+  const hasSitemap = await existsAny(cwd, [
+    'static/sitemap.xml',
+    'src/routes/sitemap.xml/+server.ts',
+    'src/routes/sitemap.xml/+server.js'
+  ]);
+  return { hasRobotsTxt, hasSitemap, htmlLang };
+}

--- a/packages/vite/src/version.ts
+++ b/packages/vite/src/version.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'node:fs';
+
+/** Read this package's version from its own package.json so the report never drifts. */
+export function readPackageVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as { version?: string };
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}

--- a/packages/vite/test/analyze.test.ts
+++ b/packages/vite/test/analyze.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { analyze } from '../src/analyze.js';
+
+describe('analyze', () => {
+  let cwd: string;
+  let pages: string;
+  beforeAll(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'sv-analyze-'));
+    pages = join(cwd, '.svelte-kit/output/prerendered/pages');
+    await mkdir(pages, { recursive: true });
+    // one good page, one missing title
+    await writeFile(
+      join(pages, 'index.html'),
+      `<html lang="en"><head><title>Home</title><meta name="description" content="d"/></head><body></body></html>`
+    );
+    await writeFile(
+      join(pages, 'bad.html'),
+      `<html lang="en"><head><meta charset="utf-8"/></head><body></body></html>`
+    );
+  });
+  afterAll(async () => rm(cwd, { recursive: true, force: true }));
+
+  it('runs all rules over rendered routes and computes a score', async () => {
+    const r = await analyze(pages, cwd, { report: false });
+    expect(r.routeCount).toBe(2);
+    // /bad is missing <title> (critical) -> headline capped at 79
+    expect(r.score).toBeLessThanOrEqual(79);
+    expect(r.results.some((x) => x.id === 'SEO001' && x.route === '/bad' && x.detection.presence === 'none')).toBe(
+      true
+    );
+    // html lang present (en) -> SEO009 not a site issue
+    const json = JSON.parse(r.jsonReport);
+    expect(json.siteIssues.map((i: { id: string }) => i.id)).not.toContain('SEO009');
+  });
+
+  it('fails when findings meet failOn', async () => {
+    const r = await analyze(pages, cwd, { report: false, failOn: 'critical' });
+    expect(r.failed).toBe(true);
+  });
+});

--- a/packages/vite/test/analyze.test.ts
+++ b/packages/vite/test/analyze.test.ts
@@ -34,6 +34,9 @@ describe('analyze', () => {
     // html lang present (en) -> SEO009 not a site issue
     const json = JSON.parse(r.jsonReport);
     expect(json.siteIssues.map((i: { id: string }) => i.id)).not.toContain('SEO009');
+    // console report must carry the plugin-mode label and not the static-mode label
+    expect(r.consoleReport).toContain('SEO (rendered / plugin)');
+    expect(r.consoleReport).not.toContain('static mode');
   });
 
   it('fails when findings meet failOn', async () => {

--- a/packages/vite/test/collect.test.ts
+++ b/packages/vite/test/collect.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { deriveRouteFromHtmlPath, collectRenderedHeads } from '../src/providers/rendered/collect.js';
+
+describe('deriveRouteFromHtmlPath', () => {
+  it('maps prerendered file paths to routes', () => {
+    expect(deriveRouteFromHtmlPath('index.html')).toBe('/');
+    expect(deriveRouteFromHtmlPath('about.html')).toBe('/about');
+    expect(deriveRouteFromHtmlPath('blog/index.html')).toBe('/blog');
+    expect(deriveRouteFromHtmlPath('blog/hello.html')).toBe('/blog/hello');
+  });
+});
+
+describe('collectRenderedHeads', () => {
+  let dir: string;
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'sv-collect-'));
+    await mkdir(join(dir, 'blog'), { recursive: true });
+    const doc = (t: string) => `<html lang="en"><head><title>${t}</title></head><body></body></html>`;
+    await writeFile(join(dir, 'index.html'), doc('Home'));
+    await writeFile(join(dir, 'blog', 'index.html'), doc('Blog'));
+  });
+  afterAll(async () => rm(dir, { recursive: true, force: true }));
+
+  it('reads every .html into a ResolvedHead with source rendered', async () => {
+    const { heads, htmlLang } = await collectRenderedHeads(dir);
+    const byRoute = new Map(heads.map((h) => [h.route, h]));
+    expect([...byRoute.keys()].sort()).toEqual(['/', '/blog']);
+    expect(byRoute.get('/')!.source).toBe('rendered');
+    expect(byRoute.get('/')!.tags).toContainEqual({ kind: 'title', presence: 'own', value: 'static' });
+    expect(htmlLang).toEqual({ presence: 'own', value: 'static' });
+  });
+});

--- a/packages/vite/test/integration.test.ts
+++ b/packages/vite/test/integration.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { svelteVitals } from '../src/index.js';
+
+describe('svelteVitals plugin', () => {
+  let cwd: string;
+  beforeAll(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'sv-int-'));
+    const pages = join(cwd, '.svelte-kit/output/prerendered/pages');
+    await mkdir(pages, { recursive: true });
+    await writeFile(join(pages, 'index.html'), `<html lang="en"><head><title>Home</title></head><body></body></html>`);
+  });
+  afterAll(async () => rm(cwd, { recursive: true, force: true }));
+
+  it('is a build-only plugin named svelte-vitals', () => {
+    const p = svelteVitals({ cwd });
+    expect(p.name).toBe('svelte-vitals');
+    expect(p.apply).toBe('build');
+  });
+
+  it('throws to fail the build when a critical finding exists (missing description on /)', async () => {
+    const p = svelteVitals({ cwd, report: false, failOn: 'critical' });
+    // closeBundle is a function on the plugin object
+    const hook = typeof p.closeBundle === 'function' ? p.closeBundle : p.closeBundle?.handler;
+    await expect((hook as () => Promise<void>).call({})).rejects.toThrow(/svelte-vitals: build failed/);
+  });
+
+  it('does not throw when all critical rules pass (fully-populated page)', async () => {
+    // Build a second fixture cwd whose only prerendered page satisfies every rule.
+    const cleanCwd = await mkdtemp(join(tmpdir(), 'sv-int-clean-'));
+    try {
+      const cleanPages = join(cleanCwd, '.svelte-kit/output/prerendered/pages');
+      await mkdir(cleanPages, { recursive: true });
+      // static/ files for robots/sitemap project rules
+      await mkdir(join(cleanCwd, 'static'), { recursive: true });
+      await writeFile(join(cleanCwd, 'static/robots.txt'), 'User-agent: *\nAllow: /');
+      await writeFile(
+        join(cleanCwd, 'static/sitemap.xml'),
+        '<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>'
+      );
+      // Fully-populated page: title, description, canonical, og:title, og:image, JSON-LD, html lang
+      await writeFile(
+        join(cleanPages, 'index.html'),
+        [
+          '<html lang="en">',
+          '<head>',
+          '<title>Clean Page</title>',
+          '<meta name="description" content="A fully SEO-optimised page for integration testing.">',
+          '<link rel="canonical" href="https://example.com/">',
+          '<meta property="og:title" content="Clean Page">',
+          '<meta property="og:image" content="https://example.com/og.png">',
+          '<script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"Clean Page"}</script>',
+          '</head>',
+          '<body></body>',
+          '</html>'
+        ].join('')
+      );
+      const p = svelteVitals({ cwd: cleanCwd, report: false, failOn: 'critical' });
+      const hook = typeof p.closeBundle === 'function' ? p.closeBundle : p.closeBundle?.handler;
+      await expect((hook as () => Promise<void>).call({})).resolves.toBeUndefined();
+    } finally {
+      await rm(cleanCwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/vite/test/parse-html.test.ts
+++ b/packages/vite/test/parse-html.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { parseHtmlHead } from '../src/providers/rendered/parse-html.js';
+
+const html = (head: string, lang = 'en') =>
+  `<!doctype html><html lang="${lang}"><head>${head}</head><body></body></html>`;
+
+describe('parseHtmlHead', () => {
+  it('extracts title, meta(name/property), link, jsonld with static/absent values', () => {
+    const { tags } = parseHtmlHead(
+      html(
+        `<title>About</title>` +
+          `<meta name="description" content="A page"/>` +
+          `<meta property="og:title" content="OG"/>` +
+          `<meta name="empty" content=""/>` +
+          `<link rel="canonical" href="https://x"/>` +
+          `<script type="application/ld+json">{"@type":"Thing"}</script>`
+      )
+    );
+    expect(tags).toContainEqual({ kind: 'title', presence: 'own', value: 'static' });
+    expect(tags).toContainEqual({ kind: 'meta', name: 'description', presence: 'own', value: 'static' });
+    expect(tags).toContainEqual({ kind: 'meta', property: 'og:title', presence: 'own', value: 'static' });
+    expect(tags).toContainEqual({ kind: 'meta', name: 'empty', presence: 'own', value: 'absent' });
+    expect(tags).toContainEqual({ kind: 'link', rel: 'canonical', presence: 'own', value: 'static' });
+    expect(tags).toContainEqual({ kind: 'jsonld', presence: 'own', value: 'static' });
+  });
+
+  it('treats an empty title as absent', () => {
+    const { tags } = parseHtmlHead(html(`<title></title>`));
+    expect(tags).toContainEqual({ kind: 'title', presence: 'own', value: 'absent' });
+  });
+
+  it('reads <html lang>', () => {
+    expect(parseHtmlHead(html(`<title>x</title>`, 'en')).htmlLang).toEqual({ presence: 'own', value: 'static' });
+    expect(parseHtmlHead(html(`<title>x</title>`, '')).htmlLang).toEqual({ presence: 'own', value: 'absent' });
+  });
+});

--- a/packages/vite/test/parse-html.test.ts
+++ b/packages/vite/test/parse-html.test.ts
@@ -33,4 +33,9 @@ describe('parseHtmlHead', () => {
     expect(parseHtmlHead(html(`<title>x</title>`, 'en')).htmlLang).toEqual({ presence: 'own', value: 'static' });
     expect(parseHtmlHead(html(`<title>x</title>`, '')).htmlLang).toEqual({ presence: 'own', value: 'absent' });
   });
+
+  it('returns presence:none when <html> has no lang attribute', () => {
+    const noLangHtml = `<!doctype html><html><head><title>x</title></head><body></body></html>`;
+    expect(parseHtmlHead(noLangHtml).htmlLang).toEqual({ presence: 'none', value: 'absent' });
+  });
 });

--- a/packages/vite/test/plugin-error.test.ts
+++ b/packages/vite/test/plugin-error.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Plugin } from 'vite';
+
+// Force the analysis itself to fail; the plugin must NOT fail the build for it.
+vi.mock('../src/analyze.js', () => ({
+  analyze: vi.fn(async () => {
+    throw new Error('boom: unreadable output');
+  })
+}));
+
+import { svelteVitals } from '../src/index.js';
+
+function closeBundleOf(p: Plugin): () => Promise<void> {
+  const hook = typeof p.closeBundle === 'function' ? p.closeBundle : p.closeBundle?.handler;
+  return (hook as () => Promise<void>).bind({});
+}
+
+describe('svelteVitals analysis failure', () => {
+  let cwd: string;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'sv-err-'));
+    const pages = join(cwd, '.svelte-kit/output/prerendered/pages');
+    await mkdir(pages, { recursive: true });
+    await writeFile(join(pages, 'index.html'), `<html lang="en"><head><title>Home</title></head></html>`);
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(async () => {
+    warnSpy.mockRestore();
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('warns and skips the gate instead of failing the build when analysis throws', async () => {
+    const p = svelteVitals({ cwd, failOn: 'critical' });
+    await expect(closeBundleOf(p)()).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]![0]).toMatch(/analysis failed: boom/);
+  });
+});

--- a/packages/vite/test/plugin-options.test.ts
+++ b/packages/vite/test/plugin-options.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm, readFile, access } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Plugin } from 'vite';
+import { svelteVitals } from '../src/index.js';
+
+type CloseBundle = () => Promise<void>;
+function closeBundleOf(p: Plugin): CloseBundle {
+  const hook = typeof p.closeBundle === 'function' ? p.closeBundle : p.closeBundle?.handler;
+  return (hook as CloseBundle).bind({});
+}
+
+describe('svelteVitals options', () => {
+  let cwd: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'sv-opt-'));
+    const pages = join(cwd, '.svelte-kit/output/prerendered/pages');
+    await mkdir(pages, { recursive: true });
+    // Page is missing <meta description> -> a critical finding on '/'.
+    await writeFile(join(pages, 'index.html'), `<html lang="en"><head><title>Home</title></head><body></body></html>`);
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(async () => {
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('writes the JSON report to a relative outFile resolved against the project root', async () => {
+    const p = svelteVitals({ cwd, report: false, failOn: 'info', outFile: 'reports/seo.json' });
+    // failOn:'info' would normally throw on findings; swallow so we can assert the file.
+    await closeBundleOf(p)().catch(() => {});
+    const written = await readFile(join(cwd, 'reports/seo.json'), 'utf8');
+    expect(() => JSON.parse(written)).not.toThrow();
+    expect(JSON.parse(written)).toHaveProperty('version');
+  });
+
+  it("logs the JSON report to the console when report is 'json'", async () => {
+    // Default failOn:'critical' throws after logging; the log fires first.
+    const p = svelteVitals({ cwd, report: 'json' });
+    await closeBundleOf(p)().catch(() => {});
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const logged = logSpy.mock.calls[0]![0] as string;
+    expect(() => JSON.parse(logged)).not.toThrow();
+  });
+
+  it('is a no-op (no report, no throw) when the prerendered dir is absent', async () => {
+    const empty = await mkdtemp(join(tmpdir(), 'sv-opt-empty-'));
+    try {
+      const p = svelteVitals({ cwd: empty, failOn: 'critical' });
+      await expect(closeBundleOf(p)()).resolves.toBeUndefined();
+      expect(logSpy).not.toHaveBeenCalled();
+    } finally {
+      await rm(empty, { recursive: true, force: true });
+    }
+  });
+
+  it('respects an absolute outFile path unchanged', async () => {
+    const abs = join(cwd, 'absolute-report.json');
+    const p = svelteVitals({ cwd, report: false, failOn: 'info', outFile: abs });
+    await closeBundleOf(p)().catch(() => {});
+    await expect(access(abs)).resolves.toBeUndefined();
+  });
+});

--- a/packages/vite/test/project.test.ts
+++ b/packages/vite/test/project.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { collectRenderedProject } from '../src/providers/rendered/project.js';
+
+describe('collectRenderedProject', () => {
+  let dir: string;
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'sv-proj-'));
+    await mkdir(join(dir, 'static'), { recursive: true });
+    await writeFile(join(dir, 'static', 'robots.txt'), 'x');
+    await mkdir(join(dir, 'src', 'routes', 'sitemap.xml'), { recursive: true });
+    await writeFile(join(dir, 'src', 'routes', 'sitemap.xml', '+server.ts'), 'export function GET(){}');
+  });
+  afterAll(async () => rm(dir, { recursive: true, force: true }));
+
+  it('detects robots (static) and sitemap (endpoint) from source; passes htmlLang through', async () => {
+    const p = await collectRenderedProject(dir, { presence: 'own', value: 'static' });
+    expect(p.hasRobotsTxt).toBe(true);
+    expect(p.hasSitemap).toBe(true);
+    expect(p.htmlLang).toEqual({ presence: 'own', value: 'static' });
+  });
+
+  it('reports missing robots/sitemap', async () => {
+    const empty = await mkdtemp(join(tmpdir(), 'sv-proj-empty-'));
+    const p = await collectRenderedProject(empty, { presence: 'none', value: 'absent' });
+    expect(p.hasRobotsTxt).toBe(false);
+    expect(p.hasSitemap).toBe(false);
+    await rm(empty, { recursive: true, force: true });
+  });
+});

--- a/packages/vite/tsconfig.json
+++ b/packages/vite/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "noEmit": true
+    "noEmit": true,
+    "types": ["node"]
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/packages/vite/tsup.config.ts
+++ b/packages/vite/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  target: 'es2022'
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ catalogs:
     mri:
       specifier: ^1.2.0
       version: 1.2.0
+    node-html-parser:
+      specifier: ^6.1.13
+      version: 6.1.13
     prettier:
       specifier: ^3.8.4
       version: 3.8.4
@@ -152,6 +155,19 @@ importers:
       '@svelte-vitals/core':
         specifier: workspace:*
         version: link:../core
+      node-html-parser:
+        specifier: 'catalog:'
+        version: 6.1.13
+      tinyglobby:
+        specifier: 'catalog:'
+        version: 0.2.17
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@24.13.2)(esbuild@0.27.7)
 
 packages:
 
@@ -919,6 +935,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
@@ -970,6 +989,13 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -1002,9 +1028,26 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
@@ -1200,6 +1243,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
 
   human-id@4.2.0:
     resolution: {integrity: sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==}
@@ -1420,6 +1467,9 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  node-html-parser@6.1.13:
+    resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
+
   node@runtime:24.16.0:
     resolution:
       type: variations
@@ -1518,6 +1568,9 @@ packages:
               os: win32
     version: 24.16.0
     hasBin: true
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -2702,6 +2755,8 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  boolbase@1.0.0: {}
+
   brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
@@ -2741,6 +2796,16 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-what@6.2.2: {}
+
   cssesc@3.0.0: {}
 
   debug@4.4.3:
@@ -2759,10 +2824,30 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
   enquirer@2.4.1:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
+
+  entities@4.5.0: {}
 
   es-module-lexer@2.1.0: {}
 
@@ -3005,6 +3090,8 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  he@1.2.0: {}
+
   human-id@4.2.0: {}
 
   iconv-lite@0.7.2:
@@ -3174,7 +3261,16 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  node-html-parser@6.1.13:
+    dependencies:
+      css-select: 5.2.2
+      he: 1.2.0
+
   node@runtime:24.16.0: {}
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
 
   object-assign@4.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,7 @@ catalog:
   eslint-plugin-svelte: ^3.19.0
   globals: ^17.6.0
   mri: ^1.2.0
+  node-html-parser: ^6.1.13
   prettier: ^3.8.4
   prettier-plugin-svelte: ^4.1.0
   publint: ^0.3.21


### PR DESCRIPTION
## Summary

Plugin mode (issue #8) — the design's "main" value. `@svelte-vitals/vite` piggybacks on `vite build`, analyzes the **prerendered HTML's `<head>`**, and runs the SAME SEO rules as the CLI by feeding the mode-independent `ResolvedHead[]` boundary into `@svelte-vitals/core`. Library-agnostic: it inspects the real output, not how it was written.

```ts
// vite.config.ts
import { sveltekit } from '@sveltejs/kit/vite';
import { svelteVitals } from '@svelte-vitals/vite';

export default { plugins: [sveltekit(), svelteVitals({ failOn: 'critical' })] };
```

## How it works

- A `closeBundle` (`enforce: 'post'`, `apply: 'build'`) hook reads `.svelte-kit/output/prerendered/pages/**/*.html`, parses each `<head>` with `node-html-parser`, and builds `ResolvedHead[]` (`source: 'rendered'`; tags `presence: 'own'`, `value: 'static'`/`'absent'`).
- Project facts: robots.txt/sitemap.xml from source; `<html lang>` from the rendered HTML. All 9 rules run.
- Reuses core unchanged: `selectRules → runRules → applyRuleSeverities → computeScore → summarize → reporters`.
- Gates the build (throws) when findings reach `failOn`. `report: 'console' | 'json' | false`, `outFile`, `prerenderDir` options.

## Build-timing (spike-verified)

A throwaway SvelteKit build confirmed SvelteKit calls `closeBundle` **twice** — once before prerendering (dir absent) and once after the adapter writes the HTML. The hook guards with `existsSync` + `routeCount === 0`, so it's a no-op on the early call and analyzes only when prerendered HTML exists.

## Design boundaries

- Reuses `@svelte-vitals/core` via `ResolvedHead[]` (no core edits). No dependency on the `svelte-vitals` CLI.
- The plugin (build-time Node) uses `node:fs`/`tinyglobby` directly (design §8). Analysis is a pure, fully-unit-tested `analyze()`; the hook is a thin wrapper.
- Only **prerendered** routes are covered; the report notes this and points to the CLI for SSR/dynamic routes.

## Verification

- 107 tests pass (core 35, cli 59, vite 13); `pnpm -r build` / `typecheck` / `pnpm lint` green.
- Integration tests drive the plugin's `closeBundle` against fixture prerendered dirs: a missing-description page fails the build (throws); a fully-populated page passes with `failOn: 'critical'`.
- Whole-branch review (Opus) caught and fixed: the JSON report version was hardcoded (now read from package.json, matching the CLI), plus lint/outFile/type cleanups.

## Release

Changeset bumps `@svelte-vitals/vite` **minor** (first real release → 0.1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a production-ready Vite/SvelteKit build-time SEO analysis plugin that inspects prerendered HTML, generates console/JSON reports, and can fail builds based on configured severity thresholds.
  * JSON reporting can be logged or written to a configured `outFile`; only prerendered routes are analyzed.
  * Console reporting now supports an optional header mode label.
* **Bug Fixes**
  * If the analysis step itself errors, the plugin warns instead of failing the build (while configured findings can still fail).
* **Documentation**
  * Documented plugin-mode behavior and added full package usage/config reference for `@svelte-vitals/vite`.
* **Chores**
  * Made the Vite package publishable/buildable and updated release tooling configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->