### PR TITLE
feat: MCP server (analyze / explain_rule) — closes #24

### DIFF
--- a/.changeset/mcp-server.md
+++ b/.changeset/mcp-server.md
@@ -4,4 +4,4 @@
 'svelte-vitals': minor
 ---
 
-Add `@svelte-vitals/mcp`, a Model Context Protocol server exposing `analyze` and `explain_rule` tools over stdio (#24). Core gains `buildJsonReport`, `explainRule`, `RuleInfo`, and `docsUrlFor`; the CLI gains `analyzeProject` for reuse.
+Add `@svelte-vitals/mcp`, a Model Context Protocol server exposing `analyze` and `explain_rule` tools over stdio (#24). Core gains `buildJsonReport`, `explainRule`, `RuleInfo`, and `docsUrlFor`; the JSON report's per-finding objects now include `docsUrl`; the CLI gains `analyzeProject` for reuse.

--- a/.changeset/mcp-server.md
+++ b/.changeset/mcp-server.md
@@ -1,0 +1,7 @@
+---
+'@svelte-vitals/mcp': minor
+'@svelte-vitals/core': minor
+'svelte-vitals': minor
+---
+
+Add `@svelte-vitals/mcp`, a Model Context Protocol server exposing `analyze` and `explain_rule` tools over stdio (#24). Core gains `buildJsonReport`, `explainRule`, `RuleInfo`, and `docsUrlFor`; the CLI gains `analyzeProject` for reuse.

--- a/README.md
+++ b/README.md
@@ -141,12 +141,11 @@ The project advances along two axes: **mode maturity** and **category coverage**
 - **Static mode (CLI)** — zero-config `npx svelte-vitals`: resolves each route's effective `<head>`, runs SEO001–SEO009, scores per route and site-wide, and gates CI via exit codes.
 - **Plugin mode** (`@svelte-vitals/vite`) — piggybacks on `vite build` and analyzes the prerendered HTML's `<head>`. Library-agnostic and exact; the real value for polished sites.
 - **Agent & CI integration** — `console`, `json`, `agent` (Markdown remediation), `sarif` (GitHub code scanning), and `github` (inline PR annotations) reporters. The `agent` reporter auto-selects under AI-agent harnesses; `github` under GitHub Actions.
+- **Dev overlay** (`@svelte-vitals/vite`) — warns in-place while developing via `transformPageChunk`, so dynamic routes are seen with real values as pages are visited.
+- **MCP server** (`@svelte-vitals/mcp`) — exposes `analyze` and `explain_rule` tools over stdio so an agent can run analysis in its tool loop and receive structured, fixable findings.
 
 **Upcoming**
 
-- **Dev overlay** ([#9](https://github.com/oekazuma/svelte-vitals/issues/9)) — warn in-place while developing via `transformPageChunk`, so dynamic routes are seen with real values as pages are visited.
-- **`--fix` autofix** ([#11](https://github.com/oekazuma/svelte-vitals/issues/11)) — generate/repair fixable findings (`robots.txt`, `sitemap.xml`, canonical).
-- **MCP server** ([#24](https://github.com/oekazuma/svelte-vitals/issues/24)) — expose svelte-vitals as a Model Context Protocol tool so agents can invoke it directly in their loop.
 - **More categories** ([#10](https://github.com/oekazuma/svelte-vitals/issues/10)) — Performance, Accessibility, and Upgrade checks, culminating in a combined Health Report at `1.0`.
 
 See the design document for the full vision.
@@ -158,6 +157,7 @@ See the design document for the full vision.
 | [`svelte-vitals`](./packages/cli)        | CLI + static mode (`npx svelte-vitals`)                     |
 | [`@svelte-vitals/core`](./packages/core) | Runtime-agnostic core: types, rule engine, scorer, reporter |
 | [`@svelte-vitals/vite`](./packages/vite) | Plugin mode (build-time): analyzes the prerendered `<head>` |
+| [`@svelte-vitals/mcp`](./packages/mcp)   | MCP server: run analysis inside an agent's tool loop        |
 
 ## Development
 

--- a/docs/superpowers/plans/2026-06-22-mcp-server.md
+++ b/docs/superpowers/plans/2026-06-22-mcp-server.md
@@ -23,11 +23,13 @@
 ### Task 1: Extract `buildJsonReport` in core
 
 **Files:**
+
 - Modify: `packages/core/src/reporter/json.ts`
 - Modify: `packages/core/src/index.ts`
 - Test: `packages/core/test/json-report.test.ts` (existing — extend)
 
 **Interfaces:**
+
 - Consumes: existing `computeScore`, `summarize`, `effectiveSeverity`, `isPenalized`, `Config`, `Result`.
 - Produces:
   - `interface JsonReport { version: string; score: number; scoreModel: ScoreModel; summary: Summary; routes: Array<{ route: string; score: number; issues: JsonIssue[] }>; siteIssues: JsonIssue[] }`
@@ -155,6 +157,7 @@ git commit -m "refactor(core): extract buildJsonReport from the json reporter"
 ### Task 2: Rule catalog — `rationale`/`fix` on `Rule`, `docsUrlFor`, `explainRule`
 
 **Files:**
+
 - Modify: `packages/core/src/rule.ts` (extend `Rule`, add `docsUrlFor`)
 - Modify: `packages/core/src/rules/seo/seo001-title.ts`
 - Modify: `packages/core/src/rules/seo/head-tag-rule.ts`
@@ -165,6 +168,7 @@ git commit -m "refactor(core): extract buildJsonReport from the json reporter"
 - Test: `packages/core/test/explain-rule.test.ts` (new)
 
 **Interfaces:**
+
 - Produces:
   - `Rule` gains `rationale: string` and `fix?: Fix`.
   - `function docsUrlFor(id: string): string` (in `rule.ts`) → `https://svelte-vitals.dev/rules/${id}`.
@@ -268,7 +272,8 @@ export const seo001Title: Rule = {
   category: 'seo',
   severity: 'critical',
   scope: 'route',
-  rationale: 'A unique, non-empty <title> is the single strongest on-page SEO signal and the text shown in search results and browser tabs.',
+  rationale:
+    'A unique, non-empty <title> is the single strongest on-page SEO signal and the text shown in search results and browser tabs.',
   fix: FIX,
   async check(ctx: RuleContext): Promise<Result[]> {
     return ctx.heads.map((head) => {
@@ -379,7 +384,8 @@ export const seo006Robots: Rule = {
   category: 'seo',
   severity: 'warning',
   scope: 'project',
-  rationale: 'robots.txt tells crawlers which paths they may fetch and points them to your sitemap; missing it leaves crawl behaviour to defaults.',
+  rationale:
+    'robots.txt tells crawlers which paths they may fetch and points them to your sitemap; missing it leaves crawl behaviour to defaults.',
   fix: SEO006_FIX,
   async check(ctx: RuleContext): Promise<Result[]> {
     const detection = ctx.project.hasRobotsTxt ? present : absent;
@@ -398,8 +404,8 @@ export const seo006Robots: Rule = {
 };
 ```
 
-  - SEO007 `rationale`: `'A sitemap.xml lists your URLs so search engines can discover and prioritise them, especially pages not well linked internally.'` — reuse the existing snippet/description as `SEO007_FIX`.
-  - SEO009 `rationale`: `'The <html lang> attribute declares the page language for search engines, screen readers, and translation tools.'` — reuse the existing snippet/description as `SEO009_FIX`.
+- SEO007 `rationale`: `'A sitemap.xml lists your URLs so search engines can discover and prioritise them, especially pages not well linked internally.'` — reuse the existing snippet/description as `SEO007_FIX`.
+- SEO009 `rationale`: `'The <html lang> attribute declares the page language for search engines, screen readers, and translation tools.'` — reuse the existing snippet/description as `SEO009_FIX`.
 
 - [ ] **Step 8: Add `explainRule`** in `packages/core/src/rules/index.ts` (append after the `allRules` array, before the re-export block):
 
@@ -470,10 +476,12 @@ git commit -m "feat(core): promote rule rationale/fix onto Rule and add explainR
 ### Task 3: Extract `analyzeProject` in the CLI
 
 **Files:**
+
 - Modify: `packages/cli/src/index.ts`
 - Test: `packages/cli/test/analyze-project.test.ts` (new)
 
 **Interfaces:**
+
 - Produces:
   - `interface AnalyzeOptions { cwd?: string; metaComponents?: string[]; treatDynamicAs?: 'pass'|'warn'|'fail'; route?: string; failOn?: Severity; rules?: Record<string, RuleSetting> }`
   - `interface AnalyzeResult { results: Result[]; config: Config; version: string }`
@@ -659,6 +667,7 @@ git commit -m "refactor(cli): extract analyzeProject for reuse by the MCP server
 ### Task 4: Scaffold `@svelte-vitals/mcp` + the `analyze` tool
 
 **Files:**
+
 - Modify: `pnpm-workspace.yaml` (add `@modelcontextprotocol/sdk` and `zod` to `catalog:`)
 - Create: `packages/mcp/package.json`
 - Create: `packages/mcp/tsconfig.json`
@@ -669,6 +678,7 @@ git commit -m "refactor(cli): extract analyzeProject for reuse by the MCP server
 - Test: `packages/mcp/test/analyze-tool.test.ts` (new)
 
 **Interfaces:**
+
 - Consumes: `analyzeProject`, `buildRulesConfig`, `findUnknownRuleIds`, `knownRuleIds`, `ProjectError` from `svelte-vitals`; `buildJsonReport` from `@svelte-vitals/core`.
 - Produces:
   - `analyzeInputShape` (a zod raw shape object) and `handleAnalyze(args): Promise<McpToolResult>` in `tools/analyze.ts`.
@@ -678,8 +688,8 @@ git commit -m "refactor(cli): extract analyzeProject for reuse by the MCP server
 - [ ] **Step 1: Add the deps to the catalog** — in `pnpm-workspace.yaml`, add under `catalog:` (alphabetical placement is fine):
 
 ```yaml
-  '@modelcontextprotocol/sdk': ^1.29.0
-  zod: ^4.4.3
+'@modelcontextprotocol/sdk': ^1.29.0
+zod: ^4.4.3
 ```
 
 - [ ] **Step 2: Create `packages/mcp/package.json`:**
@@ -842,9 +852,7 @@ export async function handleAnalyze(args: AnalyzeArgs): Promise<McpToolResult> {
   const ignore = args.ignore ?? [];
   const unknown = findUnknownRuleIds([...allow, ...ignore]);
   if (unknown.length > 0) {
-    return textError(
-      `Unknown rule id(s): ${unknown.join(', ')}. Known rule ids: ${knownRuleIds().join(', ')}.`
-    );
+    return textError(`Unknown rule id(s): ${unknown.join(', ')}. Known rule ids: ${knownRuleIds().join(', ')}.`);
   }
 
   try {
@@ -916,6 +924,7 @@ git commit -m "feat(mcp): scaffold @svelte-vitals/mcp with the analyze tool (#24
 ### Task 5: `explain_rule` tool, library entry, bin & smoke test
 
 **Files:**
+
 - Create: `packages/mcp/src/tools/explain-rule.ts`
 - Modify: `packages/mcp/src/server.ts`
 - Create: `packages/mcp/src/index.ts`
@@ -924,6 +933,7 @@ git commit -m "feat(mcp): scaffold @svelte-vitals/mcp with the analyze tool (#24
 - Test: `packages/mcp/test/server.test.ts` (new)
 
 **Interfaces:**
+
 - Consumes: `explainRule`, `knownRuleIds`-equivalent. (`knownRuleIds` lives in `svelte-vitals`; import it there.)
 - Produces: `explainRuleInputShape`, `handleExplainRule(args)`, `createServer` (now with two tools), `bin.ts` entry that starts a stdio server.
 
@@ -975,9 +985,7 @@ export async function handleExplainRule(args: ExplainRuleArgs): Promise<McpToolR
   const info = explainRule(args.id);
   if (!info) {
     return {
-      content: [
-        { type: 'text', text: `Unknown rule id: ${args.id}. Known rule ids: ${knownRuleIds().join(', ')}.` }
-      ],
+      content: [{ type: 'text', text: `Unknown rule id: ${args.id}. Known rule ids: ${knownRuleIds().join(', ')}.` }],
       isError: true
     };
   }
@@ -996,15 +1004,15 @@ import { explainRuleInputShape, handleExplainRule } from './tools/explain-rule.j
 ```
 
 ```ts
-  server.registerTool(
-    'explain_rule',
-    {
-      title: 'Explain an SEO rule',
-      description: 'Return a rule\'s title, category, default severity, rationale, docs URL, and fix template.',
-      inputSchema: explainRuleInputShape
-    },
-    async (args) => await handleExplainRule(args)
-  );
+server.registerTool(
+  'explain_rule',
+  {
+    title: 'Explain an SEO rule',
+    description: "Return a rule's title, category, default severity, rationale, docs URL, and fix template.",
+    inputSchema: explainRuleInputShape
+  },
+  async (args) => await handleExplainRule(args)
+);
 ```
 
 - [ ] **Step 5: Create the library entry `packages/mcp/src/index.ts`:**
@@ -1066,12 +1074,14 @@ Expected: no type errors; `dist/bin.js`, `dist/index.js`, `dist/index.d.ts` prod
 - [ ] **Step 10: Manual stdio smoke check** — verify the server speaks MCP over stdio (initialize + tools/list):
 
 Run:
+
 ```bash
 printf '%s\n%s\n' \
   '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}' \
   '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
   | node packages/mcp/dist/bin.js
 ```
+
 Expected: two JSON-RPC responses on stdout; the `tools/list` result lists `analyze` and `explain_rule`.
 
 - [ ] **Step 11: Commit**
@@ -1086,6 +1096,7 @@ git commit -m "feat(mcp): add explain_rule tool, stdio bin and library entry (#2
 ### Task 6: README, root scripts, changeset
 
 **Files:**
+
 - Modify: `README.md` (roadmap + packages table)
 - Modify: `package.json` (root — extend `check:publish` to include the mcp package)
 - Create: `packages/mcp/README.md`
@@ -1110,7 +1121,7 @@ And update the **Upcoming** list to:
 - [ ] **Step 2: Add the package to the packages table** in `README.md`:
 
 ```md
-| [`@svelte-vitals/mcp`](./packages/mcp)   | MCP server: run analysis inside an agent's tool loop        |
+| [`@svelte-vitals/mcp`](./packages/mcp) | MCP server: run analysis inside an agent's tool loop |
 ```
 
 - [ ] **Step 3: Create `packages/mcp/README.md`** — a short usage doc:
@@ -1180,6 +1191,7 @@ git commit -m "docs(mcp): document the MCP server, update roadmap, add changeset
 ## Self-Review
 
 **Spec coverage:**
+
 - New `@svelte-vitals/mcp` package, stdio, bin `svelte-vitals-mcp` → Task 4 (scaffold) + Task 5 (bin). ✅
 - `analyze` tool (structured JSON report, fix metadata, scores; unknown-rule + non-Kit errors) → Task 4. ✅
 - `explain_rule` tool (title/category/severity/rationale/docs/fix; unknown-id error) → Task 5. ✅

--- a/docs/superpowers/plans/2026-06-22-mcp-server.md
+++ b/docs/superpowers/plans/2026-06-22-mcp-server.md
@@ -1,0 +1,1194 @@
+# MCP server (`@svelte-vitals/mcp`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a stdio MCP server exposing `analyze` and `explain_rule` tools so an AI agent can run svelte-vitals' static-mode analysis inside its tool loop and get structured, fixable findings.
+
+**Architecture:** A new `@svelte-vitals/mcp` package adapts the existing pipeline. The CLI's analysis pipeline is extracted into `analyzeProject()`; core's JSON report is extracted into `buildJsonReport()`; rule metadata (`rationale`/`fix`) is promoted onto the `Rule` object and surfaced via `explainRule()`. The MCP layer only wires these into MCP tools — no rule logic is duplicated.
+
+**Tech Stack:** TypeScript (ESM-only), `@modelcontextprotocol/sdk` `^1.29.0`, `zod` `^4.4.3`, `tsup`, `vitest`, pnpm workspaces.
+
+## Global Constraints
+
+- **ESM-only.** Every package is `"type": "module"`; `tsup` emits `format: ['esm']` only. Never add CJS.
+- **Node ≥ 18.** Matches the MCP SDK's `engines`.
+- **`target: 'es2022'`** in `tsup.config.ts`, matching the other packages.
+- **core stays runtime-agnostic** — no `node:` imports, no I/O in `@svelte-vitals/core` (design §8). The MCP server's I/O goes through the CLI's Node runtime via `analyzeProject`.
+- **Dependency versions come from the workspace `catalog:`** in `pnpm-workspace.yaml` where one exists; add new shared deps to the catalog.
+- **Commit message trailer:** end each commit body with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- **Behaviour-preserving refactors:** Tasks 1 and 3 must not change any existing observable output; all existing tests stay green.
+
+---
+
+### Task 1: Extract `buildJsonReport` in core
+
+**Files:**
+- Modify: `packages/core/src/reporter/json.ts`
+- Modify: `packages/core/src/index.ts`
+- Test: `packages/core/test/json-report.test.ts` (existing — extend)
+
+**Interfaces:**
+- Consumes: existing `computeScore`, `summarize`, `effectiveSeverity`, `isPenalized`, `Config`, `Result`.
+- Produces:
+  - `interface JsonReport { version: string; score: number; scoreModel: ScoreModel; summary: Summary; routes: Array<{ route: string; score: number; issues: JsonIssue[] }>; siteIssues: JsonIssue[] }`
+  - `function buildJsonReport(results: Result[], config: Config, meta: { version: string }): JsonReport`
+  - `formatJsonReport` keeps its existing signature and output.
+
+- [ ] **Step 1: Read the current file** `packages/core/test/json-report.test.ts` to learn the existing assertions and the exact report shape they expect (so the extraction stays behaviour-identical).
+
+- [ ] **Step 2: Write the failing test** — add to `packages/core/test/json-report.test.ts`:
+
+```ts
+import { buildJsonReport, formatJsonReport } from '../src/index.js';
+// ...reuse whatever `results`/`config` fixture the existing tests build...
+
+it('buildJsonReport returns the object formatJsonReport stringifies', () => {
+  const report = buildJsonReport(results, config, { version: '9.9.9' });
+  expect(report.version).toBe('9.9.9');
+  expect(report).toHaveProperty('score');
+  expect(report).toHaveProperty('scoreModel');
+  expect(report).toHaveProperty('summary');
+  expect(Array.isArray(report.routes)).toBe(true);
+  expect(Array.isArray(report.siteIssues)).toBe(true);
+  expect(formatJsonReport(results, config, { version: '9.9.9' })).toBe(JSON.stringify(report, null, 2));
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `pnpm --filter @svelte-vitals/core test -- json-report`
+Expected: FAIL — `buildJsonReport is not a function` (not yet exported).
+
+- [ ] **Step 4: Refactor `json.ts`** — split the builder from the stringifier. Replace the file body so the object construction lives in `buildJsonReport` and `formatJsonReport` just stringifies it:
+
+```ts
+import type { Config, Result } from '../types.js';
+import { computeScore, type ScoreModel } from '../scoring/score.js';
+import { summarize, effectiveSeverity, type Summary } from '../summary.js';
+import { isPenalized } from '../rule.js';
+
+function issueOf(result: Result) {
+  return {
+    id: result.id,
+    title: result.message,
+    detection: result.detection,
+    location: result.location,
+    recommendation: result.recommendation,
+    ...(result.fix ? { fix: result.fix } : {})
+  };
+}
+
+type JsonIssue = ReturnType<typeof issueOf> & { severity: ReturnType<typeof effectiveSeverity> };
+
+export interface JsonReport {
+  version: string;
+  score: number;
+  scoreModel: ScoreModel;
+  summary: Summary;
+  routes: Array<{ route: string; score: number; issues: JsonIssue[] }>;
+  siteIssues: JsonIssue[];
+}
+
+/** Build the structured JSON report object (design §7). Shared by the json reporter and the MCP `analyze` tool. */
+export function buildJsonReport(results: Result[], config: Config, meta: { version: string }): JsonReport {
+  const { score, scoreModel } = computeScore(results, config);
+  const summary = summarize(results, config);
+
+  const routeMap = new Map<string, { route: string; results: Result[] }>();
+  for (const r of results) {
+    if (r.route === undefined) continue;
+    if (!routeMap.has(r.route)) routeMap.set(r.route, { route: r.route, results: [] });
+    routeMap.get(r.route)!.results.push(r);
+  }
+
+  const routes = [...routeMap.values()]
+    .sort((a, b) => a.route.localeCompare(b.route))
+    .map(({ route, results: rs }) => ({
+      route,
+      score: computeScore(rs, config, { applyCriticalCap: false }).score,
+      issues: rs
+        .filter((r) => isPenalized(r.detection, config.treatDynamicAs))
+        .map((r) => ({ ...issueOf(r), severity: effectiveSeverity(r, config) }))
+    }));
+
+  const siteIssues = results
+    .filter((r) => r.route === undefined && isPenalized(r.detection, config.treatDynamicAs))
+    .map((r) => ({ ...issueOf(r), severity: effectiveSeverity(r, config) }));
+
+  return { version: meta.version, score, scoreModel, summary, routes, siteIssues };
+}
+
+/** Render results as the documented JSON report string (design §7). */
+export function formatJsonReport(results: Result[], config: Config, meta: { version: string }): string {
+  return JSON.stringify(buildJsonReport(results, config, meta), null, 2);
+}
+```
+
+> Note: confirm `ScoreModel` is exported from `./scoring/score.js` and `Summary` from `./summary.js` (both are re-exported by `index.ts` today, so the source modules export them).
+
+- [ ] **Step 5: Export the new symbols** — in `packages/core/src/index.ts`, change the json-reporter export line:
+
+```ts
+export { buildJsonReport, formatJsonReport } from './reporter/json.js';
+export type { JsonReport } from './reporter/json.js';
+```
+
+- [ ] **Step 6: Run core tests**
+
+Run: `pnpm --filter @svelte-vitals/core test`
+Expected: PASS (new test + all existing json-report assertions unchanged).
+
+- [ ] **Step 7: Typecheck**
+
+Run: `pnpm --filter @svelte-vitals/core typecheck`
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/core/src/reporter/json.ts packages/core/src/index.ts packages/core/test/json-report.test.ts
+git commit -m "refactor(core): extract buildJsonReport from the json reporter"
+```
+
+---
+
+### Task 2: Rule catalog — `rationale`/`fix` on `Rule`, `docsUrlFor`, `explainRule`
+
+**Files:**
+- Modify: `packages/core/src/rule.ts` (extend `Rule`, add `docsUrlFor`)
+- Modify: `packages/core/src/rules/seo/seo001-title.ts`
+- Modify: `packages/core/src/rules/seo/head-tag-rule.ts`
+- Modify: `packages/core/src/rules/seo/seo002-005-008.ts`
+- Modify: `packages/core/src/rules/seo/project-rules.ts`
+- Modify: `packages/core/src/rules/index.ts` (add `explainRule`)
+- Modify: `packages/core/src/index.ts` (exports)
+- Test: `packages/core/test/explain-rule.test.ts` (new)
+
+**Interfaces:**
+- Produces:
+  - `Rule` gains `rationale: string` and `fix?: Fix`.
+  - `function docsUrlFor(id: string): string` (in `rule.ts`) → `https://svelte-vitals.dev/rules/${id}`.
+  - `interface RuleInfo { id: string; title: string; category: Category; severity: Severity; rationale: string; docsUrl: string; fix?: Fix }`
+  - `function explainRule(id: string): RuleInfo | undefined` (in `rules/index.ts`).
+- Consumes: `allRules` (existing).
+
+- [ ] **Step 1: Write the failing test** — `packages/core/test/explain-rule.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { explainRule, allRules } from '../src/index.js';
+
+describe('explainRule', () => {
+  it('returns info for a known rule id', () => {
+    const info = explainRule('SEO001');
+    expect(info).toBeDefined();
+    expect(info!.id).toBe('SEO001');
+    expect(info!.severity).toBe('critical');
+    expect(info!.docsUrl).toBe('https://svelte-vitals.dev/rules/SEO001');
+    expect(info!.rationale.length).toBeGreaterThan(0);
+    expect(info!.fix?.description.length).toBeGreaterThan(0);
+  });
+
+  it('returns undefined for an unknown id', () => {
+    expect(explainRule('NOPE999')).toBeUndefined();
+  });
+
+  it('every built-in rule has a non-empty rationale and a derivable docs url', () => {
+    for (const rule of allRules) {
+      const info = explainRule(rule.id);
+      expect(info, rule.id).toBeDefined();
+      expect(info!.rationale.length, `${rule.id} rationale`).toBeGreaterThan(0);
+      expect(info!.docsUrl).toBe(`https://svelte-vitals.dev/rules/${rule.id}`);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `pnpm --filter @svelte-vitals/core test -- explain-rule`
+Expected: FAIL — `explainRule is not a function`.
+
+- [ ] **Step 3: Extend `Rule` and add `docsUrlFor`** — in `packages/core/src/rule.ts`:
+
+Add `Fix` to the type import and extend the interface:
+
+```ts
+import type { Category, Config, Detection, Fix, Project, Result, Scope, Severity, TreatDynamicAs } from './types.js';
+```
+
+```ts
+export interface Rule {
+  id: string;
+  title: string;
+  category: Category;
+  severity: Severity;
+  scope: Scope;
+  /** Why this rule matters — one or two sentences, surfaced by explain_rule (issue #24). */
+  rationale: string;
+  /** Canonical remediation template, shared by findings and explain_rule (issue #24). */
+  fix?: Fix;
+  check(ctx: RuleContext): Promise<Result[]>;
+}
+
+/** Documentation URL for a rule id. Single source so no per-rule URL can drift (issue #24). */
+export function docsUrlFor(id: string): string {
+  return `https://svelte-vitals.dev/rules/${id}`;
+}
+```
+
+- [ ] **Step 4: Refactor `seo001-title.ts`** to carry `rationale`/`fix` on the rule and reference them in `check()`:
+
+```ts
+import type { Result, Detection, Fix } from '../../types.js';
+import type { HeadTag, ResolvedHead } from '../../head.js';
+import { docsUrlFor, type Rule, type RuleContext } from '../../rule.js';
+
+const FIX: Fix = {
+  description: 'Add a <title> inside <svelte:head> (a dynamic title is fine).',
+  snippet: '<svelte:head>\n  <title>{data.title}</title>\n</svelte:head>',
+  lang: 'svelte'
+};
+
+function detectTitle(head: ResolvedHead): Detection {
+  const title: HeadTag | undefined = head.tags.find((t) => t.kind === 'title');
+  if (!title) return { presence: 'none', value: 'absent' };
+  return { presence: title.presence, value: title.value };
+}
+
+function messageFor(detection: Detection): string {
+  if (detection.presence === 'none') return 'Missing <title>';
+  if (detection.value === 'absent') return 'Empty <title>';
+  return '<title>';
+}
+
+export const seo001Title: Rule = {
+  id: 'SEO001',
+  title: 'Title presence',
+  category: 'seo',
+  severity: 'critical',
+  scope: 'route',
+  rationale: 'A unique, non-empty <title> is the single strongest on-page SEO signal and the text shown in search results and browser tabs.',
+  fix: FIX,
+  async check(ctx: RuleContext): Promise<Result[]> {
+    return ctx.heads.map((head) => {
+      const detection = detectTitle(head);
+      return {
+        id: 'SEO001',
+        severity: 'critical',
+        detection,
+        route: head.route,
+        location: head.file,
+        message: messageFor(detection),
+        recommendation:
+          'Add a <title> inside <svelte:head>, e.g. <title>{data.title}</title>, or set it via your meta component.',
+        docsUrl: docsUrlFor('SEO001'),
+        fix: { ...FIX }
+      } satisfies Result;
+    });
+  }
+};
+```
+
+- [ ] **Step 5: Refactor `head-tag-rule.ts`** so the factory takes `rationale`, sets `rationale`/`fix` on the rule object, and derives `docsUrl`:
+
+```ts
+import type { Detection, Fix, Result, Severity } from '../../types.js';
+import type { HeadTag, ResolvedHead } from '../../head.js';
+import { docsUrlFor, type Rule, type RuleContext } from '../../rule.js';
+
+export interface HeadTagRuleOptions {
+  id: string;
+  title: string;
+  severity: Severity;
+  match: (tag: HeadTag) => boolean;
+  label: string;
+  recommendation: string;
+  /** Why this rule matters — surfaced by explain_rule (issue #24). */
+  rationale: string;
+  fix?: Fix;
+}
+
+function detect(head: ResolvedHead, match: (t: HeadTag) => boolean): Detection {
+  const tag = head.tags.find(match);
+  return tag ? { presence: tag.presence, value: tag.value } : { presence: 'none', value: 'absent' };
+}
+
+/** Build a route-scope rule asserting the presence of a single head tag (design §11). */
+export function headTagRule(opts: HeadTagRuleOptions): Rule {
+  const docsUrl = docsUrlFor(opts.id);
+  return {
+    id: opts.id,
+    title: opts.title,
+    category: 'seo',
+    severity: opts.severity,
+    scope: 'route',
+    rationale: opts.rationale,
+    ...(opts.fix ? { fix: opts.fix } : {}),
+    async check(ctx: RuleContext): Promise<Result[]> {
+      return ctx.heads.map((head) => {
+        const detection = detect(head, opts.match);
+        const message =
+          detection.presence === 'none'
+            ? `Missing ${opts.label}`
+            : detection.value === 'absent'
+              ? `Empty ${opts.label}`
+              : opts.label;
+        return {
+          id: opts.id,
+          severity: opts.severity,
+          detection,
+          route: head.route,
+          location: head.file,
+          message,
+          recommendation: opts.recommendation,
+          docsUrl,
+          ...(opts.fix ? { fix: { ...opts.fix } } : {})
+        } satisfies Result;
+      });
+    }
+  };
+}
+```
+
+- [ ] **Step 6: Add `rationale` to each `headTagRule(...)` call** in `packages/core/src/rules/seo/seo002-005-008.ts`. Insert a `rationale` field into each of the five option objects (keep everything else). Use:
+  - SEO002: `rationale: 'A meta description is the snippet search engines show under your title; without one they invent one from page text, often poorly.'`
+  - SEO003: `rationale: 'A canonical URL tells search engines which URL is authoritative, preventing duplicate-content dilution across query strings and trailing-slash variants.'`
+  - SEO004: `rationale: 'og:image is the preview thumbnail shown when the page is shared on social platforms; without it links render bare and get fewer clicks.'`
+  - SEO005: `rationale: 'og:title controls the headline shown when the page is shared on social platforms, independent of the document <title>.'`
+  - SEO008: `rationale: 'JSON-LD structured data lets search engines render rich results (breadcrumbs, articles, products) for the page.'`
+
+- [ ] **Step 7: Refactor `project-rules.ts`** to carry `rationale`/`fix` on each rule and reference them (use `docsUrlFor`). For each of `seo006Robots`, `seo007Sitemap`, `seo009HtmlLang`, lift the inline `fix` into a module const, set `rationale` + `fix` on the rule object, and emit `fix: { ...FIX }` + `docsUrl: docsUrlFor(id)` in `check()`. Example for SEO006 (apply the same shape to 007 and 009):
+
+```ts
+import type { Detection, Fix, Result } from '../../types.js';
+import { docsUrlFor, type Rule, type RuleContext } from '../../rule.js';
+
+const present: Detection = { presence: 'own', value: 'static' };
+const absent: Detection = { presence: 'none', value: 'absent' };
+
+const SEO006_FIX: Fix = {
+  description: 'Create static/robots.txt (or a src/routes/robots.txt/+server endpoint).',
+  snippet: 'User-agent: *\nAllow: /\n\nSitemap: https://example.com/sitemap.xml',
+  lang: 'text'
+};
+
+export const seo006Robots: Rule = {
+  id: 'SEO006',
+  title: 'robots.txt',
+  category: 'seo',
+  severity: 'warning',
+  scope: 'project',
+  rationale: 'robots.txt tells crawlers which paths they may fetch and points them to your sitemap; missing it leaves crawl behaviour to defaults.',
+  fix: SEO006_FIX,
+  async check(ctx: RuleContext): Promise<Result[]> {
+    const detection = ctx.project.hasRobotsTxt ? present : absent;
+    return [
+      {
+        id: 'SEO006',
+        severity: 'warning',
+        detection,
+        message: ctx.project.hasRobotsTxt ? 'robots.txt' : 'Missing robots.txt',
+        recommendation: 'Add static/robots.txt or a src/routes/robots.txt/+server endpoint.',
+        docsUrl: docsUrlFor('SEO006'),
+        fix: { ...SEO006_FIX }
+      }
+    ];
+  }
+};
+```
+
+  - SEO007 `rationale`: `'A sitemap.xml lists your URLs so search engines can discover and prioritise them, especially pages not well linked internally.'` — reuse the existing snippet/description as `SEO007_FIX`.
+  - SEO009 `rationale`: `'The <html lang> attribute declares the page language for search engines, screen readers, and translation tools.'` — reuse the existing snippet/description as `SEO009_FIX`.
+
+- [ ] **Step 8: Add `explainRule`** in `packages/core/src/rules/index.ts` (append after the `allRules` array, before the re-export block):
+
+```ts
+import type { Category, Fix, Severity } from '../types.js';
+import { docsUrlFor } from '../rule.js';
+
+export interface RuleInfo {
+  id: string;
+  title: string;
+  category: Category;
+  severity: Severity;
+  rationale: string;
+  docsUrl: string;
+  fix?: Fix;
+}
+
+/** Look up a rule's static metadata for the MCP explain_rule tool (issue #24). */
+export function explainRule(id: string): RuleInfo | undefined {
+  const rule = allRules.find((r) => r.id === id);
+  if (!rule) return undefined;
+  return {
+    id: rule.id,
+    title: rule.title,
+    category: rule.category,
+    severity: rule.severity,
+    rationale: rule.rationale,
+    docsUrl: docsUrlFor(rule.id),
+    ...(rule.fix ? { fix: rule.fix } : {})
+  };
+}
+```
+
+- [ ] **Step 9: Export the new symbols** in `packages/core/src/index.ts`:
+
+```ts
+export { isPenalized, docsUrlFor } from './rule.js';
+```
+
+and in the rules export block add `explainRule` plus the type:
+
+```ts
+export { allRules, explainRule, seo001Title, /* …unchanged… */ seo009HtmlLang } from './rules/index.js';
+export type { RuleInfo } from './rules/index.js';
+```
+
+> The current `index.ts` imports `allRules`/rules from `./rules/index.js` in a single statement — add `explainRule` to that list and a separate `export type { RuleInfo }` line.
+
+- [ ] **Step 10: Run core tests**
+
+Run: `pnpm --filter @svelte-vitals/core test`
+Expected: PASS — new `explain-rule` test plus all existing tests (rule-fixes, project-rules, json-report, agent/sarif/github reporters) unchanged, since `recommendation`/`docsUrl`/`fix` emitted by `check()` are byte-identical to before.
+
+- [ ] **Step 11: Typecheck**
+
+Run: `pnpm --filter @svelte-vitals/core typecheck`
+Expected: no errors.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add packages/core/src packages/core/test/explain-rule.test.ts
+git commit -m "feat(core): promote rule rationale/fix onto Rule and add explainRule (#24)"
+```
+
+---
+
+### Task 3: Extract `analyzeProject` in the CLI
+
+**Files:**
+- Modify: `packages/cli/src/index.ts`
+- Test: `packages/cli/test/analyze-project.test.ts` (new)
+
+**Interfaces:**
+- Produces:
+  - `interface AnalyzeOptions { cwd?: string; metaComponents?: string[]; treatDynamicAs?: 'pass'|'warn'|'fail'; route?: string; failOn?: Severity; rules?: Record<string, RuleSetting> }`
+  - `interface AnalyzeResult { results: Result[]; config: Config; version: string }`
+  - `function analyzeProject(opts?: AnalyzeOptions): Promise<AnalyzeResult>` — throws `ProjectError` for a non-Kit dir.
+  - Re-exports `buildRulesConfig`, `findUnknownRuleIds`, `knownRuleIds` from `./rules-config.js`, and `ProjectError` from the project provider.
+- Consumes: `analyzeProject` is used by `run()` (refactored) and later by the MCP package.
+
+- [ ] **Step 1: Read** `packages/cli/src/index.ts` again to confirm the exact pipeline lines being moved.
+
+- [ ] **Step 2: Write the failing test** — `packages/cli/test/analyze-project.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { analyzeProject } from '../src/index.js';
+import { ProjectError } from '../src/providers/source/project.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixtureDir = join(here, 'fixtures', 'basic-project');
+
+describe('analyzeProject', () => {
+  it('returns results, config and version for a SvelteKit project', async () => {
+    const { results, config, version } = await analyzeProject({ cwd: fixtureDir });
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.some((r) => r.id === 'SEO001')).toBe(true);
+    expect(config.treatDynamicAs).toBe('pass');
+    expect(typeof version).toBe('string');
+  });
+
+  it('respects the route glob filter', async () => {
+    const { results } = await analyzeProject({ cwd: fixtureDir, route: 'none' });
+    const routes = new Set(results.filter((r) => r.route).map((r) => r.route));
+    for (const route of routes) expect(route).toBe('/none');
+  });
+
+  it('throws ProjectError for a non-SvelteKit directory', async () => {
+    await expect(analyzeProject({ cwd: here })).rejects.toBeInstanceOf(ProjectError);
+  });
+});
+```
+
+> Confirm the fixture's route paths in `packages/cli/test/fixtures/basic-project` (the existing `run.test.ts` references `/none` and `/dynamic`). Adjust the glob/route assertion to a route that actually exists if needed.
+
+- [ ] **Step 3: Run it to verify it fails**
+
+Run: `pnpm --filter svelte-vitals test -- analyze-project`
+Expected: FAIL — `analyzeProject is not a function`.
+
+- [ ] **Step 4: Refactor `index.ts`** — extract the pipeline. Replace the current `run()` body so the analysis lives in `analyzeProject` and `run()` consumes it. New code:
+
+```ts
+export interface AnalyzeOptions {
+  cwd?: string;
+  metaComponents?: string[];
+  treatDynamicAs?: 'pass' | 'warn' | 'fail';
+  route?: string;
+  failOn?: Severity;
+  rules?: Record<string, RuleSetting>;
+}
+
+export interface AnalyzeResult {
+  results: Result[];
+  config: Config;
+  version: string;
+}
+
+/**
+ * Run static-mode analysis and return the structured findings + resolved config.
+ * Throws ProjectError when `cwd` is not a SvelteKit project. Shared by the CLI's
+ * run() and by @svelte-vitals/mcp (issue #24).
+ */
+export async function analyzeProject(opts: AnalyzeOptions = {}): Promise<AnalyzeResult> {
+  const cwd = opts.cwd ?? process.cwd();
+  const rt = createNodeRuntime();
+  const config = defineConfig({
+    treatDynamicAs: opts.treatDynamicAs ?? 'pass',
+    metaComponents: opts.metaComponents ?? [],
+    rules: opts.rules ?? {},
+    failOn: opts.failOn ?? 'critical'
+  });
+
+  await detectProject(rt, cwd); // throws ProjectError if not a SvelteKit project
+
+  const matches = routeMatcher(opts.route);
+  const heads = (await sourceHeadProvider.collect(rt, cwd, config)).filter((h) => matches(h.route));
+  const project = await collectProjectFacts(rt, cwd);
+  const rules = selectRules(allRules, config);
+  const results = applyRuleSeverities(await runRules(rules, { heads, project, config }), config);
+  return { results, config, version: readPackageVersion() };
+}
+```
+
+Then rewrite `run()` to delegate (preserving the exact error mapping and reporter logic):
+
+```ts
+export async function run(opts: RunOptions = {}): Promise<number> {
+  const log = opts.log ?? ((line: string) => console.log(line));
+  const errorLog = opts.errorLog ?? ((line: string) => console.error(line));
+
+  let analysis: AnalyzeResult;
+  try {
+    analysis = await analyzeProject({
+      cwd: opts.cwd ?? process.cwd(),
+      metaComponents: opts.metaComponents,
+      treatDynamicAs: opts.treatDynamicAs,
+      route: opts.route,
+      failOn: opts.failOn,
+      rules: opts.rules
+    });
+  } catch (err) {
+    if (err instanceof ProjectError) {
+      errorLog(err.message);
+      return 2;
+    }
+    errorLog(`svelte-vitals: ${err instanceof Error ? err.message : String(err)}`);
+    return 2;
+  }
+
+  try {
+    const { results, config, version } = analysis;
+    const env = opts.env ?? process.env;
+    const reporter = resolveReporter(opts.reporter, env);
+    if (reporter === 'agent' && isAutoDetectedAgent(opts.reporter, env)) {
+      errorLog(
+        'svelte-vitals: agent reporter auto-selected (AI-agent env detected); override with --reporter console|json.'
+      );
+    }
+    if (reporter === 'github' && isAutoDetectedGithub(opts.reporter, env)) {
+      errorLog(
+        'svelte-vitals: github reporter auto-selected (GitHub Actions detected); override with --reporter console|json|sarif.'
+      );
+    }
+    if (reporter === 'json') {
+      log(formatJsonReport(results, config, { version }));
+    } else if (reporter === 'agent') {
+      log(formatAgentReport(results, config));
+    } else if (reporter === 'sarif') {
+      log(formatSarifReport(results, config, { version }));
+    } else if (reporter === 'github') {
+      const output = formatGithubReport(results, config);
+      if (output) log(output);
+    } else {
+      log(formatConsoleReport(results, config, { byRoute: opts.byRoute ?? false }));
+    }
+    const summary = summarize(results, config);
+    return hasFailureAtOrAbove(summary, config.failOn) ? 1 : 0;
+  } catch (err) {
+    errorLog(`svelte-vitals: ${err instanceof Error ? err.message : String(err)}`);
+    return 2;
+  }
+}
+```
+
+> Update imports at the top of `index.ts`: add `type Result`, `type Config` to the `@svelte-vitals/core` import; ensure `ProjectError` is imported from `./providers/source/project.js` (it already is, alongside `detectProject`/`collectProjectFacts`). `readPackageVersion` is already imported.
+
+- [ ] **Step 5: Re-export helpers for the MCP package** — append to `packages/cli/src/index.ts`:
+
+```ts
+export { ProjectError } from './providers/source/project.js';
+export { buildRulesConfig, findUnknownRuleIds, knownRuleIds } from './rules-config.js';
+```
+
+- [ ] **Step 6: Run the full CLI test suite** (the existing `run.test.ts` must stay green — this proves the refactor preserved behaviour):
+
+Run: `pnpm --filter svelte-vitals test`
+Expected: PASS — `analyze-project` test + all existing `run()` tests.
+
+- [ ] **Step 7: Typecheck**
+
+Run: `pnpm --filter svelte-vitals typecheck`
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/cli/src/index.ts packages/cli/test/analyze-project.test.ts
+git commit -m "refactor(cli): extract analyzeProject for reuse by the MCP server (#24)"
+```
+
+---
+
+### Task 4: Scaffold `@svelte-vitals/mcp` + the `analyze` tool
+
+**Files:**
+- Modify: `pnpm-workspace.yaml` (add `@modelcontextprotocol/sdk` and `zod` to `catalog:`)
+- Create: `packages/mcp/package.json`
+- Create: `packages/mcp/tsconfig.json`
+- Create: `packages/mcp/tsup.config.ts`
+- Create: `packages/mcp/src/tools/analyze.ts`
+- Create: `packages/mcp/src/server.ts`
+- Create: `packages/mcp/src/bin.ts`
+- Test: `packages/mcp/test/analyze-tool.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `analyzeProject`, `buildRulesConfig`, `findUnknownRuleIds`, `knownRuleIds`, `ProjectError` from `svelte-vitals`; `buildJsonReport` from `@svelte-vitals/core`.
+- Produces:
+  - `analyzeInputShape` (a zod raw shape object) and `handleAnalyze(args): Promise<McpToolResult>` in `tools/analyze.ts`.
+  - `type McpToolResult = { content: Array<{ type: 'text'; text: string }>; structuredContent?: unknown; isError?: boolean }`.
+  - `createServer(): McpServer` in `server.ts`.
+
+- [ ] **Step 1: Add the deps to the catalog** — in `pnpm-workspace.yaml`, add under `catalog:` (alphabetical placement is fine):
+
+```yaml
+  '@modelcontextprotocol/sdk': ^1.29.0
+  zod: ^4.4.3
+```
+
+- [ ] **Step 2: Create `packages/mcp/package.json`:**
+
+```json
+{
+  "name": "@svelte-vitals/mcp",
+  "version": "0.0.0",
+  "description": "Model Context Protocol server for svelte-vitals — run SEO analysis inside an agent's tool loop.",
+  "type": "module",
+  "license": "MIT",
+  "author": "Kazuma Oe (https://github.com/oekazuma)",
+  "keywords": ["svelte", "sveltekit", "seo", "mcp", "model-context-protocol", "svelte-vitals"],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/oekazuma/svelte-vitals.git",
+    "directory": "packages/mcp"
+  },
+  "bugs": { "url": "https://github.com/oekazuma/svelte-vitals/issues" },
+  "homepage": "https://github.com/oekazuma/svelte-vitals#readme",
+  "bin": { "svelte-vitals-mcp": "./dist/bin.js" },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "catalog:",
+    "@svelte-vitals/core": "workspace:*",
+    "svelte-vitals": "workspace:*",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:"
+  }
+}
+```
+
+> An `index.ts` entry is added in Task 5 (it exports `createServer`). The `exports` map above points to `dist/index.js`; create the entry in Task 5.
+
+- [ ] **Step 3: Create `packages/mcp/tsconfig.json`:**
+
+```json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src", "test"]
+}
+```
+
+- [ ] **Step 4: Create `packages/mcp/tsup.config.ts`** (two entries; types only for the library entry, matching the CLI's pattern):
+
+```ts
+import { defineConfig } from 'tsup';
+
+// ESM-only by design (issue #20) — never add 'cjs'.
+export default defineConfig({
+  entry: ['src/index.ts', 'src/bin.ts'],
+  format: ['esm'],
+  dts: { entry: 'src/index.ts' },
+  clean: true,
+  target: 'es2022'
+});
+```
+
+- [ ] **Step 5: Install deps** so the SDK resolves:
+
+Run: `pnpm install`
+Expected: lockfile updates; `@svelte-vitals/mcp` links `svelte-vitals` and `@svelte-vitals/core` as workspace deps.
+
+- [ ] **Step 6: Write the failing test** — `packages/mcp/test/analyze-tool.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { handleAnalyze } from '../src/tools/analyze.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+// Reuse the CLI's fixture project so we don't duplicate a SvelteKit tree.
+const fixtureDir = join(here, '..', '..', 'cli', 'test', 'fixtures', 'basic-project');
+
+describe('analyze tool', () => {
+  it('returns a structured JSON report for a project path', async () => {
+    const res = await handleAnalyze({ path: fixtureDir });
+    expect(res.isError).toBeFalsy();
+    const report = res.structuredContent as { score: number; routes: unknown[]; summary: unknown };
+    expect(typeof report.score).toBe('number');
+    expect(Array.isArray(report.routes)).toBe(true);
+    expect(res.content[0]!.text).toContain('score');
+  });
+
+  it('reports an error for an unknown rule id', async () => {
+    const res = await handleAnalyze({ path: fixtureDir, rules: ['NOPE999'] });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain('NOPE999');
+  });
+
+  it('reports an error for a non-SvelteKit path', async () => {
+    const res = await handleAnalyze({ path: here });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain('SvelteKit');
+  });
+});
+```
+
+- [ ] **Step 7: Run it to verify it fails**
+
+Run: `pnpm --filter @svelte-vitals/mcp test -- analyze-tool`
+Expected: FAIL — cannot find `../src/tools/analyze.js`.
+
+- [ ] **Step 8: Implement `packages/mcp/src/tools/analyze.ts`:**
+
+```ts
+import { z } from 'zod';
+import { analyzeProject, buildRulesConfig, findUnknownRuleIds, knownRuleIds, ProjectError } from 'svelte-vitals';
+import { buildJsonReport } from '@svelte-vitals/core';
+
+export interface McpToolResult {
+  content: Array<{ type: 'text'; text: string }>;
+  structuredContent?: unknown;
+  isError?: boolean;
+}
+
+function textError(message: string): McpToolResult {
+  return { content: [{ type: 'text', text: message }], isError: true };
+}
+
+/** zod raw shape for the analyze tool's input (registered with the MCP server). */
+export const analyzeInputShape = {
+  path: z.string().optional().describe('Project root to analyze (defaults to the server cwd).'),
+  route: z.string().optional().describe('Glob to restrict which routes are analyzed, e.g. "blog/**".'),
+  treatDynamicAs: z
+    .enum(['pass', 'warn', 'fail'])
+    .optional()
+    .describe('How dynamic ({data.title}) values are scored. Default: pass.'),
+  rules: z.array(z.string()).optional().describe('Enable only these rule ids (all others disabled).'),
+  ignore: z.array(z.string()).optional().describe('Disable these rule ids.'),
+  failOn: z
+    .enum(['critical', 'warning', 'info'])
+    .optional()
+    .describe('Minimum severity that counts as a failure in the summary. Default: critical.')
+};
+
+const analyzeInput = z.object(analyzeInputShape);
+export type AnalyzeArgs = z.infer<typeof analyzeInput>;
+
+export async function handleAnalyze(args: AnalyzeArgs): Promise<McpToolResult> {
+  const allow = args.rules ?? [];
+  const ignore = args.ignore ?? [];
+  const unknown = findUnknownRuleIds([...allow, ...ignore]);
+  if (unknown.length > 0) {
+    return textError(
+      `Unknown rule id(s): ${unknown.join(', ')}. Known rule ids: ${knownRuleIds().join(', ')}.`
+    );
+  }
+
+  try {
+    const { results, config, version } = await analyzeProject({
+      cwd: args.path,
+      treatDynamicAs: args.treatDynamicAs,
+      route: args.route,
+      failOn: args.failOn,
+      rules: buildRulesConfig(allow, ignore)
+    });
+    const report = buildJsonReport(results, config, { version });
+    return {
+      content: [{ type: 'text', text: JSON.stringify(report, null, 2) }],
+      structuredContent: report
+    };
+  } catch (err) {
+    if (err instanceof ProjectError) return textError(err.message);
+    return textError(`svelte-vitals: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+```
+
+- [ ] **Step 9: Run the analyze-tool test**
+
+Run: `pnpm --filter @svelte-vitals/mcp test -- analyze-tool`
+Expected: PASS (all three cases).
+
+- [ ] **Step 10: Create `packages/mcp/src/server.ts`** (registers the analyze tool; explain_rule is added in Task 5):
+
+```ts
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { analyzeInputShape, handleAnalyze } from './tools/analyze.js';
+
+/** Build the svelte-vitals MCP server with all tools registered. */
+export function createServer(): McpServer {
+  const server = new McpServer({ name: 'svelte-vitals', version: '0.0.0' });
+
+  server.registerTool(
+    'analyze',
+    {
+      title: 'Analyze SvelteKit SEO',
+      description:
+        'Run svelte-vitals static-mode SEO analysis on a SvelteKit project and return a structured report (per-route and site-wide scores, findings with fix/recommendation/docs).',
+      inputSchema: analyzeInputShape
+    },
+    async (args) => await handleAnalyze(args)
+  );
+
+  return server;
+}
+```
+
+> The server's `version` string is cosmetic; leaving `0.0.0` is fine for v1 (changesets manage the published version). If a real version is preferred, read it from the package at build time in a later polish pass.
+
+- [ ] **Step 11: Typecheck**
+
+Run: `pnpm --filter @svelte-vitals/mcp typecheck`
+Expected: no errors. (If the SDK's tool callback type complains about the `args` shape, ensure `inputSchema` is the raw shape object `analyzeInputShape`, not `z.object(...)` — the SDK derives the arg type from the raw shape.)
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add pnpm-workspace.yaml packages/mcp/package.json packages/mcp/tsconfig.json packages/mcp/tsup.config.ts packages/mcp/src/tools/analyze.ts packages/mcp/src/server.ts packages/mcp/test/analyze-tool.test.ts pnpm-lock.yaml
+git commit -m "feat(mcp): scaffold @svelte-vitals/mcp with the analyze tool (#24)"
+```
+
+---
+
+### Task 5: `explain_rule` tool, library entry, bin & smoke test
+
+**Files:**
+- Create: `packages/mcp/src/tools/explain-rule.ts`
+- Modify: `packages/mcp/src/server.ts`
+- Create: `packages/mcp/src/index.ts`
+- Create: `packages/mcp/src/bin.ts`
+- Test: `packages/mcp/test/explain-rule-tool.test.ts` (new)
+- Test: `packages/mcp/test/server.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `explainRule`, `knownRuleIds`-equivalent. (`knownRuleIds` lives in `svelte-vitals`; import it there.)
+- Produces: `explainRuleInputShape`, `handleExplainRule(args)`, `createServer` (now with two tools), `bin.ts` entry that starts a stdio server.
+
+- [ ] **Step 1: Write the failing test** — `packages/mcp/test/explain-rule-tool.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { handleExplainRule } from '../src/tools/explain-rule.js';
+
+describe('explain_rule tool', () => {
+  it('returns rule info for a known id', async () => {
+    const res = await handleExplainRule({ id: 'SEO001' });
+    expect(res.isError).toBeFalsy();
+    const info = res.structuredContent as { id: string; severity: string; docsUrl: string };
+    expect(info.id).toBe('SEO001');
+    expect(info.severity).toBe('critical');
+    expect(info.docsUrl).toBe('https://svelte-vitals.dev/rules/SEO001');
+  });
+
+  it('reports an error for an unknown id', async () => {
+    const res = await handleExplainRule({ id: 'NOPE999' });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain('NOPE999');
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `pnpm --filter @svelte-vitals/mcp test -- explain-rule-tool`
+Expected: FAIL — cannot find `../src/tools/explain-rule.js`.
+
+- [ ] **Step 3: Implement `packages/mcp/src/tools/explain-rule.ts`:**
+
+```ts
+import { z } from 'zod';
+import { explainRule } from '@svelte-vitals/core';
+import { knownRuleIds } from 'svelte-vitals';
+import type { McpToolResult } from './analyze.js';
+
+export const explainRuleInputShape = {
+  id: z.string().describe('Rule id to explain, e.g. "SEO001".')
+};
+
+const explainRuleInput = z.object(explainRuleInputShape);
+export type ExplainRuleArgs = z.infer<typeof explainRuleInput>;
+
+export async function handleExplainRule(args: ExplainRuleArgs): Promise<McpToolResult> {
+  const info = explainRule(args.id);
+  if (!info) {
+    return {
+      content: [
+        { type: 'text', text: `Unknown rule id: ${args.id}. Known rule ids: ${knownRuleIds().join(', ')}.` }
+      ],
+      isError: true
+    };
+  }
+  const text =
+    `${info.id} — ${info.title} (${info.severity}, ${info.category})\n\n` +
+    `${info.rationale}\n\nDocs: ${info.docsUrl}` +
+    (info.fix ? `\n\nFix: ${info.fix.description}` : '');
+  return { content: [{ type: 'text', text }], structuredContent: info };
+}
+```
+
+- [ ] **Step 4: Register the tool in `server.ts`** — add the import and a second `registerTool` call inside `createServer`, before `return server`:
+
+```ts
+import { explainRuleInputShape, handleExplainRule } from './tools/explain-rule.js';
+```
+
+```ts
+  server.registerTool(
+    'explain_rule',
+    {
+      title: 'Explain an SEO rule',
+      description: 'Return a rule\'s title, category, default severity, rationale, docs URL, and fix template.',
+      inputSchema: explainRuleInputShape
+    },
+    async (args) => await handleExplainRule(args)
+  );
+```
+
+- [ ] **Step 5: Create the library entry `packages/mcp/src/index.ts`:**
+
+```ts
+export { createServer } from './server.js';
+export { handleAnalyze, analyzeInputShape } from './tools/analyze.js';
+export type { McpToolResult, AnalyzeArgs } from './tools/analyze.js';
+export { handleExplainRule, explainRuleInputShape } from './tools/explain-rule.js';
+export type { ExplainRuleArgs } from './tools/explain-rule.js';
+```
+
+- [ ] **Step 6: Create the bin `packages/mcp/src/bin.ts`:**
+
+```ts
+#!/usr/bin/env node
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { createServer } from './server.js';
+
+async function main(): Promise<void> {
+  const server = createServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+void main().catch((err) => {
+  // stderr is safe on stdio transport (stdout carries the protocol).
+  console.error(`svelte-vitals-mcp: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 7: Write the smoke test** — `packages/mcp/test/server.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { createServer } from '../src/server.js';
+
+describe('createServer', () => {
+  it('builds a server without throwing', () => {
+    const server = createServer();
+    expect(server).toBeDefined();
+  });
+});
+```
+
+> This is a light registration smoke test (the SDK's `McpServer` does not expose a public tool-list getter to assert against; the per-tool handler tests in this task and Task 4 cover behaviour). If the installed SDK version exposes a way to enumerate registered tools, assert both `analyze` and `explain_rule` are present.
+
+- [ ] **Step 8: Run the mcp test suite**
+
+Run: `pnpm --filter @svelte-vitals/mcp test`
+Expected: PASS — analyze-tool, explain-rule-tool, server.
+
+- [ ] **Step 9: Typecheck + build**
+
+Run: `pnpm --filter @svelte-vitals/mcp typecheck && pnpm --filter @svelte-vitals/mcp build`
+Expected: no type errors; `dist/bin.js`, `dist/index.js`, `dist/index.d.ts` produced.
+
+- [ ] **Step 10: Manual stdio smoke check** — verify the server speaks MCP over stdio (initialize + tools/list):
+
+Run:
+```bash
+printf '%s\n%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+  | node packages/mcp/dist/bin.js
+```
+Expected: two JSON-RPC responses on stdout; the `tools/list` result lists `analyze` and `explain_rule`.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add packages/mcp/src packages/mcp/test
+git commit -m "feat(mcp): add explain_rule tool, stdio bin and library entry (#24)"
+```
+
+---
+
+### Task 6: README, root scripts, changeset
+
+**Files:**
+- Modify: `README.md` (roadmap + packages table)
+- Modify: `package.json` (root — extend `check:publish` to include the mcp package)
+- Create: `packages/mcp/README.md`
+- Create: `.changeset/<name>.md`
+
+**Interfaces:** none (docs/release only).
+
+- [ ] **Step 1: Update the README roadmap** — in `README.md`, edit the **Upcoming** list: remove the `--fix` autofix bullet (closed as agent-delegated) and the MCP bullet; move MCP into **Shipped**. Add to the Shipped list:
+
+```md
+- **MCP server** (`@svelte-vitals/mcp`) — exposes `analyze` and `explain_rule` tools over stdio so an agent can run analysis in its tool loop and receive structured, fixable findings.
+```
+
+And update the **Upcoming** list to:
+
+```md
+**Upcoming**
+
+- **More categories** ([#10](https://github.com/oekazuma/svelte-vitals/issues/10)) — Performance, Accessibility, and Upgrade checks, culminating in a combined Health Report at `1.0`.
+```
+
+- [ ] **Step 2: Add the package to the packages table** in `README.md`:
+
+```md
+| [`@svelte-vitals/mcp`](./packages/mcp)   | MCP server: run analysis inside an agent's tool loop        |
+```
+
+- [ ] **Step 3: Create `packages/mcp/README.md`** — a short usage doc:
+
+````md
+# @svelte-vitals/mcp
+
+A [Model Context Protocol](https://modelcontextprotocol.io) server for [svelte-vitals](https://github.com/oekazuma/svelte-vitals). Lets an AI agent run SvelteKit SEO analysis inside its tool loop and receive structured, fixable findings.
+
+## Tools
+
+- **`analyze`** — run static-mode analysis on a project path; returns per-route and site-wide scores plus findings with `fix`/`recommendation`/`docs`. Inputs: `path?`, `route?`, `treatDynamicAs?`, `rules?`, `ignore?`, `failOn?`.
+- **`explain_rule`** — given a rule id (e.g. `SEO001`), returns its title, category, severity, rationale, docs URL, and fix template.
+
+## Usage (stdio)
+
+Add to your MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "svelte-vitals": {
+      "command": "npx",
+      "args": ["-y", "@svelte-vitals/mcp"]
+    }
+  }
+}
+```
+
+ESM-only. Requires Node 18+.
+````
+
+- [ ] **Step 4: Extend the root publish check** — in `package.json`, add the mcp package to `check:publish`:
+
+```json
+"check:publish": "pnpm --filter @svelte-vitals/core --filter @svelte-vitals/vite --filter svelte-vitals --filter @svelte-vitals/mcp exec publint",
+```
+
+- [ ] **Step 5: Create the changeset** — `.changeset/mcp-server.md`:
+
+```md
+---
+'@svelte-vitals/mcp': minor
+'@svelte-vitals/core': minor
+'svelte-vitals': minor
+---
+
+Add `@svelte-vitals/mcp`, a Model Context Protocol server exposing `analyze` and `explain_rule` tools over stdio (#24). Core gains `buildJsonReport`, `explainRule`, `RuleInfo`, and `docsUrlFor`; the CLI gains `analyzeProject` for reuse.
+```
+
+> `@svelte-vitals/mcp` starts at `0.0.0`; a `minor` bump publishes it at `0.1.0`. Confirm the changeset version bumps match the changesets config (the repo uses Changesets + npm Trusted Publishing — do not publish manually).
+
+- [ ] **Step 6: Run the whole repo's checks**
+
+Run: `pnpm -r typecheck && pnpm -r test && pnpm build && pnpm check:publish && pnpm lint`
+Expected: all green. (Run `pnpm format` first if `lint`'s prettier check fails.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add README.md package.json packages/mcp/README.md .changeset/mcp-server.md
+git commit -m "docs(mcp): document the MCP server, update roadmap, add changeset (#24)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- New `@svelte-vitals/mcp` package, stdio, bin `svelte-vitals-mcp` → Task 4 (scaffold) + Task 5 (bin). ✅
+- `analyze` tool (structured JSON report, fix metadata, scores; unknown-rule + non-Kit errors) → Task 4. ✅
+- `explain_rule` tool (title/category/severity/rationale/docs/fix; unknown-id error) → Task 5. ✅
+- Reuse pipeline, no rule duplication: `analyzeProject` (Task 3) + `buildJsonReport` (Task 1) + `explainRule`/Rule catalog (Task 2). ✅
+- Error handling via `isError` tool results → Tasks 4 & 5. ✅
+- Testing (core/cli/mcp, TDD) → every task is test-first; existing suites kept green in Tasks 1 & 3. ✅
+- README roadmap (drop `--fix`, MCP→Shipped), changeset → Task 6. ✅
+- `suggest_fix`, HTTP transport, AGENTS.md → explicitly out of scope (not planned). ✅
+
+**Placeholder scan:** No "TBD"/"add error handling"-style placeholders; every code step shows full code. The `0.0.0` server version and the fixture-route confirmation are called out as explicit notes, not gaps.
+
+**Type consistency:** `analyzeProject`/`AnalyzeResult`/`AnalyzeOptions` (Task 3) consumed verbatim in Task 4. `buildJsonReport`/`JsonReport` (Task 1) consumed in Task 4. `explainRule`/`RuleInfo`/`docsUrlFor` (Task 2) consumed in Task 5. `McpToolResult` defined in `tools/analyze.ts` (Task 4) and imported by `tools/explain-rule.ts` (Task 5). `analyzeInputShape`/`explainRuleInputShape` are raw zod shapes passed as `inputSchema` to `registerTool` consistently.

--- a/docs/superpowers/specs/2026-06-22-mcp-server-design.md
+++ b/docs/superpowers/specs/2026-06-22-mcp-server-design.md
@@ -1,0 +1,176 @@
+# Design: MCP server (`@svelte-vitals/mcp`)
+
+Issue: [#24](https://github.com/oekazuma/svelte-vitals/issues/24). Final increment of the agent-native epic (#18).
+
+## Goal
+
+Expose svelte-vitals as a Model Context Protocol (MCP) server so an AI agent can invoke
+static-mode analysis directly inside its tool loop and receive structured, fixable findings —
+instead of shelling out to the CLI and parsing text. The MCP layer is an **adapter** over the
+existing core pipeline; no rule logic is duplicated.
+
+`#11` (`--fix` autofix) was closed as agent-delegated: the only mechanically-safe fixes
+(robots.txt/sitemap.xml) are trivial for an agent, and the valuable ones need the real domain /
+page content an agent already has. MCP is the higher-leverage path: give the agent fixable
+context, let it apply the fix.
+
+## Scope (v1)
+
+Two MCP tools over **stdio** transport:
+
+1. **`analyze`** — run static-mode analysis on a project path; return the structured JSON report
+   (same shape the `json` reporter produces), including per-finding `fix`/`recommendation`/`docsUrl`,
+   per-route and site-wide scores, and the summary.
+2. **`explain_rule`** — given a rule id (e.g. `SEO001`), return its title, category, default
+   severity, rationale, docs URL, and fix template.
+
+`suggest_fix` is **out of scope** for v1: `analyze` already returns each finding's `fix` template,
+so a dedicated tool would be largely redundant. Add later if a per-rule lookup (without running
+analysis) proves needed.
+
+## Package
+
+- New workspace package `packages/mcp` → published as `@svelte-vitals/mcp`.
+- Dependencies: `@svelte-vitals/core` (types, rule catalog, `buildJsonReport`, `explainRule`),
+  `svelte-vitals` (the CLI package — for `analyzeProject` + the Node runtime/providers),
+  `@modelcontextprotocol/sdk`, `zod`.
+- Binary `svelte-vitals-mcp` starts a stdio MCP server.
+- ESM-only, `tsup` `format: ['esm']`, matching the existing packages' build/exports conventions
+  (per #20: `exports`-only is the eventual target; follow whatever convention the other packages
+  use at implementation time).
+
+## Architecture & data flow
+
+```
+agent (MCP client)
+  │  tools/call: analyze { path, route?, treatDynamicAs?, rules?, ignore?, failOn? }
+  ▼
+@svelte-vitals/mcp  (stdio server, zod-validated tool inputs)
+  │  analyzeProject(opts)            ← extracted from CLI run()
+  ▼
+svelte-vitals (CLI)  detectProject → heads → project facts → runRules → applyRuleSeverities
+  │  → { results, config, version }
+  ▼
+@svelte-vitals/core  buildJsonReport(results, config, { version })
+  │  → { version, score, scoreModel, summary, routes, siteIssues }
+  ▼
+MCP tool result: structuredContent = report object + a short text summary
+```
+
+### CLI refactor — extract `analyzeProject`
+
+`packages/cli/src/index.ts` currently inlines the analysis pipeline inside `run()`. Extract it:
+
+```ts
+export interface AnalyzeOptions {
+  cwd?: string;
+  metaComponents?: string[];
+  treatDynamicAs?: 'pass' | 'warn' | 'fail';
+  route?: string;
+  failOn?: Severity;
+  rules?: Record<string, RuleSetting>;
+}
+export interface AnalyzeResult { results: Result[]; config: Config; version: string; }
+
+export async function analyzeProject(opts: AnalyzeOptions): Promise<AnalyzeResult>;
+```
+
+- Throws `ProjectError` when the directory is not a SvelteKit project (callers map to their own
+  error channel: `run()` → exit 2; MCP → `isError` tool result).
+- `run()` is refactored to call `analyzeProject` and then do reporter resolution + formatting +
+  exit-code computation. **Behaviour is unchanged** — existing CLI tests must stay green.
+
+### core refactor — extract `buildJsonReport`
+
+`formatJsonReport` builds a report object then `JSON.stringify`s it. Split:
+
+```ts
+export function buildJsonReport(results: Result[], config: Config, meta: { version: string }): JsonReport;
+export function formatJsonReport(results, config, meta): string; // = JSON.stringify(buildJsonReport(...), null, 2)
+```
+
+`JsonReport` is the existing shape: `{ version, score, scoreModel, summary, routes, siteIssues }`.
+The `analyze` tool returns this object as `structuredContent`. No behaviour change to the string output.
+
+### Rule catalog — single source of truth for `explain_rule`
+
+Today each rule's `rationale`(≈recommendation)/`docsUrl`/`fix` live inside `check()` output. Promote
+them to the `Rule` definition so the catalog and the findings share one source:
+
+- Extend `Rule`: add `rationale: string` and `fix?: Fix`. `docsUrl` is **not** stored — it is
+  derived everywhere as `https://svelte-vitals.dev/rules/${id}` (one helper, no per-rule URL to
+  drift).
+- Populate all nine rules declaratively. `headTagRule` already accepts `opts.fix`; extend its
+  options to also carry `rationale`, and have `check()` reference the rule's own `rationale`/`fix`
+  and the derived `docsUrl` instead of inline literals. Project rules (SEO006/007/009) move their
+  inline `recommendation`/`fix` onto the rule object and derive `docsUrl`.
+- core exports:
+
+```ts
+export interface RuleInfo {
+  id: string; title: string; category: Category; severity: Severity;
+  rationale: string; docsUrl: string; fix?: Fix;
+}
+export function explainRule(id: string): RuleInfo | undefined;
+```
+
+`docsUrl` stays derivable (`https://svelte-vitals.dev/rules/${id}`) to avoid a hand-maintained URL
+per rule; `rationale` is authored prose per rule (the existing `recommendation` text is a good seed).
+
+## Tool contracts
+
+### `analyze`
+
+Input (zod):
+
+| field            | type                          | default | notes                                  |
+| ---------------- | ----------------------------- | ------- | -------------------------------------- |
+| `path`           | string                        | cwd     | project root to analyze                |
+| `route`          | string                        | —       | glob, restrict routes (matches CLI)    |
+| `treatDynamicAs` | `'pass'\|'warn'\|'fail'`       | `pass`  |                                        |
+| `rules`          | string[]                      | —       | enable only these rule ids             |
+| `ignore`         | string[]                      | —       | disable these rule ids                 |
+| `failOn`         | `'critical'\|'warning'\|'info'`| `critical` | informational in the report's summary |
+
+- Unknown rule ids in `rules`/`ignore` → `isError` tool result listing the unknown ids and the
+  known ids (mirrors the CLI's exit-2 message).
+- Returns `structuredContent` = `JsonReport`, plus a one-line text summary (`score`, counts).
+- Not a SvelteKit project → `isError` tool result with the `ProjectError` message.
+
+### `explain_rule`
+
+- Input: `{ id: string }`.
+- Returns `structuredContent` = `RuleInfo`, plus a text rendering.
+- Unknown id → `isError` tool result listing known rule ids.
+
+## Error handling
+
+- Tool-level failures (bad project, unknown rule/id) return `{ isError: true, content: [...] }`
+  rather than throwing out of the transport — the agent sees a usable message and can retry.
+- Unexpected errors are caught at the handler boundary and surfaced as `isError` too; the process
+  stays alive to serve further calls.
+
+## Testing (TDD)
+
+- **core**: `buildJsonReport` returns the expected object (and `formatJsonReport` ===
+  `JSON.stringify(buildJsonReport(...))`); `explainRule` returns each rule's info and `undefined`
+  for unknown ids; every rule in `allRules` has non-empty `rationale`/`docsUrl`.
+- **cli**: `analyzeProject` over an in-memory `Runtime` returns expected `results`/`config`/`version`;
+  throws `ProjectError` for a non-Kit dir. Existing `run()` tests stay green (no behaviour change).
+- **mcp**: tool handlers called directly (not through a live transport) for `analyze`
+  (happy path, unknown rule id, non-Kit path) and `explain_rule` (known id, unknown id). A thin
+  smoke test that the server registers both tools.
+
+## Out of scope / follow-ups
+
+- `suggest_fix` tool (redundant with `analyze` for now).
+- HTTP/SSE transport (stdio only for v1).
+- Generated `AGENTS.md`/rules doc (separate idea from #18).
+- Plugin-mode (build-time) analysis via MCP — v1 is static-mode only, matching the CLI.
+
+## Roadmap / release
+
+- Update README roadmap: remove the closed `--fix` item; move MCP from **Upcoming** to **Shipped**
+  once landed.
+- Add a changeset (new `@svelte-vitals/mcp` package; `@svelte-vitals/core` minor for
+  `buildJsonReport`/`explainRule`/`Rule` additions; `svelte-vitals` minor for `analyzeProject`).

--- a/docs/superpowers/specs/2026-06-22-mcp-server-design.md
+++ b/docs/superpowers/specs/2026-06-22-mcp-server-design.md
@@ -82,7 +82,10 @@ export async function analyzeProject(opts: AnalyzeOptions): Promise<AnalyzeResul
 - Throws `ProjectError` when the directory is not a SvelteKit project (callers map to their own
   error channel: `run()` → exit 2; MCP → `isError` tool result).
 - `run()` is refactored to call `analyzeProject` and then do reporter resolution + formatting +
-  exit-code computation. **Behaviour is unchanged** — existing CLI tests must stay green.
+  exit-code computation. The documented exit-code contract is preserved (0/1/2) and existing CLI
+  tests stay green. One deliberate consistency change: a non-`ProjectError` failure during project
+  detection now returns exit 2 (an "internal error" per `--help`) instead of propagating as an
+  uncaught throw — matching how pipeline/reporter errors were already handled.
 
 ### core refactor — extract `buildJsonReport`
 

--- a/docs/superpowers/specs/2026-06-22-mcp-server-design.md
+++ b/docs/superpowers/specs/2026-06-22-mcp-server-design.md
@@ -41,7 +41,7 @@ analysis) proves needed.
 
 ## Architecture & data flow
 
-```
+```text
 agent (MCP client)
   │  tools/call: analyze { path, route?, treatDynamicAs?, rules?, ignore?, failOn? }
   ▼

--- a/docs/superpowers/specs/2026-06-22-mcp-server-design.md
+++ b/docs/superpowers/specs/2026-06-22-mcp-server-design.md
@@ -70,7 +70,11 @@ export interface AnalyzeOptions {
   failOn?: Severity;
   rules?: Record<string, RuleSetting>;
 }
-export interface AnalyzeResult { results: Result[]; config: Config; version: string; }
+export interface AnalyzeResult {
+  results: Result[];
+  config: Config;
+  version: string;
+}
 
 export async function analyzeProject(opts: AnalyzeOptions): Promise<AnalyzeResult>;
 ```
@@ -108,8 +112,13 @@ them to the `Rule` definition so the catalog and the findings share one source:
 
 ```ts
 export interface RuleInfo {
-  id: string; title: string; category: Category; severity: Severity;
-  rationale: string; docsUrl: string; fix?: Fix;
+  id: string;
+  title: string;
+  category: Category;
+  severity: Severity;
+  rationale: string;
+  docsUrl: string;
+  fix?: Fix;
 }
 export function explainRule(id: string): RuleInfo | undefined;
 ```
@@ -123,14 +132,14 @@ per rule; `rationale` is authored prose per rule (the existing `recommendation` 
 
 Input (zod):
 
-| field            | type                          | default | notes                                  |
-| ---------------- | ----------------------------- | ------- | -------------------------------------- |
-| `path`           | string                        | cwd     | project root to analyze                |
-| `route`          | string                        | —       | glob, restrict routes (matches CLI)    |
-| `treatDynamicAs` | `'pass'\|'warn'\|'fail'`       | `pass`  |                                        |
-| `rules`          | string[]                      | —       | enable only these rule ids             |
-| `ignore`         | string[]                      | —       | disable these rule ids                 |
-| `failOn`         | `'critical'\|'warning'\|'info'`| `critical` | informational in the report's summary |
+| field            | type                            | default    | notes                                 |
+| ---------------- | ------------------------------- | ---------- | ------------------------------------- |
+| `path`           | string                          | cwd        | project root to analyze               |
+| `route`          | string                          | —          | glob, restrict routes (matches CLI)   |
+| `treatDynamicAs` | `'pass'\|'warn'\|'fail'`        | `pass`     |                                       |
+| `rules`          | string[]                        | —          | enable only these rule ids            |
+| `ignore`         | string[]                        | —          | disable these rule ids                |
+| `failOn`         | `'critical'\|'warning'\|'info'` | `critical` | informational in the report's summary |
 
 - Unknown rule ids in `rules`/`ignore` → `isError` tool result listing the unknown ids and the
   known ids (mirrors the CLI's exit-2 message).

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "pnpm -r test",
     "lint": "prettier --check . && eslint .",
     "format": "prettier --write .",
-    "check:publish": "pnpm --filter @svelte-vitals/core --filter @svelte-vitals/vite --filter svelte-vitals exec publint",
+    "check:publish": "pnpm --filter @svelte-vitals/core --filter @svelte-vitals/vite --filter svelte-vitals --filter @svelte-vitals/mcp exec publint",
     "release": "changeset publish",
     "changeset": "changeset"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -117,6 +117,9 @@ export async function run(opts: RunOptions = {}): Promise<number> {
       errorLog(err.message);
       return 2;
     }
+    // Any other failure during analysis is an internal error: report it and exit 2,
+    // matching the documented exit-code contract (see --help). We deliberately do
+    // not rethrow — the CLI surfaces a clean message rather than an uncaught stack.
     errorLog(`svelte-vitals: ${err instanceof Error ? err.message : String(err)}`);
     return 2;
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,7 +12,9 @@ import {
   selectRules,
   applyRuleSeverities,
   type Severity,
-  type RuleSetting
+  type RuleSetting,
+  type Result,
+  type Config
 } from '@svelte-vitals/core';
 import { createNodeRuntime } from './runtime/node.js';
 import { sourceHeadProvider } from './providers/source/routes.js';
@@ -51,14 +53,29 @@ export function routeMatcher(glob: string | undefined): (route: string) => boole
   return (route) => re.test(route.replace(/^\//, ''));
 }
 
+export interface AnalyzeOptions {
+  cwd?: string;
+  metaComponents?: string[];
+  treatDynamicAs?: 'pass' | 'warn' | 'fail';
+  /** Restrict analysis to routes whose path matches this glob (matched against the route path without leading slash). */
+  route?: string;
+  failOn?: Severity;
+  rules?: Record<string, RuleSetting>;
+}
+
+export interface AnalyzeResult {
+  results: Result[];
+  config: Config;
+  version: string;
+}
+
 /**
- * Run static-mode analysis once and return the process exit code (design §6):
- *   0 = no failing findings, 1 = critical finding present, 2 = execution error.
+ * Run static-mode analysis and return the structured findings + resolved config.
+ * Throws ProjectError when `cwd` is not a SvelteKit project. Shared by the CLI's
+ * run() and by @svelte-vitals/mcp (issue #24).
  */
-export async function run(opts: RunOptions = {}): Promise<number> {
+export async function analyzeProject(opts: AnalyzeOptions = {}): Promise<AnalyzeResult> {
   const cwd = opts.cwd ?? process.cwd();
-  const log = opts.log ?? ((line: string) => console.log(line));
-  const errorLog = opts.errorLog ?? ((line: string) => console.error(line));
   const rt = createNodeRuntime();
   const config = defineConfig({
     treatDynamicAs: opts.treatDynamicAs ?? 'pass',
@@ -67,22 +84,45 @@ export async function run(opts: RunOptions = {}): Promise<number> {
     failOn: opts.failOn ?? 'critical'
   });
 
+  await detectProject(rt, cwd); // throws ProjectError if not a SvelteKit project
+
+  const matches = routeMatcher(opts.route);
+  const heads = (await sourceHeadProvider.collect(rt, cwd, config)).filter((h) => matches(h.route));
+  const project = await collectProjectFacts(rt, cwd);
+  const rules = selectRules(allRules, config);
+  const results = applyRuleSeverities(await runRules(rules, { heads, project, config }), config);
+  return { results, config, version: readPackageVersion() };
+}
+
+/**
+ * Run static-mode analysis once and return the process exit code (design §6):
+ *   0 = no failing findings, 1 = critical finding present, 2 = execution error.
+ */
+export async function run(opts: RunOptions = {}): Promise<number> {
+  const log = opts.log ?? ((line: string) => console.log(line));
+  const errorLog = opts.errorLog ?? ((line: string) => console.error(line));
+
+  let analysis: AnalyzeResult;
   try {
-    await detectProject(rt, cwd);
+    analysis = await analyzeProject({
+      cwd: opts.cwd ?? process.cwd(),
+      metaComponents: opts.metaComponents,
+      treatDynamicAs: opts.treatDynamicAs,
+      route: opts.route,
+      failOn: opts.failOn,
+      rules: opts.rules
+    });
   } catch (err) {
     if (err instanceof ProjectError) {
       errorLog(err.message);
       return 2;
     }
-    throw err;
+    errorLog(`svelte-vitals: ${err instanceof Error ? err.message : String(err)}`);
+    return 2;
   }
 
   try {
-    const matches = routeMatcher(opts.route);
-    const heads = (await sourceHeadProvider.collect(rt, cwd, config)).filter((h) => matches(h.route));
-    const project = await collectProjectFacts(rt, cwd);
-    const rules = selectRules(allRules, config);
-    const results = applyRuleSeverities(await runRules(rules, { heads, project, config }), config);
+    const { results, config, version } = analysis;
     const env = opts.env ?? process.env;
     const reporter = resolveReporter(opts.reporter, env);
     if (reporter === 'agent' && isAutoDetectedAgent(opts.reporter, env)) {
@@ -96,11 +136,11 @@ export async function run(opts: RunOptions = {}): Promise<number> {
       );
     }
     if (reporter === 'json') {
-      log(formatJsonReport(results, config, { version: readPackageVersion() }));
+      log(formatJsonReport(results, config, { version }));
     } else if (reporter === 'agent') {
       log(formatAgentReport(results, config));
     } else if (reporter === 'sarif') {
-      log(formatSarifReport(results, config, { version: readPackageVersion() }));
+      log(formatSarifReport(results, config, { version }));
     } else if (reporter === 'github') {
       // The github reporter returns '' when there are no findings; skip logging so
       // a clean run emits no stray blank line into the Actions log.
@@ -116,3 +156,6 @@ export async function run(opts: RunOptions = {}): Promise<number> {
     return 2;
   }
 }
+
+export { ProjectError } from './providers/source/project.js';
+export { buildRulesConfig, findUnknownRuleIds, knownRuleIds } from './rules-config.js';

--- a/packages/cli/test/analyze-project.test.ts
+++ b/packages/cli/test/analyze-project.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { analyzeProject } from '../src/index.js';
+import { ProjectError } from '../src/providers/source/project.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixtureDir = join(here, 'fixtures', 'basic-project');
+
+describe('analyzeProject', () => {
+  it('returns results, config and version for a SvelteKit project', async () => {
+    const { results, config, version } = await analyzeProject({ cwd: fixtureDir });
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.some((r) => r.id === 'SEO001')).toBe(true);
+    expect(config.treatDynamicAs).toBe('pass');
+    expect(typeof version).toBe('string');
+  });
+
+  it('respects the route glob filter', async () => {
+    const { results } = await analyzeProject({ cwd: fixtureDir, route: 'none' });
+    const routes = new Set(results.filter((r) => r.route).map((r) => r.route));
+    expect(routes.size).toBeGreaterThan(0);
+    for (const route of routes) expect(route).toBe('/none');
+  });
+
+  it('throws ProjectError for a non-SvelteKit directory', async () => {
+    await expect(analyzeProject({ cwd: here })).rejects.toBeInstanceOf(ProjectError);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,7 +43,8 @@ export { summarize, classify, hasFailureAtOrAbove, effectiveSeverity } from './s
 
 export type { ConsoleReportOptions } from './reporter/console.js';
 export { formatConsoleReport } from './reporter/console.js';
-export { formatJsonReport } from './reporter/json.js';
+export { buildJsonReport, formatJsonReport } from './reporter/json.js';
+export type { JsonReport } from './reporter/json.js';
 export { formatAgentReport } from './reporter/agent.js';
 export { formatSarifReport } from './reporter/sarif.js';
 export { formatGithubReport } from './reporter/github.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,11 +21,12 @@ export type { HeadTag, ResolvedHead, HeadProvider } from './head.js';
 export { ROBOTS_SOURCE_PATHS, SITEMAP_SOURCE_PATHS } from './project-paths.js';
 export type { Runtime } from './runtime.js';
 export type { Rule, RuleContext } from './rule.js';
-export { isPenalized } from './rule.js';
+export { isPenalized, docsUrlFor } from './rule.js';
 
 export { runRules } from './engine.js';
 export {
   allRules,
+  explainRule,
   seo001Title,
   seo002Description,
   seo003Canonical,
@@ -36,6 +37,7 @@ export {
   seo008JsonLd,
   seo009HtmlLang
 } from './rules/index.js';
+export type { RuleInfo } from './rules/index.js';
 export { headTagRule } from './rules/seo/head-tag-rule.js';
 
 export type { Summary, Classification } from './summary.js';

--- a/packages/core/src/reporter/json.ts
+++ b/packages/core/src/reporter/json.ts
@@ -10,6 +10,7 @@ function issueOf(result: Result) {
     detection: result.detection,
     location: result.location,
     recommendation: result.recommendation,
+    ...(result.docsUrl ? { docsUrl: result.docsUrl } : {}),
     ...(result.fix ? { fix: result.fix } : {})
   };
 }

--- a/packages/core/src/reporter/json.ts
+++ b/packages/core/src/reporter/json.ts
@@ -1,6 +1,6 @@
 import type { Config, Result } from '../types.js';
-import { computeScore } from '../scoring/score.js';
-import { summarize, effectiveSeverity } from '../summary.js';
+import { computeScore, type ScoreModel } from '../scoring/score.js';
+import { summarize, effectiveSeverity, type Summary } from '../summary.js';
 import { isPenalized } from '../rule.js';
 
 function issueOf(result: Result) {
@@ -14,8 +14,19 @@ function issueOf(result: Result) {
   };
 }
 
-/** Render results as the documented JSON report string (design §7). */
-export function formatJsonReport(results: Result[], config: Config, meta: { version: string }): string {
+type JsonIssue = ReturnType<typeof issueOf> & { severity: ReturnType<typeof effectiveSeverity> };
+
+export interface JsonReport {
+  version: string;
+  score: number;
+  scoreModel: ScoreModel;
+  summary: Summary;
+  routes: Array<{ route: string; score: number; issues: JsonIssue[] }>;
+  siteIssues: JsonIssue[];
+}
+
+/** Build the structured JSON report object (design §7). Shared by the json reporter and the MCP `analyze` tool (issue #24). */
+export function buildJsonReport(results: Result[], config: Config, meta: { version: string }): JsonReport {
   const { score, scoreModel } = computeScore(results, config);
   const summary = summarize(results, config);
 
@@ -40,5 +51,10 @@ export function formatJsonReport(results: Result[], config: Config, meta: { vers
     .filter((r) => r.route === undefined && isPenalized(r.detection, config.treatDynamicAs))
     .map((r) => ({ ...issueOf(r), severity: effectiveSeverity(r, config) }));
 
-  return JSON.stringify({ version: meta.version, score, scoreModel, summary, routes, siteIssues }, null, 2);
+  return { version: meta.version, score, scoreModel, summary, routes, siteIssues };
+}
+
+/** Render results as the documented JSON report string (design §7). */
+export function formatJsonReport(results: Result[], config: Config, meta: { version: string }): string {
+  return JSON.stringify(buildJsonReport(results, config, meta), null, 2);
 }

--- a/packages/core/src/rule.ts
+++ b/packages/core/src/rule.ts
@@ -1,4 +1,4 @@
-import type { Category, Config, Detection, Project, Result, Scope, Severity, TreatDynamicAs } from './types.js';
+import type { Category, Config, Detection, Fix, Project, Result, Scope, Severity, TreatDynamicAs } from './types.js';
 import type { ResolvedHead } from './head.js';
 
 /** Input given to every rule. Mode-independent: rules see only ResolvedHead[] (design §8, §10). */
@@ -16,11 +16,20 @@ export interface Rule {
   severity: Severity;
   /** 'route' = evaluated per route, 'project' = site-wide (design §10, §12). */
   scope: Scope;
+  /** Why this rule matters — one or two sentences, surfaced by explain_rule (issue #24). */
+  rationale: string;
+  /** Canonical remediation template, shared by findings and explain_rule (issue #24). */
+  fix?: Fix;
   /**
    * Evaluate the resolved heads. A single rule may return one Result per route,
    * so it always returns an array. Project-scoped rules return a single element.
    */
   check(ctx: RuleContext): Promise<Result[]>;
+}
+
+/** Documentation URL for a rule id. Single source so no per-rule URL can drift (issue #24). */
+export function docsUrlFor(id: string): string {
+  return `https://svelte-vitals.dev/rules/${id}`;
 }
 
 /**

--- a/packages/core/src/rules/index.ts
+++ b/packages/core/src/rules/index.ts
@@ -44,9 +44,10 @@ export interface RuleInfo {
   fix?: Fix;
 }
 
-/** Look up a rule's static metadata for the MCP explain_rule tool (issue #24). */
+/** Look up a rule's static metadata for the MCP explain_rule tool (issue #24). Rule ids are matched case-insensitively. */
 export function explainRule(id: string): RuleInfo | undefined {
-  const rule = allRules.find((r) => r.id === id);
+  const target = id.toUpperCase();
+  const rule = allRules.find((r) => r.id === target);
   if (!rule) return undefined;
   return {
     id: rule.id,

--- a/packages/core/src/rules/index.ts
+++ b/packages/core/src/rules/index.ts
@@ -1,4 +1,5 @@
-import type { Rule } from '../rule.js';
+import type { Category, Fix, Severity } from '../types.js';
+import { docsUrlFor, type Rule } from '../rule.js';
 import { seo001Title } from './seo/seo001-title.js';
 import {
   seo002Description,
@@ -32,3 +33,28 @@ export {
   seo008JsonLd,
   seo009HtmlLang
 };
+
+export interface RuleInfo {
+  id: string;
+  title: string;
+  category: Category;
+  severity: Severity;
+  rationale: string;
+  docsUrl: string;
+  fix?: Fix;
+}
+
+/** Look up a rule's static metadata for the MCP explain_rule tool (issue #24). */
+export function explainRule(id: string): RuleInfo | undefined {
+  const rule = allRules.find((r) => r.id === id);
+  if (!rule) return undefined;
+  return {
+    id: rule.id,
+    title: rule.title,
+    category: rule.category,
+    severity: rule.severity,
+    rationale: rule.rationale,
+    docsUrl: docsUrlFor(rule.id),
+    ...(rule.fix ? { fix: rule.fix } : {})
+  };
+}

--- a/packages/core/src/rules/seo/head-tag-rule.ts
+++ b/packages/core/src/rules/seo/head-tag-rule.ts
@@ -1,6 +1,6 @@
 import type { Detection, Fix, Result, Severity } from '../../types.js';
 import type { HeadTag, ResolvedHead } from '../../head.js';
-import type { Rule, RuleContext } from '../../rule.js';
+import { docsUrlFor, type Rule, type RuleContext } from '../../rule.js';
 
 export interface HeadTagRuleOptions {
   id: string;
@@ -11,6 +11,8 @@ export interface HeadTagRuleOptions {
   /** Short human label, e.g. 'description'. */
   label: string;
   recommendation: string;
+  /** Why this rule matters — surfaced by explain_rule (issue #24). */
+  rationale: string;
   /** Agent-actionable remediation attached to every finding (issue #18). */
   fix?: Fix;
 }
@@ -22,13 +24,15 @@ function detect(head: ResolvedHead, match: (t: HeadTag) => boolean): Detection {
 
 /** Build a route-scope rule asserting the presence of a single head tag (design §11). */
 export function headTagRule(opts: HeadTagRuleOptions): Rule {
-  const docsUrl = `https://svelte-vitals.dev/rules/${opts.id}`;
+  const docsUrl = docsUrlFor(opts.id);
   return {
     id: opts.id,
     title: opts.title,
     category: 'seo',
     severity: opts.severity,
     scope: 'route',
+    rationale: opts.rationale,
+    ...(opts.fix ? { fix: opts.fix } : {}),
     async check(ctx: RuleContext): Promise<Result[]> {
       return ctx.heads.map((head) => {
         const detection = detect(head, opts.match);

--- a/packages/core/src/rules/seo/project-rules.ts
+++ b/packages/core/src/rules/seo/project-rules.ts
@@ -1,8 +1,14 @@
-import type { Detection, Result } from '../../types.js';
-import type { Rule, RuleContext } from '../../rule.js';
+import type { Detection, Fix, Result } from '../../types.js';
+import { docsUrlFor, type Rule, type RuleContext } from '../../rule.js';
 
 const present: Detection = { presence: 'own', value: 'static' };
 const absent: Detection = { presence: 'none', value: 'absent' };
+
+const SEO006_FIX: Fix = {
+  description: 'Create static/robots.txt (or a src/routes/robots.txt/+server endpoint).',
+  snippet: 'User-agent: *\nAllow: /\n\nSitemap: https://example.com/sitemap.xml',
+  lang: 'text'
+};
 
 export const seo006Robots: Rule = {
   id: 'SEO006',
@@ -10,6 +16,9 @@ export const seo006Robots: Rule = {
   category: 'seo',
   severity: 'warning',
   scope: 'project',
+  rationale:
+    'robots.txt tells crawlers which paths they may fetch and points them to your sitemap; missing it leaves crawl behaviour to defaults.',
+  fix: SEO006_FIX,
   async check(ctx: RuleContext): Promise<Result[]> {
     const detection = ctx.project.hasRobotsTxt ? present : absent;
     return [
@@ -19,15 +28,18 @@ export const seo006Robots: Rule = {
         detection,
         message: ctx.project.hasRobotsTxt ? 'robots.txt' : 'Missing robots.txt',
         recommendation: 'Add static/robots.txt or a src/routes/robots.txt/+server endpoint.',
-        docsUrl: 'https://svelte-vitals.dev/rules/SEO006',
-        fix: {
-          description: 'Create static/robots.txt (or a src/routes/robots.txt/+server endpoint).',
-          snippet: 'User-agent: *\nAllow: /\n\nSitemap: https://example.com/sitemap.xml',
-          lang: 'text'
-        }
+        docsUrl: docsUrlFor('SEO006'),
+        fix: { ...SEO006_FIX }
       }
     ];
   }
+};
+
+const SEO007_FIX: Fix = {
+  description: 'Create static/sitemap.xml (or a src/routes/sitemap.xml/+server endpoint).',
+  snippet:
+    '<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n  <url><loc>https://example.com/</loc></url>\n</urlset>',
+  lang: 'xml'
 };
 
 export const seo007Sitemap: Rule = {
@@ -36,6 +48,9 @@ export const seo007Sitemap: Rule = {
   category: 'seo',
   severity: 'warning',
   scope: 'project',
+  rationale:
+    'A sitemap.xml lists your URLs so search engines can discover and prioritise them, especially pages not well linked internally.',
+  fix: SEO007_FIX,
   async check(ctx: RuleContext): Promise<Result[]> {
     const detection = ctx.project.hasSitemap ? present : absent;
     return [
@@ -45,16 +60,17 @@ export const seo007Sitemap: Rule = {
         detection,
         message: ctx.project.hasSitemap ? 'sitemap.xml' : 'Missing sitemap.xml',
         recommendation: 'Add static/sitemap.xml or a src/routes/sitemap.xml/+server endpoint.',
-        docsUrl: 'https://svelte-vitals.dev/rules/SEO007',
-        fix: {
-          description: 'Create static/sitemap.xml (or a src/routes/sitemap.xml/+server endpoint).',
-          snippet:
-            '<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n  <url><loc>https://example.com/</loc></url>\n</urlset>',
-          lang: 'xml'
-        }
+        docsUrl: docsUrlFor('SEO007'),
+        fix: { ...SEO007_FIX }
       }
     ];
   }
+};
+
+const SEO009_FIX: Fix = {
+  description: 'Set the lang attribute on <html> in src/app.html.',
+  snippet: '<html lang="en">',
+  lang: 'html'
 };
 
 export const seo009HtmlLang: Rule = {
@@ -63,6 +79,9 @@ export const seo009HtmlLang: Rule = {
   category: 'seo',
   severity: 'warning',
   scope: 'project',
+  rationale:
+    'The <html lang> attribute declares the page language for search engines, screen readers, and translation tools.',
+  fix: SEO009_FIX,
   async check(ctx: RuleContext): Promise<Result[]> {
     const detection = ctx.project.htmlLang;
     const message =
@@ -78,12 +97,8 @@ export const seo009HtmlLang: Rule = {
         detection,
         message,
         recommendation: 'Set <html lang="..."> in src/app.html.',
-        docsUrl: 'https://svelte-vitals.dev/rules/SEO009',
-        fix: {
-          description: 'Set the lang attribute on <html> in src/app.html.',
-          snippet: '<html lang="en">',
-          lang: 'html'
-        }
+        docsUrl: docsUrlFor('SEO009'),
+        fix: { ...SEO009_FIX }
       }
     ];
   }

--- a/packages/core/src/rules/seo/seo001-title.ts
+++ b/packages/core/src/rules/seo/seo001-title.ts
@@ -1,8 +1,12 @@
-import type { Result, Detection } from '../../types.js';
+import type { Result, Detection, Fix } from '../../types.js';
 import type { HeadTag, ResolvedHead } from '../../head.js';
-import type { Rule, RuleContext } from '../../rule.js';
+import { docsUrlFor, type Rule, type RuleContext } from '../../rule.js';
 
-const DOCS_URL = 'https://svelte-vitals.dev/rules/SEO001';
+const FIX: Fix = {
+  description: 'Add a <title> inside <svelte:head> (a dynamic title is fine).',
+  snippet: '<svelte:head>\n  <title>{data.title}</title>\n</svelte:head>',
+  lang: 'svelte'
+};
 
 function detectTitle(head: ResolvedHead): Detection {
   const title: HeadTag | undefined = head.tags.find((t) => t.kind === 'title');
@@ -30,6 +34,9 @@ export const seo001Title: Rule = {
   category: 'seo',
   severity: 'critical',
   scope: 'route',
+  rationale:
+    'A unique, non-empty <title> is the single strongest on-page SEO signal and the text shown in search results and browser tabs.',
+  fix: FIX,
 
   async check(ctx: RuleContext): Promise<Result[]> {
     return ctx.heads.map((head) => {
@@ -44,12 +51,8 @@ export const seo001Title: Rule = {
         recommendation:
           'Add a <title> inside <svelte:head>, e.g. <title>{data.title}</title>, ' +
           'or set it via your meta component.',
-        docsUrl: DOCS_URL,
-        fix: {
-          description: 'Add a <title> inside <svelte:head> (a dynamic title is fine).',
-          snippet: '<svelte:head>\n  <title>{data.title}</title>\n</svelte:head>',
-          lang: 'svelte'
-        }
+        docsUrl: docsUrlFor('SEO001'),
+        fix: { ...FIX }
       } satisfies Result;
     });
   }

--- a/packages/core/src/rules/seo/seo002-005-008.ts
+++ b/packages/core/src/rules/seo/seo002-005-008.ts
@@ -8,6 +8,8 @@ export const seo002Description = headTagRule({
   match: (t: HeadTag) => t.kind === 'meta' && t.name === 'description',
   label: '<meta name="description">',
   recommendation: 'Add a <meta name="description"> in <svelte:head>, or set the description on your meta component.',
+  rationale:
+    'A meta description is the snippet search engines show under your title; without one they invent one from page text, often poorly.',
   fix: {
     description: 'Add a <meta name="description"> inside <svelte:head>, or set description on your meta component.',
     snippet: '<svelte:head>\n  <meta name="description" content="A concise page summary." />\n</svelte:head>',
@@ -22,6 +24,8 @@ export const seo003Canonical = headTagRule({
   match: (t: HeadTag) => t.kind === 'link' && t.rel === 'canonical',
   label: '<link rel="canonical">',
   recommendation: 'Add <link rel="canonical"> in <svelte:head>, or set the canonical prop on your meta component.',
+  rationale:
+    'A canonical URL tells search engines which URL is authoritative, preventing duplicate-content dilution across query strings and trailing-slash variants.',
   fix: {
     description: 'Add <link rel="canonical"> inside <svelte:head>, or set the canonical prop on your meta component.',
     snippet: '<svelte:head>\n  <link rel="canonical" href="https://example.com/this-page" />\n</svelte:head>',
@@ -36,6 +40,8 @@ export const seo004OgImage = headTagRule({
   match: (t: HeadTag) => t.kind === 'meta' && t.property === 'og:image',
   label: '<meta property="og:image">',
   recommendation: 'Add <meta property="og:image">, or set openGraph.images on your meta component.',
+  rationale:
+    'og:image is the preview thumbnail shown when the page is shared on social platforms; without it links render bare and get fewer clicks.',
   fix: {
     description: 'Add <meta property="og:image">, or set openGraph.images on your meta component.',
     snippet: '<svelte:head>\n  <meta property="og:image" content="https://example.com/og.png" />\n</svelte:head>',
@@ -50,6 +56,8 @@ export const seo005OgTitle = headTagRule({
   match: (t: HeadTag) => t.kind === 'meta' && t.property === 'og:title',
   label: '<meta property="og:title">',
   recommendation: 'Add <meta property="og:title">, or set openGraph.title on your meta component.',
+  rationale:
+    'og:title controls the headline shown when the page is shared on social platforms, independent of the document <title>.',
   fix: {
     description: 'Add <meta property="og:title">, or set openGraph.title on your meta component.',
     snippet: '<svelte:head>\n  <meta property="og:title" content="Page title" />\n</svelte:head>',
@@ -64,6 +72,8 @@ export const seo008JsonLd = headTagRule({
   match: (t: HeadTag) => t.kind === 'jsonld',
   label: 'JSON-LD (<script type="application/ld+json">)',
   recommendation: 'Add JSON-LD structured data, e.g. via <svelte:head> or a JsonLd component.',
+  rationale:
+    'JSON-LD structured data lets search engines render rich results (breadcrumbs, articles, products) for the page.',
   fix: {
     // Svelte ships <script> contents verbatim (the body is raw text, not Svelte
     // markup), so use literal JSON here — an interpolation like {JSON.stringify(...)}

--- a/packages/core/test/config-apply.test.ts
+++ b/packages/core/test/config-apply.test.ts
@@ -7,6 +7,7 @@ const ruleA = {
   category: 'seo',
   severity: 'critical',
   scope: 'route',
+  rationale: 'r',
   check: async () => []
 } as Rule;
 const ruleB = {
@@ -15,6 +16,7 @@ const ruleB = {
   category: 'seo',
   severity: 'info',
   scope: 'route',
+  rationale: 'r',
   check: async () => []
 } as Rule;
 

--- a/packages/core/test/explain-rule.test.ts
+++ b/packages/core/test/explain-rule.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { explainRule, allRules } from '../src/index.js';
+
+describe('explainRule', () => {
+  it('returns info for a known rule id', () => {
+    const info = explainRule('SEO001');
+    expect(info).toBeDefined();
+    expect(info!.id).toBe('SEO001');
+    expect(info!.severity).toBe('critical');
+    expect(info!.docsUrl).toBe('https://svelte-vitals.dev/rules/SEO001');
+    expect(info!.rationale.length).toBeGreaterThan(0);
+    expect(info!.fix?.description.length).toBeGreaterThan(0);
+  });
+
+  it('returns undefined for an unknown id', () => {
+    expect(explainRule('NOPE999')).toBeUndefined();
+  });
+
+  it('every built-in rule has a non-empty rationale and a derivable docs url', () => {
+    for (const rule of allRules) {
+      const info = explainRule(rule.id);
+      expect(info, rule.id).toBeDefined();
+      expect(info!.rationale.length, `${rule.id} rationale`).toBeGreaterThan(0);
+      expect(info!.docsUrl).toBe(`https://svelte-vitals.dev/rules/${rule.id}`);
+    }
+  });
+});

--- a/packages/core/test/explain-rule.test.ts
+++ b/packages/core/test/explain-rule.test.ts
@@ -12,6 +12,13 @@ describe('explainRule', () => {
     expect(info!.fix?.description.length).toBeGreaterThan(0);
   });
 
+  it('resolves a rule id case-insensitively and returns the canonical id', () => {
+    const info = explainRule('seo001');
+    expect(info).toBeDefined();
+    expect(info!.id).toBe('SEO001');
+    expect(info!.docsUrl).toBe('https://svelte-vitals.dev/rules/SEO001');
+  });
+
   it('returns undefined for an unknown id', () => {
     expect(explainRule('NOPE999')).toBeUndefined();
   });

--- a/packages/core/test/json-report.test.ts
+++ b/packages/core/test/json-report.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatJsonReport, defineConfig, type Result } from '../src/index.js';
+import { buildJsonReport, formatJsonReport, defineConfig, type Result } from '../src/index.js';
 
 const config = defineConfig({});
 const results: Result[] = [
@@ -34,5 +34,16 @@ describe('formatJsonReport', () => {
     expect(routeA.issues[0].detection).toEqual({ presence: 'none', value: 'absent' });
     expect(json.siteIssues).toHaveLength(1);
     expect(json.siteIssues[0].id).toBe('SEO006');
+  });
+
+  it('buildJsonReport returns the object formatJsonReport stringifies', () => {
+    const report = buildJsonReport(results, config, { version: '9.9.9' });
+    expect(report.version).toBe('9.9.9');
+    expect(report).toHaveProperty('score');
+    expect(report).toHaveProperty('scoreModel');
+    expect(report).toHaveProperty('summary');
+    expect(Array.isArray(report.routes)).toBe(true);
+    expect(Array.isArray(report.siteIssues)).toBe(true);
+    expect(formatJsonReport(results, config, { version: '9.9.9' })).toBe(JSON.stringify(report, null, 2));
   });
 });

--- a/packages/core/test/json-report.test.ts
+++ b/packages/core/test/json-report.test.ts
@@ -16,7 +16,8 @@ const results: Result[] = [
     detection: { presence: 'none', value: 'absent' },
     route: '/a',
     location: 'src/routes/a/+page.svelte',
-    message: 'Missing description'
+    message: 'Missing description',
+    docsUrl: 'https://svelte-vitals.dev/rules/SEO002'
   },
   { id: 'SEO006', severity: 'warning', detection: { presence: 'none', value: 'absent' }, message: 'Missing robots.txt' }
 ];
@@ -32,6 +33,7 @@ describe('formatJsonReport', () => {
     expect(routeA.issues).toHaveLength(1); // only the missing description (SEO001 passed)
     expect(routeA.issues[0].id).toBe('SEO002');
     expect(routeA.issues[0].detection).toEqual({ presence: 'none', value: 'absent' });
+    expect(routeA.issues[0].docsUrl).toBe('https://svelte-vitals.dev/rules/SEO002');
     expect(json.siteIssues).toHaveLength(1);
     expect(json.siteIssues[0].id).toBe('SEO006');
   });

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -4,7 +4,7 @@ A [Model Context Protocol](https://modelcontextprotocol.io) server for [svelte-v
 
 ## Tools
 
-- **`analyze`** — run static-mode analysis on a project path; returns per-route and site-wide scores plus findings with `fix`/`recommendation`/`docsUrl`. Inputs: `path?`, `route?`, `treatDynamicAs?`, `rules?`, `ignore?`, `failOn?`.
+- **`analyze`** — run static-mode analysis on a project path; returns per-route and site-wide scores plus findings with `fix`/`recommendation`/`docsUrl`. Inputs: `path?`, `metaComponents?`, `route?`, `treatDynamicAs?`, `rules?`, `ignore?`, `failOn?`.
 - **`explain_rule`** — given a rule id (e.g. `SEO001`), returns its title, category, severity, rationale, docs URL, and fix template.
 
 ## Usage (stdio)

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,25 @@
+# @svelte-vitals/mcp
+
+A [Model Context Protocol](https://modelcontextprotocol.io) server for [svelte-vitals](https://github.com/oekazuma/svelte-vitals). Lets an AI agent run SvelteKit SEO analysis inside its tool loop and receive structured, fixable findings.
+
+## Tools
+
+- **`analyze`** — run static-mode analysis on a project path; returns per-route and site-wide scores plus findings with `fix`/`recommendation`/`docs`. Inputs: `path?`, `route?`, `treatDynamicAs?`, `rules?`, `ignore?`, `failOn?`.
+- **`explain_rule`** — given a rule id (e.g. `SEO001`), returns its title, category, severity, rationale, docs URL, and fix template.
+
+## Usage (stdio)
+
+Add to your MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "svelte-vitals": {
+      "command": "npx",
+      "args": ["-y", "@svelte-vitals/mcp"]
+    }
+  }
+}
+```
+
+ESM-only. Requires Node 18+.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -4,7 +4,7 @@ A [Model Context Protocol](https://modelcontextprotocol.io) server for [svelte-v
 
 ## Tools
 
-- **`analyze`** — run static-mode analysis on a project path; returns per-route and site-wide scores plus findings with `fix`/`recommendation`/`docs`. Inputs: `path?`, `route?`, `treatDynamicAs?`, `rules?`, `ignore?`, `failOn?`.
+- **`analyze`** — run static-mode analysis on a project path; returns per-route and site-wide scores plus findings with `fix`/`recommendation`/`docsUrl`. Inputs: `path?`, `route?`, `treatDynamicAs?`, `rules?`, `ignore?`, `failOn?`.
 - **`explain_rule`** — given a rule id (e.g. `SEO001`), returns its title, category, severity, rationale, docs URL, and fix template.
 
 ## Usage (stdio)

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@svelte-vitals/mcp",
+  "version": "0.0.0",
+  "description": "Model Context Protocol server for svelte-vitals — run SEO analysis inside an agent's tool loop.",
+  "type": "module",
+  "license": "MIT",
+  "author": "Kazuma Oe (https://github.com/oekazuma)",
+  "keywords": [
+    "svelte",
+    "sveltekit",
+    "seo",
+    "mcp",
+    "model-context-protocol",
+    "svelte-vitals"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/oekazuma/svelte-vitals.git",
+    "directory": "packages/mcp"
+  },
+  "bugs": {
+    "url": "https://github.com/oekazuma/svelte-vitals/issues"
+  },
+  "homepage": "https://github.com/oekazuma/svelte-vitals#readme",
+  "bin": {
+    "svelte-vitals-mcp": "./dist/bin.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "catalog:",
+    "@svelte-vitals/core": "workspace:*",
+    "svelte-vitals": "workspace:*",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:"
+  }
+}

--- a/packages/mcp/src/bin.ts
+++ b/packages/mcp/src/bin.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { createServer } from './server.js';
+
+async function main(): Promise<void> {
+  const server = createServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+void main().catch((err) => {
+  // stderr is safe on stdio transport (stdout carries the protocol).
+  console.error(`svelte-vitals-mcp: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+});

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,0 +1,5 @@
+export { createServer } from './server.js';
+export { handleAnalyze, analyzeInputShape } from './tools/analyze.js';
+export type { McpToolResult, AnalyzeArgs } from './tools/analyze.js';
+export { handleExplainRule, explainRuleInputShape } from './tools/explain-rule.js';
+export type { ExplainRuleArgs } from './tools/explain-rule.js';

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { analyzeInputShape, handleAnalyze } from './tools/analyze.js';
+import { explainRuleInputShape, handleExplainRule } from './tools/explain-rule.js';
 
 /** Build the svelte-vitals MCP server with all tools registered. */
 export function createServer(): McpServer {
@@ -15,6 +16,16 @@ export function createServer(): McpServer {
       inputSchema: analyzeInputShape
     },
     async (args) => (await handleAnalyze(args)) as CallToolResult
+  );
+
+  server.registerTool(
+    'explain_rule',
+    {
+      title: 'Explain an SEO rule',
+      description: "Return a rule's title, category, default severity, rationale, docs URL, and fix template.",
+      inputSchema: explainRuleInputShape
+    },
+    async (args) => (await handleExplainRule(args)) as CallToolResult
   );
 
   return server;

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,0 +1,21 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { analyzeInputShape, handleAnalyze } from './tools/analyze.js';
+
+/** Build the svelte-vitals MCP server with all tools registered. */
+export function createServer(): McpServer {
+  const server = new McpServer({ name: 'svelte-vitals', version: '0.0.0' });
+
+  server.registerTool(
+    'analyze',
+    {
+      title: 'Analyze SvelteKit SEO',
+      description:
+        'Run svelte-vitals static-mode SEO analysis on a SvelteKit project and return a structured report (per-route and site-wide scores, findings with fix/recommendation/docs).',
+      inputSchema: analyzeInputShape
+    },
+    async (args) => (await handleAnalyze(args)) as CallToolResult
+  );
+
+  return server;
+}

--- a/packages/mcp/src/tools/analyze.ts
+++ b/packages/mcp/src/tools/analyze.ts
@@ -14,6 +14,12 @@ function textError(message: string): McpToolResult {
 
 const analyzeInputSchema = z.object({
   path: z.string().optional().describe('Project root to analyze (defaults to the server cwd).'),
+  metaComponents: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Component names that resolve SEO tags into <head> (e.g. ["Seo"]); their presence suppresses missing-tag findings for the head they own. Mirrors the CLI --meta-components flag.'
+    ),
   route: z.string().optional().describe('Glob to restrict which routes are analyzed, e.g. "blog/**".'),
   treatDynamicAs: z
     .enum(['pass', 'warn', 'fail'])
@@ -37,8 +43,10 @@ export type AnalyzeArgs = z.infer<typeof analyzeInputSchema>;
  * and non-SvelteKit paths are returned as `isError` results, not thrown.
  */
 export async function handleAnalyze(args: AnalyzeArgs): Promise<McpToolResult> {
-  const allow = args.rules ?? [];
-  const ignore = args.ignore ?? [];
+  // Rule ids are accepted case-insensitively; normalize to the canonical
+  // uppercase form before validation and config building.
+  const allow = (args.rules ?? []).map((id) => id.toUpperCase());
+  const ignore = (args.ignore ?? []).map((id) => id.toUpperCase());
   const unknown = findUnknownRuleIds([...allow, ...ignore]);
   if (unknown.length > 0) {
     return textError(`Unknown rule id(s): ${unknown.join(', ')}. Known rule ids: ${knownRuleIds().join(', ')}.`);
@@ -47,6 +55,7 @@ export async function handleAnalyze(args: AnalyzeArgs): Promise<McpToolResult> {
   try {
     const { results, config, version } = await analyzeProject({
       cwd: args.path,
+      metaComponents: args.metaComponents,
       treatDynamicAs: args.treatDynamicAs,
       route: args.route,
       failOn: args.failOn,

--- a/packages/mcp/src/tools/analyze.ts
+++ b/packages/mcp/src/tools/analyze.ts
@@ -12,8 +12,7 @@ function textError(message: string): McpToolResult {
   return { content: [{ type: 'text', text: message }], isError: true };
 }
 
-/** zod raw shape for the analyze tool's input (registered with the MCP server). */
-export const analyzeInputShape = {
+const analyzeInputSchema = z.object({
   path: z.string().optional().describe('Project root to analyze (defaults to the server cwd).'),
   route: z.string().optional().describe('Glob to restrict which routes are analyzed, e.g. "blog/**".'),
   treatDynamicAs: z
@@ -26,10 +25,11 @@ export const analyzeInputShape = {
     .enum(['critical', 'warning', 'info'])
     .optional()
     .describe('Minimum severity that counts as a failure in the summary. Default: critical.')
-};
+});
 
-const analyzeInput = z.object(analyzeInputShape);
-export type AnalyzeArgs = z.infer<typeof analyzeInput>;
+/** zod raw shape for the analyze tool's input (registered with the MCP server). */
+export const analyzeInputShape = analyzeInputSchema.shape;
+export type AnalyzeArgs = z.infer<typeof analyzeInputSchema>;
 
 export async function handleAnalyze(args: AnalyzeArgs): Promise<McpToolResult> {
   const allow = args.rules ?? [];

--- a/packages/mcp/src/tools/analyze.ts
+++ b/packages/mcp/src/tools/analyze.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+import { analyzeProject, buildRulesConfig, findUnknownRuleIds, knownRuleIds, ProjectError } from 'svelte-vitals';
+import { buildJsonReport } from '@svelte-vitals/core';
+
+export interface McpToolResult {
+  content: Array<{ type: 'text'; text: string }>;
+  structuredContent?: unknown;
+  isError?: boolean;
+}
+
+function textError(message: string): McpToolResult {
+  return { content: [{ type: 'text', text: message }], isError: true };
+}
+
+/** zod raw shape for the analyze tool's input (registered with the MCP server). */
+export const analyzeInputShape = {
+  path: z.string().optional().describe('Project root to analyze (defaults to the server cwd).'),
+  route: z.string().optional().describe('Glob to restrict which routes are analyzed, e.g. "blog/**".'),
+  treatDynamicAs: z
+    .enum(['pass', 'warn', 'fail'])
+    .optional()
+    .describe('How dynamic ({data.title}) values are scored. Default: pass.'),
+  rules: z.array(z.string()).optional().describe('Enable only these rule ids (all others disabled).'),
+  ignore: z.array(z.string()).optional().describe('Disable these rule ids.'),
+  failOn: z
+    .enum(['critical', 'warning', 'info'])
+    .optional()
+    .describe('Minimum severity that counts as a failure in the summary. Default: critical.')
+};
+
+const analyzeInput = z.object(analyzeInputShape);
+export type AnalyzeArgs = z.infer<typeof analyzeInput>;
+
+export async function handleAnalyze(args: AnalyzeArgs): Promise<McpToolResult> {
+  const allow = args.rules ?? [];
+  const ignore = args.ignore ?? [];
+  const unknown = findUnknownRuleIds([...allow, ...ignore]);
+  if (unknown.length > 0) {
+    return textError(`Unknown rule id(s): ${unknown.join(', ')}. Known rule ids: ${knownRuleIds().join(', ')}.`);
+  }
+
+  try {
+    const { results, config, version } = await analyzeProject({
+      cwd: args.path,
+      treatDynamicAs: args.treatDynamicAs,
+      route: args.route,
+      failOn: args.failOn,
+      rules: buildRulesConfig(allow, ignore)
+    });
+    const report = buildJsonReport(results, config, { version });
+    return {
+      content: [{ type: 'text', text: JSON.stringify(report, null, 2) }],
+      structuredContent: report
+    };
+  } catch (err) {
+    if (err instanceof ProjectError) return textError(err.message);
+    return textError(`svelte-vitals: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}

--- a/packages/mcp/src/tools/analyze.ts
+++ b/packages/mcp/src/tools/analyze.ts
@@ -31,6 +31,11 @@ const analyzeInputSchema = z.object({
 export const analyzeInputShape = analyzeInputSchema.shape;
 export type AnalyzeArgs = z.infer<typeof analyzeInputSchema>;
 
+/**
+ * Handle the `analyze` tool call: run static-mode analysis and return the
+ * structured JSON report as both text and `structuredContent`. Unknown rule ids
+ * and non-SvelteKit paths are returned as `isError` results, not thrown.
+ */
 export async function handleAnalyze(args: AnalyzeArgs): Promise<McpToolResult> {
   const allow = args.rules ?? [];
   const ignore = args.ignore ?? [];

--- a/packages/mcp/src/tools/explain-rule.ts
+++ b/packages/mcp/src/tools/explain-rule.ts
@@ -10,6 +10,11 @@ const explainRuleInputSchema = z.object({
 export const explainRuleInputShape = explainRuleInputSchema.shape;
 export type ExplainRuleArgs = z.infer<typeof explainRuleInputSchema>;
 
+/**
+ * Handle the `explain_rule` tool call: look up a rule's static metadata and
+ * return it as both a text rendering and `structuredContent`. An unknown id is
+ * returned as an `isError` result listing the known rule ids.
+ */
 export async function handleExplainRule(args: ExplainRuleArgs): Promise<McpToolResult> {
   const info = explainRule(args.id);
   if (!info) {

--- a/packages/mcp/src/tools/explain-rule.ts
+++ b/packages/mcp/src/tools/explain-rule.ts
@@ -3,20 +3,18 @@ import { explainRule } from '@svelte-vitals/core';
 import { knownRuleIds } from 'svelte-vitals';
 import type { McpToolResult } from './analyze.js';
 
-export const explainRuleInputShape = {
+const explainRuleInputSchema = z.object({
   id: z.string().describe('Rule id to explain, e.g. "SEO001".')
-};
+});
 
-const explainRuleInput = z.object(explainRuleInputShape);
-export type ExplainRuleArgs = z.infer<typeof explainRuleInput>;
+export const explainRuleInputShape = explainRuleInputSchema.shape;
+export type ExplainRuleArgs = z.infer<typeof explainRuleInputSchema>;
 
 export async function handleExplainRule(args: ExplainRuleArgs): Promise<McpToolResult> {
   const info = explainRule(args.id);
   if (!info) {
     return {
-      content: [
-        { type: 'text', text: `Unknown rule id: ${args.id}. Known rule ids: ${knownRuleIds().join(', ')}.` }
-      ],
+      content: [{ type: 'text', text: `Unknown rule id: ${args.id}. Known rule ids: ${knownRuleIds().join(', ')}.` }],
       isError: true
     };
   }

--- a/packages/mcp/src/tools/explain-rule.ts
+++ b/packages/mcp/src/tools/explain-rule.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import { explainRule } from '@svelte-vitals/core';
+import { knownRuleIds } from 'svelte-vitals';
+import type { McpToolResult } from './analyze.js';
+
+export const explainRuleInputShape = {
+  id: z.string().describe('Rule id to explain, e.g. "SEO001".')
+};
+
+const explainRuleInput = z.object(explainRuleInputShape);
+export type ExplainRuleArgs = z.infer<typeof explainRuleInput>;
+
+export async function handleExplainRule(args: ExplainRuleArgs): Promise<McpToolResult> {
+  const info = explainRule(args.id);
+  if (!info) {
+    return {
+      content: [
+        { type: 'text', text: `Unknown rule id: ${args.id}. Known rule ids: ${knownRuleIds().join(', ')}.` }
+      ],
+      isError: true
+    };
+  }
+  const text =
+    `${info.id} — ${info.title} (${info.severity}, ${info.category})\n\n` +
+    `${info.rationale}\n\nDocs: ${info.docsUrl}` +
+    (info.fix ? `\n\nFix: ${info.fix.description}` : '');
+  return { content: [{ type: 'text', text }], structuredContent: info };
+}

--- a/packages/mcp/test/analyze-tool.test.ts
+++ b/packages/mcp/test/analyze-tool.test.ts
@@ -14,18 +14,24 @@ describe('analyze tool', () => {
     const report = res.structuredContent as { score: number; routes: unknown[]; summary: unknown };
     expect(typeof report.score).toBe('number');
     expect(Array.isArray(report.routes)).toBe(true);
-    expect(res.content[0]!.text).toContain('score');
+    // The text payload and the structured payload must be the same report — guard
+    // against drift between the two shapes (summary, finding metadata, scores).
+    expect(JSON.parse(res.content[0]!.text)).toEqual(report);
   });
 
   it('reports an error for an unknown rule id', async () => {
     const res = await handleAnalyze({ path: fixtureDir, rules: ['NOPE999'] });
     expect(res.isError).toBe(true);
-    expect(res.content[0]!.text).toContain('NOPE999');
+    const text = res.content[0]!.text;
+    expect(text).toContain('Unknown rule id(s): NOPE999');
+    expect(text).toContain('Known rule ids:');
+    expect(text).toContain('SEO001');
   });
 
   it('reports an error for a non-SvelteKit path', async () => {
     const res = await handleAnalyze({ path: here });
     expect(res.isError).toBe(true);
-    expect(res.content[0]!.text).toContain('SvelteKit');
+    // Propagates the CLI's ProjectError message verbatim.
+    expect(res.content[0]!.text).toContain('No SvelteKit project found');
   });
 });

--- a/packages/mcp/test/analyze-tool.test.ts
+++ b/packages/mcp/test/analyze-tool.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { handleAnalyze } from '../src/tools/analyze.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+// Reuse the CLI's fixture project so we don't duplicate a SvelteKit tree.
+const fixtureDir = join(here, '..', '..', 'cli', 'test', 'fixtures', 'basic-project');
+
+describe('analyze tool', () => {
+  it('returns a structured JSON report for a project path', async () => {
+    const res = await handleAnalyze({ path: fixtureDir });
+    expect(res.isError).toBeFalsy();
+    const report = res.structuredContent as { score: number; routes: unknown[]; summary: unknown };
+    expect(typeof report.score).toBe('number');
+    expect(Array.isArray(report.routes)).toBe(true);
+    expect(res.content[0]!.text).toContain('score');
+  });
+
+  it('reports an error for an unknown rule id', async () => {
+    const res = await handleAnalyze({ path: fixtureDir, rules: ['NOPE999'] });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain('NOPE999');
+  });
+
+  it('reports an error for a non-SvelteKit path', async () => {
+    const res = await handleAnalyze({ path: here });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain('SvelteKit');
+  });
+});

--- a/packages/mcp/test/analyze-tool.test.ts
+++ b/packages/mcp/test/analyze-tool.test.ts
@@ -19,6 +19,30 @@ describe('analyze tool', () => {
     expect(JSON.parse(res.content[0]!.text)).toEqual(report);
   });
 
+  it('honors metaComponents so a wrapper-supplied title is not flagged', async () => {
+    type Report = { routes: Array<{ route: string; issues: Array<{ id: string }> }> };
+    const widgetIssues = (report: Report) =>
+      report.routes.find((r) => r.route === '/widget')?.issues.map((i) => i.id) ?? [];
+
+    // Baseline: /widget renders <Widget /> with no <title>, so SEO001 fires there.
+    const base = await handleAnalyze({ path: fixtureDir });
+    expect(widgetIssues(base.structuredContent as Report)).toContain('SEO001');
+
+    // Declaring Widget as a meta component promotes its title to dynamic/pass.
+    const withMeta = await handleAnalyze({ path: fixtureDir, metaComponents: ['Widget'] });
+    expect(withMeta.isError).toBeFalsy();
+    expect(widgetIssues(withMeta.structuredContent as Report)).not.toContain('SEO001');
+  });
+
+  it('accepts rule ids case-insensitively', async () => {
+    const res = await handleAnalyze({ path: fixtureDir, rules: ['seo001'] });
+    expect(res.isError).toBeFalsy();
+    const report = res.structuredContent as { routes: Array<{ issues: Array<{ id: string }> }> };
+    const ids = new Set(report.routes.flatMap((r) => r.issues.map((i) => i.id)));
+    // Allow-list of a single rule disables the others, so only SEO001 can appear.
+    for (const id of ids) expect(id).toBe('SEO001');
+  });
+
   it('reports an error for an unknown rule id', async () => {
     const res = await handleAnalyze({ path: fixtureDir, rules: ['NOPE999'] });
     expect(res.isError).toBe(true);

--- a/packages/mcp/test/analyze-tool.test.ts
+++ b/packages/mcp/test/analyze-tool.test.ts
@@ -40,6 +40,8 @@ describe('analyze tool', () => {
     const report = res.structuredContent as { routes: Array<{ issues: Array<{ id: string }> }> };
     const ids = new Set(report.routes.flatMap((r) => r.issues.map((i) => i.id)));
     // Allow-list of a single rule disables the others, so only SEO001 can appear.
+    // Guard against a vacuous pass: the fixture must surface at least one SEO001.
+    expect(ids.size).toBeGreaterThan(0);
     for (const id of ids) expect(id).toBe('SEO001');
   });
 

--- a/packages/mcp/test/explain-rule-tool.test.ts
+++ b/packages/mcp/test/explain-rule-tool.test.ts
@@ -2,18 +2,36 @@ import { describe, it, expect } from 'vitest';
 import { handleExplainRule } from '../src/tools/explain-rule.js';
 
 describe('explain_rule tool', () => {
-  it('returns rule info for a known id', async () => {
+  it('returns the full RuleInfo payload for a known id', async () => {
     const res = await handleExplainRule({ id: 'SEO001' });
     expect(res.isError).toBeFalsy();
-    const info = res.structuredContent as { id: string; severity: string; docsUrl: string };
+    const info = res.structuredContent as {
+      id: string;
+      title: string;
+      category: string;
+      severity: string;
+      rationale: string;
+      docsUrl: string;
+      fix?: { description: string };
+    };
     expect(info.id).toBe('SEO001');
+    expect(info.title).toBe('Title presence');
+    expect(info.category).toBe('seo');
     expect(info.severity).toBe('critical');
+    expect(info.rationale.length).toBeGreaterThan(0);
     expect(info.docsUrl).toBe('https://svelte-vitals.dev/rules/SEO001');
+    expect(info.fix?.description.length).toBeGreaterThan(0);
+    // The text rendering carries the same id and docs link.
+    expect(res.content[0]!.text).toContain('SEO001');
+    expect(res.content[0]!.text).toContain('https://svelte-vitals.dev/rules/SEO001');
   });
 
   it('reports an error for an unknown id', async () => {
     const res = await handleExplainRule({ id: 'NOPE999' });
     expect(res.isError).toBe(true);
-    expect(res.content[0]!.text).toContain('NOPE999');
+    const text = res.content[0]!.text;
+    expect(text).toContain('Unknown rule id: NOPE999');
+    expect(text).toContain('Known rule ids:');
+    expect(text).toContain('SEO001');
   });
 });

--- a/packages/mcp/test/explain-rule-tool.test.ts
+++ b/packages/mcp/test/explain-rule-tool.test.ts
@@ -26,6 +26,13 @@ describe('explain_rule tool', () => {
     expect(res.content[0]!.text).toContain('https://svelte-vitals.dev/rules/SEO001');
   });
 
+  it('resolves the rule id case-insensitively', async () => {
+    const res = await handleExplainRule({ id: 'seo001' });
+    expect(res.isError).toBeFalsy();
+    const info = res.structuredContent as { id: string };
+    expect(info.id).toBe('SEO001');
+  });
+
   it('reports an error for an unknown id', async () => {
     const res = await handleExplainRule({ id: 'NOPE999' });
     expect(res.isError).toBe(true);

--- a/packages/mcp/test/explain-rule-tool.test.ts
+++ b/packages/mcp/test/explain-rule-tool.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { handleExplainRule } from '../src/tools/explain-rule.js';
+
+describe('explain_rule tool', () => {
+  it('returns rule info for a known id', async () => {
+    const res = await handleExplainRule({ id: 'SEO001' });
+    expect(res.isError).toBeFalsy();
+    const info = res.structuredContent as { id: string; severity: string; docsUrl: string };
+    expect(info.id).toBe('SEO001');
+    expect(info.severity).toBe('critical');
+    expect(info.docsUrl).toBe('https://svelte-vitals.dev/rules/SEO001');
+  });
+
+  it('reports an error for an unknown id', async () => {
+    const res = await handleExplainRule({ id: 'NOPE999' });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain('NOPE999');
+  });
+});

--- a/packages/mcp/test/server.test.ts
+++ b/packages/mcp/test/server.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { createServer } from '../src/server.js';
+
+describe('createServer', () => {
+  it('builds a server without throwing', () => {
+    const server = createServer();
+    expect(server).toBeDefined();
+  });
+});

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src", "test"]
+}

--- a/packages/mcp/tsup.config.ts
+++ b/packages/mcp/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup';
+
+// ESM-only by design (issue #20) — never add 'cjs'.
+export default defineConfig({
+  entry: ['src/index.ts', 'src/bin.ts'],
+  format: ['esm'],
+  dts: { entry: 'src/index.ts' },
+  clean: true,
+  target: 'es2022'
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ catalogs:
     '@eslint/js':
       specifier: ^10.0.1
       version: 10.0.1
+    '@modelcontextprotocol/sdk':
+      specifier: ^1.29.0
+      version: 1.29.0
     '@sveltejs/kit':
       specifier: ^2.0.0
       version: 2.66.0
@@ -75,6 +78,9 @@ catalogs:
     vitest:
       specifier: ^4.1.8
       version: 4.1.8
+    zod:
+      specifier: ^4.4.3
+      version: 4.4.3
 
 importers:
 
@@ -155,6 +161,25 @@ importers:
         version: 24.13.2
 
   packages/core: {}
+
+  packages/mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 'catalog:'
+        version: 1.29.0(zod@4.4.3)
+      '@svelte-vitals/core':
+        specifier: workspace:*
+        version: link:../core
+      svelte-vitals:
+        specifier: workspace:*
+        version: link:../cli
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
 
   packages/vite:
     dependencies:
@@ -458,6 +483,12 @@ packages:
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -508,6 +539,16 @@ packages:
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@1.1.5':
     resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
@@ -925,6 +966,10 @@ packages:
   '@vitest/utils@4.1.8':
     resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -935,8 +980,19 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -979,6 +1035,10 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -996,9 +1056,21 @@ packages:
     peerDependencies:
       esbuild: '>=0.18'
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1026,12 +1098,36 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
 
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1065,6 +1161,10 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -1093,6 +1193,17 @@ packages:
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
@@ -1101,13 +1212,28 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1202,9 +1328,31 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -1221,6 +1369,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -1242,6 +1393,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -1260,6 +1415,14 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -1272,6 +1435,17 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1293,12 +1467,32 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
 
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  hono@4.12.26:
+    resolution: {integrity: sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==}
+    engines: {node: '>=16.9.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   human-id@4.2.0:
     resolution: {integrity: sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==}
@@ -1320,6 +1514,17 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1331,6 +1536,9 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
@@ -1345,6 +1553,9 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -1363,6 +1574,12 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -1490,6 +1707,18 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -1497,6 +1726,14 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -1526,6 +1763,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
 
   node-html-parser@6.1.13:
     resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
@@ -1636,9 +1877,20 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1681,6 +1933,10 @@ packages:
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1688,6 +1944,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -1714,6 +1973,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -1789,6 +2052,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   publint@0.3.21:
     resolution: {integrity: sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ==}
     engines: {node: '>=18'}
@@ -1798,11 +2065,23 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+    engines: {node: '>=0.6'}
+
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -1811,6 +2090,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -1830,6 +2113,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -1845,8 +2132,19 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1855,6 +2153,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1887,6 +2201,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
@@ -1950,6 +2268,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -1993,6 +2315,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typescript-eslint@8.61.0:
     resolution: {integrity: sha512-8y31Rd0eGTrDKqhy6vT0HtzhN+YLjQizwX3aA3hPXP/ynSfnrBXcQY5IzsP9/DM7+klX4IUncZZjkchP0z+rUw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2015,11 +2341,19 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
@@ -2127,6 +2461,9 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   yaml@1.10.3:
     resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
@@ -2137,6 +2474,14 @@ packages:
 
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -2419,6 +2764,10 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
+  '@hono/node-server@1.19.14(hono@4.12.26)':
+    dependencies:
+      hono: 4.12.26
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -2476,6 +2825,28 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.26)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.26
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -2828,11 +3199,20 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
 
   acorn@8.17.0: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
 
   ajv@6.15.0:
     dependencies:
@@ -2840,6 +3220,13 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-colors@4.1.3: {}
 
@@ -2867,6 +3254,20 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.2
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   boolbase@1.0.0: {}
 
   brace-expansion@5.0.6:
@@ -2882,7 +3283,19 @@ snapshots:
       esbuild: 0.27.7
       load-tsconfig: 0.2.5
 
+  bytes@3.1.2: {}
+
   cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   chai@6.2.2: {}
 
@@ -2900,9 +3313,24 @@ snapshots:
 
   consola@3.4.2: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
 
+  cookie-signature@1.2.2: {}
+
   cookie@0.6.0: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -2929,6 +3357,8 @@ snapshots:
   deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
+
+  depd@2.0.0: {}
 
   detect-indent@6.1.0: {}
 
@@ -2958,6 +3388,16 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  encodeurl@2.0.0: {}
+
   enquirer@2.4.1:
     dependencies:
       ansi-colors: 4.1.3
@@ -2965,7 +3405,15 @@ snapshots:
 
   entities@4.5.0: {}
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.1.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -2995,6 +3443,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.7
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -3111,7 +3561,53 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.2
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extendable-error@0.1.7: {}
 
@@ -3129,6 +3625,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-uri@3.1.2: {}
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -3144,6 +3642,17 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   find-up@4.1.0:
     dependencies:
@@ -3168,6 +3677,10 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -3182,6 +3695,26 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   glob-parent@5.1.2:
     dependencies:
@@ -3204,9 +3737,27 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
   he@1.2.0: {}
+
+  hono@4.12.26: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   human-id@4.2.0: {}
 
@@ -3220,6 +3771,12 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  inherits@2.0.4: {}
+
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
+
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
@@ -3227,6 +3784,8 @@ snapshots:
       is-extglob: 2.1.1
 
   is-number@7.0.0: {}
+
+  is-promise@4.0.0: {}
 
   is-reference@3.0.3:
     dependencies:
@@ -3239,6 +3798,8 @@ snapshots:
   is-windows@1.0.2: {}
 
   isexe@2.0.0: {}
+
+  jose@6.2.3: {}
 
   joycon@3.1.1: {}
 
@@ -3254,6 +3815,10 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -3347,12 +3912,24 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.2
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   minimatch@10.2.5:
     dependencies:
@@ -3381,6 +3958,8 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@1.0.0: {}
+
   node-html-parser@6.1.13:
     dependencies:
       css-select: 5.2.2
@@ -3394,7 +3973,17 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-inspect@1.13.4: {}
+
   obug@2.1.3: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   optionator@0.9.4:
     dependencies:
@@ -3437,9 +4026,13 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
@@ -3454,6 +4047,8 @@ snapshots:
   pify@4.0.1: {}
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -3504,6 +4099,11 @@ snapshots:
 
   prettier@3.8.4: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   publint@0.3.21:
     dependencies:
       '@publint/pack': 0.1.4
@@ -3513,9 +4113,22 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qs@6.15.2:
+    dependencies:
+      side-channel: 1.1.1
+
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -3525,6 +4138,8 @@ snapshots:
       strip-bom: 3.0.0
 
   readdirp@4.1.2: {}
+
+  require-from-string@2.0.2: {}
 
   resolve-from@5.0.0: {}
 
@@ -3582,6 +4197,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.0
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -3594,13 +4219,68 @@ snapshots:
 
   semver@7.8.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   set-cookie-parser@3.1.0: {}
+
+  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -3626,6 +4306,8 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@4.1.0: {}
 
@@ -3705,6 +4387,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   totalist@3.0.1: {}
 
   tree-kill@1.2.2: {}
@@ -3750,6 +4434,12 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript-eslint@8.61.0(eslint@10.5.0)(typescript@6.0.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0)(typescript@6.0.3))(eslint@10.5.0)(typescript@6.0.3)
@@ -3769,11 +4459,15 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  unpipe@1.0.0: {}
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  vary@1.1.2: {}
 
   vite@8.0.16(@types/node@24.13.2)(esbuild@0.27.7):
     dependencies:
@@ -3829,8 +4523,16 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrappy@1.0.2: {}
+
   yaml@1.10.3: {}
 
   yocto-queue@0.1.0: {}
 
   zimmerframe@1.1.4: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
+  zod@4.4.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ allowBuilds:
 catalog:
   '@changesets/cli': ^2.31.0
   '@eslint/compat': ^2.1.0
+  '@modelcontextprotocol/sdk': ^1.29.0
   '@eslint/js': ^10.0.1
   '@sveltejs/kit': ^2.0.0
   '@types/eslint': ^9.6.1
@@ -30,3 +31,4 @@ catalog:
   typescript-eslint: ^8.61.0
   vite: ^8.0.16
   vitest: ^4.1.8
+  zod: ^4.4.3


### PR DESCRIPTION
## Summary

Ships `@svelte-vitals/mcp`, a Model Context Protocol server exposing svelte-vitals' static-mode SEO analysis to AI agents — the final increment of the agent-native epic (#18). Closes #24.

Two tools over **stdio**:

- **`analyze`** — run static-mode analysis on a project path; returns the structured JSON report (per-route + site-wide scores, findings with `fix`/`recommendation`/`docsUrl`). Inputs mirror the CLI: `path?`, `route?`, `treatDynamicAs?`, `rules?`, `ignore?`, `failOn?`.
- **`explain_rule`** — given a rule id (e.g. `SEO001`), returns its title, category, severity, rationale, docs URL, and fix template.

The MCP layer is an **adapter** over the existing pipeline — no rule logic is duplicated.

## Changes

- **core**: extract `buildJsonReport` from the json reporter; promote `rationale`/`fix` onto the `Rule` object as the single source of truth; add `explainRule`, `RuleInfo`, `docsUrlFor`; the JSON report's per-finding objects now carry `docsUrl`.
- **cli**: extract `analyzeProject()` (the analysis pipeline) so both `run()` and the MCP server reuse it; re-export `ProjectError` + rules-config helpers. `run()` keeps its documented 0/1/2 exit-code contract, with one deliberate consistency change: a non-`ProjectError` failure during project detection now returns exit 2 (the documented "internal error" code) instead of propagating as an uncaught throw — uniform with how pipeline/reporter errors were already handled.
- **mcp** (new package): `analyze` + `explain_rule` tool handlers, stdio server (`svelte-vitals-mcp` bin), library entry.
- **docs/release**: README roadmap (drop closed `--fix`, move dev overlay + MCP to Shipped), package README, `check:publish` extended, changeset (mcp/core/cli minor).

## Note on #11

`--fix` autofix (#11) was closed as agent-delegated during design: the only mechanically-safe fixes (robots.txt/sitemap.xml) are trivial for an agent, while the valuable ones (canonical/description/og) need the real domain & page content an agent already has. MCP is the higher-leverage path — give the agent fixable context, let it apply the fix.

## Validation

- `pnpm -r test` — **194 passed** (core 69, vite 31, cli 88, mcp 6)
- `pnpm -r typecheck`, `pnpm lint`, `pnpm check:publish` (publint, all 4 packages) — green
- Manual stdio smoke: `initialize` + `tools/list` return both tools; `tools/call explain_rule` round-trips with `structuredContent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `@svelte-vitals/mcp`, an MCP server for integrating Svelte Vitals analysis with AI agents via `analyze` and `explain_rule` tools
  * Added `explainRule()` API for retrieving rule metadata including documentation URLs
  * Enhanced JSON reports with documentation URLs for all findings

* **Documentation**
  * Updated roadmap to reflect MCP server and dev overlay as shipped features
  * Added MCP package documentation with tool specifications and usage examples

* **Chores**
  * Refactored CLI analysis pipeline to expose reusable `analyzeProject()` API
  * Extended workspace with new `@svelte-vitals/mcp` package

<!-- end of auto-generated comment: release notes by coderabbit.ai -->