### PR TITLE
feat: SARIF & GitHub Actions reporters (--reporter sarif|github)

### DIFF
--- a/.changeset/sarif-github-reporters.md
+++ b/.changeset/sarif-github-reporters.md
@@ -1,0 +1,6 @@
+---
+'@svelte-vitals/core': minor
+'svelte-vitals': minor
+---
+
+Add SARIF 2.1.0 (`--reporter sarif`) and GitHub Actions workflow-command (`--reporter github`) reporters. The `github` reporter is auto-selected under GitHub Actions for inline PR annotations; SARIF can be uploaded to GitHub code scanning.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,28 @@ Passed (3)
 
 It is selected **automatically** when run inside a known AI-agent harness (e.g. Claude Code sets `CLAUDECODE`). Force it anywhere with `SVELTE_VITALS_REPORTER=agent`, or override with `--reporter console|json`. When auto-selected (not requested explicitly), a one-line hint is printed to stderr explaining how to override, so a human running it in an agent terminal isn't surprised by the Markdown output.
 
+### GitHub integration
+
+**Inline PR annotations (zero config).** Under GitHub Actions, svelte-vitals auto-selects the `github` reporter, emitting workflow commands that GitHub turns into inline annotations on the PR diff and the job summary:
+
+```yaml
+- run: npx svelte-vitals
+```
+
+Override with `--reporter console|json` (or `SVELTE_VITALS_REPORTER`) if you want different output in CI.
+
+**Code scanning (Security tab).** Emit SARIF and upload it to surface findings as persistent code-scanning alerts:
+
+```yaml
+- run: npx svelte-vitals --reporter sarif > svelte-vitals.sarif
+  continue-on-error: true
+- uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: svelte-vitals.sarif
+```
+
+`--reporter sarif` writes SARIF 2.1.0 to stdout; redirect it to a file for upload.
+
 ### Exit codes
 
 | Code | Meaning                                                         |

