### PR TITLE
chore: Slice 1 review polish (#13)

### DIFF
--- a/.changeset/slice1-polish.md
+++ b/.changeset/slice1-polish.md
@@ -4,6 +4,6 @@
 
 Slice 1 polish (#13): capture the imported name from string-literal import
 specifiers (`import { 'a-b' as c }`) instead of falling back to the local alias,
-and warn instead of silently defaulting when `--treat-dynamic-as` gets an
-unknown value. Adds direct unit coverage for `attrValueOf` and for component
-detection inside `{#if}` branches.
+and warn instead of silently defaulting when `--treat-dynamic-as` or `--fail-on`
+gets an unknown value. Adds direct unit coverage for `attrValueOf` and for
+component detection inside `{#if}` branches.

--- a/.changeset/slice1-polish.md
+++ b/.changeset/slice1-polish.md
@@ -1,0 +1,9 @@
+---
+'svelte-vitals': patch
+---
+
+Slice 1 polish (#13): capture the imported name from string-literal import
+specifiers (`import { 'a-b' as c }`) instead of falling back to the local alias,
+and warn instead of silently defaulting when `--treat-dynamic-as` gets an
+unknown value. Adds direct unit coverage for `attrValueOf` and for component
+detection inside `{#if}` branches.

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -2,8 +2,7 @@
 import mri from 'mri';
 import { run } from './index.js';
 import { readPackageVersion } from './version.js';
-import { buildRulesConfig, findUnknownRuleIds, knownRuleIds } from './rules-config.js';
-import { isReporterName, type ReporterName } from './reporter-resolve.js';
+import { resolveArgs } from './resolve-args.js';
 
 const HELP = `svelte-vitals — a SvelteKit SEO checker (static mode)
 
@@ -47,67 +46,12 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  const positional = argv._[0];
-  const metaComponents =
-    typeof argv['meta-components'] === 'string'
-      ? argv['meta-components']
-          .split(',')
-          .map((s) => s.trim())
-          .filter(Boolean)
-      : undefined;
-  const treatRaw = argv['treat-dynamic-as'];
-  const treatDynamicAs = treatRaw === 'warn' || treatRaw === 'fail' || treatRaw === 'pass' ? treatRaw : undefined;
-  if (typeof treatRaw === 'string' && treatDynamicAs === undefined) {
-    console.error(
-      `svelte-vitals: unknown --treat-dynamic-as '${treatRaw}'; expected pass|warn|fail. Defaulting to 'pass'.`
-    );
-  }
-  const route = typeof argv.route === 'string' ? argv.route : undefined;
+  const { options, warnings, errors } = resolveArgs(argv);
+  for (const w of warnings) console.error(w);
+  for (const e of errors) console.error(e);
+  if (!options) process.exit(2);
 
-  const toList = (v: unknown) =>
-    typeof v === 'string'
-      ? v
-          .split(',')
-          .map((s) => s.trim())
-          .filter(Boolean)
-      : [];
-  const allow = toList(argv.rules);
-  const ignore = toList(argv.ignore);
-  const unknown = findUnknownRuleIds([...allow, ...ignore]);
-  if (unknown.length > 0) {
-    console.error(`svelte-vitals: unknown rule id(s) in --rules/--ignore: ${unknown.join(', ')}`);
-    console.error(`Known rule ids: ${knownRuleIds().join(', ')}`);
-    process.exit(2);
-  }
-  let reporter: ReporterName | undefined;
-  if (argv.json) {
-    reporter = 'json';
-  } else if (typeof argv.reporter === 'string') {
-    if (!isReporterName(argv.reporter)) {
-      console.error(
-        `svelte-vitals: unknown reporter '${argv.reporter}'. Valid values: console, json, agent, sarif, github.`
-      );
-      process.exit(2);
-    }
-    reporter = argv.reporter;
-  }
-  const failOnRaw = argv['fail-on'];
-  const failOn = argv['fail-on-warning']
-    ? 'warning'
-    : failOnRaw === 'warning' || failOnRaw === 'info' || failOnRaw === 'critical'
-      ? failOnRaw
-      : undefined;
-
-  const code = await run({
-    cwd: positional ?? process.cwd(),
-    metaComponents,
-    treatDynamicAs,
-    route,
-    reporter,
-    byRoute: Boolean(argv['by-route']),
-    failOn,
-    rules: buildRulesConfig(allow, ignore)
-  });
+  const code = await run(options);
   process.exit(code);
 }
 

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -57,6 +57,11 @@ async function main(): Promise<void> {
       : undefined;
   const treatRaw = argv['treat-dynamic-as'];
   const treatDynamicAs = treatRaw === 'warn' || treatRaw === 'fail' || treatRaw === 'pass' ? treatRaw : undefined;
+  if (typeof treatRaw === 'string' && treatDynamicAs === undefined) {
+    console.error(
+      `svelte-vitals: unknown --treat-dynamic-as '${treatRaw}'; expected pass|warn|fail. Defaulting to 'pass'.`
+    );
+  }
   const route = typeof argv.route === 'string' ? argv.route : undefined;
 
   const toList = (v: unknown) =>

--- a/packages/cli/src/providers/source/imports.ts
+++ b/packages/cli/src/providers/source/imports.ts
@@ -20,7 +20,10 @@ function addImportsFromProgram(program: Node, map: ImportMap): void {
       if (spec.type === 'ImportDefaultSpecifier') {
         map.set(local, { source, imported: 'default' });
       } else if (spec.type === 'ImportSpecifier') {
-        map.set(local, { source, imported: spec.imported?.name ?? local });
+        // `imported` is an Identifier (`.name`) for normal specifiers, or a string
+        // Literal (`.value`) for string-literal specifiers (`import { 'a-b' as c }`).
+        // Falling back to `local` would mislabel the latter (`c` instead of `a-b`).
+        map.set(local, { source, imported: spec.imported?.name ?? spec.imported?.value ?? local });
       }
     }
   }

--- a/packages/cli/src/resolve-args.ts
+++ b/packages/cli/src/resolve-args.ts
@@ -1,0 +1,98 @@
+import type mri from 'mri';
+import type { RunOptions } from './index.js';
+import { buildRulesConfig, findUnknownRuleIds, knownRuleIds } from './rules-config.js';
+import { isReporterName, type ReporterName } from './reporter-resolve.js';
+
+/** Result of normalizing parsed argv: the `run` options, plus any diagnostics to print. */
+export interface ResolvedArgs {
+  /** Options to pass to `run`, or `null` when a fatal (exit-2) error was found. */
+  options: RunOptions | null;
+  /** Non-fatal messages (printed to stderr; analysis still proceeds). */
+  warnings: string[];
+  /** Fatal messages (printed to stderr; the CLI exits 2 without running). */
+  errors: string[];
+}
+
+const toList = (v: unknown): string[] =>
+  typeof v === 'string'
+    ? v
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : [];
+
+/**
+ * Normalize parsed CLI argv into `run` options without any I/O or process exit,
+ * so the validation/warning behavior is unit-testable. `main` (in bin.ts) is the
+ * thin wrapper that prints the diagnostics and maps a fatal result to exit code 2.
+ */
+export function resolveArgs(argv: mri.Argv): ResolvedArgs {
+  const warnings: string[] = [];
+  const errors: string[] = [];
+
+  const positional = argv._[0];
+  const metaComponents =
+    typeof argv['meta-components'] === 'string'
+      ? argv['meta-components']
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : undefined;
+
+  const treatRaw = argv['treat-dynamic-as'];
+  const treatDynamicAs = treatRaw === 'warn' || treatRaw === 'fail' || treatRaw === 'pass' ? treatRaw : undefined;
+  if (typeof treatRaw === 'string' && treatDynamicAs === undefined) {
+    warnings.push(
+      `svelte-vitals: unknown --treat-dynamic-as '${treatRaw}'; expected pass|warn|fail. Defaulting to 'pass'.`
+    );
+  }
+
+  const route = typeof argv.route === 'string' ? argv.route : undefined;
+
+  const allow = toList(argv.rules);
+  const ignore = toList(argv.ignore);
+  const unknown = findUnknownRuleIds([...allow, ...ignore]);
+  if (unknown.length > 0) {
+    errors.push(`svelte-vitals: unknown rule id(s) in --rules/--ignore: ${unknown.join(', ')}`);
+    errors.push(`Known rule ids: ${knownRuleIds().join(', ')}`);
+  }
+
+  let reporter: ReporterName | undefined;
+  if (argv.json) {
+    reporter = 'json';
+  } else if (typeof argv.reporter === 'string') {
+    if (!isReporterName(argv.reporter)) {
+      errors.push(
+        `svelte-vitals: unknown reporter '${argv.reporter}'. Valid values: console, json, agent, sarif, github.`
+      );
+    } else {
+      reporter = argv.reporter;
+    }
+  }
+
+  const failOnRaw = argv['fail-on'];
+  const failOnValid = failOnRaw === 'warning' || failOnRaw === 'info' || failOnRaw === 'critical';
+  if (typeof failOnRaw === 'string' && !failOnValid) {
+    warnings.push(
+      `svelte-vitals: unknown --fail-on '${failOnRaw}'; expected critical|warning|info. No threshold applied.`
+    );
+  }
+  const failOn = argv['fail-on-warning'] ? 'warning' : failOnValid ? failOnRaw : undefined;
+
+  if (errors.length > 0) return { options: null, warnings, errors };
+
+  return {
+    options: {
+      cwd: positional ?? process.cwd(),
+      metaComponents,
+      treatDynamicAs,
+      route,
+      reporter,
+      byRoute: Boolean(argv['by-route']),
+      failOn,
+      rules: buildRulesConfig(allow, ignore)
+    },
+    warnings,
+    errors
+  };
+}

--- a/packages/cli/test/imports.test.ts
+++ b/packages/cli/test/imports.test.ts
@@ -19,6 +19,11 @@ describe('collectImports', () => {
     expect(map.get('Mod')).toEqual({ source: 'mod', imported: 'default' });
   });
 
+  it('captures the imported name from a string-literal specifier', () => {
+    const map = imports(`<script>import { 'a-b' as c } from 'mod';</script>`);
+    expect(map.get('c')).toEqual({ source: 'mod', imported: 'a-b' });
+  });
+
   it('returns an empty map when there is no script', () => {
     expect(imports('<title>x</title>').size).toBe(0);
   });

--- a/packages/cli/test/parse-file.test.ts
+++ b/packages/cli/test/parse-file.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseFile } from '../src/providers/source/parse.js';
+import { parseFile, attrValueOf } from '../src/providers/source/parse.js';
 
 describe('parseFile', () => {
   it('returns head tags, component usages, and imports', () => {
@@ -37,5 +37,34 @@ describe('parseFile', () => {
       'x.svelte'
     );
     expect(pf.components.map((c) => c.name)).toContain('MetaTags');
+  });
+
+  it('finds component usages in both branches of an {#if} block (consequent + alternate)', () => {
+    const pf = parseFile(
+      `<script>import { A } from 'a'; import { B } from 'b';</script>{#if cond}<A />{:else}<B />{/if}`,
+      'x.svelte'
+    );
+    expect(pf.components.map((c) => c.name).sort()).toEqual(['A', 'B']);
+  });
+});
+
+describe('attrValueOf', () => {
+  it('treats a boolean attribute as absent', () => {
+    expect(attrValueOf({ value: true })).toBe('absent');
+  });
+
+  it('treats a missing/empty value as absent', () => {
+    expect(attrValueOf(undefined)).toBe('absent');
+    expect(attrValueOf({ value: [] })).toBe('absent');
+    expect(attrValueOf({ value: [{ type: 'Text', data: '   ' }] })).toBe('absent');
+  });
+
+  it('treats non-whitespace Text as static', () => {
+    expect(attrValueOf({ value: [{ type: 'Text', data: 'hello' }] })).toBe('static');
+  });
+
+  it('treats an ExpressionTag value as dynamic (array or single node)', () => {
+    expect(attrValueOf({ value: [{ type: 'ExpressionTag' }] })).toBe('dynamic');
+    expect(attrValueOf({ value: { type: 'ExpressionTag' } })).toBe('dynamic');
   });
 });

