### PR TITLE
chore(cli): drop change-narrative comment in run() catch

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -117,9 +117,6 @@ export async function run(opts: RunOptions = {}): Promise<number> {
       errorLog(err.message);
       return 2;
     }
-    // Any other failure during analysis is an internal error: report it and exit 2,
-    // matching the documented exit-code contract (see --help). We deliberately do
-    // not rethrow — the CLI surfaces a clean message rather than an uncaught stack.
     errorLog(`svelte-vitals: ${err instanceof Error ? err.message : String(err)}`);
     return 2;
   }


### PR DESCRIPTION
Removes a comment in `run()`'s catch block that only justified the behavior *at the time of the change* ("we deliberately do not rethrow…"). The catch mirrors the `ProjectError` branch directly above it — which returns exit 2 with no commentary — so the code is self-evident to a fresh reader and the narrative comment adds noise.

No behavior change; comment-only (stripped from `dist` by tsup, so no changeset needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)