### PR TITLE
docs: sync README roadmap & status with shipped reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npx svelte-vitals
 ```
 
 > [!WARNING]
-> **Pre-1.0 — not recommended for production use yet.** Development is moving fast and aggressively: APIs, rule IDs, scoring, and output formats can change at any time, including breaking changes between minor releases. Feel free to experiment and share feedback, but hold off on relying on it in critical pipelines until `1.0`.
+> **Pre-1.0 — not recommended for production use yet.** Development is moving fast and aggressively, driven at the maintainer's discretion until `1.0`: APIs, rule IDs, scoring, and output formats can change at any time, including breaking changes between minor releases. Relying on it in critical pipelines is discouraged until `1.0`.
 >
 > See the [roadmap](#roadmap) for what's available and what's planned.
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@
 npx svelte-vitals
 ```
 
-> [!NOTE]
-> **Pre-1.0.** Static mode (SEO001–SEO009 + scoring), plugin mode (`@svelte-vitals/vite`), and the `console` / `json` / `agent` / `sarif` / `github` reporters all ship today. A dev overlay, `--fix`, an MCP server, and more categories are on the [roadmap](#roadmap). APIs and output may change before `1.0`.
+> [!WARNING]
+> **Pre-1.0 — not recommended for production use yet.** Development is moving fast and aggressively: APIs, rule IDs, scoring, and output formats can change at any time, including breaking changes between minor releases. Feel free to experiment and share feedback, but hold off on relying on it in critical pipelines until `1.0`.
+>
+> Static mode (SEO001–SEO009 + scoring), plugin mode (`@svelte-vitals/vite`), and the `console` / `json` / `agent` / `sarif` / `github` reporters all ship today. A dev overlay, `--fix`, an MCP server, and more categories are on the [roadmap](#roadmap).
 
 ## Why
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npx svelte-vitals
 ```
 
 > [!NOTE]
-> **Early development.** The CLI currently ships the static-mode foundation and the first SEO rule (`<title>` presence). More rules, scoring, and the build-time plugin are on the [roadmap](#roadmap). APIs and output may change before `1.0`.
+> **Pre-1.0.** Static mode (SEO001–SEO009 + scoring), plugin mode (`@svelte-vitals/vite`), and the `console` / `json` / `agent` / `sarif` / `github` reporters all ship today. A dev overlay, `--fix`, an MCP server, and more categories are on the [roadmap](#roadmap). APIs and output may change before `1.0`.
 
 ## Why
 
@@ -116,12 +116,20 @@ A dynamic title such as `<title>{data.title}</title>` — the most common and co
 
 ## Roadmap
 
-The project advances along two axes: **mode maturity** and **category coverage**.
+The project advances along two axes: **mode maturity** and **category coverage**. SEO is the first category; more follow.
 
-- **v0.1 — Static mode / SEO** _(current)_ — zero-config `npx svelte-vitals`, all routes analyzed shallowly.
-- **v0.2 — Plugin mode** (`@svelte-vitals/vite`) — piggybacks on `vite build` and analyzes the prerendered HTML's `<head>`. Library-agnostic and exact; the real value for polished sites.
-- **v0.3 — Dev overlay** — warn in-place while developing via `transformPageChunk`.
-- **v0.4+ — Performance, Accessibility, Upgrade** categories, culminating in a combined Health Report.
+**Shipped**
+
+- **Static mode (CLI)** — zero-config `npx svelte-vitals`: resolves each route's effective `<head>`, runs SEO001–SEO009, scores per route and site-wide, and gates CI via exit codes.
+- **Plugin mode** (`@svelte-vitals/vite`) — piggybacks on `vite build` and analyzes the prerendered HTML's `<head>`. Library-agnostic and exact; the real value for polished sites.
+- **Agent & CI integration** — `console`, `json`, `agent` (Markdown remediation), `sarif` (GitHub code scanning), and `github` (inline PR annotations) reporters. The `agent` reporter auto-selects under AI-agent harnesses; `github` under GitHub Actions.
+
+**Upcoming**
+
+- **Dev overlay** ([#9](https://github.com/oekazuma/svelte-vitals/issues/9)) — warn in-place while developing via `transformPageChunk`, so dynamic routes are seen with real values as pages are visited.
+- **`--fix` autofix** ([#11](https://github.com/oekazuma/svelte-vitals/issues/11)) — generate/repair fixable findings (`robots.txt`, `sitemap.xml`, canonical).
+- **MCP server** ([#24](https://github.com/oekazuma/svelte-vitals/issues/24)) — expose svelte-vitals as a Model Context Protocol tool so agents can invoke it directly in their loop.
+- **More categories** ([#10](https://github.com/oekazuma/svelte-vitals/issues/10)) — Performance, Accessibility, and Upgrade checks, culminating in a combined Health Report at `1.0`.
 
 See the design document for the full vision.
 
@@ -131,7 +139,7 @@ See the design document for the full vision.
 | ---------------------------------------- | ----------------------------------------------------------- |
 | [`svelte-vitals`](./packages/cli)        | CLI + static mode (`npx svelte-vitals`)                     |
 | [`@svelte-vitals/core`](./packages/core) | Runtime-agnostic core: types, rule engine, scorer, reporter |
-| [`@svelte-vitals/vite`](./packages/vite) | Plugin mode (build-time). Stub — lands in v0.2              |
+| [`@svelte-vitals/vite`](./packages/vite) | Plugin mode (build-time): analyzes the prerendered `<head>` |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npx svelte-vitals
 > [!WARNING]
 > **Pre-1.0 — not recommended for production use yet.** Development is moving fast and aggressively: APIs, rule IDs, scoring, and output formats can change at any time, including breaking changes between minor releases. Feel free to experiment and share feedback, but hold off on relying on it in critical pipelines until `1.0`.
 >
-> Static mode (SEO001–SEO009 + scoring), plugin mode (`@svelte-vitals/vite`), and the `console` / `json` / `agent` / `sarif` / `github` reporters all ship today. A dev overlay, `--fix`, an MCP server, and more categories are on the [roadmap](#roadmap).
+> See the [roadmap](#roadmap) for what's available and what's planned.
 
 ## Why
 


### PR DESCRIPTION
## What

Docs-only sync of the README with what actually ships, plus the matching issue-tracker cleanup (done separately on the tracker).

The "Early development" note and the `v0.1/v0.2/...` roadmap predated most of the project: they still claimed only the `<title>` rule existed and that plugin mode was unshipped. In reality SEO001–SEO009, scoring, the `console`/`json`/`agent`/`sarif`/`github` reporters, and `@svelte-vitals/vite` (published) are all live.

## Changes

- **Pre-1.0 note** — restated to list what ships today vs what's on the roadmap.
- **Roadmap** — reframed from `v0.x` version labels (which collided with package semver) to **Shipped** vs **Upcoming** capability tiers. Remaining work links to issues: dev overlay (#9), `--fix` (#11), MCP server (#24), more categories (#10).
- **Packages table** — `@svelte-vitals/vite` is no longer described as a "stub — lands in v0.2".

## Related tracker cleanup (not in this PR)

- Closed #18 (agent-native epic) as its foundation shipped (metadata + agent/SARIF/GitHub reporters); spun the remaining MCP work out to #24.
- Retitled #9 / #10 to drop stale `v0.x` labels.

Docs-only — no code, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Updated development status messaging** from Early Development to Pre-1.0 with clarified capabilities
* **Restructured roadmap** to highlight shipped features (static/CLI mode, plugin mode, CI reporter integration) and upcoming items (dev overlay, auto-fix functionality, MCP server support)
* **Clarified Vite plugin availability** as an active feature with build-time analysis capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->