--- a/packages/cli/test/resolve-args.test.ts
+++ b/packages/cli/test/resolve-args.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import mri from 'mri';
+import { resolveArgs } from '../src/resolve-args.js';
+
+/** Parse CLI args the same way `main` does, then normalize them. */
+function resolve(...args: string[]) {
+  const argv = mri(args, {
+    alias: { h: 'help', v: 'version' },
+    boolean: ['by-route', 'json', 'fail-on-warning'],
+    string: ['meta-components', 'treat-dynamic-as', 'route', 'fail-on', 'reporter', 'rules', 'ignore']
+  });
+  return resolveArgs(argv);
+}
+
+describe('resolveArgs', () => {
+  it('accepts a valid --treat-dynamic-as without warning', () => {
+    const { options, warnings } = resolve('--treat-dynamic-as', 'fail');
+    expect(options?.treatDynamicAs).toBe('fail');
+    expect(warnings).toEqual([]);
+  });
+
+  it('warns and defaults to pass on an unknown --treat-dynamic-as', () => {
+    const { options, warnings } = resolve('--treat-dynamic-as', 'warning');
+    expect(options?.treatDynamicAs).toBeUndefined();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("unknown --treat-dynamic-as 'warning'");
+  });
+
+  it('accepts a valid --fail-on without warning', () => {
+    const { options, warnings } = resolve('--fail-on', 'warning');
+    expect(options?.failOn).toBe('warning');
+    expect(warnings).toEqual([]);
+  });
+
+  it('warns and applies no threshold on an unknown --fail-on', () => {
+    const { options, warnings } = resolve('--fail-on', 'warn');
+    expect(options?.failOn).toBeUndefined();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("unknown --fail-on 'warn'");
+  });
+
+  it('lets --fail-on-warning override the threshold', () => {
+    const { options, warnings } = resolve('--fail-on-warning');
+    expect(options?.failOn).toBe('warning');
+    expect(warnings).toEqual([]);
+  });
+
+  it('reports an unknown reporter as a fatal error (no options)', () => {
+    const { options, errors } = resolve('--reporter', 'xml');
+    expect(options).toBeNull();
+    expect(errors.some((e) => e.includes("unknown reporter 'xml'"))).toBe(true);
+  });
+
+  it('reports unknown rule ids as a fatal error (no options)', () => {
+    const { options, errors } = resolve('--rules', 'not-a-rule');
+    expect(options).toBeNull();
+    expect(errors.some((e) => e.includes('unknown rule id(s)'))).toBe(true);
+  });
+
+  it('parses --meta-components into a trimmed, non-empty list', () => {
+    const { options } = resolve('--meta-components', 'MetaTags, Seo ,');
+    expect(options?.metaComponents).toEqual(['MetaTags', 'Seo']);
+  });
+
+  it('maps --json to the json reporter', () => {
+    const { options } = resolve('--json');
+    expect(options?.reporter).toBe('json');
+  });
+});