--- a/README.md
+++ b/README.md
@@ -70,16 +70,22 @@ It is selected **automatically** when run inside a known AI-agent harness (e.g. 
 - run: npx svelte-vitals
 ```
 
-Override with `--reporter console|json` (or `SVELTE_VITALS_REPORTER`) if you want different output in CI.
+Override with `--reporter console|json|sarif` (or `SVELTE_VITALS_REPORTER`) if you want different output in CI.
 
-**Code scanning (Security tab).** Emit SARIF and upload it to surface findings as persistent code-scanning alerts:
+**Code scanning (Security tab).** Emit SARIF and upload it to surface findings as persistent code-scanning alerts. The upload action needs `security-events: write`, so grant it at the job (or workflow) level:
 
 ```yaml
-- run: npx svelte-vitals --reporter sarif > svelte-vitals.sarif
-  continue-on-error: true
-- uses: github/codeql-action/upload-sarif@v3
-  with:
-    sarif_file: svelte-vitals.sarif
+jobs:
+  seo:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - run: npx svelte-vitals --reporter sarif > svelte-vitals.sarif
+        continue-on-error: true
+      - uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: svelte-vitals.sarif
 ```
 
 `--reporter sarif` writes SARIF 2.1.0 to stdout; redirect it to a file for upload.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ jobs:
 
 `--reporter sarif` writes SARIF 2.1.0 to stdout; redirect it to a file for upload.
 
+> [!NOTE]
+> Code scanning only displays results that carry a file location, so project-scoped checks that aren't tied to a route file (`robots.txt`, `sitemap`, `<html lang>`) don't appear as alerts in the Security tab. They are still reported by the `github`, `console`, and `json` reporters — keep one of those in your pipeline if you rely on those checks.
+
 ### Exit codes
 
 | Code | Meaning                                                         |

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ It is selected **automatically** when run inside a known AI-agent harness (e.g. 
 
 ### GitHub integration
 
-**Inline PR annotations (zero config).** Under GitHub Actions, svelte-vitals auto-selects the `github` reporter, emitting workflow commands that GitHub turns into inline annotations on the PR diff and the job summary:
+**Inline PR annotations (zero config).** Under GitHub Actions, svelte-vitals auto-selects the `github` reporter, emitting workflow commands that GitHub turns into inline annotations on the PR diff and in the workflow run's annotations:
 
 ```yaml
 - run: npx svelte-vitals

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -15,7 +15,7 @@ Options:
   --treat-dynamic-as <mode>   pass | warn | fail (default: pass)
   --route <glob>              Only analyze routes matching this glob
   --by-route                  Show per-route score breakdown in console output
-  --reporter <fmt>            console | json | agent (auto: agent under AI-agent envs)
+  --reporter <fmt>            console | json | agent | sarif | github (auto: agent under AI-agent envs, github under GitHub Actions)
   --json                      Alias for --reporter=json
   --fail-on <severity>        Fail (exit 1) when any finding reaches this severity: critical | warning | info
   --fail-on-warning           Alias for --fail-on=warning
@@ -79,7 +79,9 @@ async function main(): Promise<void> {
     reporter = 'json';
   } else if (typeof argv.reporter === 'string') {
     if (!isReporterName(argv.reporter)) {
-      console.error(`svelte-vitals: unknown reporter '${argv.reporter}'. Valid values: console, json, agent.`);
+      console.error(
+        `svelte-vitals: unknown reporter '${argv.reporter}'. Valid values: console, json, agent, sarif, github.`
+      );
       process.exit(2);
     }
     reporter = argv.reporter;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -92,7 +92,7 @@ export async function run(opts: RunOptions = {}): Promise<number> {
     }
     if (reporter === 'github' && isAutoDetectedGithub(opts.reporter, env)) {
       errorLog(
-        'svelte-vitals: github reporter auto-selected (GitHub Actions detected); override with --reporter console|json.'
+        'svelte-vitals: github reporter auto-selected (GitHub Actions detected); override with --reporter console|json|sarif.'
       );
     }
     if (reporter === 'json') {
@@ -102,7 +102,10 @@ export async function run(opts: RunOptions = {}): Promise<number> {
     } else if (reporter === 'sarif') {
       log(formatSarifReport(results, config, { version: readPackageVersion() }));
     } else if (reporter === 'github') {
-      log(formatGithubReport(results, config));
+      // The github reporter returns '' when there are no findings; skip logging so
+      // a clean run emits no stray blank line into the Actions log.
+      const output = formatGithubReport(results, config);
+      if (output) log(output);
     } else {
       log(formatConsoleReport(results, config, { byRoute: opts.byRoute ?? false }));
     }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,6 +4,8 @@ import {
   formatConsoleReport,
   formatJsonReport,
   formatAgentReport,
+  formatSarifReport,
+  formatGithubReport,
   summarize,
   hasFailureAtOrAbove,
   defineConfig,
@@ -16,7 +18,7 @@ import { createNodeRuntime } from './runtime/node.js';
 import { sourceHeadProvider } from './providers/source/routes.js';
 import { detectProject, ProjectError, collectProjectFacts } from './providers/source/project.js';
 import { readPackageVersion } from './version.js';
-import { resolveReporter, isAutoDetectedAgent, type ReporterName } from './reporter-resolve.js';
+import { resolveReporter, isAutoDetectedAgent, isAutoDetectedGithub, type ReporterName } from './reporter-resolve.js';
 
 export interface RunOptions {
   cwd?: string;
@@ -88,10 +90,19 @@ export async function run(opts: RunOptions = {}): Promise<number> {
         'svelte-vitals: agent reporter auto-selected (AI-agent env detected); override with --reporter console|json.'
       );
     }
+    if (reporter === 'github' && isAutoDetectedGithub(opts.reporter, env)) {
+      errorLog(
+        'svelte-vitals: github reporter auto-selected (GitHub Actions detected); override with --reporter console|json.'
+      );
+    }
     if (reporter === 'json') {
       log(formatJsonReport(results, config, { version: readPackageVersion() }));
     } else if (reporter === 'agent') {
       log(formatAgentReport(results, config));
+    } else if (reporter === 'sarif') {
+      log(formatSarifReport(results, config, { version: readPackageVersion() }));
+    } else if (reporter === 'github') {
+      log(formatGithubReport(results, config));
     } else {
       log(formatConsoleReport(results, config, { byRoute: opts.byRoute ?? false }));
     }

--- a/packages/cli/src/reporter-resolve.ts
+++ b/packages/cli/src/reporter-resolve.ts
@@ -4,9 +4,7 @@ export type ReporterName = 'console' | 'json' | 'agent' | 'sarif' | 'github';
 const AGENT_ENV_VARS = ['CLAUDECODE', 'SVELTE_VITALS_AGENT'];
 
 export function isReporterName(value: string | undefined): value is ReporterName {
-  return (
-    value === 'console' || value === 'json' || value === 'agent' || value === 'sarif' || value === 'github'
-  );
+  return value === 'console' || value === 'json' || value === 'agent' || value === 'sarif' || value === 'github';
 }
 
 /** True when run by a known AI-agent harness (design: curated allow-list, no TTY heuristic). */
@@ -59,7 +57,5 @@ export function isAutoDetectedGithub(
   explicit: ReporterName | undefined,
   env: NodeJS.ProcessEnv = process.env
 ): boolean {
-  return (
-    !explicit && !isReporterName(env.SVELTE_VITALS_REPORTER) && !isAgentEnv(env) && isGithubActionsEnv(env)
-  );
+  return !explicit && !isReporterName(env.SVELTE_VITALS_REPORTER) && !isAgentEnv(env) && isGithubActionsEnv(env);
 }

--- a/packages/cli/src/reporter-resolve.ts
+++ b/packages/cli/src/reporter-resolve.ts
@@ -1,10 +1,12 @@
-export type ReporterName = 'console' | 'json' | 'agent';
+export type ReporterName = 'console' | 'json' | 'agent' | 'sarif' | 'github';
 
 /** Env vars set by AI-agent harnesses. Curated + extensible; SVELTE_VITALS_AGENT is the universal opt-in. */
 const AGENT_ENV_VARS = ['CLAUDECODE', 'SVELTE_VITALS_AGENT'];
 
 export function isReporterName(value: string | undefined): value is ReporterName {
-  return value === 'console' || value === 'json' || value === 'agent';
+  return (
+    value === 'console' || value === 'json' || value === 'agent' || value === 'sarif' || value === 'github'
+  );
 }
 
 /** True when run by a known AI-agent harness (design: curated allow-list, no TTY heuristic). */
@@ -15,9 +17,15 @@ export function isAgentEnv(env: NodeJS.ProcessEnv = process.env): boolean {
   });
 }
 
+/** True when running inside GitHub Actions (GITHUB_ACTIONS is 'true' there). */
+export function isGithubActionsEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = env.GITHUB_ACTIONS;
+  return v !== undefined && v !== '';
+}
+
 /**
  * Resolve the reporter: explicit flag → SVELTE_VITALS_REPORTER → agent-env
- * auto-detect → console.
+ * auto-detect → GitHub-Actions auto-detect → console.
  */
 export function resolveReporter(
   explicit: ReporterName | undefined,
@@ -27,6 +35,7 @@ export function resolveReporter(
   const fromEnv = env.SVELTE_VITALS_REPORTER;
   if (isReporterName(fromEnv)) return fromEnv;
   if (isAgentEnv(env)) return 'agent';
+  if (isGithubActionsEnv(env)) return 'github';
   return 'console';
 }
 
@@ -38,4 +47,19 @@ export function resolveReporter(
  */
 export function isAutoDetectedAgent(explicit: ReporterName | undefined, env: NodeJS.ProcessEnv = process.env): boolean {
   return !explicit && !isReporterName(env.SVELTE_VITALS_REPORTER) && isAgentEnv(env);
+}
+
+/**
+ * True when the github reporter is chosen purely by GITHUB_ACTIONS auto-detection
+ * (no explicit flag, no SVELTE_VITALS_REPORTER, not an agent env). Used to surface
+ * a one-line "how to override" hint so an existing CI user isn't surprised by the
+ * switch from console output to workflow commands.
+ */
+export function isAutoDetectedGithub(
+  explicit: ReporterName | undefined,
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return (
+    !explicit && !isReporterName(env.SVELTE_VITALS_REPORTER) && !isAgentEnv(env) && isGithubActionsEnv(env)
+  );
 }

--- a/packages/cli/src/reporter-resolve.ts
+++ b/packages/cli/src/reporter-resolve.ts
@@ -15,10 +15,9 @@ export function isAgentEnv(env: NodeJS.ProcessEnv = process.env): boolean {
   });
 }
 
-/** True when running inside GitHub Actions (GITHUB_ACTIONS is 'true' there). */
+/** True when running inside GitHub Actions, which always sets GITHUB_ACTIONS to exactly 'true'. */
 export function isGithubActionsEnv(env: NodeJS.ProcessEnv = process.env): boolean {
-  const v = env.GITHUB_ACTIONS;
-  return v !== undefined && v !== '';
+  return env.GITHUB_ACTIONS === 'true';
 }
 
 /**

--- a/packages/cli/test/reporter-resolve.test.ts
+++ b/packages/cli/test/reporter-resolve.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { isAgentEnv, isAutoDetectedAgent, isReporterName, resolveReporter } from '../src/reporter-resolve.js';
+import {
+  isAgentEnv,
+  isAutoDetectedAgent,
+  isAutoDetectedGithub,
+  isGithubActionsEnv,
+  isReporterName,
+  resolveReporter
+} from '../src/reporter-resolve.js';
 
 describe('isAgentEnv', () => {
   it('is true when a known agent env var is set', () => {
@@ -33,7 +40,7 @@ describe('resolveReporter', () => {
 
 describe('isReporterName', () => {
   it('accepts only the known reporter names', () => {
-    for (const name of ['console', 'json', 'agent']) expect(isReporterName(name)).toBe(true);
+    for (const name of ['console', 'json', 'agent', 'sarif', 'github']) expect(isReporterName(name)).toBe(true);
     for (const bad of ['jsonn', 'Agent', '', undefined]) expect(isReporterName(bad)).toBe(false);
   });
 });
@@ -52,5 +59,42 @@ describe('isAutoDetectedAgent', () => {
   it('is false outside an agent env', () => {
     expect(isAutoDetectedAgent(undefined, {})).toBe(false);
     expect(isAutoDetectedAgent(undefined, { CI: 'true' })).toBe(false);
+  });
+});
+
+describe('isGithubActionsEnv', () => {
+  it('is true when GITHUB_ACTIONS is a non-empty string', () => {
+    expect(isGithubActionsEnv({ GITHUB_ACTIONS: 'true' })).toBe(true);
+  });
+  it('is false otherwise', () => {
+    expect(isGithubActionsEnv({})).toBe(false);
+    expect(isGithubActionsEnv({ GITHUB_ACTIONS: '' })).toBe(false);
+  });
+});
+
+describe('resolveReporter — github auto-detect', () => {
+  it('auto-selects github under GitHub Actions', () => {
+    expect(resolveReporter(undefined, { GITHUB_ACTIONS: 'true' })).toBe('github');
+  });
+  it('lets agent env outrank GitHub Actions', () => {
+    expect(resolveReporter(undefined, { GITHUB_ACTIONS: 'true', CLAUDECODE: '1' })).toBe('agent');
+  });
+  it('lets an explicit flag and SVELTE_VITALS_REPORTER outrank GitHub Actions', () => {
+    expect(resolveReporter('sarif', { GITHUB_ACTIONS: 'true' })).toBe('sarif');
+    expect(resolveReporter(undefined, { GITHUB_ACTIONS: 'true', SVELTE_VITALS_REPORTER: 'json' })).toBe('json');
+  });
+});
+
+describe('isAutoDetectedGithub', () => {
+  it('is true only when github is chosen purely by GITHUB_ACTIONS', () => {
+    expect(isAutoDetectedGithub(undefined, { GITHUB_ACTIONS: 'true' })).toBe(true);
+  });
+  it('is false with an explicit flag, an agent env, or an explicit reporter env', () => {
+    expect(isAutoDetectedGithub('github', { GITHUB_ACTIONS: 'true' })).toBe(false);
+    expect(isAutoDetectedGithub(undefined, { GITHUB_ACTIONS: 'true', CLAUDECODE: '1' })).toBe(false);
+    expect(isAutoDetectedGithub(undefined, { GITHUB_ACTIONS: 'true', SVELTE_VITALS_REPORTER: 'github' })).toBe(false);
+  });
+  it('is false outside GitHub Actions', () => {
+    expect(isAutoDetectedGithub(undefined, {})).toBe(false);
   });
 });

--- a/packages/cli/test/reporter-resolve.test.ts
+++ b/packages/cli/test/reporter-resolve.test.ts
@@ -63,12 +63,13 @@ describe('isAutoDetectedAgent', () => {
 });
 
 describe('isGithubActionsEnv', () => {
-  it('is true when GITHUB_ACTIONS is a non-empty string', () => {
+  it('is true only when GITHUB_ACTIONS is exactly "true"', () => {
     expect(isGithubActionsEnv({ GITHUB_ACTIONS: 'true' })).toBe(true);
   });
-  it('is false otherwise', () => {
+  it('is false otherwise — including the explicit opt-out value "false"', () => {
     expect(isGithubActionsEnv({})).toBe(false);
     expect(isGithubActionsEnv({ GITHUB_ACTIONS: '' })).toBe(false);
+    expect(isGithubActionsEnv({ GITHUB_ACTIONS: 'false' })).toBe(false);
   });
 });
 

--- a/packages/cli/test/run.test.ts
+++ b/packages/cli/test/run.test.ts
@@ -146,9 +146,7 @@ describe('run() sarif & github reporters', () => {
     await run({ cwd: fixtureDir, log: cap.log, errorLog: cap.errorLog, reporter: 'sarif', env: CLEAN_ENV });
     const sarif = JSON.parse(cap.out.join('\n'));
     expect(sarif.version).toBe('2.1.0');
-    const seo001 = sarif.runs[0].results.find(
-      (r: { ruleId: string; level: string }) => r.ruleId === 'SEO001'
-    );
+    const seo001 = sarif.runs[0].results.find((r: { ruleId: string; level: string }) => r.ruleId === 'SEO001');
     expect(seo001.level).toBe('error');
   });
 

--- a/packages/cli/test/run.test.ts
+++ b/packages/cli/test/run.test.ts
@@ -173,4 +173,21 @@ describe('run() sarif & github reporters', () => {
     });
     expect(cap.out.join('\n')).toContain('# svelte-vitals — SEO fixes'); // agent Markdown, not workflow commands
   });
+
+  it('emits nothing on stdout for a clean github run (no stray blank line)', async () => {
+    const cap = capture();
+    // A route glob that matches nothing leaves zero route findings; the fixture's
+    // project rules (robots/sitemap/html lang) all pass, so the github reporter
+    // produces an empty string — which must not be logged as a blank line.
+    const code = await run({
+      cwd: fixtureDir,
+      log: cap.log,
+      errorLog: cap.errorLog,
+      reporter: 'github',
+      route: 'no-such-route',
+      env: CLEAN_ENV
+    });
+    expect(code).toBe(0);
+    expect(cap.out).toEqual([]);
+  });
 });

--- a/packages/cli/test/run.test.ts
+++ b/packages/cli/test/run.test.ts
@@ -139,3 +139,40 @@ describe('run() agent reporter', () => {
     expect(explicit.err.join('\n')).not.toContain('auto-selected');
   });
 });
+
+describe('run() sarif & github reporters', () => {
+  it('emits parseable SARIF with the missing-title finding as an error', async () => {
+    const cap = capture();
+    await run({ cwd: fixtureDir, log: cap.log, errorLog: cap.errorLog, reporter: 'sarif', env: CLEAN_ENV });
+    const sarif = JSON.parse(cap.out.join('\n'));
+    expect(sarif.version).toBe('2.1.0');
+    const seo001 = sarif.runs[0].results.find(
+      (r: { ruleId: string; level: string }) => r.ruleId === 'SEO001'
+    );
+    expect(seo001.level).toBe('error');
+  });
+
+  it('emits github workflow commands for the missing-title finding', async () => {
+    const cap = capture();
+    await run({ cwd: fixtureDir, log: cap.log, errorLog: cap.errorLog, reporter: 'github', env: CLEAN_ENV });
+    expect(cap.out.join('\n')).toMatch(/::error file=.*\+page\.svelte,title=SEO001%3A/);
+  });
+
+  it('auto-selects github under GitHub Actions and hints how to override', async () => {
+    const cap = capture();
+    await run({ cwd: fixtureDir, log: cap.log, errorLog: cap.errorLog, env: { GITHUB_ACTIONS: 'true' } });
+    expect(cap.out.join('\n')).toContain('::error ');
+    expect(cap.err.join('\n')).toContain('github reporter auto-selected');
+  });
+
+  it('lets an agent env outrank GitHub Actions', async () => {
+    const cap = capture();
+    await run({
+      cwd: fixtureDir,
+      log: cap.log,
+      errorLog: cap.errorLog,
+      env: { GITHUB_ACTIONS: 'true', CLAUDECODE: '1' }
+    });
+    expect(cap.out.join('\n')).toContain('# svelte-vitals — SEO fixes'); // agent Markdown, not workflow commands
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,7 @@ export { formatConsoleReport } from './reporter/console.js';
 export { formatJsonReport } from './reporter/json.js';
 export { formatAgentReport } from './reporter/agent.js';
 export { formatSarifReport } from './reporter/sarif.js';
+export { formatGithubReport } from './reporter/github.js';
 
 export { selectRules, applyRuleSeverities } from './config-apply.js';
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,6 +45,7 @@ export type { ConsoleReportOptions } from './reporter/console.js';
 export { formatConsoleReport } from './reporter/console.js';
 export { formatJsonReport } from './reporter/json.js';
 export { formatAgentReport } from './reporter/agent.js';
+export { formatSarifReport } from './reporter/sarif.js';
 
 export { selectRules, applyRuleSeverities } from './config-apply.js';
 

--- a/packages/core/src/reporter/github.ts
+++ b/packages/core/src/reporter/github.ts
@@ -15,7 +15,7 @@ function escapeProp(s: string): string {
 
 /**
  * Render penalized findings as GitHub Actions workflow commands (issue #18, design slice 5).
- * GitHub turns these into inline PR annotations and job-summary entries. Returns '' when clean.
+ * GitHub turns these into inline PR annotations and run-annotation entries. Returns '' when clean.
  */
 export function formatGithubReport(results: Result[], config: Config): string {
   const penalized = results.filter((r) => isPenalized(r.detection, config.treatDynamicAs));

--- a/packages/core/src/reporter/github.ts
+++ b/packages/core/src/reporter/github.ts
@@ -1,0 +1,32 @@
+import type { Config, Result } from '../types.js';
+import { isPenalized } from '../rule.js';
+import { effectiveSeverity } from '../summary.js';
+import { messageText, ruleMetaById, severityToGithubLevel } from './shared.js';
+
+/** Escape workflow-command message data (the text after `::`). */
+function escapeData(s: string): string {
+  return s.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+}
+
+/** Escape a workflow-command property value: message-data escapes plus `:` and `,`. */
+function escapeProp(s: string): string {
+  return escapeData(s).replace(/:/g, '%3A').replace(/,/g, '%2C');
+}
+
+/**
+ * Render penalized findings as GitHub Actions workflow commands (issue #18, design slice 5).
+ * GitHub turns these into inline PR annotations and job-summary entries. Returns '' when clean.
+ */
+export function formatGithubReport(results: Result[], config: Config): string {
+  const penalized = results.filter((r) => isPenalized(r.detection, config.treatDynamicAs));
+  const lines = penalized.map((r) => {
+    const level = severityToGithubLevel(effectiveSeverity(r, config));
+    const meta = ruleMetaById(r.id);
+    const title = meta ? `${r.id}: ${meta.title}` : r.id;
+    const props: string[] = [];
+    if (r.location) props.push(`file=${escapeProp(r.location)}`);
+    props.push(`title=${escapeProp(title)}`);
+    return `::${level} ${props.join(',')}::${escapeData(messageText(r))}`;
+  });
+  return lines.join('\n');
+}

--- a/packages/core/src/reporter/sarif.ts
+++ b/packages/core/src/reporter/sarif.ts
@@ -1,0 +1,77 @@
+import type { Config, Result } from '../types.js';
+import { isPenalized } from '../rule.js';
+import { effectiveSeverity } from '../summary.js';
+import { messageText, ruleMetaById, severityToSarifLevel } from './shared.js';
+
+type SarifLevel = 'error' | 'warning' | 'note';
+
+interface SarifRule {
+  id: string;
+  name: string;
+  shortDescription: { text: string };
+  helpUri: string;
+  defaultConfiguration: { level: SarifLevel };
+}
+
+interface SarifResult {
+  ruleId: string;
+  ruleIndex: number;
+  level: SarifLevel;
+  message: { text: string };
+  locations?: { physicalLocation: { artifactLocation: { uri: string } } }[];
+  partialFingerprints: Record<string, string>;
+}
+
+/** Render penalized findings as a SARIF 2.1.0 log string (issue #18, design slice 5). */
+export function formatSarifReport(results: Result[], config: Config, meta: { version: string }): string {
+  const penalized = results.filter((r) => isPenalized(r.detection, config.treatDynamicAs));
+
+  const rules: SarifRule[] = [];
+  const ruleIndex = new Map<string, number>();
+
+  const sarifResults: SarifResult[] = penalized.map((r) => {
+    if (!ruleIndex.has(r.id)) {
+      const m = ruleMetaById(r.id);
+      const name = m?.title ?? r.id;
+      ruleIndex.set(r.id, rules.length);
+      rules.push({
+        id: r.id,
+        name,
+        shortDescription: { text: name },
+        helpUri: r.docsUrl ?? m?.docsUrl ?? `https://svelte-vitals.dev/rules/${r.id}`,
+        defaultConfiguration: { level: severityToSarifLevel(m?.severity ?? r.severity) }
+      });
+    }
+    const result: SarifResult = {
+      ruleId: r.id,
+      ruleIndex: ruleIndex.get(r.id)!,
+      level: severityToSarifLevel(effectiveSeverity(r, config)),
+      message: { text: messageText(r) },
+      partialFingerprints: { 'svelteVitals/v1': `${r.id}:${r.route ?? 'project'}` }
+    };
+    if (r.location) {
+      result.locations = [{ physicalLocation: { artifactLocation: { uri: r.location } } }];
+    }
+    return result;
+  });
+
+  const log = {
+    $schema: 'https://json.schemastore.org/sarif-2.1.0.json',
+    version: '2.1.0',
+    runs: [
+      {
+        tool: {
+          driver: {
+            name: 'svelte-vitals',
+            informationUri: 'https://svelte-vitals.dev',
+            version: meta.version,
+            rules
+          }
+        },
+        results: sarifResults
+      }
+    ]
+  };
+
+  return JSON.stringify(log, null, 2);
+}

--- a/packages/core/src/reporter/sarif.ts
+++ b/packages/core/src/reporter/sarif.ts
@@ -1,7 +1,7 @@
 import type { Config, Result } from '../types.js';
 import { isPenalized } from '../rule.js';
 import { effectiveSeverity } from '../summary.js';
-import { messageText, ruleMetaById, severityToSarifLevel } from './shared.js';
+import { docsUrlFor, messageText, ruleMetaById, severityToSarifLevel } from './shared.js';
 
 type SarifLevel = 'error' | 'warning' | 'note';
 
@@ -38,7 +38,7 @@ export function formatSarifReport(results: Result[], config: Config, meta: { ver
         id: r.id,
         name,
         shortDescription: { text: name },
-        helpUri: r.docsUrl ?? m?.docsUrl ?? `https://svelte-vitals.dev/rules/${r.id}`,
+        helpUri: r.docsUrl ?? m?.docsUrl ?? docsUrlFor(r.id),
         defaultConfiguration: { level: severityToSarifLevel(m?.severity ?? r.severity) }
       });
     }

--- a/packages/core/src/reporter/shared.ts
+++ b/packages/core/src/reporter/shared.ts
@@ -1,0 +1,35 @@
+import type { Result, Severity } from '../types.js';
+import { allRules } from '../rules/index.js';
+
+/** Map a rule severity to a SARIF result/configuration level. */
+export function severityToSarifLevel(sev: Severity): 'error' | 'warning' | 'note' {
+  return sev === 'critical' ? 'error' : sev === 'warning' ? 'warning' : 'note';
+}
+
+/** Map a rule severity to a GitHub Actions workflow-command level. */
+export function severityToGithubLevel(sev: Severity): 'error' | 'warning' | 'notice' {
+  return sev === 'critical' ? 'error' : sev === 'warning' ? 'warning' : 'notice';
+}
+
+/** Human-readable text for a finding: its message, plus the recommendation when present. */
+export function messageText(result: Result): string {
+  return result.recommendation ? `${result.message} ${result.recommendation}` : result.message;
+}
+
+/** Stable, registry-sourced metadata for a rule id (single source of titles/severities). */
+export interface RuleMeta {
+  title: string;
+  severity: Severity;
+  docsUrl: string;
+}
+
+const RULE_META: Map<string, RuleMeta> = new Map(
+  allRules.map((r) => [
+    r.id,
+    { title: r.title, severity: r.severity, docsUrl: `https://svelte-vitals.dev/rules/${r.id}` }
+  ])
+);
+
+export function ruleMetaById(id: string): RuleMeta | undefined {
+  return RULE_META.get(id);
+}

--- a/packages/core/src/reporter/shared.ts
+++ b/packages/core/src/reporter/shared.ts
@@ -16,6 +16,11 @@ export function messageText(result: Result): string {
   return result.recommendation ? `${result.message} ${result.recommendation}` : result.message;
 }
 
+/** Canonical docs URL for a rule id. The single place this URL shape is defined. */
+export function docsUrlFor(id: string): string {
+  return `https://svelte-vitals.dev/rules/${id}`;
+}
+
 /** Stable, registry-sourced metadata for a rule id (single source of titles/severities). */
 export interface RuleMeta {
   title: string;
@@ -24,10 +29,7 @@ export interface RuleMeta {
 }
 
 const RULE_META: Map<string, RuleMeta> = new Map(
-  allRules.map((r) => [
-    r.id,
-    { title: r.title, severity: r.severity, docsUrl: `https://svelte-vitals.dev/rules/${r.id}` }
-  ])
+  allRules.map((r) => [r.id, { title: r.title, severity: r.severity, docsUrl: docsUrlFor(r.id) }])
 );
 
 export function ruleMetaById(id: string): RuleMeta | undefined {

--- a/packages/core/test/github-report.test.ts
+++ b/packages/core/test/github-report.test.ts
@@ -38,7 +38,9 @@ describe('formatGithubReport', () => {
     ];
     const lines = formatGithubReport(results, config).split('\n');
     expect(lines[0]).toBe('::warning title=SEO006%3A robots.txt::Missing robots.txt');
-    expect(lines[1]).toBe('::notice file=src/routes/x/+page.svelte,title=SEO008%3A JSON-LD structured data::JSON-LD missing');
+    expect(lines[1]).toBe(
+      '::notice file=src/routes/x/+page.svelte,title=SEO008%3A JSON-LD structured data::JSON-LD missing'
+    );
   });
 
   it('escapes property values (: ,) and message data (newline), but not : or , in message data', () => {

--- a/packages/core/test/github-report.test.ts
+++ b/packages/core/test/github-report.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { formatGithubReport, defineConfig, type Result } from '../src/index.js';
+
+const config = defineConfig({});
+
+describe('formatGithubReport', () => {
+  it('emits a workflow command per penalized finding with mapped level and file', () => {
+    const results: Result[] = [
+      {
+        id: 'SEO001',
+        severity: 'critical',
+        detection: { presence: 'none', value: 'absent' },
+        route: '/none',
+        location: 'src/routes/none/+page.svelte',
+        message: 'Missing <title>'
+      }
+    ];
+    const out = formatGithubReport(results, config);
+    expect(out).toBe('::error file=src/routes/none/+page.svelte,title=SEO001%3A Title presence::Missing <title>');
+  });
+
+  it('omits file= for findings without a location and maps info → notice', () => {
+    const results: Result[] = [
+      {
+        id: 'SEO006',
+        severity: 'warning',
+        detection: { presence: 'none', value: 'absent' },
+        message: 'Missing robots.txt'
+      },
+      {
+        id: 'SEO008',
+        severity: 'info',
+        detection: { presence: 'none', value: 'absent' },
+        route: '/x',
+        location: 'src/routes/x/+page.svelte',
+        message: 'JSON-LD missing'
+      }
+    ];
+    const lines = formatGithubReport(results, config).split('\n');
+    expect(lines[0]).toBe('::warning title=SEO006%3A robots.txt::Missing robots.txt');
+    expect(lines[1]).toBe('::notice file=src/routes/x/+page.svelte,title=SEO008%3A JSON-LD structured data::JSON-LD missing');
+  });
+
+  it('escapes property values (: ,) and message data (newline), but not : or , in message data', () => {
+    const results: Result[] = [
+      {
+        id: 'SEO001',
+        severity: 'critical',
+        detection: { presence: 'none', value: 'absent' },
+        route: '/a',
+        location: 'src/routes/a/+page.svelte',
+        message: 'Missing title: needed',
+        recommendation: 'Add <title>, set it.\nSecond line'
+      }
+    ];
+    const out = formatGithubReport(results, config);
+    // title property: colon escaped to %3A
+    expect(out).toContain('title=SEO001%3A Title presence');
+    // message data: newline → %0A; colon and comma stay literal
+    expect(out).toContain('::Missing title: needed Add <title>, set it.%0ASecond line');
+  });
+
+  it('returns an empty string when there are no penalized findings', () => {
+    const passing: Result[] = [
+      {
+        id: 'SEO001',
+        severity: 'critical',
+        detection: { presence: 'own', value: 'static' },
+        route: '/ok',
+        location: 'src/routes/ok/+page.svelte',
+        message: '<title>'
+      }
+    ];
+    expect(formatGithubReport(passing, config)).toBe('');
+  });
+});

--- a/packages/core/test/reporter-shared.test.ts
+++ b/packages/core/test/reporter-shared.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import {
+  severityToSarifLevel,
+  severityToGithubLevel,
+  messageText,
+  ruleMetaById
+} from '../src/reporter/shared.js';
+import type { Result } from '../src/index.js';
+
+describe('severity level maps', () => {
+  it('maps to SARIF levels', () => {
+    expect(severityToSarifLevel('critical')).toBe('error');
+    expect(severityToSarifLevel('warning')).toBe('warning');
+    expect(severityToSarifLevel('info')).toBe('note');
+  });
+  it('maps to GitHub levels', () => {
+    expect(severityToGithubLevel('critical')).toBe('error');
+    expect(severityToGithubLevel('warning')).toBe('warning');
+    expect(severityToGithubLevel('info')).toBe('notice');
+  });
+});
+
+describe('messageText', () => {
+  const base: Result = {
+    id: 'SEO001',
+    severity: 'critical',
+    detection: { presence: 'none', value: 'absent' },
+    message: 'Missing <title>'
+  };
+  it('appends the recommendation when present', () => {
+    expect(messageText({ ...base, recommendation: 'Add a <title>.' })).toBe('Missing <title> Add a <title>.');
+  });
+  it('is just the message when there is no recommendation', () => {
+    expect(messageText(base)).toBe('Missing <title>');
+  });
+});
+
+describe('ruleMetaById', () => {
+  it('returns canonical metadata for a known rule', () => {
+    const m = ruleMetaById('SEO001');
+    expect(m).toEqual({
+      title: 'Title presence',
+      severity: 'critical',
+      docsUrl: 'https://svelte-vitals.dev/rules/SEO001'
+    });
+  });
+  it('returns undefined for an unknown rule id', () => {
+    expect(ruleMetaById('NOPE999')).toBeUndefined();
+  });
+});

--- a/packages/core/test/reporter-shared.test.ts
+++ b/packages/core/test/reporter-shared.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { severityToSarifLevel, severityToGithubLevel, messageText, ruleMetaById } from '../src/reporter/shared.js';
+import {
+  severityToSarifLevel,
+  severityToGithubLevel,
+  messageText,
+  ruleMetaById,
+  docsUrlFor
+} from '../src/reporter/shared.js';
 import type { Result } from '../src/index.js';
 
 describe('severity level maps', () => {
@@ -41,5 +47,14 @@ describe('ruleMetaById', () => {
   });
   it('returns undefined for an unknown rule id', () => {
     expect(ruleMetaById('NOPE999')).toBeUndefined();
+  });
+  it('sources its docsUrl from docsUrlFor', () => {
+    expect(ruleMetaById('SEO001')?.docsUrl).toBe(docsUrlFor('SEO001'));
+  });
+});
+
+describe('docsUrlFor', () => {
+  it('builds the canonical rule docs URL', () => {
+    expect(docsUrlFor('SEO001')).toBe('https://svelte-vitals.dev/rules/SEO001');
   });
 });

--- a/packages/core/test/reporter-shared.test.ts
+++ b/packages/core/test/reporter-shared.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  severityToSarifLevel,
-  severityToGithubLevel,
-  messageText,
-  ruleMetaById
-} from '../src/reporter/shared.js';
+import { severityToSarifLevel, severityToGithubLevel, messageText, ruleMetaById } from '../src/reporter/shared.js';
 import type { Result } from '../src/index.js';
 
 describe('severity level maps', () => {

--- a/packages/core/test/sarif-report.test.ts
+++ b/packages/core/test/sarif-report.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { formatSarifReport, defineConfig, type Result } from '../src/index.js';
+
+const config = defineConfig({});
+
+const results: Result[] = [
+  {
+    id: 'SEO001',
+    severity: 'critical',
+    detection: { presence: 'none', value: 'absent' },
+    route: '/none',
+    location: 'src/routes/none/+page.svelte',
+    message: 'Missing <title>',
+    recommendation: 'Add a <title>.',
+    docsUrl: 'https://svelte-vitals.dev/rules/SEO001'
+  },
+  // project-scoped: no location, no route
+  {
+    id: 'SEO006',
+    severity: 'warning',
+    detection: { presence: 'none', value: 'absent' },
+    message: 'Missing robots.txt'
+  },
+  // passing finding → must be excluded
+  {
+    id: 'SEO002',
+    severity: 'critical',
+    detection: { presence: 'own', value: 'static' },
+    route: '/ok',
+    location: 'src/routes/ok/+page.svelte',
+    message: '<meta name="description">'
+  }
+];
+
+describe('formatSarifReport', () => {
+  it('emits a valid SARIF 2.1.0 envelope', () => {
+    const sarif = JSON.parse(formatSarifReport(results, config, { version: '9.9.9' }));
+    expect(sarif.version).toBe('2.1.0');
+    expect(sarif.$schema).toContain('sarif-2.1.0');
+    expect(sarif.runs[0].tool.driver.name).toBe('svelte-vitals');
+    expect(sarif.runs[0].tool.driver.version).toBe('9.9.9');
+  });
+
+  it('emits only penalized findings, in order', () => {
+    const run = JSON.parse(formatSarifReport(results, config, { version: '0.0.0' })).runs[0];
+    expect(run.results.map((r: { ruleId: string }) => r.ruleId)).toEqual(['SEO001', 'SEO006']);
+  });
+
+  it('maps severity to SARIF level', () => {
+    const run = JSON.parse(formatSarifReport(results, config, { version: '0.0.0' })).runs[0];
+    expect(run.results[0].level).toBe('error');
+    expect(run.results[1].level).toBe('warning');
+  });
+
+  it('builds a deduplicated rules table that ruleIndex points into', () => {
+    const run = JSON.parse(formatSarifReport(results, config, { version: '0.0.0' })).runs[0];
+    const r0 = run.results[0];
+    expect(run.tool.driver.rules[r0.ruleIndex].id).toBe('SEO001');
+    const seo001 = run.tool.driver.rules.find((x: { id: string }) => x.id === 'SEO001');
+    expect(seo001.name).toBe('Title presence');
+    expect(seo001.shortDescription.text).toBe('Title presence');
+    expect(seo001.helpUri).toBe('https://svelte-vitals.dev/rules/SEO001');
+    expect(seo001.defaultConfiguration.level).toBe('error');
+  });
+
+  it('sets physicalLocation when location is present and omits locations otherwise', () => {
+    const run = JSON.parse(formatSarifReport(results, config, { version: '0.0.0' })).runs[0];
+    expect(run.results[0].locations[0].physicalLocation.artifactLocation.uri).toBe('src/routes/none/+page.svelte');
+    expect(run.results[1].locations).toBeUndefined();
+  });
+
+  it('sets message text and partial fingerprints', () => {
+    const run = JSON.parse(formatSarifReport(results, config, { version: '0.0.0' })).runs[0];
+    expect(run.results[0].message.text).toBe('Missing <title> Add a <title>.');
+    expect(run.results[0].partialFingerprints['svelteVitals/v1']).toBe('SEO001:/none');
+    expect(run.results[1].partialFingerprints['svelteVitals/v1']).toBe('SEO006:project');
+  });
+
+  it('emits a valid empty log when there are no penalized findings', () => {
+    const passing: Result[] = [results[2]!];
+    const sarif = JSON.parse(formatSarifReport(passing, config, { version: '0.0.0' }));
+    expect(sarif.runs[0].results).toEqual([]);
+    expect(sarif.runs[0].tool.driver.rules).toEqual([]);
+  });
+
+  it('emits a dynamic finding only when treatDynamicAs penalizes it', () => {
+    const dyn: Result[] = [
+      {
+        id: 'SEO001',
+        severity: 'critical',
+        detection: { presence: 'own', value: 'dynamic' },
+        route: '/d',
+        location: 'src/routes/d/+page.svelte',
+        message: '<title>'
+      }
+    ];
+    expect(JSON.parse(formatSarifReport(dyn, config, { version: '0' })).runs[0].results).toEqual([]);
+    const warned = JSON.parse(formatSarifReport(dyn, defineConfig({ treatDynamicAs: 'warn' }), { version: '0' }));
+    expect(warned.runs[0].results[0].level).toBe('warning'); // effectiveSeverity → warning
+  });
+});


### PR DESCRIPTION
## What

Adds two GitHub-native reporters to svelte-vitals so findings flow into CI / PR review with no human translation. Part of #18 (AI-agent-native output), sequence 2.

- **`--reporter sarif`** — emits SARIF 2.1.0 to stdout. Redirect to a file and upload via `github/codeql-action/upload-sarif` to surface findings as persistent code-scanning alerts in the Security tab.
- **`--reporter github`** — emits GitHub Actions workflow commands (`::error/::warning/::notice`). GitHub turns these into inline PR-diff annotations and run annotations. **Auto-selected under GitHub Actions** (`GITHUB_ACTIONS`), so `npx svelte-vitals` in a workflow just works.

## How

- New pure formatters in `@svelte-vitals/core`: `formatSarifReport(results, config, {version})` and `formatGithubReport(results, config)`, mirroring the existing `console`/`json`/`agent` reporters. A shared `reporter/shared.ts` holds the severity maps, `messageText`, and a rule-metadata lookup (titles/severities sourced from `allRules`, single source of truth).
- Both emit only **penalized** findings (`isPenalized`), consistent with the JSON reporter's issues.
- SARIF level map: critical→error / warning→warning / info→note. GitHub level map: critical→error / warning→warning / info→notice. Per-result level uses `effectiveSeverity` (warn-dynamic → warning); the SARIF rules table's `defaultConfiguration.level` uses the rule's static severity.
- Findings without a `location` (project-scoped robots/sitemap/html-lang) omit SARIF `locations` / the GitHub `file=` property — the reporters hold no rule-specific knowledge.
- GitHub workflow-command escaping is spec-exact (`%`→%25 first, then `\r`/`\n`; property values additionally `:`→%3A, `,`→%2C).
- CLI `resolveReporter` precedence: explicit flag → `SVELTE_VITALS_REPORTER` → agent env (`agent`) → `GITHUB_ACTIONS` (`github`) → `console`. Agent env outranks GitHub Actions. A one-line stderr hint is printed when `github` is auto-selected.

## Scope (intentionally out)

Line/column regions (file-level location is correct for "tag absent" findings), `--out <file>` (stdout redirect suffices), plugin-mode emission, `$GITHUB_STEP_SUMMARY` writing.

## Testing

Built via brainstorming → writing-plans → subagent-driven-development (6 tasks, per-task spec+quality review, final whole-branch review = ready to merge). Full suite green: **165 tests** (core 63 / cli 84 / vite 18), typecheck clean, prettier + eslint pass. New tests cover SARIF envelope/rules-dedup/level-map/locations/fingerprints/empty-log/penalized-filter, GitHub level-map/file-omission/escaping/empty-output, and CLI resolution + run-loop wiring + `GITHUB_ACTIONS` auto-detect (agent outranks it).

Changeset: minor bump for `@svelte-vitals/core` and `svelte-vitals`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SARIF 2.1.0 reporter for GitHub code scanning integration via `--reporter sarif`
  * Added GitHub Actions reporter for inline PR annotations via `--reporter github`
  * Automatic reporter detection when running in GitHub Actions environments
  * Updated CLI help to list all available reporters

* **Documentation**
  * Added GitHub integration guide covering auto-detection and reporter override options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->