### PR DESCRIPTION
Batches the deferred minor findings from the Slice 1 reviews. Closes #13.

## Changes

- **`imports.ts` — string-literal specifiers.** `import { 'a-b' as c } from 'mod'` now records `imported: 'a-b'` (read from the `Literal.value`) instead of falling back to the local alias `c`. The fallback only mattered if meta-source detection ever keys off a string-literal export name, but it's now correct regardless.
- **`--treat-dynamic-as` — warn on unknown values.** An invalid value (e.g. a typo'd `--treat-dynamic-as warning`) was silently coerced to `pass`; it now prints a stderr warning naming the expected values before continuing with the `pass` default, so the footgun is visible.
- **Test/coverage polish.**
  - direct unit tests for `attrValueOf` (boolean → absent, empty/whitespace → absent, Text → static, ExpressionTag array/single → dynamic);
  - a `{#if}…{:else}` test covering the `consequent` + `alternate` traversal keys (the AST child-key allowlist — Svelte 5 forbids `<svelte:head>` inside blocks, so completeness is exercised via component detection, matching the existing `{#each}`/`{#await}` tests);
  - a string-literal import test.

The AST child-key allowlist (`fragment, nodes, consequent, alternate, body, pending, then, catch, fallback`) was reviewed against Svelte 5's fragment-bearing block kinds and is complete; the new `{#if}` test plus the existing block tests lock that in.

## Validation

- `pnpm -r test` — **204 passed** (core 70, vite 31, cli 94, mcp 9)
- `pnpm -r typecheck`, `pnpm build`, `pnpm lint` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)