### PR TITLE
feat: Performance v0.4 — static <img> checks + multi-category foundation (#10)

### DIFF
--- a/.changeset/performance-v0.4.md
+++ b/.changeset/performance-v0.4.md
@@ -1,0 +1,12 @@
+---
+'@svelte-vitals/core': minor
+'svelte-vitals': minor
+---
+
+Add the Performance category (v0.4, #10): static `<img>` checks — **PERF001** (missing
+`width`/`height`, CLS risk; warning) and **PERF002** (missing `loading` attribute; info
+advisory) — with dynamically-bound attributes counting as present. Introduces the
+multi-category foundation: `Result.category`/`line`, the `ImageInfo`/`ResolvedImages` IR,
+`RuleContext.images`, `imageRule`, `scoresByCategory`, and category-aware reporters
+(per-category scores; JSON `categories` map). Existing SEO findings, scores, and output
+are unchanged.

--- a/README.md
+++ b/README.md
@@ -147,10 +147,11 @@ The project advances along two axes: **mode maturity** and **category coverage**
 - **Agent & CI integration** — `console`, `json`, `agent` (Markdown remediation), `sarif` (GitHub code scanning), and `github` (inline PR annotations) reporters. The `agent` reporter auto-selects under AI-agent harnesses; `github` under GitHub Actions.
 - **Dev overlay** (`@svelte-vitals/vite`) — warns in-place while developing via `transformPageChunk`, so dynamic routes are seen with real values as pages are visited.
 - **MCP server** (`@svelte-vitals/mcp`) — exposes `analyze` and `explain_rule` tools over stdio so an agent can run analysis in its tool loop and receive structured, fixable findings.
+- **Performance checks** (`0.4`) — static `<img>` analysis: `width`/`height` (CLS) and a `loading` advisory, scored as a separate Performance category alongside SEO.
 
 **Upcoming**
 
-- **More categories** ([#10](https://github.com/oekazuma/svelte-vitals/issues/10)) — Performance, Accessibility, and Upgrade checks, culminating in a combined Health Report at `1.0`.
+- **More categories** ([#10](https://github.com/oekazuma/svelte-vitals/issues/10)) — Accessibility and Upgrade checks, then a combined weighted Health Report — all landing across `0.x` ahead of the `1.0` polish.
 
 See the design document for the full vision.
 

--- a/docs/superpowers/plans/2026-06-22-performance-v0.4.md
+++ b/docs/superpowers/plans/2026-06-22-performance-v0.4.md
@@ -23,11 +23,13 @@
 ### Task 1: `Result.category` + `line`; tag SEO rules
 
 **Files:**
+
 - Modify: `packages/core/src/types.ts` (add `category?`, `line?` to `Result`)
 - Modify: `packages/core/src/rules/seo/seo001-title.ts`, `packages/core/src/rules/seo/head-tag-rule.ts`, `packages/core/src/rules/seo/project-rules.ts` (set `category: 'seo'`)
 - Test: `packages/core/test/rule-category.test.ts` (new)
 
 **Interfaces:**
+
 - Produces: `Result.category?: Category`, `Result.line?: number`. Existing SEO rules emit `category: 'seo'`.
 
 - [ ] **Step 1: Write the failing test** — `packages/core/test/rule-category.test.ts`:
@@ -94,6 +96,7 @@ Expected: FAIL — `category` is `undefined`.
         category: 'seo',
         severity: 'warning',
 ```
+
 (and the same for `SEO007`, `SEO009`)
 
 - [ ] **Step 7: Run core tests**
@@ -115,6 +118,7 @@ git commit -m "feat(core): add Result.category/line and tag SEO rules (#10)"
 ### Task 2: Image IR, `RuleContext.images`, `imageRule`, PERF001/PERF002
 
 **Files:**
+
 - Create: `packages/core/src/images.ts`
 - Modify: `packages/core/src/rule.ts` (add `images?` to `RuleContext`)
 - Create: `packages/core/src/rules/perf/image-rule.ts`
@@ -124,6 +128,7 @@ git commit -m "feat(core): add Result.category/line and tag SEO rules (#10)"
 - Test: `packages/core/test/perf-rules.test.ts` (new)
 
 **Interfaces:**
+
 - Consumes: `Result`, `Category`, `docsUrlFor`, `Rule`, `RuleContext`.
 - Produces:
   - `interface ImageInfo { hasWidth: boolean; hasHeight: boolean; hasLoading: boolean; line: number; file: string }`
@@ -162,6 +167,7 @@ export interface ResolvedImages {
 import type { ResolvedHead } from './head.js';
 import type { ResolvedImages } from './images.js';
 ```
+
 ```ts
 export interface RuleContext {
   heads: ResolvedHead[];
@@ -181,7 +187,12 @@ import type { ResolvedImages } from '../src/images.js';
 
 const config = defaultConfig;
 const img = (over: Partial<{ hasWidth: boolean; hasHeight: boolean; hasLoading: boolean }>) => ({
-  hasWidth: true, hasHeight: true, hasLoading: true, line: 7, file: 'src/routes/+page.svelte', ...over
+  hasWidth: true,
+  hasHeight: true,
+  hasLoading: true,
+  line: 7,
+  file: 'src/routes/+page.svelte',
+  ...over
 });
 const ctxWith = (images: ResolvedImages[]) => ({ heads: [], images, project: defaultProject, config });
 
@@ -350,14 +361,18 @@ export const perf002ImageLoading = imageRule({
 import { seo006Robots, seo007Sitemap, seo009HtmlLang } from './seo/project-rules.js';
 import { perf001ImageDimensions, perf002ImageLoading } from './perf/images.js';
 ```
+
 Add to the `allRules` array (after `seo009HtmlLang`):
+
 ```ts
   seo009HtmlLang,
   perf001ImageDimensions,
   perf002ImageLoading
 ];
 ```
+
 Add to the re-export block:
+
 ```ts
   seo009HtmlLang,
   perf001ImageDimensions,
@@ -370,7 +385,9 @@ Add to the re-export block:
 ```ts
 export type { ImageInfo, ResolvedImages } from './images.js';
 ```
+
 and add `perf001ImageDimensions, perf002ImageLoading` to the rules export line, plus:
+
 ```ts
 export { headTagRule } from './rules/seo/head-tag-rule.js';
 export { imageRule } from './rules/perf/image-rule.js';
@@ -395,11 +412,13 @@ git commit -m "feat(core): add image IR, imageRule, PERF001/PERF002 (#10)"
 ### Task 3: Per-category scoring (`scoresByCategory`)
 
 **Files:**
+
 - Modify: `packages/core/src/scoring/score.ts` (add `scoresByCategory`)
 - Modify: `packages/core/src/index.ts` (export it)
 - Test: `packages/core/test/score.test.ts` (extend)
 
 **Interfaces:**
+
 - Consumes: `computeScore`, `ScoreResult`, `Category`, `Result`, `Config`.
 - Produces: `function scoresByCategory(results: Result[], config: Config): Partial<Record<Category, ScoreResult>>`.
 
@@ -412,9 +431,30 @@ describe('scoresByCategory', () => {
   it('scores each category independently', () => {
     const config = defineConfig({});
     const results = [
-      { id: 'SEO001', category: 'seo', severity: 'critical', detection: { presence: 'none', value: 'absent' }, route: '/a', message: 'x' },
-      { id: 'PERF001', category: 'performance', severity: 'warning', detection: { presence: 'none', value: 'absent' }, route: '/a', message: 'y' },
-      { id: 'PERF001', category: 'performance', severity: 'warning', detection: { presence: 'own', value: 'static' }, route: '/b', message: 'ok' }
+      {
+        id: 'SEO001',
+        category: 'seo',
+        severity: 'critical',
+        detection: { presence: 'none', value: 'absent' },
+        route: '/a',
+        message: 'x'
+      },
+      {
+        id: 'PERF001',
+        category: 'performance',
+        severity: 'warning',
+        detection: { presence: 'none', value: 'absent' },
+        route: '/a',
+        message: 'y'
+      },
+      {
+        id: 'PERF001',
+        category: 'performance',
+        severity: 'warning',
+        detection: { presence: 'own', value: 'static' },
+        route: '/b',
+        message: 'ok'
+      }
     ] as const;
     const byCat = scoresByCategory(results as never, config);
     expect(byCat.seo).toBeDefined();
@@ -426,7 +466,15 @@ describe('scoresByCategory', () => {
   it('treats a missing category as seo', () => {
     const config = defineConfig({});
     const byCat = scoresByCategory(
-      [{ id: 'SEO001', severity: 'warning', detection: { presence: 'none', value: 'absent' }, route: '/a', message: 'x' }] as never,
+      [
+        {
+          id: 'SEO001',
+          severity: 'warning',
+          detection: { presence: 'none', value: 'absent' },
+          route: '/a',
+          message: 'x'
+        }
+      ] as never,
       config
     );
     expect(byCat.seo).toBeDefined();
@@ -447,7 +495,9 @@ Expected: FAIL — `scoresByCategory` is not a function.
 ```ts
 import type { Category, Config, Result, Severity } from '../types.js';
 ```
+
 (append at end of file:)
+
 ```ts
 /** Compute an independent score per category present in `results` (issue #10). */
 export function scoresByCategory(results: Result[], config: Config): Partial<Record<Category, ScoreResult>> {
@@ -487,11 +537,13 @@ git commit -m "feat(core): add scoresByCategory for per-category scores (#10)"
 ### Task 4: Collect `<img>` in the CLI provider
 
 **Files:**
+
 - Modify: `packages/cli/src/providers/source/parse.ts` (collect images + line)
 - Modify: `packages/cli/src/providers/source/routes.ts` (per-route images → `RuleContext.images`)
 - Test: `packages/cli/test/parse-file.test.ts` (extend), `packages/cli/test/source-provider.test.ts` (extend) or a new `packages/cli/test/images.test.ts`
 
 **Interfaces:**
+
 - Consumes: `ResolvedImages`, `ImageInfo` from `@svelte-vitals/core`.
 - Produces:
   - `parse.ts`: `interface ParsedImage { hasWidth: boolean; hasHeight: boolean; hasLoading: boolean; line: number }`; `ParsedFile.images: ParsedImage[]`.
@@ -533,7 +585,9 @@ export interface ParsedImage {
   line: number;
 }
 ```
+
 Add a line helper near the top (after `type Node = any;`):
+
 ```ts
 function lineOf(source: string, offset: unknown): number {
   if (typeof offset !== 'number' || offset < 0) return 0;
@@ -543,7 +597,9 @@ function lineOf(source: string, offset: unknown): number {
   return line;
 }
 ```
+
 Add a collector (parallels `collectComponents`, reusing `CHILD_NODE_KEYS` and `findAttr`):
+
 ```ts
 function collectImages(node: Node, source: string, acc: ParsedImage[]): void {
   if (Array.isArray(node)) {
@@ -565,7 +621,9 @@ function collectImages(node: Node, source: string, acc: ParsedImage[]): void {
   }
 }
 ```
+
 Extend `ParsedFile`:
+
 ```ts
 export interface ParsedFile {
   headTags: ParsedTag[];
@@ -574,18 +632,20 @@ export interface ParsedFile {
   images: ParsedImage[];
 }
 ```
+
 In `parseFile`, collect and return images:
+
 ```ts
-  const components: ComponentUse[] = [];
-  collectComponents(ast.fragment ?? ast, components);
-  const images: ParsedImage[] = [];
-  collectImages(ast.fragment ?? ast, source, images);
-  return {
-    headTags: heads.flatMap(tagsFromHead),
-    components,
-    imports: collectImports(ast),
-    images
-  };
+const components: ComponentUse[] = [];
+collectComponents(ast.fragment ?? ast, components);
+const images: ParsedImage[] = [];
+collectImages(ast.fragment ?? ast, source, images);
+return {
+  headTags: heads.flatMap(tagsFromHead),
+  components,
+  imports: collectImports(ast),
+  images
+};
 ```
 
 > `findAttr` returns the attribute node whether its value is a literal or an `ExpressionTag`, so `width={w}` yields `hasWidth: true` — dynamic counts as present, per the no-false-positives constraint.
@@ -615,8 +675,9 @@ In `resolveRoute`, accumulate images while walking `files` (it already reads + p
 The cleanest seam: `routes.ts` currently only builds `ResolvedHead[]` and the rules run elsewhere? **No** — rules run in `packages/cli/src/index.ts` via `runRules(rules, { heads, project, config })` (see `analyzeProject`). So `sourceHeadProvider.collect` returns heads only; images must travel a parallel path. Add an images collector to the provider and thread it into `analyzeProject`'s `runRules` call.
 
 Concretely:
-  1. In `routes.ts`, add an exported `collectImages(rt, cwd, config): Promise<ResolvedImages[]>` that enumerates route pages, walks each route's chain (reuse `chainFiles`), parses each file, and maps `ParsedImage[]` → `ImageInfo[]` (adding `file`), returning one `ResolvedImages` per route. Factor the chain walk so it isn't duplicated (e.g. have `resolveRoute` and the image collector share `chainFiles`).
-  2. In `packages/cli/src/index.ts` `analyzeProject`, after collecting heads, also collect images and pass them:
+
+1. In `routes.ts`, add an exported `collectImages(rt, cwd, config): Promise<ResolvedImages[]>` that enumerates route pages, walks each route's chain (reuse `chainFiles`), parses each file, and maps `ParsedImage[]` → `ImageInfo[]` (adding `file`), returning one `ResolvedImages` per route. Factor the chain walk so it isn't duplicated (e.g. have `resolveRoute` and the image collector share `chainFiles`).
+2. In `packages/cli/src/index.ts` `analyzeProject`, after collecting heads, also collect images and pass them:
 
 ```ts
 const heads = (await sourceHeadProvider.collect(rt, cwd, config)).filter((h) => matches(h.route));
@@ -636,6 +697,7 @@ export const sourceImageProvider = {
   }
 };
 ```
+
 where `resolveRouteImages` walks `chainFiles(rt, cwd, page)`, parses each file, and collects `ImageInfo[]` (tagging `file: rel`, `route: deriveRoute(page)`).
 
 > `config` is currently unused by image collection but is accepted for symmetry/future use.
@@ -657,6 +719,7 @@ git commit -m "feat(cli): collect <img> facts per route for Performance rules (#
 ### Task 5: Category-aware reporters
 
 **Files:**
+
 - Modify: `packages/core/src/reporter/console.ts`
 - Modify: `packages/core/src/reporter/json.ts`
 - Modify: `packages/core/src/reporter/agent.ts`
@@ -664,17 +727,28 @@ git commit -m "feat(cli): collect <img> facts per route for Performance rules (#
 - Test: `packages/core/test/console-report.test.ts`, `json-report.test.ts`, `agent-report.test.ts` (extend with performance fixtures)
 
 **Interfaces:**
+
 - Consumes: `scoresByCategory`, `Result.category`, `Result.line`.
 - Produces: console per-category score sections; json `categories` map + per-issue `category`; agent generalized heading; github/sarif line-accurate locations.
 
 - [ ] **Step 1: Write failing reporter tests** — add a performance fixture + assertions.
 
 `console-report.test.ts` — add:
+
 ```ts
 it('adds a Performance score section when performance findings exist', () => {
   const withPerf: Result[] = [
     ...results,
-    { id: 'PERF001', category: 'performance', severity: 'warning', detection: { presence: 'none', value: 'absent' }, route: '/blog', location: 'src/routes/blog/+page.svelte', line: 42, message: 'Missing <img> width/height' }
+    {
+      id: 'PERF001',
+      category: 'performance',
+      severity: 'warning',
+      detection: { presence: 'none', value: 'absent' },
+      route: '/blog',
+      location: 'src/routes/blog/+page.svelte',
+      line: 42,
+      message: 'Missing <img> width/height'
+    }
   ];
   const out = formatConsoleReport(withPerf, config);
   expect(out).toMatch(/SEO Score: \d+\/100/);
@@ -685,11 +759,21 @@ it('adds a Performance score section when performance findings exist', () => {
 ```
 
 `json-report.test.ts` — add:
+
 ```ts
 it('exposes a per-category scores map and tags issues with category', () => {
   const withPerf: Result[] = [
     ...results,
-    { id: 'PERF001', category: 'performance', severity: 'warning', detection: { presence: 'none', value: 'absent' }, route: '/blog', location: 'src/routes/blog/+page.svelte', line: 42, message: 'Missing <img> width/height' }
+    {
+      id: 'PERF001',
+      category: 'performance',
+      severity: 'warning',
+      detection: { presence: 'none', value: 'absent' },
+      route: '/blog',
+      location: 'src/routes/blog/+page.svelte',
+      line: 42,
+      message: 'Missing <img> width/height'
+    }
   ];
   const json = JSON.parse(formatJsonReport(withPerf, config, { version: '0.1.0' }));
   expect(json.categories.seo.score).toBeTypeOf('number');
@@ -701,11 +785,22 @@ it('exposes a per-category scores map and tags issues with category', () => {
 ```
 
 `agent-report.test.ts` — add (heading generalized, perf grouped):
+
 ```ts
 it('groups performance findings and uses a category-neutral heading', () => {
   const withPerf: Result[] = [
     ...results,
-    { id: 'PERF001', category: 'performance', severity: 'warning', detection: { presence: 'none', value: 'absent' }, route: '/blog', location: 'src/routes/blog/+page.svelte', line: 42, message: 'Missing <img> width/height', fix: { description: 'Add width/height.', snippet: '<img width="1" height="1" />', lang: 'svelte' } }
+    {
+      id: 'PERF001',
+      category: 'performance',
+      severity: 'warning',
+      detection: { presence: 'none', value: 'absent' },
+      route: '/blog',
+      location: 'src/routes/blog/+page.svelte',
+      line: 42,
+      message: 'Missing <img> width/height',
+      fix: { description: 'Add width/height.', snippet: '<img width="1" height="1" />', lang: 'svelte' }
+    }
   ];
   const md = formatAgentReport(withPerf, config);
   expect(md).toContain('PERF001');
@@ -721,6 +816,7 @@ Expected: FAIL (no `Performance Score:`, no `categories`, heading still "SEO fix
 - [ ] **Step 3: Update `console.ts`** — render a score section per category present, reusing the `"<Label> Score: N/100"` line so existing assertions pass.
 
 Replace `scoreHeader` and the body so categories are iterated. Key changes:
+
 ```ts
 import { computeScore, scoresByCategory } from '../scoring/score.js';
 import type { Category } from '../types.js';
@@ -741,18 +837,30 @@ function scoreLine(label: string, results: Result[], config: Config): string {
   return `${label} Score: ${score}/100   (${parts.join(' · ')})`;
 }
 ```
+
 In `formatConsoleReport`: replace the single `scoreHeader(...)` header line with one score line per category that has results, and prefix each finding's location with `:line` when present. Concretely, build the header as:
+
 ```ts
-  const byCat = scoresByCategory(results, config);
-  const present = CATEGORY_ORDER.filter((c) => byCat[c] !== undefined);
-  const header: string[] = [`Svelte Vitals  (${options.mode ?? 'static mode'})`, ''];
-  for (const c of present) header.push(scoreLine(CATEGORY_LABEL[c] ?? c, results.filter((r) => (r.category ?? 'seo') === c), config));
-  const lines: string[] = [...header, ''];
+const byCat = scoresByCategory(results, config);
+const present = CATEGORY_ORDER.filter((c) => byCat[c] !== undefined);
+const header: string[] = [`Svelte Vitals  (${options.mode ?? 'static mode'})`, ''];
+for (const c of present)
+  header.push(
+    scoreLine(
+      CATEGORY_LABEL[c] ?? c,
+      results.filter((r) => (r.category ?? 'seo') === c),
+      config
+    )
+  );
+const lines: string[] = [...header, ''];
 ```
+
 And in the failures loop, change the location line to include `line`:
+
 ```ts
-      if (r.location) lines.push(`            ${r.location}${r.line ? `:${r.line}` : ''}`);
+if (r.location) lines.push(`            ${r.location}${r.line ? `:${r.line}` : ''}`);
 ```
+
 (Severity buckets and the Passed section stay as-is — findings already show `r.id`, which distinguishes SEO vs PERF.)
 
 > This keeps `SEO Score: N/100` (now per-category) so `console-report.test`'s existing regex passes, and adds `Performance Score: N/100` only when performance results exist. The `byRouteTree` helper is unchanged.
@@ -760,6 +868,7 @@ And in the failures loop, change the location line to include `line`:
 - [ ] **Step 4: Update `json.ts`** — add `categories` and per-issue `category`/`line`.
 
 In `issueOf`, include category and line:
+
 ```ts
 function issueOf(result: Result) {
   return {
@@ -775,25 +884,32 @@ function issueOf(result: Result) {
   };
 }
 ```
+
 In `buildJsonReport`, add a `categories` field (keep top-level `score` = SEO for backward compat):
+
 ```ts
 import { computeScore, scoresByCategory, type ScoreModel } from '../scoring/score.js';
 ```
+
 ```ts
-  const byCat = scoresByCategory(results, config);
-  const categories = Object.fromEntries(
-    Object.entries(byCat).map(([cat, sr]) => [cat, { score: sr.score, scoreModel: sr.scoreModel }])
-  );
-  return { version: meta.version, score, scoreModel, summary, categories, routes, siteIssues };
+const byCat = scoresByCategory(results, config);
+const categories = Object.fromEntries(
+  Object.entries(byCat).map(([cat, sr]) => [cat, { score: sr.score, scoreModel: sr.scoreModel }])
+);
+return { version: meta.version, score, scoreModel, summary, categories, routes, siteIssues };
 ```
+
 Add `categories` to the `JsonReport` interface:
+
 ```ts
-  categories: Record<string, { score: number; scoreModel: ScoreModel }>;
+categories: Record<string, { score: number; scoreModel: ScoreModel }>;
 ```
+
 (Place it after `scoreModel`.) The top-level `score`/`scoreModel` stay computed via `computeScore(results, config)` — which now includes PERF results. **To keep the top-level score = SEO only (backward compat), compute it from the SEO subset:**
+
 ```ts
-  const seoResults = results.filter((r) => (r.category ?? 'seo') === 'seo');
-  const { score, scoreModel } = computeScore(seoResults, config);
+const seoResults = results.filter((r) => (r.category ?? 'seo') === 'seo');
+const { score, scoreModel } = computeScore(seoResults, config);
 ```
 
 > Important: changing the top-level `score` to the SEO subset preserves existing json-report assertions (their fixtures are all SEO, so subset === full). Verify the existing test still sees `summary.critical` etc. — `summary` stays over all results (counts include PERF); the existing fixture has no PERF so unchanged.
@@ -801,13 +917,17 @@ Add `categories` to the `JsonReport` interface:
 - [ ] **Step 5: Update `agent.ts`** — generalize the heading and group by category.
 
 Change the H1 from SEO-specific to neutral, and (minimal) keep the existing file-grouping but ensure PERF findings (which are `fail` and have `fix`) flow through. The only required change for the test is the heading:
+
 ```ts
-  const lines: string[] = ['# svelte-vitals — fixes', ''];
+const lines: string[] = ['# svelte-vitals — fixes', ''];
 ```
+
 and the empty-state line stays `'No issues to fix.'`. PERF findings already classify as `fail` (penalized detection) and carry `fix`, so they render in their `location` group with their snippet automatically. Show `line` in the group header when present:
+
 ```ts
-    const key = r.location ?? r.route ?? '(project)';
+const key = r.location ?? r.route ?? '(project)';
 ```
+
 (unchanged grouping is acceptable; `line` appears via the `## ${loc}` not carrying line — optionally append `:line`. Keep minimal: no line in agent group header for v0.4.)
 
 > Check `agent-report.test.ts`'s "No issues to fix" case (if present) for an H1 assertion; update it to the new `# svelte-vitals — fixes` heading if it checks the old text.
@@ -833,6 +953,7 @@ git commit -m "feat(core): category-aware reporters with per-category scores (#1
 ### Task 6: e2e fixture, README, changeset, full verification
 
 **Files:**
+
 - Create: `packages/cli/test/fixtures/basic-project/src/routes/img/+page.svelte` (an `<img>` missing dimensions) — or add an `<img>` to an existing fixture route
 - Modify: `packages/cli/test/run.test.ts` (assert PERF001 surfaces end-to-end)
 - Modify: `README.md` (roadmap)
@@ -868,6 +989,7 @@ Expected: PASS (after Tasks 2 & 4 the pipeline emits PERF001 for `/img`). If the
 <svelte:head><title>{data.title}</title></svelte:head>
 <img src="/hero.png" alt="hero" />
 ```
+
 so `/img` passes SEO (dynamic title) and only contributes the PERF finding.
 
 - [ ] **Step 4: Run the full CLI suite** and fix any count drift
@@ -880,6 +1002,7 @@ Expected: PASS. If a count assertion drifted from the new route, update it to th
 ```md
 - **Performance checks** (`0.4`) — static `<img>` analysis: `width`/`height` (CLS) and a `loading` advisory, scored as a separate Performance category alongside SEO.
 ```
+
 And under **Upcoming**, replace the single #10 bullet with:
 
 ```md
@@ -920,6 +1043,7 @@ git commit -m "docs(perf): ship Performance v0.4, roadmap + changeset (#10)"
 ## Self-Review
 
 **Spec coverage:**
+
 - PERF001 dimensions + PERF002 loading, dynamic-as-present → Task 2 (rules) + Task 4 (`findAttr` presence). ✅
 - Per-image findings with `file` + `line` → Task 2 (imageRule emits per bad image) + Task 4 (`line` from AST). ✅
 - Image IR (`ImageInfo`/`ResolvedImages`) + `RuleContext.images` → Task 2. ✅

--- a/docs/superpowers/plans/2026-06-22-performance-v0.4.md
+++ b/docs/superpowers/plans/2026-06-22-performance-v0.4.md
@@ -1,0 +1,936 @@
+# Performance v0.4 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add static-analysis Performance checks for `<img>` (PERF001 dimensions, PERF002 loading hint) and the multi-category foundation (per-category findings, per-category scores, category-aware reporters) that later categories reuse.
+
+**Architecture:** Mirror the head pipeline for images: the CLI provider collects per-route `<img>` facts across the layout chain into a normalized `ResolvedImages[]`, fed via `RuleContext.images`. New `imageRule`-built PERF rules emit per-image findings tagged `category: 'performance'`. Scoring and reporters split results by `category` (defaulting missing → `'seo'`), so the change is additive and existing SEO output/tests are unchanged.
+
+**Tech Stack:** TypeScript (ESM-only), `svelte/compiler` (modern AST), `vitest`, `tsup`, pnpm workspaces.
+
+## Global Constraints
+
+- **ESM-only**, `tsup` `format: ['esm']`, `target: 'es2022'`; never add CJS (#20).
+- **core stays runtime-agnostic** — no `node:` imports / no I/O in `@svelte-vitals/core`; image collection (I/O + AST) lives in `packages/cli`.
+- **No false positives**: a dynamically-bound attribute (`width={w}`) counts as **present** and passes — never flag a value we can't prove is missing (mirrors the SEO "dynamic title passes" stance).
+- **`category` is optional on `Result`**, but every production rule sets it; all consumers treat a missing category as `'seo'`. PERF rules set `'performance'`.
+- **Static mode only** for v0.4; `@svelte-vitals/vite` is untouched (plugin-mode image checks deferred).
+- **Additive**: existing SEO findings, scores, and reporter output must not change. All existing tests stay green.
+- Commit trailer: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+### Task 1: `Result.category` + `line`; tag SEO rules
+
+**Files:**
+- Modify: `packages/core/src/types.ts` (add `category?`, `line?` to `Result`)
+- Modify: `packages/core/src/rules/seo/seo001-title.ts`, `packages/core/src/rules/seo/head-tag-rule.ts`, `packages/core/src/rules/seo/project-rules.ts` (set `category: 'seo'`)
+- Test: `packages/core/test/rule-category.test.ts` (new)
+
+**Interfaces:**
+- Produces: `Result.category?: Category`, `Result.line?: number`. Existing SEO rules emit `category: 'seo'`.
+
+- [ ] **Step 1: Write the failing test** — `packages/core/test/rule-category.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { allRules, defaultProject, defaultConfig, type ResolvedHead } from '../src/index.js';
+
+const head: ResolvedHead = { route: '/x', source: 'static', file: 'src/routes/x/+page.svelte', tags: [] };
+const ctx = { heads: [head], project: defaultProject, config: defaultConfig };
+
+describe('rule results carry a category', () => {
+  it('every SEO rule tags its results category "seo"', async () => {
+    for (const rule of allRules) {
+      const results = await rule.check(ctx);
+      for (const r of results) expect(r.category, rule.id).toBe('seo');
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `pnpm --filter @svelte-vitals/core test -- rule-category`
+Expected: FAIL — `category` is `undefined`.
+
+- [ ] **Step 3: Extend `Result`** in `packages/core/src/types.ts` — add two fields to the interface (after `fix?`):
+
+```ts
+  /** Agent-actionable remediation (issue #18). */
+  fix?: Fix;
+  /** Vitals category this finding belongs to (default 'seo' when absent). */
+  category?: Category;
+  /** 1-based source line for element-level findings (e.g. a specific <img>). */
+  line?: number;
+}
+```
+
+> `Category` is already defined in this file and imported where needed; no new import.
+
+- [ ] **Step 4: Tag `seo001-title.ts`** — in the returned `Result` object literal, add `category: 'seo'` (next to `id: 'SEO001'`):
+
+```ts
+      return {
+        id: 'SEO001',
+        category: 'seo',
+        severity: 'critical',
+```
+
+- [ ] **Step 5: Tag `head-tag-rule.ts`** — in `check`'s returned `Result`, add `category: 'seo'`:
+
+```ts
+        return {
+          id: opts.id,
+          category: 'seo',
+          severity: opts.severity,
+```
+
+- [ ] **Step 6: Tag `project-rules.ts`** — add `category: 'seo'` to each of the three returned results (SEO006, SEO007, SEO009), next to their `id`:
+
+```ts
+      {
+        id: 'SEO006',
+        category: 'seo',
+        severity: 'warning',
+```
+(and the same for `SEO007`, `SEO009`)
+
+- [ ] **Step 7: Run core tests**
+
+Run: `pnpm --filter @svelte-vitals/core test`
+Expected: PASS (new test + all existing unchanged — `category` is additive).
+
+- [ ] **Step 8: Typecheck + commit**
+
+Run: `pnpm --filter @svelte-vitals/core typecheck`
+
+```bash
+git add packages/core/src/types.ts packages/core/src/rules/seo packages/core/test/rule-category.test.ts
+git commit -m "feat(core): add Result.category/line and tag SEO rules (#10)"
+```
+
+---
+
+### Task 2: Image IR, `RuleContext.images`, `imageRule`, PERF001/PERF002
+
+**Files:**
+- Create: `packages/core/src/images.ts`
+- Modify: `packages/core/src/rule.ts` (add `images?` to `RuleContext`)
+- Create: `packages/core/src/rules/perf/image-rule.ts`
+- Create: `packages/core/src/rules/perf/images.ts`
+- Modify: `packages/core/src/rules/index.ts` (add PERF rules to `allRules` + re-export)
+- Modify: `packages/core/src/index.ts` (export `ImageInfo`, `ResolvedImages`, `imageRule`, PERF rules)
+- Test: `packages/core/test/perf-rules.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `Result`, `Category`, `docsUrlFor`, `Rule`, `RuleContext`.
+- Produces:
+  - `interface ImageInfo { hasWidth: boolean; hasHeight: boolean; hasLoading: boolean; line: number; file: string }`
+  - `interface ResolvedImages { route: string; images: ImageInfo[] }`
+  - `RuleContext.images?: ResolvedImages[]`
+  - `imageRule(opts): Rule`, `perf001ImageDimensions`, `perf002ImageLoading`.
+
+- [ ] **Step 1: Create `packages/core/src/images.ts`:**
+
+```ts
+/**
+ * A normalized <img> occurrence — the mode-independent boundary for Performance
+ * rules (mirrors head.ts). Attribute presence only: a dynamically-bound attribute
+ * (width={w}) still counts as present, so dynamic values are never flagged.
+ */
+export interface ImageInfo {
+  hasWidth: boolean;
+  hasHeight: boolean;
+  hasLoading: boolean;
+  /** 1-based source line, or 0 if unknown. */
+  line: number;
+  /** Source file the <img> came from. */
+  file: string;
+}
+
+/** Resolved <img> elements for a single route (page + layout chain). */
+export interface ResolvedImages {
+  route: string;
+  images: ImageInfo[];
+}
+```
+
+- [ ] **Step 2: Add `images` to `RuleContext`** in `packages/core/src/rule.ts`:
+
+```ts
+import type { ResolvedHead } from './head.js';
+import type { ResolvedImages } from './images.js';
+```
+```ts
+export interface RuleContext {
+  heads: ResolvedHead[];
+  /** Per-route <img> elements for Performance rules (absent in modes that don't collect them). */
+  images?: ResolvedImages[];
+  project: Project;
+  config: Config;
+}
+```
+
+- [ ] **Step 3: Write the failing test** — `packages/core/test/perf-rules.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { perf001ImageDimensions, perf002ImageLoading, defaultProject, defaultConfig } from '../src/index.js';
+import type { ResolvedImages } from '../src/images.js';
+
+const config = defaultConfig;
+const img = (over: Partial<{ hasWidth: boolean; hasHeight: boolean; hasLoading: boolean }>) => ({
+  hasWidth: true, hasHeight: true, hasLoading: true, line: 7, file: 'src/routes/+page.svelte', ...over
+});
+const ctxWith = (images: ResolvedImages[]) => ({ heads: [], images, project: defaultProject, config });
+
+describe('PERF001 image dimensions', () => {
+  it('flags an <img> missing width or height, with file and line', async () => {
+    const ctx = ctxWith([{ route: '/a', images: [img({ hasWidth: false })] }]);
+    const [r] = await perf001ImageDimensions.check(ctx);
+    expect(r!.category).toBe('performance');
+    expect(r!.severity).toBe('warning');
+    expect(r!.route).toBe('/a');
+    expect(r!.location).toBe('src/routes/+page.svelte');
+    expect(r!.line).toBe(7);
+    expect(r!.detection).toEqual({ presence: 'none', value: 'absent' });
+  });
+
+  it('passes an <img> with both dimensions (dynamic counts as present)', async () => {
+    const ctx = ctxWith([{ route: '/a', images: [img({})] }]);
+    const [r] = await perf001ImageDimensions.check(ctx);
+    expect(r!.detection).toEqual({ presence: 'own', value: 'static' }); // a seeding pass result
+  });
+
+  it('emits one passing result for a route with no images', async () => {
+    const ctx = ctxWith([{ route: '/empty', images: [] }]);
+    const results = await perf001ImageDimensions.check(ctx);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.detection.presence).toBe('own');
+  });
+
+  it('emits one finding per offending image', async () => {
+    const ctx = ctxWith([{ route: '/a', images: [img({ hasWidth: false }), img({ hasHeight: false })] }]);
+    const results = await perf001ImageDimensions.check(ctx);
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.detection.presence === 'none')).toBe(true);
+  });
+});
+
+describe('PERF002 image loading', () => {
+  it('flags a missing loading attribute as info', async () => {
+    const ctx = ctxWith([{ route: '/a', images: [img({ hasLoading: false })] }]);
+    const [r] = await perf002ImageLoading.check(ctx);
+    expect(r!.severity).toBe('info');
+    expect(r!.category).toBe('performance');
+    expect(r!.detection.presence).toBe('none');
+  });
+});
+```
+
+- [ ] **Step 4: Run it to verify it fails**
+
+Run: `pnpm --filter @svelte-vitals/core test -- perf-rules`
+Expected: FAIL — `perf001ImageDimensions` not exported.
+
+- [ ] **Step 5: Create the factory `packages/core/src/rules/perf/image-rule.ts`:**
+
+```ts
+import type { Fix, Result, Severity } from '../../types.js';
+import type { ImageInfo } from '../../images.js';
+import { docsUrlFor, type Rule, type RuleContext } from '../../rule.js';
+
+export interface ImageRuleOptions {
+  id: string;
+  title: string;
+  severity: Severity;
+  /** Noun phrase for messages, e.g. '<img> width/height'. */
+  label: string;
+  recommendation: string;
+  rationale: string;
+  fix?: Fix;
+  /** Returns true when the image satisfies the rule (passes). */
+  ok: (img: ImageInfo) => boolean;
+}
+
+/** Build a route-scoped Performance rule that checks each <img> against `ok` (issue #10). */
+export function imageRule(opts: ImageRuleOptions): Rule {
+  const docsUrl = docsUrlFor(opts.id);
+  return {
+    id: opts.id,
+    title: opts.title,
+    category: 'performance',
+    severity: opts.severity,
+    scope: 'route',
+    rationale: opts.rationale,
+    ...(opts.fix ? { fix: opts.fix } : {}),
+    async check(ctx: RuleContext): Promise<Result[]> {
+      const out: Result[] = [];
+      for (const route of ctx.images ?? []) {
+        const bad = route.images.filter((img) => !opts.ok(img));
+        if (bad.length === 0) {
+          // One passing result per route seeds it at 100 for the per-category score.
+          out.push({
+            id: opts.id,
+            category: 'performance',
+            severity: opts.severity,
+            detection: { presence: 'own', value: 'static' },
+            route: route.route,
+            message: opts.label,
+            recommendation: opts.recommendation,
+            docsUrl,
+            ...(opts.fix ? { fix: { ...opts.fix } } : {})
+          });
+          continue;
+        }
+        for (const img of bad) {
+          out.push({
+            id: opts.id,
+            category: 'performance',
+            severity: opts.severity,
+            detection: { presence: 'none', value: 'absent' },
+            route: route.route,
+            location: img.file,
+            line: img.line,
+            message: `Missing ${opts.label}`,
+            recommendation: opts.recommendation,
+            docsUrl,
+            ...(opts.fix ? { fix: { ...opts.fix } } : {})
+          });
+        }
+      }
+      return out;
+    }
+  };
+}
+```
+
+- [ ] **Step 6: Create `packages/core/src/rules/perf/images.ts`:**
+
+```ts
+import { imageRule } from './image-rule.js';
+
+export const perf001ImageDimensions = imageRule({
+  id: 'PERF001',
+  title: 'Image dimensions',
+  severity: 'warning',
+  label: '<img> width/height',
+  recommendation: 'Set explicit width and height on <img> to reserve space and avoid layout shift (CLS).',
+  rationale:
+    'An <img> without explicit width and height triggers layout shift (CLS) as it loads, hurting Core Web Vitals and visual stability.',
+  fix: {
+    description: 'Add explicit width and height attributes to the <img>.',
+    snippet: '<img src="/hero.jpg" width="1200" height="630" alt="…" />',
+    lang: 'svelte'
+  },
+  ok: (img) => img.hasWidth && img.hasHeight
+});
+
+export const perf002ImageLoading = imageRule({
+  id: 'PERF002',
+  title: 'Image loading hint',
+  severity: 'info',
+  label: '<img> loading attribute',
+  recommendation: 'Set loading="lazy" for offscreen images; keep the LCP image eager (consider fetchpriority="high").',
+  rationale:
+    'A loading attribute lets the browser defer offscreen images; without it images load eagerly and can delay more important content. Static analysis cannot tell which image is the LCP, so this is advisory.',
+  fix: {
+    description: 'Add loading="lazy" to offscreen <img> elements (leave the LCP/hero image eager).',
+    snippet: '<img src="/thumb.jpg" width="320" height="240" loading="lazy" alt="…" />',
+    lang: 'svelte'
+  },
+  ok: (img) => img.hasLoading
+});
+```
+
+- [ ] **Step 7: Register in `packages/core/src/rules/index.ts`** — import and append the PERF rules to `allRules`, and re-export them:
+
+```ts
+import { seo006Robots, seo007Sitemap, seo009HtmlLang } from './seo/project-rules.js';
+import { perf001ImageDimensions, perf002ImageLoading } from './perf/images.js';
+```
+Add to the `allRules` array (after `seo009HtmlLang`):
+```ts
+  seo009HtmlLang,
+  perf001ImageDimensions,
+  perf002ImageLoading
+];
+```
+Add to the re-export block:
+```ts
+  seo009HtmlLang,
+  perf001ImageDimensions,
+  perf002ImageLoading
+};
+```
+
+- [ ] **Step 8: Export from `packages/core/src/index.ts`:**
+
+```ts
+export type { ImageInfo, ResolvedImages } from './images.js';
+```
+and add `perf001ImageDimensions, perf002ImageLoading` to the rules export line, plus:
+```ts
+export { headTagRule } from './rules/seo/head-tag-rule.js';
+export { imageRule } from './rules/perf/image-rule.js';
+```
+
+- [ ] **Step 9: Run tests + typecheck**
+
+Run: `pnpm --filter @svelte-vitals/core test -- perf-rules` then `pnpm --filter @svelte-vitals/core test` and `pnpm --filter @svelte-vitals/core typecheck`
+Expected: PASS. (`rule-category` test now also iterates PERF rules — they pass `ctx` with no `images`, so `check` returns `[]`; the "every result is seo" loop sees no PERF results and stays green. Confirm.)
+
+> If `rule-category.test` fails because a PERF rule has category 'performance': it won't — with no `images` in that ctx, PERF `check` returns `[]`, so no results are checked. Leave as is.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add packages/core/src/images.ts packages/core/src/rule.ts packages/core/src/rules/perf packages/core/src/rules/index.ts packages/core/src/index.ts packages/core/test/perf-rules.test.ts
+git commit -m "feat(core): add image IR, imageRule, PERF001/PERF002 (#10)"
+```
+
+---
+
+### Task 3: Per-category scoring (`scoresByCategory`)
+
+**Files:**
+- Modify: `packages/core/src/scoring/score.ts` (add `scoresByCategory`)
+- Modify: `packages/core/src/index.ts` (export it)
+- Test: `packages/core/test/score.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `computeScore`, `ScoreResult`, `Category`, `Result`, `Config`.
+- Produces: `function scoresByCategory(results: Result[], config: Config): Partial<Record<Category, ScoreResult>>`.
+
+- [ ] **Step 1: Write the failing test** — append to `packages/core/test/score.test.ts`:
+
+```ts
+import { scoresByCategory } from '../src/index.js';
+
+describe('scoresByCategory', () => {
+  it('scores each category independently', () => {
+    const config = defineConfig({});
+    const results = [
+      { id: 'SEO001', category: 'seo', severity: 'critical', detection: { presence: 'none', value: 'absent' }, route: '/a', message: 'x' },
+      { id: 'PERF001', category: 'performance', severity: 'warning', detection: { presence: 'none', value: 'absent' }, route: '/a', message: 'y' },
+      { id: 'PERF001', category: 'performance', severity: 'warning', detection: { presence: 'own', value: 'static' }, route: '/b', message: 'ok' }
+    ] as const;
+    const byCat = scoresByCategory(results as never, config);
+    expect(byCat.seo).toBeDefined();
+    expect(byCat.performance).toBeDefined();
+    // SEO has a critical on its only route → capped/low; performance has one bad route and one clean route.
+    expect(byCat.performance!.score).toBeGreaterThan(byCat.seo!.score);
+  });
+
+  it('treats a missing category as seo', () => {
+    const config = defineConfig({});
+    const byCat = scoresByCategory(
+      [{ id: 'SEO001', severity: 'warning', detection: { presence: 'none', value: 'absent' }, route: '/a', message: 'x' }] as never,
+      config
+    );
+    expect(byCat.seo).toBeDefined();
+    expect(byCat.performance).toBeUndefined();
+  });
+});
+```
+
+> Check the existing `score.test.ts` imports — it already imports `defineConfig`. If not, add it to the import.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `pnpm --filter @svelte-vitals/core test -- score`
+Expected: FAIL — `scoresByCategory` is not a function.
+
+- [ ] **Step 3: Implement `scoresByCategory`** in `packages/core/src/scoring/score.ts` — add the import and the function:
+
+```ts
+import type { Category, Config, Result, Severity } from '../types.js';
+```
+(append at end of file:)
+```ts
+/** Compute an independent score per category present in `results` (issue #10). */
+export function scoresByCategory(results: Result[], config: Config): Partial<Record<Category, ScoreResult>> {
+  const byCat = new Map<Category, Result[]>();
+  for (const r of results) {
+    const cat = r.category ?? 'seo';
+    let bucket = byCat.get(cat);
+    if (!bucket) byCat.set(cat, (bucket = []));
+    bucket.push(r);
+  }
+  const out: Partial<Record<Category, ScoreResult>> = {};
+  for (const [cat, rs] of byCat) out[cat] = computeScore(rs, config);
+  return out;
+}
+```
+
+- [ ] **Step 4: Export** from `packages/core/src/index.ts` — extend the scoring export:
+
+```ts
+export { computeScore, scoresByCategory } from './scoring/score.js';
+```
+
+- [ ] **Step 5: Run tests + typecheck**
+
+Run: `pnpm --filter @svelte-vitals/core test -- score` then `pnpm --filter @svelte-vitals/core typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/scoring/score.ts packages/core/src/index.ts packages/core/test/score.test.ts
+git commit -m "feat(core): add scoresByCategory for per-category scores (#10)"
+```
+
+---
+
+### Task 4: Collect `<img>` in the CLI provider
+
+**Files:**
+- Modify: `packages/cli/src/providers/source/parse.ts` (collect images + line)
+- Modify: `packages/cli/src/providers/source/routes.ts` (per-route images → `RuleContext.images`)
+- Test: `packages/cli/test/parse-file.test.ts` (extend), `packages/cli/test/source-provider.test.ts` (extend) or a new `packages/cli/test/images.test.ts`
+
+**Interfaces:**
+- Consumes: `ResolvedImages`, `ImageInfo` from `@svelte-vitals/core`.
+- Produces:
+  - `parse.ts`: `interface ParsedImage { hasWidth: boolean; hasHeight: boolean; hasLoading: boolean; line: number }`; `ParsedFile.images: ParsedImage[]`.
+  - `routes.ts`: `resolveRoute` builds `ResolvedImages` and `collect` passes `images` into `runRules` context.
+
+- [ ] **Step 1: Write the failing test** — add to `packages/cli/test/parse-file.test.ts`:
+
+```ts
+describe('parseFile images', () => {
+  it('collects <img> attribute presence and line (dynamic counts as present)', () => {
+    const src = `<div>\n  <img src="/a.png" width="10" height="10" loading="lazy" />\n  <img src="/b.png" width={w} />\n</div>`;
+    const pf = parseFile(src, 'src/routes/+page.svelte');
+    expect(pf.images).toHaveLength(2);
+    expect(pf.images[0]).toMatchObject({ hasWidth: true, hasHeight: true, hasLoading: true, line: 2 });
+    // width={w} (dynamic) still counts as present; height/loading absent.
+    expect(pf.images[1]).toMatchObject({ hasWidth: true, hasHeight: false, hasLoading: false, line: 3 });
+  });
+
+  it('finds <img> nested inside a block', () => {
+    const pf = parseFile(`{#if cond}<img src="/x.png" />{/if}`, 'x.svelte');
+    expect(pf.images).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `pnpm --filter svelte-vitals test -- parse-file`
+Expected: FAIL — `pf.images` is undefined.
+
+- [ ] **Step 3: Implement image collection in `parse.ts`** — add the type, a line helper, a collector, and wire it into `ParsedFile`/`parseFile`:
+
+```ts
+export interface ParsedImage {
+  hasWidth: boolean;
+  hasHeight: boolean;
+  hasLoading: boolean;
+  /** 1-based source line, or 0 if unknown. */
+  line: number;
+}
+```
+Add a line helper near the top (after `type Node = any;`):
+```ts
+function lineOf(source: string, offset: unknown): number {
+  if (typeof offset !== 'number' || offset < 0) return 0;
+  let line = 1;
+  const end = Math.min(offset, source.length);
+  for (let i = 0; i < end; i++) if (source[i] === '\n') line++;
+  return line;
+}
+```
+Add a collector (parallels `collectComponents`, reusing `CHILD_NODE_KEYS` and `findAttr`):
+```ts
+function collectImages(node: Node, source: string, acc: ParsedImage[]): void {
+  if (Array.isArray(node)) {
+    for (const child of node) collectImages(child, source, acc);
+    return;
+  }
+  if (!node || typeof node !== 'object') return;
+  if (node.type === 'RegularElement' && node.name === 'img') {
+    const attrs: Node[] = node.attributes ?? [];
+    acc.push({
+      hasWidth: Boolean(findAttr(attrs, 'width')),
+      hasHeight: Boolean(findAttr(attrs, 'height')),
+      hasLoading: Boolean(findAttr(attrs, 'loading')),
+      line: lineOf(source, node.start)
+    });
+  }
+  for (const key of CHILD_NODE_KEYS) {
+    if (key in node) collectImages(node[key], source, acc);
+  }
+}
+```
+Extend `ParsedFile`:
+```ts
+export interface ParsedFile {
+  headTags: ParsedTag[];
+  components: ComponentUse[];
+  imports: ImportMap;
+  images: ParsedImage[];
+}
+```
+In `parseFile`, collect and return images:
+```ts
+  const components: ComponentUse[] = [];
+  collectComponents(ast.fragment ?? ast, components);
+  const images: ParsedImage[] = [];
+  collectImages(ast.fragment ?? ast, source, images);
+  return {
+    headTags: heads.flatMap(tagsFromHead),
+    components,
+    imports: collectImports(ast),
+    images
+  };
+```
+
+> `findAttr` returns the attribute node whether its value is a literal or an `ExpressionTag`, so `width={w}` yields `hasWidth: true` — dynamic counts as present, per the no-false-positives constraint.
+
+- [ ] **Step 4: Run the parse-file test**
+
+Run: `pnpm --filter svelte-vitals test -- parse-file`
+Expected: PASS.
+
+- [ ] **Step 5: Write the provider test** — add to `packages/cli/test/source-provider.test.ts` (or create `packages/cli/test/images.test.ts`); use the in-memory runtime pattern already used in that file. Minimal new case:
+
+```ts
+// Assumes the file's existing in-memory `makeRuntime`/fixture helpers; adapt to them.
+it('resolveRoute exposes per-route images including layout images', async () => {
+  // A layout with a bad <img> and a page with a good <img>; the route should see both.
+  // (Build via the file's existing runtime helper; assert the collect() result drives
+  //  PERF findings — or assert ResolvedImages directly if resolveRoute is exported.)
+});
+```
+
+> If `resolveRoute`/`chainFiles` are not exported, test image collection end-to-end through `sourceHeadProvider`-style flow by adding a fixture under `packages/cli/test/fixtures/` with an `<img>` missing dimensions and asserting (in Task 6's `run` e2e) that PERF001 fires. Keep this step's unit assertion to what the file already exposes; do not export internals solely for the test unless the file already does.
+
+- [ ] **Step 6: Wire images into the rule context in `routes.ts`** — collect per-route images across the chain and pass them to `runRules`.
+
+In `resolveRoute`, accumulate images while walking `files` (it already reads + parses each chain file). Add an `images` accumulator and return it alongside the head. Change `resolveRoute` to also produce `ResolvedImages`, and have `collect` assemble `RuleContext.images`.
+
+The cleanest seam: `routes.ts` currently only builds `ResolvedHead[]` and the rules run elsewhere? **No** — rules run in `packages/cli/src/index.ts` via `runRules(rules, { heads, project, config })` (see `analyzeProject`). So `sourceHeadProvider.collect` returns heads only; images must travel a parallel path. Add an images collector to the provider and thread it into `analyzeProject`'s `runRules` call.
+
+Concretely:
+  1. In `routes.ts`, add an exported `collectImages(rt, cwd, config): Promise<ResolvedImages[]>` that enumerates route pages, walks each route's chain (reuse `chainFiles`), parses each file, and maps `ParsedImage[]` → `ImageInfo[]` (adding `file`), returning one `ResolvedImages` per route. Factor the chain walk so it isn't duplicated (e.g. have `resolveRoute` and the image collector share `chainFiles`).
+  2. In `packages/cli/src/index.ts` `analyzeProject`, after collecting heads, also collect images and pass them:
+
+```ts
+const heads = (await sourceHeadProvider.collect(rt, cwd, config)).filter((h) => matches(h.route));
+const images = (await sourceImageProvider.collect(rt, cwd, config)).filter((i) => matches(i.route));
+const project = await collectProjectFacts(rt, cwd);
+const rules = selectRules(allRules, config);
+const results = applyRuleSeverities(await runRules(rules, { heads, images, project, config }), config);
+```
+
+Define `sourceImageProvider` in `routes.ts` next to `sourceHeadProvider`:
+
+```ts
+export const sourceImageProvider = {
+  async collect(rt: Runtime, cwd: string, config: Config = defaultConfig): Promise<ResolvedImages[]> {
+    const pages = await enumerateRoutePages(rt, cwd);
+    return Promise.all(pages.map((page) => resolveRouteImages(rt, cwd, page, config)));
+  }
+};
+```
+where `resolveRouteImages` walks `chainFiles(rt, cwd, page)`, parses each file, and collects `ImageInfo[]` (tagging `file: rel`, `route: deriveRoute(page)`).
+
+> `config` is currently unused by image collection but is accepted for symmetry/future use.
+
+- [ ] **Step 7: Run CLI tests + typecheck**
+
+Run: `pnpm --filter svelte-vitals test` then `pnpm --filter svelte-vitals typecheck`
+Expected: PASS (existing run/provider tests unchanged; image tests pass).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/cli/src/providers/source/parse.ts packages/cli/src/providers/source/routes.ts packages/cli/src/index.ts packages/cli/test
+git commit -m "feat(cli): collect <img> facts per route for Performance rules (#10)"
+```
+
+---
+
+### Task 5: Category-aware reporters
+
+**Files:**
+- Modify: `packages/core/src/reporter/console.ts`
+- Modify: `packages/core/src/reporter/json.ts`
+- Modify: `packages/core/src/reporter/agent.ts`
+- Modify: `packages/core/src/reporter/github.ts`, `packages/core/src/reporter/sarif.ts` (use `line` when present)
+- Test: `packages/core/test/console-report.test.ts`, `json-report.test.ts`, `agent-report.test.ts` (extend with performance fixtures)
+
+**Interfaces:**
+- Consumes: `scoresByCategory`, `Result.category`, `Result.line`.
+- Produces: console per-category score sections; json `categories` map + per-issue `category`; agent generalized heading; github/sarif line-accurate locations.
+
+- [ ] **Step 1: Write failing reporter tests** — add a performance fixture + assertions.
+
+`console-report.test.ts` — add:
+```ts
+it('adds a Performance score section when performance findings exist', () => {
+  const withPerf: Result[] = [
+    ...results,
+    { id: 'PERF001', category: 'performance', severity: 'warning', detection: { presence: 'none', value: 'absent' }, route: '/blog', location: 'src/routes/blog/+page.svelte', line: 42, message: 'Missing <img> width/height' }
+  ];
+  const out = formatConsoleReport(withPerf, config);
+  expect(out).toMatch(/SEO Score: \d+\/100/);
+  expect(out).toMatch(/Performance Score: \d+\/100/);
+  expect(out).toContain('PERF001');
+  expect(out).toContain('src/routes/blog/+page.svelte:42');
+});
+```
+
+`json-report.test.ts` — add:
+```ts
+it('exposes a per-category scores map and tags issues with category', () => {
+  const withPerf: Result[] = [
+    ...results,
+    { id: 'PERF001', category: 'performance', severity: 'warning', detection: { presence: 'none', value: 'absent' }, route: '/blog', location: 'src/routes/blog/+page.svelte', line: 42, message: 'Missing <img> width/height' }
+  ];
+  const json = JSON.parse(formatJsonReport(withPerf, config, { version: '0.1.0' }));
+  expect(json.categories.seo.score).toBeTypeOf('number');
+  expect(json.categories.performance.score).toBeTypeOf('number');
+  const blog = json.routes.find((r: { route: string }) => r.route === '/blog');
+  expect(blog.issues[0].category).toBe('performance');
+  expect(blog.issues[0].line).toBe(42);
+});
+```
+
+`agent-report.test.ts` — add (heading generalized, perf grouped):
+```ts
+it('groups performance findings and uses a category-neutral heading', () => {
+  const withPerf: Result[] = [
+    ...results,
+    { id: 'PERF001', category: 'performance', severity: 'warning', detection: { presence: 'none', value: 'absent' }, route: '/blog', location: 'src/routes/blog/+page.svelte', line: 42, message: 'Missing <img> width/height', fix: { description: 'Add width/height.', snippet: '<img width="1" height="1" />', lang: 'svelte' } }
+  ];
+  const md = formatAgentReport(withPerf, config);
+  expect(md).toContain('PERF001');
+  expect(md).toMatch(/^# svelte-vitals/m); // heading no longer says "SEO fixes"
+});
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `pnpm --filter @svelte-vitals/core test -- console-report json-report agent-report`
+Expected: FAIL (no `Performance Score:`, no `categories`, heading still "SEO fixes").
+
+- [ ] **Step 3: Update `console.ts`** — render a score section per category present, reusing the `"<Label> Score: N/100"` line so existing assertions pass.
+
+Replace `scoreHeader` and the body so categories are iterated. Key changes:
+```ts
+import { computeScore, scoresByCategory } from '../scoring/score.js';
+import type { Category } from '../types.js';
+
+const CATEGORY_LABEL: Partial<Record<Category, string>> = {
+  seo: 'SEO',
+  performance: 'Performance',
+  a11y: 'Accessibility',
+  maintainability: 'Maintainability'
+};
+const CATEGORY_ORDER: Category[] = ['seo', 'performance', 'a11y', 'maintainability'];
+
+function scoreLine(label: string, results: Result[], config: Config): string {
+  const { score, scoreModel } = computeScore(results, config);
+  const parts = [`route avg ${scoreModel.routeAverage}`];
+  if (scoreModel.sitePenalty > 0) parts.push(`site −${scoreModel.sitePenalty}`);
+  if (scoreModel.criticalCap !== null) parts.push(`capped at ${scoreModel.criticalCap}: critical present`);
+  return `${label} Score: ${score}/100   (${parts.join(' · ')})`;
+}
+```
+In `formatConsoleReport`: replace the single `scoreHeader(...)` header line with one score line per category that has results, and prefix each finding's location with `:line` when present. Concretely, build the header as:
+```ts
+  const byCat = scoresByCategory(results, config);
+  const present = CATEGORY_ORDER.filter((c) => byCat[c] !== undefined);
+  const header: string[] = [`Svelte Vitals  (${options.mode ?? 'static mode'})`, ''];
+  for (const c of present) header.push(scoreLine(CATEGORY_LABEL[c] ?? c, results.filter((r) => (r.category ?? 'seo') === c), config));
+  const lines: string[] = [...header, ''];
+```
+And in the failures loop, change the location line to include `line`:
+```ts
+      if (r.location) lines.push(`            ${r.location}${r.line ? `:${r.line}` : ''}`);
+```
+(Severity buckets and the Passed section stay as-is — findings already show `r.id`, which distinguishes SEO vs PERF.)
+
+> This keeps `SEO Score: N/100` (now per-category) so `console-report.test`'s existing regex passes, and adds `Performance Score: N/100` only when performance results exist. The `byRouteTree` helper is unchanged.
+
+- [ ] **Step 4: Update `json.ts`** — add `categories` and per-issue `category`/`line`.
+
+In `issueOf`, include category and line:
+```ts
+function issueOf(result: Result) {
+  return {
+    id: result.id,
+    category: result.category ?? 'seo',
+    title: result.message,
+    detection: result.detection,
+    location: result.location,
+    ...(result.line !== undefined ? { line: result.line } : {}),
+    recommendation: result.recommendation,
+    ...(result.docsUrl ? { docsUrl: result.docsUrl } : {}),
+    ...(result.fix ? { fix: result.fix } : {})
+  };
+}
+```
+In `buildJsonReport`, add a `categories` field (keep top-level `score` = SEO for backward compat):
+```ts
+import { computeScore, scoresByCategory, type ScoreModel } from '../scoring/score.js';
+```
+```ts
+  const byCat = scoresByCategory(results, config);
+  const categories = Object.fromEntries(
+    Object.entries(byCat).map(([cat, sr]) => [cat, { score: sr.score, scoreModel: sr.scoreModel }])
+  );
+  return { version: meta.version, score, scoreModel, summary, categories, routes, siteIssues };
+```
+Add `categories` to the `JsonReport` interface:
+```ts
+  categories: Record<string, { score: number; scoreModel: ScoreModel }>;
+```
+(Place it after `scoreModel`.) The top-level `score`/`scoreModel` stay computed via `computeScore(results, config)` — which now includes PERF results. **To keep the top-level score = SEO only (backward compat), compute it from the SEO subset:**
+```ts
+  const seoResults = results.filter((r) => (r.category ?? 'seo') === 'seo');
+  const { score, scoreModel } = computeScore(seoResults, config);
+```
+
+> Important: changing the top-level `score` to the SEO subset preserves existing json-report assertions (their fixtures are all SEO, so subset === full). Verify the existing test still sees `summary.critical` etc. — `summary` stays over all results (counts include PERF); the existing fixture has no PERF so unchanged.
+
+- [ ] **Step 5: Update `agent.ts`** — generalize the heading and group by category.
+
+Change the H1 from SEO-specific to neutral, and (minimal) keep the existing file-grouping but ensure PERF findings (which are `fail` and have `fix`) flow through. The only required change for the test is the heading:
+```ts
+  const lines: string[] = ['# svelte-vitals — fixes', ''];
+```
+and the empty-state line stays `'No issues to fix.'`. PERF findings already classify as `fail` (penalized detection) and carry `fix`, so they render in their `location` group with their snippet automatically. Show `line` in the group header when present:
+```ts
+    const key = r.location ?? r.route ?? '(project)';
+```
+(unchanged grouping is acceptable; `line` appears via the `## ${loc}` not carrying line — optionally append `:line`. Keep minimal: no line in agent group header for v0.4.)
+
+> Check `agent-report.test.ts`'s "No issues to fix" case (if present) for an H1 assertion; update it to the new `# svelte-vitals — fixes` heading if it checks the old text.
+
+- [ ] **Step 6: Update `github.ts` and `sarif.ts`** to use `r.line` when present.
+
+In `github.ts`, where the annotation line is set (currently defaults to `1`), use `result.line ?? 1`. In `sarif.ts`, set the region `startLine` to `result.line ?? 1`. (Locate the existing line assignment in each file and swap the literal `1` for `result.line ?? 1`.) Add a one-line test in each existing reporter test asserting a PERF finding's line surfaces, mirroring the fixtures above.
+
+- [ ] **Step 7: Run all reporter tests + full core suite + typecheck**
+
+Run: `pnpm --filter @svelte-vitals/core test` then `pnpm --filter @svelte-vitals/core typecheck`
+Expected: PASS — new performance assertions pass; all existing SEO reporter tests unchanged.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/core/src/reporter packages/core/test
+git commit -m "feat(core): category-aware reporters with per-category scores (#10)"
+```
+
+---
+
+### Task 6: e2e fixture, README, changeset, full verification
+
+**Files:**
+- Create: `packages/cli/test/fixtures/basic-project/src/routes/img/+page.svelte` (an `<img>` missing dimensions) — or add an `<img>` to an existing fixture route
+- Modify: `packages/cli/test/run.test.ts` (assert PERF001 surfaces end-to-end)
+- Modify: `README.md` (roadmap)
+- Create: `.changeset/performance-v0.4.md`
+
+**Interfaces:** none (integration + docs/release).
+
+- [ ] **Step 1: Add an e2e fixture image.** Create `packages/cli/test/fixtures/basic-project/src/routes/img/+page.svelte`:
+
+```svelte
+<img src="/hero.png" alt="hero" />
+```
+
+- [ ] **Step 2: Write the failing e2e assertion** — add to `packages/cli/test/run.test.ts` (json reporter makes assertions robust):
+
+```ts
+it('reports a Performance finding for an <img> missing dimensions', async () => {
+  const cap = capture();
+  await run({ cwd: fixtureDir, reporter: 'json', log: cap.log, errorLog: cap.errorLog, env: CLEAN_ENV });
+  const json = JSON.parse(cap.out.join('\n'));
+  expect(json.categories.performance).toBeDefined();
+  const img = json.routes.find((r: { route: string }) => r.route === '/img');
+  expect(img.issues.some((i: { id: string }) => i.id === 'PERF001')).toBe(true);
+});
+```
+
+- [ ] **Step 3: Run it**
+
+Run: `pnpm --filter svelte-vitals test -- run`
+Expected: PASS (after Tasks 2 & 4 the pipeline emits PERF001 for `/img`). If the existing `run.test` "returns exit 1 and reports the missing title" asserts exact counts that now include the new `/img` route, adjust those counts. Re-read the assertions and update any route-count-sensitive expectation; the missing-title/critical assertions should be unaffected because `/img` has no title either — **verify**: if `/img` lacks a title, it adds an SEO001 critical. To avoid perturbing existing SEO count assertions, give the fixture page a dynamic title:
+
+```svelte
+<svelte:head><title>{data.title}</title></svelte:head>
+<img src="/hero.png" alt="hero" />
+```
+so `/img` passes SEO (dynamic title) and only contributes the PERF finding.
+
+- [ ] **Step 4: Run the full CLI suite** and fix any count drift
+
+Run: `pnpm --filter svelte-vitals test`
+Expected: PASS. If a count assertion drifted from the new route, update it to the correct value and note why.
+
+- [ ] **Step 5: Update the README roadmap.** In `README.md`, under **Shipped**, add:
+
+```md
+- **Performance checks** (`0.4`) — static `<img>` analysis: `width`/`height` (CLS) and a `loading` advisory, scored as a separate Performance category alongside SEO.
+```
+And under **Upcoming**, replace the single #10 bullet with:
+
+```md
+- **More categories** ([#10](https://github.com/oekazuma/svelte-vitals/issues/10)) — Accessibility and Upgrade checks, then a combined weighted Health Report — all landing across `0.x` ahead of the `1.0` polish.
+```
+
+- [ ] **Step 6: Add the changeset** — `.changeset/performance-v0.4.md`:
+
+```md
+---
+'@svelte-vitals/core': minor
+'svelte-vitals': minor
+---
+
+Add the Performance category (v0.4, #10): static `<img>` checks — **PERF001** (missing
+`width`/`height`, CLS risk; warning) and **PERF002** (missing `loading` attribute; info
+advisory) — with dynamically-bound attributes counting as present. Introduces the
+multi-category foundation: `Result.category`/`line`, the `ImageInfo`/`ResolvedImages` IR,
+`RuleContext.images`, `imageRule`, `scoresByCategory`, and category-aware reporters
+(per-category scores; JSON `categories` map). Existing SEO findings, scores, and output
+are unchanged.
+```
+
+- [ ] **Step 7: Full repo verification**
+
+Run: `pnpm -r typecheck && pnpm -r test && pnpm build && pnpm lint && pnpm check:publish`
+Expected: all green. (Run `pnpm format` first if prettier flags formatting; locally `check:publish`'s attw step may hit the root-owned npm cache — if so, verify attw via `pnpm --workspace-concurrency=1 --filter … exec attw --pack . --profile esm-only` with `npm_config_cache` set, as in #20.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add README.md .changeset/performance-v0.4.md packages/cli/test
+git commit -m "docs(perf): ship Performance v0.4, roadmap + changeset (#10)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- PERF001 dimensions + PERF002 loading, dynamic-as-present → Task 2 (rules) + Task 4 (`findAttr` presence). ✅
+- Per-image findings with `file` + `line` → Task 2 (imageRule emits per bad image) + Task 4 (`line` from AST). ✅
+- Image IR (`ImageInfo`/`ResolvedImages`) + `RuleContext.images` → Task 2. ✅
+- Provider collects across layout chain (page + layouts) → Task 4 (`resolveRouteImages` over `chainFiles`). ✅
+- `Result.category`/`line`; SEO rules tagged → Task 1. ✅
+- Per-category scoring (`scoresByCategory`, reuse `computeScore`) → Task 3. ✅
+- Category-aware reporters (console per-category score, json `categories`, agent heading, github/sarif line) → Task 5. ✅
+- failOn/exit unchanged → no task changes them; verified in Task 6 e2e. ✅
+- README roadmap + changeset → Task 6. ✅
+- Out of scope (plugin img, preload/adapter/large-imports, Health Report) → not implemented; noted as later 0.x. ✅
+
+**Placeholder scan:** Task 4 Step 5 (provider unit test) intentionally defers to the file's existing in-memory runtime helpers rather than inventing a harness; the e2e coverage in Task 6 guarantees the path. Task 5 Steps 5–6 reference "the existing line assignment" in github/sarif — these are real, locatable literals (`1`), not placeholders. No "TBD"/"add error handling"-style gaps.
+
+**Type consistency:** `ImageInfo { hasWidth, hasHeight, hasLoading, line, file }` (Task 2) ⇄ `ParsedImage { hasWidth, hasHeight, hasLoading, line }` + `file` added in Task 4. `ResolvedImages { route, images: ImageInfo[] }` consumed by `imageRule` (Task 2) and produced by `sourceImageProvider` (Task 4). `scoresByCategory` (Task 3) consumed by console + json (Task 5). `Result.category`/`line` (Task 1) consumed everywhere. `imageRule`/`perf001ImageDimensions`/`perf002ImageLoading` names consistent across Tasks 2, 5, 6.

--- a/docs/superpowers/specs/2026-06-22-performance-v0.4-design.md
+++ b/docs/superpowers/specs/2026-06-22-performance-v0.4-design.md
@@ -1,0 +1,94 @@
+# Design: Performance v0.4 (first non-SEO Vitals category)
+
+Issue: [#10](https://github.com/oekazuma/svelte-vitals/issues/10) (roadmap epic). This spec covers **only Performance v0.4** — the first category beyond SEO — plus the multi-category foundation it needs.
+
+## Goal
+
+Add static-analysis **Performance** checks for `<img>` elements (the highest-confidence, highest-impact performance signal a static checker can give), and establish the **multi-category foundation** (per-category findings + per-category scores + category-aware reporters) that Accessibility v0.5 and Upgrade v0.6 will reuse, culminating in the v1.0 weighted Health Report.
+
+Static-analysis-only; **no runtime Core Web Vitals**. Static mode (CLI) first; plugin-mode image checks are a follow-up.
+
+## Scope (v0.4)
+
+Two route-scoped rules over `<img>` elements found in each route's `+page.svelte` and its `+layout.svelte` chain:
+
+- **PERF001 — image dimensions (`warning`).** An `<img>` without an explicit `width` **and** `height` risks layout shift (CLS). A dynamically-bound dimension (`width={w}`) counts as present and **passes** — we never flag a dimension we can't prove is missing (mirrors the SEO "dynamic title passes" stance).
+- **PERF002 — image loading hint (`info`).** An `<img>` with no `loading` attribute gets an advisory: set `loading="lazy"` for offscreen images, or keep it eager (and consider `fetchpriority="high"`) for the LCP image. `info` because static analysis cannot know which images are above the fold — this must not produce noisy false-positive failures.
+
+**Out of scope for v0.4** (deferred, tracked under #10): `preload` checks, adapter-config checks, large-import/bundle-size analysis, plugin-mode (output-HTML) image checks, and the v1.0 weighted combined Health Report.
+
+## Findings granularity
+
+One finding **per offending `<img>`**, carrying `category: 'performance'`, `location` (the `.svelte` file the `<img>` is in), and `line` (1-based, from the AST node). Multiple bad images on a route therefore produce multiple findings; scoring dedups per `(route, rule id)` (existing behavior), so a route is not over-penalized for many images, while the report still lists each one with its line.
+
+A `<img>` declared in a `+layout.svelte` appears on every child route, so it is reported per route it renders on (consistent with how inherited head findings already surface per route).
+
+## Architecture & data flow
+
+```text
+src/routes/**/+page.svelte (+ layout chain)
+  │  parseFile → ParsedFile { headTags, components, imports, images }   ← NEW: images
+  ▼
+routes.ts resolveRoute  → walks the chain, collects per-route images
+  │  → ResolvedImages { route, images: Array<ImageInfo & { file }> }
+  ▼
+RuleContext { heads, images, project, config }   ← NEW: images
+  ▼
+runRules(rules) → SEO rules read heads; PERF rules read images
+  │  → Result[]  (each Result now carries `category`; PERF results carry `line`)
+  ▼
+scoring + reporters: split results by category → per-category score + sections
+```
+
+### core — types
+
+- **`ImageInfo`** (new, normalized, no AST): `{ hasWidth: boolean; hasHeight: boolean; hasLoading: boolean; line: number }`.
+- **`ResolvedImages`** (new): `{ route: string; images: Array<ImageInfo & { file: string }> }` — one per route, mirroring `ResolvedHead`.
+- **`RuleContext`** gains `images: ResolvedImages[]`.
+- **`Result`** gains `category: Category` (required) and `line?: number` (optional, 1-based). Every existing SEO rule sets `category: 'seo'`; `headTagRule` and the project rules set it centrally.
+- A small **`imageRule` factory** (parallels `headTagRule`) builds a route-scoped rule that maps each route's images to findings via a per-image predicate.
+
+### cli — provider
+
+- `parse.ts`: extend the template walk (the existing `collectComponents`/`CHILD_NODE_KEYS` traversal) to also collect `<img>` `RegularElement`s, recording attribute presence (`width`/`height`/`loading`) and the node's 1-based line (derived from `node.start` + the source, or the AST's location if present). Add `images: ParsedImage[]` to `ParsedFile`.
+- `routes.ts`: in `resolveRoute`, collect images from every file in the chain (page + layouts) into one `ResolvedImages` for the route, tagging each image with its source `file`. Feed `images` into the `RuleContext` passed to `runRules`.
+
+### core — scoring (per-category)
+
+- Compute a score **per category** by running the existing `computeScore` over the category's result subset: `computeScore(results.filter(r => r.category === 'seo'), …)` and `computeScore(results.filter(r => r.category === 'performance'), …)`. The route-average + critical-cap model is reused unchanged; Performance has no `critical` rule, so the cap simply never binds.
+- A new helper `scoresByCategory(results, config): Record<Category, ScoreResult>` (only for categories that have findings) centralizes this so reporters don't each re-filter.
+- The CLI headline keeps the **SEO score as primary** (preserving existing output/exit semantics) and additionally surfaces the **Performance score**. The combined weighted Health Report is explicitly a v1.0 concern.
+
+### core — reporters (category-aware)
+
+All reporters group findings by `category` and show each category's score:
+
+- **console**: an `SEO` section (unchanged formatting) followed by a `Performance` section (its score + findings, each with `file:line`).
+- **json**: add a top-level `categories` map — `{ seo: { score, … }, performance: { score, … } }` — and tag each issue with its `category`; the existing top-level `score` stays = the SEO score for backward compatibility.
+- **agent**: generalize the heading from "SEO fixes" to "fixes", group remediation by category then file.
+- **sarif / github**: include Performance findings (the rule id + `line` already give SARIF/GitHub the location); no structural change beyond carrying the new findings.
+
+`summary`/`hasFailureAtOrAbove`/exit codes are unchanged: PERF findings count by their effective severity, and under the default `--fail-on=critical` the warning/info PERF findings do not fail the build.
+
+## Error handling
+
+No new failure modes. Files that fail to parse already surface as execution errors (exit 2) in the existing pipeline; image collection rides the same parse and inherits that behavior.
+
+## Testing (TDD)
+
+- **core**: `imageRule`/PERF001/PERF002 over synthetic `ResolvedImages` (present dims pass; missing dims → penalized; dynamic dims pass; missing `loading` → info); `scoresByCategory` returns independent SEO/Performance scores; every rule exposes a `category`.
+- **cli**: `parseFile` collects `<img>` attribute presence + line; a `<img>` in a layout surfaces on child routes; an `<img>` inside a block (`{#if}`/`{#each}`) is found (reuses the existing traversal-coverage approach).
+- **reporters**: console shows a Performance section + score; json carries `categories` + per-issue `category`; agent groups by category.
+- All existing SEO tests stay green (adding `category` to results and a Performance section must not change SEO output or scores).
+
+## Roadmap / release
+
+- README roadmap: note Performance checks shipping at `0.4` (first category beyond SEO); keep A11y/Upgrade and the v1.0 Health Report as upcoming.
+- Changeset: `@svelte-vitals/core` minor (new rules, types, scoring, reporters) and `svelte-vitals` minor (image collection in the provider). `@svelte-vitals/vite` unchanged (plugin-mode image checks deferred).
+
+## Non-goals / follow-ups
+
+- Plugin-mode (`@svelte-vitals/vite`) image checks on prerendered HTML.
+- `preload`, adapter-config, and large-import performance rules.
+- Per-image precise locations beyond `line` (e.g. column), and report-level dedup of a shared layout image across routes.
+- The v1.0 weighted combined Health Report (how SEO/Performance/A11y/Upgrade roll up into one number).

--- a/docs/superpowers/specs/2026-06-22-performance-v0.4-design.md
+++ b/docs/superpowers/specs/2026-06-22-performance-v0.4-design.md
@@ -4,7 +4,7 @@ Issue: [#10](https://github.com/oekazuma/svelte-vitals/issues/10) (roadmap epic)
 
 ## Goal
 
-Add static-analysis **Performance** checks for `<img>` elements (the highest-confidence, highest-impact performance signal a static checker can give), and establish the **multi-category foundation** (per-category findings + per-category scores + category-aware reporters) that Accessibility v0.5 and Upgrade v0.6 will reuse, culminating in the v1.0 weighted Health Report.
+Add static-analysis **Performance** checks for `<img>` elements (the highest-confidence, highest-impact performance signal a static checker can give), and establish the **multi-category foundation** (per-category findings + per-category scores + category-aware reporters) that Accessibility v0.5 and Upgrade v0.6 will reuse. The weighted combined Health Report is built as a **later 0.x increment** once the categories exist; `1.0` is the polished culmination, not where new integration lands.
 
 Static-analysis-only; **no runtime Core Web Vitals**. Static mode (CLI) first; plugin-mode image checks are a follow-up.
 
@@ -15,7 +15,7 @@ Two route-scoped rules over `<img>` elements found in each route's `+page.svelte
 - **PERF001 — image dimensions (`warning`).** An `<img>` without an explicit `width` **and** `height` risks layout shift (CLS). A dynamically-bound dimension (`width={w}`) counts as present and **passes** — we never flag a dimension we can't prove is missing (mirrors the SEO "dynamic title passes" stance).
 - **PERF002 — image loading hint (`info`).** An `<img>` with no `loading` attribute gets an advisory: set `loading="lazy"` for offscreen images, or keep it eager (and consider `fetchpriority="high"`) for the LCP image. `info` because static analysis cannot know which images are above the fold — this must not produce noisy false-positive failures.
 
-**Out of scope for v0.4** (deferred, tracked under #10): `preload` checks, adapter-config checks, large-import/bundle-size analysis, plugin-mode (output-HTML) image checks, and the v1.0 weighted combined Health Report.
+**Out of scope for v0.4** (later 0.x increments, tracked under #10): `preload` checks, adapter-config checks, large-import/bundle-size analysis, plugin-mode (output-HTML) image checks, and the weighted combined Health Report (built once the categories exist, before the 1.0 polish).
 
 ## Findings granularity
 
@@ -57,7 +57,7 @@ scoring + reporters: split results by category → per-category score + sections
 
 - Compute a score **per category** by running the existing `computeScore` over the category's result subset: `computeScore(results.filter(r => r.category === 'seo'), …)` and `computeScore(results.filter(r => r.category === 'performance'), …)`. The route-average + critical-cap model is reused unchanged; Performance has no `critical` rule, so the cap simply never binds.
 - A new helper `scoresByCategory(results, config): Record<Category, ScoreResult>` (only for categories that have findings) centralizes this so reporters don't each re-filter.
-- The CLI headline keeps the **SEO score as primary** (preserving existing output/exit semantics) and additionally surfaces the **Performance score**. The combined weighted Health Report is explicitly a v1.0 concern.
+- The CLI headline keeps the **SEO score as primary** (preserving existing output/exit semantics) and additionally surfaces the **Performance score**. The combined weighted Health Report is a later 0.x increment (once more categories exist), not a 1.0 deliverable.
 
 ### core — reporters (category-aware)
 
@@ -83,7 +83,7 @@ No new failure modes. Files that fail to parse already surface as execution erro
 
 ## Roadmap / release
 
-- README roadmap: note Performance checks shipping at `0.4` (first category beyond SEO); keep A11y/Upgrade and the v1.0 Health Report as upcoming.
+- README roadmap: note Performance checks shipping at `0.4` (first category beyond SEO); keep A11y/Upgrade and the combined Health Report as upcoming 0.x increments leading into the 1.0 polish.
 - Changeset: `@svelte-vitals/core` minor (new rules, types, scoring, reporters) and `svelte-vitals` minor (image collection in the provider). `@svelte-vitals/vite` unchanged (plugin-mode image checks deferred).
 
 ## Non-goals / follow-ups
@@ -91,4 +91,4 @@ No new failure modes. Files that fail to parse already surface as execution erro
 - Plugin-mode (`@svelte-vitals/vite`) image checks on prerendered HTML.
 - `preload`, adapter-config, and large-import performance rules.
 - Per-image precise locations beyond `line` (e.g. column), and report-level dedup of a shared layout image across routes.
-- The v1.0 weighted combined Health Report (how SEO/Performance/A11y/Upgrade roll up into one number).
+- The weighted combined Health Report (how SEO/Performance/A11y/Upgrade roll up into one number) — a later 0.x increment, not 1.0 work.

--- a/docs/superpowers/specs/2026-06-22-performance-v0.4-design.md
+++ b/docs/superpowers/specs/2026-06-22-performance-v0.4-design.md
@@ -90,5 +90,6 @@ No new failure modes. Files that fail to parse already surface as execution erro
 
 - Plugin-mode (`@svelte-vitals/vite`) image checks on prerendered HTML.
 - `preload`, adapter-config, and large-import performance rules.
+- **Image sources other than a literal `<img>` element**: `<enhanced:img>` (`@sveltejs/enhanced-img`), `<picture>`/`<source>`, `<svelte:element this="img">`, and component-based images (e.g. a `<Image>` wrapper). Only `RegularElement` nodes named `img` are inspected in v0.4; the others surface no findings (no false positives, but also no coverage) and are candidates for later increments.
 - Per-image precise locations beyond `line` (e.g. column), and report-level dedup of a shared layout image across routes.
 - The weighted combined Health Report (how SEO/Performance/A11y/Upgrade roll up into one number) — a later 0.x increment, not 1.0 work.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,7 +17,7 @@ import {
   type Config
 } from '@svelte-vitals/core';
 import { createNodeRuntime } from './runtime/node.js';
-import { sourceHeadProvider } from './providers/source/routes.js';
+import { sourceHeadProvider, sourceImageProvider } from './providers/source/routes.js';
 import { detectProject, ProjectError, collectProjectFacts } from './providers/source/project.js';
 import { readPackageVersion } from './version.js';
 import { resolveReporter, isAutoDetectedAgent, isAutoDetectedGithub, type ReporterName } from './reporter-resolve.js';
@@ -88,9 +88,10 @@ export async function analyzeProject(opts: AnalyzeOptions = {}): Promise<Analyze
 
   const matches = routeMatcher(opts.route);
   const heads = (await sourceHeadProvider.collect(rt, cwd, config)).filter((h) => matches(h.route));
+  const images = (await sourceImageProvider.collect(rt, cwd, config)).filter((i) => matches(i.route));
   const project = await collectProjectFacts(rt, cwd);
   const rules = selectRules(allRules, config);
-  const results = applyRuleSeverities(await runRules(rules, { heads, project, config }), config);
+  const results = applyRuleSeverities(await runRules(rules, { heads, images, project, config }), config);
   return { results, config, version: readPackageVersion() };
 }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,7 +17,7 @@ import {
   type Config
 } from '@svelte-vitals/core';
 import { createNodeRuntime } from './runtime/node.js';
-import { sourceHeadProvider, sourceImageProvider } from './providers/source/routes.js';
+import { collectRoutes } from './providers/source/routes.js';
 import { detectProject, ProjectError, collectProjectFacts } from './providers/source/project.js';
 import { readPackageVersion } from './version.js';
 import { resolveReporter, isAutoDetectedAgent, isAutoDetectedGithub, type ReporterName } from './reporter-resolve.js';
@@ -87,8 +87,9 @@ export async function analyzeProject(opts: AnalyzeOptions = {}): Promise<Analyze
   await detectProject(rt, cwd); // throws ProjectError if not a SvelteKit project
 
   const matches = routeMatcher(opts.route);
-  const heads = (await sourceHeadProvider.collect(rt, cwd, config)).filter((h) => matches(h.route));
-  const images = (await sourceImageProvider.collect(rt, cwd, config)).filter((i) => matches(i.route));
+  const collected = await collectRoutes(rt, cwd, config);
+  const heads = collected.heads.filter((h) => matches(h.route));
+  const images = collected.images.filter((i) => matches(i.route));
   const project = await collectProjectFacts(rt, cwd);
   const rules = selectRules(allRules, config);
   const results = applyRuleSeverities(await runRules(rules, { heads, images, project, config }), config);

--- a/packages/cli/src/providers/source/parse.ts
+++ b/packages/cli/src/providers/source/parse.ts
@@ -179,10 +179,11 @@ function collectImages(node: Node, source: string, acc: ParsedImage[]): void {
   if (!node || typeof node !== 'object') return;
   if (node.type === 'RegularElement' && node.name === 'img') {
     const attrs: Node[] = node.attributes ?? [];
+    const hasSpread = attrs.some((a: Node) => a?.type === 'SpreadAttribute');
     acc.push({
-      hasWidth: Boolean(findAttr(attrs, 'width')),
-      hasHeight: Boolean(findAttr(attrs, 'height')),
-      hasLoading: Boolean(findAttr(attrs, 'loading')),
+      hasWidth: hasSpread || Boolean(findAttr(attrs, 'width')),
+      hasHeight: hasSpread || Boolean(findAttr(attrs, 'height')),
+      hasLoading: hasSpread || Boolean(findAttr(attrs, 'loading')),
       line: lineOf(source, node.start)
     });
   }

--- a/packages/cli/src/providers/source/parse.ts
+++ b/packages/cli/src/providers/source/parse.ts
@@ -73,6 +73,14 @@ export function attrValue(attributes: Node[], name: string): Value {
   return 'absent';
 }
 
+function lineOf(source: string, offset: unknown): number {
+  if (typeof offset !== 'number' || offset < 0) return 0;
+  let line = 1;
+  const end = Math.min(offset, source.length);
+  for (let i = 0; i < end; i++) if (source[i] === '\n') line++;
+  return line;
+}
+
 function findAttr(attributes: Node[], name: string): Node | undefined {
   if (!Array.isArray(attributes)) return undefined;
   return attributes.find((a) => a?.type === 'Attribute' && a.name === name);
@@ -155,10 +163,39 @@ function collectComponents(node: Node, acc: ComponentUse[]): void {
   }
 }
 
+export interface ParsedImage {
+  hasWidth: boolean;
+  hasHeight: boolean;
+  hasLoading: boolean;
+  /** 1-based source line, or 0 if unknown. */
+  line: number;
+}
+
+function collectImages(node: Node, source: string, acc: ParsedImage[]): void {
+  if (Array.isArray(node)) {
+    for (const child of node) collectImages(child, source, acc);
+    return;
+  }
+  if (!node || typeof node !== 'object') return;
+  if (node.type === 'RegularElement' && node.name === 'img') {
+    const attrs: Node[] = node.attributes ?? [];
+    acc.push({
+      hasWidth: Boolean(findAttr(attrs, 'width')),
+      hasHeight: Boolean(findAttr(attrs, 'height')),
+      hasLoading: Boolean(findAttr(attrs, 'loading')),
+      line: lineOf(source, node.start)
+    });
+  }
+  for (const key of CHILD_NODE_KEYS) {
+    if (key in node) collectImages(node[key], source, acc);
+  }
+}
+
 export interface ParsedFile {
   headTags: ParsedTag[];
   components: ComponentUse[];
   imports: ImportMap;
+  images: ParsedImage[];
 }
 
 /** Parse a .svelte source into its layer-1 head tags, component usages, and imports. */
@@ -168,10 +205,13 @@ export function parseFile(source: string, filename: string): ParsedFile {
   collectSvelteHeads(ast.fragment ?? ast, heads);
   const components: ComponentUse[] = [];
   collectComponents(ast.fragment ?? ast, components);
+  const images: ParsedImage[] = [];
+  collectImages(ast.fragment ?? ast, source, images);
   return {
     headTags: heads.flatMap(tagsFromHead),
     components,
-    imports: collectImports(ast)
+    imports: collectImports(ast),
+    images
   };
 }
 

--- a/packages/cli/src/providers/source/routes.ts
+++ b/packages/cli/src/providers/source/routes.ts
@@ -47,18 +47,33 @@ async function chainFiles(rt: Runtime, cwd: string, pageRel: string): Promise<Ar
   return files;
 }
 
-/** Compose the effective head for one route by walking its chain (child overrides parent). */
-async function resolveRoute(rt: Runtime, cwd: string, pageRel: string, config: Config): Promise<ResolvedHead> {
+/** Per-route facts produced by a single walk of the layout chain. */
+interface RouteFacts {
+  head: ResolvedHead;
+  images: ResolvedImages;
+}
+
+/**
+ * Resolve one route by walking its layout chain once: each file is read and
+ * parsed a single time, yielding both the composed head (child overrides parent)
+ * and the route's <img> facts. Heads and images therefore share one parse pass.
+ */
+async function resolveRoute(rt: Runtime, cwd: string, pageRel: string, config: Config): Promise<RouteFacts> {
   const files = await chainFiles(rt, cwd, pageRel);
   const composed = new Map<string, HeadTag>();
   let broadOwn = false;
   let broadInherited = false;
+  const images: ImageInfo[] = [];
 
   for (const { rel, isPage } of files) {
     const source = await rt.readFile(rt.join(cwd, rel));
     const parsed = parseFile(source, rel);
-    const resolved = await resolveFileTags(rt, cwd, rel, parsed, config, MAX_DEPTH, new Set([rel]));
 
+    for (const img of parsed.images) {
+      images.push({ ...img, file: rel });
+    }
+
+    const resolved = await resolveFileTags(rt, cwd, rel, parsed, config, MAX_DEPTH, new Set([rel]));
     for (const tag of resolved.tags) {
       composed.set(tagKey(tag), { ...tag, presence: isPage ? 'own' : 'inherited', file: rel });
     }
@@ -77,11 +92,29 @@ async function resolveRoute(rt: Runtime, cwd: string, pageRel: string, config: C
     }
   }
 
+  const route = deriveRoute(pageRel);
   return {
-    route: deriveRoute(pageRel),
-    source: 'static',
-    tags: [...composed.values()],
-    file: pageRel
+    head: { route, source: 'static', tags: [...composed.values()], file: pageRel },
+    images: { route, images }
+  };
+}
+
+/**
+ * Static-mode collection: enumerate route pages and walk each route's layout
+ * chain exactly once, returning both the mode-independent ResolvedHead[] (design
+ * §8) and the per-route ResolvedImages[] for Performance rules from a single
+ * parse pass per file.
+ */
+export async function collectRoutes(
+  rt: Runtime,
+  cwd: string,
+  config: Config = defaultConfig
+): Promise<{ heads: ResolvedHead[]; images: ResolvedImages[] }> {
+  const pages = await enumerateRoutePages(rt, cwd);
+  const facts = await Promise.all(pages.map((page) => resolveRoute(rt, cwd, page, config)));
+  return {
+    heads: facts.map((f) => f.head),
+    images: facts.map((f) => f.images)
   };
 }
 
@@ -92,38 +125,16 @@ async function resolveRoute(rt: Runtime, cwd: string, pageRel: string, config: C
 export const sourceHeadProvider: HeadProvider = {
   mode: 'static',
   async collect(rt, cwd, config = defaultConfig) {
-    const pages = await enumerateRoutePages(rt, cwd);
-    return Promise.all(pages.map((page) => resolveRoute(rt, cwd, page, config)));
+    return (await collectRoutes(rt, cwd, config)).heads;
   }
 };
 
-/** Collect all <img> elements for one route across its layout chain. */
-async function resolveRouteImages(
-  rt: Runtime,
-  cwd: string,
-  pageRel: string,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _config: Config
-): Promise<ResolvedImages> {
-  const files = await chainFiles(rt, cwd, pageRel);
-  const images: ImageInfo[] = [];
-  for (const { rel } of files) {
-    const source = await rt.readFile(rt.join(cwd, rel));
-    const parsed = parseFile(source, rel);
-    for (const img of parsed.images) {
-      images.push({ ...img, file: rel });
-    }
-  }
-  return { route: deriveRoute(pageRel), images };
-}
-
 /**
- * SourceImageProvider — static mode. Enumerates route pages, walks each route's
- * layout chain, and returns one ResolvedImages per route for Performance rules.
+ * SourceImageProvider — static mode. Returns one ResolvedImages per route for
+ * Performance rules (a route's facts include images from its layout chain).
  */
 export const sourceImageProvider = {
   async collect(rt: Runtime, cwd: string, config: Config = defaultConfig): Promise<ResolvedImages[]> {
-    const pages = await enumerateRoutePages(rt, cwd);
-    return Promise.all(pages.map((page) => resolveRouteImages(rt, cwd, page, config)));
+    return (await collectRoutes(rt, cwd, config)).images;
   }
 };

--- a/packages/cli/src/providers/source/routes.ts
+++ b/packages/cli/src/providers/source/routes.ts
@@ -1,4 +1,12 @@
-import type { Config, HeadProvider, HeadTag, ImageInfo, ResolvedHead, ResolvedImages, Runtime } from '@svelte-vitals/core';
+import type {
+  Config,
+  HeadProvider,
+  HeadTag,
+  ImageInfo,
+  ResolvedHead,
+  ResolvedImages,
+  Runtime
+} from '@svelte-vitals/core';
 import { defaultConfig } from '@svelte-vitals/core';
 import { enumerateRoutePages } from './project.js';
 import { parseFile } from './parse.js';

--- a/packages/cli/src/providers/source/routes.ts
+++ b/packages/cli/src/providers/source/routes.ts
@@ -128,13 +128,3 @@ export const sourceHeadProvider: HeadProvider = {
     return (await collectRoutes(rt, cwd, config)).heads;
   }
 };
-
-/**
- * SourceImageProvider — static mode. Returns one ResolvedImages per route for
- * Performance rules (a route's facts include images from its layout chain).
- */
-export const sourceImageProvider = {
-  async collect(rt: Runtime, cwd: string, config: Config = defaultConfig): Promise<ResolvedImages[]> {
-    return (await collectRoutes(rt, cwd, config)).images;
-  }
-};

--- a/packages/cli/src/providers/source/routes.ts
+++ b/packages/cli/src/providers/source/routes.ts
@@ -1,4 +1,4 @@
-import type { Config, HeadProvider, HeadTag, ResolvedHead, Runtime } from '@svelte-vitals/core';
+import type { Config, HeadProvider, HeadTag, ImageInfo, ResolvedHead, ResolvedImages, Runtime } from '@svelte-vitals/core';
 import { defaultConfig } from '@svelte-vitals/core';
 import { enumerateRoutePages } from './project.js';
 import { parseFile } from './parse.js';
@@ -86,5 +86,36 @@ export const sourceHeadProvider: HeadProvider = {
   async collect(rt, cwd, config = defaultConfig) {
     const pages = await enumerateRoutePages(rt, cwd);
     return Promise.all(pages.map((page) => resolveRoute(rt, cwd, page, config)));
+  }
+};
+
+/** Collect all <img> elements for one route across its layout chain. */
+async function resolveRouteImages(
+  rt: Runtime,
+  cwd: string,
+  pageRel: string,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _config: Config
+): Promise<ResolvedImages> {
+  const files = await chainFiles(rt, cwd, pageRel);
+  const images: ImageInfo[] = [];
+  for (const { rel } of files) {
+    const source = await rt.readFile(rt.join(cwd, rel));
+    const parsed = parseFile(source, rel);
+    for (const img of parsed.images) {
+      images.push({ ...img, file: rel });
+    }
+  }
+  return { route: deriveRoute(pageRel), images };
+}
+
+/**
+ * SourceImageProvider — static mode. Enumerates route pages, walks each route's
+ * layout chain, and returns one ResolvedImages per route for Performance rules.
+ */
+export const sourceImageProvider = {
+  async collect(rt: Runtime, cwd: string, config: Config = defaultConfig): Promise<ResolvedImages[]> {
+    const pages = await enumerateRoutePages(rt, cwd);
+    return Promise.all(pages.map((page) => resolveRouteImages(rt, cwd, page, config)));
   }
 };

--- a/packages/cli/test/fixtures/basic-project/src/routes/img/+page.svelte
+++ b/packages/cli/test/fixtures/basic-project/src/routes/img/+page.svelte
@@ -1,0 +1,6 @@
+<script>
+  let { data } = $props();
+</script>
+
+<svelte:head><title>{data.title}</title></svelte:head>
+<img src="/hero.png" alt="hero" />

--- a/packages/cli/test/parse-file.test.ts
+++ b/packages/cli/test/parse-file.test.ts
@@ -62,6 +62,24 @@ describe('parseFile images', () => {
     const pf = parseFile(`{#if cond}<img src="/x.png" />{/if}`, 'x.svelte');
     expect(pf.images).toHaveLength(1);
   });
+
+  it('treats spread-only <img> as all attributes present (no false positives)', () => {
+    const pf = parseFile(`<img {...props} />`, 'x.svelte');
+    expect(pf.images).toHaveLength(1);
+    expect(pf.images[0]).toMatchObject({ hasWidth: true, hasHeight: true, hasLoading: true });
+  });
+
+  it('treats <img> with spread + explicit attr as all attributes present', () => {
+    const pf = parseFile(`<img src="/a.png" {...props} />`, 'x.svelte');
+    expect(pf.images).toHaveLength(1);
+    expect(pf.images[0]).toMatchObject({ hasWidth: true, hasHeight: true, hasLoading: true });
+  });
+
+  it('still marks missing attrs as absent when there is no spread', () => {
+    const pf = parseFile(`<img src="/a.png" />`, 'x.svelte');
+    expect(pf.images).toHaveLength(1);
+    expect(pf.images[0]).toMatchObject({ hasWidth: false, hasHeight: false, hasLoading: false });
+  });
 });
 
 describe('attrValueOf', () => {

--- a/packages/cli/test/parse-file.test.ts
+++ b/packages/cli/test/parse-file.test.ts
@@ -48,6 +48,22 @@ describe('parseFile', () => {
   });
 });
 
+describe('parseFile images', () => {
+  it('collects <img> attribute presence and line (dynamic counts as present)', () => {
+    const src = `<div>\n  <img src="/a.png" width="10" height="10" loading="lazy" />\n  <img src="/b.png" width={w} />\n</div>`;
+    const pf = parseFile(src, 'src/routes/+page.svelte');
+    expect(pf.images).toHaveLength(2);
+    expect(pf.images[0]).toMatchObject({ hasWidth: true, hasHeight: true, hasLoading: true, line: 2 });
+    // width={w} (dynamic) still counts as present; height/loading absent.
+    expect(pf.images[1]).toMatchObject({ hasWidth: true, hasHeight: false, hasLoading: false, line: 3 });
+  });
+
+  it('finds <img> nested inside a block', () => {
+    const pf = parseFile(`{#if cond}<img src="/x.png" />{/if}`, 'x.svelte');
+    expect(pf.images).toHaveLength(1);
+  });
+});
+
 describe('attrValueOf', () => {
   it('treats a boolean attribute as absent', () => {
     expect(attrValueOf({ value: true })).toBe('absent');

--- a/packages/cli/test/run.test.ts
+++ b/packages/cli/test/run.test.ts
@@ -116,12 +116,23 @@ describe('run() reporters and gating', () => {
   });
 });
 
+describe('run() performance rules', () => {
+  it('reports a Performance finding for an <img> missing dimensions', async () => {
+    const cap = capture();
+    await run({ cwd: fixtureDir, reporter: 'json', log: cap.log, errorLog: cap.errorLog, env: CLEAN_ENV });
+    const json = JSON.parse(cap.out.join('\n'));
+    expect(json.categories.performance).toBeDefined();
+    const img = json.routes.find((r: { route: string }) => r.route === '/img');
+    expect(img.issues.some((i: { id: string }) => i.id === 'PERF001')).toBe(true);
+  });
+});
+
 describe('run() agent reporter', () => {
   it('emits the agent Markdown report when reporter is agent', async () => {
     const cap = capture();
     await run({ cwd: fixtureDir, log: cap.log, errorLog: cap.errorLog, reporter: 'agent' });
     const out = cap.out.join('\n');
-    expect(out).toContain('# svelte-vitals — SEO fixes');
+    expect(out).toContain('# svelte-vitals — fixes');
     expect(out).toMatch(/### SEO00\d/);
     expect(out).toContain('- Fix:');
   });
@@ -130,7 +141,7 @@ describe('run() agent reporter', () => {
     // Auto-detected: no explicit reporter, agent env present → hint on stderr, Markdown on stdout.
     const auto = capture();
     await run({ cwd: fixtureDir, log: auto.log, errorLog: auto.errorLog, env: { CLAUDECODE: '1' } });
-    expect(auto.out.join('\n')).toContain('# svelte-vitals — SEO fixes');
+    expect(auto.out.join('\n')).toContain('# svelte-vitals — fixes');
     expect(auto.err.join('\n')).toContain('agent reporter auto-selected');
 
     // Explicit agent reporter: no hint (the user asked for it).
@@ -171,7 +182,7 @@ describe('run() sarif & github reporters', () => {
       errorLog: cap.errorLog,
       env: { GITHUB_ACTIONS: 'true', CLAUDECODE: '1' }
     });
-    expect(cap.out.join('\n')).toContain('# svelte-vitals — SEO fixes'); // agent Markdown, not workflow commands
+    expect(cap.out.join('\n')).toContain('# svelte-vitals — fixes'); // agent Markdown, not workflow commands
   });
 
   it('emits nothing on stdout for a clean github run (no stray blank line)', async () => {

--- a/packages/cli/test/source-provider.test.ts
+++ b/packages/cli/test/source-provider.test.ts
@@ -11,7 +11,7 @@ import {
   defineConfig
 } from '@svelte-vitals/core';
 import { createNodeRuntime } from '../src/runtime/node.js';
-import { collectRoutes, sourceHeadProvider, sourceImageProvider } from '../src/providers/source/routes.js';
+import { collectRoutes, sourceHeadProvider } from '../src/providers/source/routes.js';
 import { createMemoryRuntime } from './helpers/memory-runtime.js';
 
 const fixtureDir = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'basic-project');
@@ -97,13 +97,13 @@ describe('SourceHeadProvider component detection (layers 2-4)', () => {
   });
 });
 
-describe('SourceImageProvider (in-memory runtime)', () => {
+describe('collectRoutes image collection (in-memory runtime)', () => {
   it('collects images from layout and page per route', async () => {
     const rt = createMemoryRuntime({
       'src/routes/+layout.svelte': '<img src="/logo.png" width="100" height="100" loading="lazy" />',
       'src/routes/blog/+page.svelte': '<img src="/hero.png" />'
     });
-    const resolved = await sourceImageProvider.collect(rt, '');
+    const { images: resolved } = await collectRoutes(rt, '');
     const byRoute = new Map(resolved.map((r) => [r.route, r]));
     const blog = byRoute.get('/blog')!;
     expect(blog).toBeDefined();

--- a/packages/cli/test/source-provider.test.ts
+++ b/packages/cli/test/source-provider.test.ts
@@ -11,7 +11,7 @@ import {
   defineConfig
 } from '@svelte-vitals/core';
 import { createNodeRuntime } from '../src/runtime/node.js';
-import { sourceHeadProvider, sourceImageProvider } from '../src/providers/source/routes.js';
+import { collectRoutes, sourceHeadProvider, sourceImageProvider } from '../src/providers/source/routes.js';
 import { createMemoryRuntime } from './helpers/memory-runtime.js';
 
 const fixtureDir = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'basic-project');
@@ -113,6 +113,27 @@ describe('SourceImageProvider (in-memory runtime)', () => {
     expect(layoutImg).toMatchObject({ hasWidth: true, hasHeight: true, hasLoading: true });
     const pageImg = blog.images.find((i: ImageInfo) => i.file === 'src/routes/blog/+page.svelte');
     expect(pageImg).toMatchObject({ hasWidth: false, hasHeight: false, hasLoading: false });
+  });
+});
+
+describe('collectRoutes (single-pass heads + images)', () => {
+  it('returns heads and images for the same routes from one collection', async () => {
+    const rt = createMemoryRuntime({
+      'src/routes/+page.svelte': '<svelte:head><title>Home</title></svelte:head>',
+      'src/routes/blog/+page.svelte': '<img src="/hero.png" />'
+    });
+    const { heads, images } = await collectRoutes(rt, '');
+    expect(heads.map((h) => h.route).sort()).toEqual(['/', '/blog']);
+    expect(images.map((i) => i.route).sort()).toEqual(['/', '/blog']);
+
+    // The image-bearing route exposes its <img>; the image-less route is empty.
+    const byRoute = new Map(images.map((i) => [i.route, i]));
+    expect(byRoute.get('/blog')!.images).toHaveLength(1);
+    expect(byRoute.get('/')!.images).toHaveLength(0);
+
+    // Head composition is intact alongside image collection.
+    const home = heads.find((h) => h.route === '/')!;
+    expect(home.tags.some((t) => t.kind === 'title')).toBe(true);
   });
 });
 

--- a/packages/cli/test/source-provider.test.ts
+++ b/packages/cli/test/source-provider.test.ts
@@ -4,13 +4,14 @@ import { dirname, join } from 'node:path';
 import {
   seo001Title,
   type Detection,
+  type ImageInfo,
   type ResolvedHead,
   defaultConfig,
   defaultProject,
   defineConfig
 } from '@svelte-vitals/core';
 import { createNodeRuntime } from '../src/runtime/node.js';
-import { sourceHeadProvider } from '../src/providers/source/routes.js';
+import { sourceHeadProvider, sourceImageProvider } from '../src/providers/source/routes.js';
 import { createMemoryRuntime } from './helpers/memory-runtime.js';
 
 const fixtureDir = join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'basic-project');
@@ -92,6 +93,25 @@ describe('SourceHeadProvider component detection (layers 2-4)', () => {
     const config = defineConfig({ metaComponents: ['Widget'] });
     const [head] = await sourceHeadProvider.collect(rt, '', config);
     expect(titleDetection(head!)).toEqual({ presence: 'own', value: 'dynamic' });
+  });
+});
+
+describe('SourceImageProvider (in-memory runtime)', () => {
+  it('collects images from layout and page per route', async () => {
+    const rt = createMemoryRuntime({
+      'src/routes/+layout.svelte': '<img src="/logo.png" width="100" height="100" loading="lazy" />',
+      'src/routes/blog/+page.svelte': '<img src="/hero.png" />'
+    });
+    const resolved = await sourceImageProvider.collect(rt, '');
+    const byRoute = new Map(resolved.map((r) => [r.route, r]));
+    const blog = byRoute.get('/blog')!;
+    expect(blog).toBeDefined();
+    // layout image (with all attrs) + page image (missing attrs)
+    expect(blog.images).toHaveLength(2);
+    const layoutImg = blog.images.find((i: ImageInfo) => i.file === 'src/routes/+layout.svelte');
+    expect(layoutImg).toMatchObject({ hasWidth: true, hasHeight: true, hasLoading: true });
+    const pageImg = blog.images.find((i: ImageInfo) => i.file === 'src/routes/blog/+page.svelte');
+    expect(pageImg).toMatchObject({ hasWidth: false, hasHeight: false, hasLoading: false });
   });
 });
 

--- a/packages/cli/test/source-provider.test.ts
+++ b/packages/cli/test/source-provider.test.ts
@@ -30,6 +30,7 @@ describe('SourceHeadProvider (Node runtime, real fixture)', () => {
     expect([...byRoute.keys()].sort()).toEqual([
       '/blog',
       '/dynamic',
+      '/img',
       '/none',
       '/smt',
       '/smt-spread',

--- a/packages/core/src/images.ts
+++ b/packages/core/src/images.ts
@@ -1,0 +1,20 @@
+/**
+ * A normalized <img> occurrence — the mode-independent boundary for Performance
+ * rules (mirrors head.ts). Attribute presence only: a dynamically-bound attribute
+ * (width={w}) still counts as present, so dynamic values are never flagged.
+ */
+export interface ImageInfo {
+  hasWidth: boolean;
+  hasHeight: boolean;
+  hasLoading: boolean;
+  /** 1-based source line, or 0 if unknown. */
+  line: number;
+  /** Source file the <img> came from. */
+  file: string;
+}
+
+/** Resolved <img> elements for a single route (page + layout chain). */
+export interface ResolvedImages {
+  route: string;
+  images: ImageInfo[];
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,4 +58,4 @@ export { formatGithubReport } from './reporter/github.js';
 export { selectRules, applyRuleSeverities } from './config-apply.js';
 
 export type { ScoreModel, ScoreResult, ScoreOptions } from './scoring/score.js';
-export { computeScore } from './scoring/score.js';
+export { computeScore, scoresByCategory } from './scoring/score.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export type {
 export { defaultConfig, defineConfig, defaultProject } from './types.js';
 
 export type { HeadTag, ResolvedHead, HeadProvider } from './head.js';
+export type { ImageInfo, ResolvedImages } from './images.js';
 export { ROBOTS_SOURCE_PATHS, SITEMAP_SOURCE_PATHS } from './project-paths.js';
 export type { Runtime } from './runtime.js';
 export type { Rule, RuleContext } from './rule.js';
@@ -35,10 +36,13 @@ export {
   seo006Robots,
   seo007Sitemap,
   seo008JsonLd,
-  seo009HtmlLang
+  seo009HtmlLang,
+  perf001ImageDimensions,
+  perf002ImageLoading
 } from './rules/index.js';
 export type { RuleInfo } from './rules/index.js';
 export { headTagRule } from './rules/seo/head-tag-rule.js';
+export { imageRule } from './rules/perf/image-rule.js';
 
 export type { Summary, Classification } from './summary.js';
 export { summarize, classify, hasFailureAtOrAbove, effectiveSeverity } from './summary.js';

--- a/packages/core/src/reporter/agent.ts
+++ b/packages/core/src/reporter/agent.ts
@@ -17,7 +17,7 @@ function mdTags(text: string): string {
 /** Render failing findings as an agent-actionable Markdown remediation document (issue #18). */
 export function formatAgentReport(results: Result[], config: Config): string {
   const failing = results.filter((r) => classify(r, config) === 'fail');
-  const lines: string[] = ['# svelte-vitals — SEO fixes', ''];
+  const lines: string[] = ['# svelte-vitals — fixes', ''];
 
   if (failing.length === 0) {
     lines.push('No issues to fix.', '');

--- a/packages/core/src/reporter/console.ts
+++ b/packages/core/src/reporter/console.ts
@@ -1,6 +1,6 @@
-import type { Config, Result, Severity } from '../types.js';
+import type { Category, Config, Result, Severity } from '../types.js';
 import { classify, summarize, effectiveSeverity } from '../summary.js';
-import { computeScore } from '../scoring/score.js';
+import { computeScore, scoresByCategory } from '../scoring/score.js';
 
 const RULE = '────────────────────────';
 const SEVERITY_TITLE: Record<Severity, string> = {
@@ -9,18 +9,26 @@ const SEVERITY_TITLE: Record<Severity, string> = {
   info: 'Info'
 };
 
+const CATEGORY_LABEL: Partial<Record<Category, string>> = {
+  seo: 'SEO',
+  performance: 'Performance',
+  a11y: 'Accessibility',
+  maintainability: 'Maintainability'
+};
+const CATEGORY_ORDER: Category[] = ['seo', 'performance', 'a11y', 'maintainability'];
+
 export interface ConsoleReportOptions {
   byRoute?: boolean;
   /** Mode label shown in the header (default 'static mode'). */
   mode?: string;
 }
 
-function scoreHeader(results: Result[], config: Config): string {
+function scoreLine(label: string, results: Result[], config: Config): string {
   const { score, scoreModel } = computeScore(results, config);
   const parts = [`route avg ${scoreModel.routeAverage}`];
   if (scoreModel.sitePenalty > 0) parts.push(`site −${scoreModel.sitePenalty}`);
   if (scoreModel.criticalCap !== null) parts.push(`capped at ${scoreModel.criticalCap}: critical present`);
-  return `SEO Score: ${score}/100   (${parts.join(' · ')})`;
+  return `${label} Score: ${score}/100   (${parts.join(' · ')})`;
 }
 
 function byRouteTree(results: Result[], config: Config): string[] {
@@ -49,12 +57,13 @@ function byRouteTree(results: Result[], config: Config): string[] {
  */
 export function formatConsoleReport(results: Result[], config: Config, options: ConsoleReportOptions = {}): string {
   const summary = summarize(results, config);
-  const lines: string[] = [
-    `Svelte Vitals  ·  SEO (${options.mode ?? 'static mode'})`,
-    '',
-    scoreHeader(results, config),
-    ''
-  ];
+  const byCat = scoresByCategory(results, config);
+  const present = CATEGORY_ORDER.filter((c) => byCat[c] !== undefined);
+  const header: string[] = [`Svelte Vitals  (${options.mode ?? 'static mode'})`, ''];
+  for (const c of present) {
+    header.push(scoreLine(CATEGORY_LABEL[c] ?? c, results.filter((r) => (r.category ?? 'seo') === c), config));
+  }
+  const lines: string[] = [...header, ''];
 
   const failures = results.filter((r) => classify(r, config) === 'fail');
   for (const severity of ['critical', 'warning', 'info'] as const) {
@@ -64,7 +73,7 @@ export function formatConsoleReport(results: Result[], config: Config, options: 
     for (const r of bucket) {
       lines.push(`✗ ${r.id}  ${r.message}`);
       if (r.route) lines.push(`            ${r.route}`);
-      if (r.location) lines.push(`            ${r.location}`);
+      if (r.location) lines.push(`            ${r.location}${r.line ? `:${r.line}` : ''}`);
     }
     lines.push('');
   }

--- a/packages/core/src/reporter/console.ts
+++ b/packages/core/src/reporter/console.ts
@@ -1,6 +1,6 @@
 import type { Category, Config, Result, Severity } from '../types.js';
 import { classify, summarize, effectiveSeverity } from '../summary.js';
-import { computeScore, scoresByCategory } from '../scoring/score.js';
+import { computeScore, scoresByCategory, type ScoreResult } from '../scoring/score.js';
 
 const RULE = '────────────────────────';
 const SEVERITY_TITLE: Record<Severity, string> = {
@@ -23,8 +23,7 @@ export interface ConsoleReportOptions {
   mode?: string;
 }
 
-function scoreLine(label: string, results: Result[], config: Config): string {
-  const { score, scoreModel } = computeScore(results, config);
+function scoreLine(label: string, { score, scoreModel }: ScoreResult): string {
   const parts = [`route avg ${scoreModel.routeAverage}`];
   if (scoreModel.sitePenalty > 0) parts.push(`site −${scoreModel.sitePenalty}`);
   if (scoreModel.criticalCap !== null) parts.push(`capped at ${scoreModel.criticalCap}: critical present`);
@@ -61,13 +60,7 @@ export function formatConsoleReport(results: Result[], config: Config, options: 
   const present = CATEGORY_ORDER.filter((c) => byCat[c] !== undefined);
   const header: string[] = [`Svelte Vitals  ·  ${options.mode ?? 'static mode'}`, ''];
   for (const c of present) {
-    header.push(
-      scoreLine(
-        CATEGORY_LABEL[c] ?? c,
-        results.filter((r) => (r.category ?? 'seo') === c),
-        config
-      )
-    );
+    header.push(scoreLine(CATEGORY_LABEL[c] ?? c, byCat[c]!));
   }
   const lines: string[] = [...header, ''];
 

--- a/packages/core/src/reporter/console.ts
+++ b/packages/core/src/reporter/console.ts
@@ -61,7 +61,13 @@ export function formatConsoleReport(results: Result[], config: Config, options: 
   const present = CATEGORY_ORDER.filter((c) => byCat[c] !== undefined);
   const header: string[] = [`Svelte Vitals  (${options.mode ?? 'static mode'})`, ''];
   for (const c of present) {
-    header.push(scoreLine(CATEGORY_LABEL[c] ?? c, results.filter((r) => (r.category ?? 'seo') === c), config));
+    header.push(
+      scoreLine(
+        CATEGORY_LABEL[c] ?? c,
+        results.filter((r) => (r.category ?? 'seo') === c),
+        config
+      )
+    );
   }
   const lines: string[] = [...header, ''];
 

--- a/packages/core/src/reporter/console.ts
+++ b/packages/core/src/reporter/console.ts
@@ -59,7 +59,7 @@ export function formatConsoleReport(results: Result[], config: Config, options: 
   const summary = summarize(results, config);
   const byCat = scoresByCategory(results, config);
   const present = CATEGORY_ORDER.filter((c) => byCat[c] !== undefined);
-  const header: string[] = [`Svelte Vitals  (${options.mode ?? 'static mode'})`, ''];
+  const header: string[] = [`Svelte Vitals  ·  ${options.mode ?? 'static mode'}`, ''];
   for (const c of present) {
     header.push(
       scoreLine(

--- a/packages/core/src/reporter/github.ts
+++ b/packages/core/src/reporter/github.ts
@@ -24,7 +24,10 @@ export function formatGithubReport(results: Result[], config: Config): string {
     const meta = ruleMetaById(r.id);
     const title = meta ? `${r.id}: ${meta.title}` : r.id;
     const props: string[] = [];
-    if (r.location) props.push(`file=${escapeProp(r.location)}`);
+    if (r.location) {
+      props.push(`file=${escapeProp(r.location)}`);
+      if (r.line !== undefined) props.push(`line=${r.line}`);
+    }
     props.push(`title=${escapeProp(title)}`);
     return `::${level} ${props.join(',')}::${escapeData(messageText(r))}`;
   });

--- a/packages/core/src/reporter/json.ts
+++ b/packages/core/src/reporter/json.ts
@@ -1,14 +1,16 @@
 import type { Config, Result } from '../types.js';
-import { computeScore, type ScoreModel } from '../scoring/score.js';
+import { computeScore, scoresByCategory, type ScoreModel } from '../scoring/score.js';
 import { summarize, effectiveSeverity, type Summary } from '../summary.js';
 import { isPenalized } from '../rule.js';
 
 function issueOf(result: Result) {
   return {
     id: result.id,
+    category: result.category ?? 'seo',
     title: result.message,
     detection: result.detection,
     location: result.location,
+    ...(result.line !== undefined ? { line: result.line } : {}),
     recommendation: result.recommendation,
     ...(result.docsUrl ? { docsUrl: result.docsUrl } : {}),
     ...(result.fix ? { fix: result.fix } : {})
@@ -21,6 +23,7 @@ export interface JsonReport {
   version: string;
   score: number;
   scoreModel: ScoreModel;
+  categories: Record<string, { score: number; scoreModel: ScoreModel }>;
   summary: Summary;
   routes: Array<{ route: string; score: number; issues: JsonIssue[] }>;
   siteIssues: JsonIssue[];
@@ -28,8 +31,15 @@ export interface JsonReport {
 
 /** Build the structured JSON report object (design §7). Shared by the json reporter and the MCP `analyze` tool (issue #24). */
 export function buildJsonReport(results: Result[], config: Config, meta: { version: string }): JsonReport {
-  const { score, scoreModel } = computeScore(results, config);
+  // Top-level score = SEO subset for backward compat (existing consumers only see SEO).
+  const seoResults = results.filter((r) => (r.category ?? 'seo') === 'seo');
+  const { score, scoreModel } = computeScore(seoResults, config);
   const summary = summarize(results, config);
+
+  const byCat = scoresByCategory(results, config);
+  const categories = Object.fromEntries(
+    Object.entries(byCat).map(([cat, sr]) => [cat, { score: sr.score, scoreModel: sr.scoreModel }])
+  );
 
   const routeMap = new Map<string, { route: string; results: Result[] }>();
   for (const r of results) {
@@ -52,7 +62,7 @@ export function buildJsonReport(results: Result[], config: Config, meta: { versi
     .filter((r) => r.route === undefined && isPenalized(r.detection, config.treatDynamicAs))
     .map((r) => ({ ...issueOf(r), severity: effectiveSeverity(r, config) }));
 
-  return { version: meta.version, score, scoreModel, summary, routes, siteIssues };
+  return { version: meta.version, score, scoreModel, categories, summary, routes, siteIssues };
 }
 
 /** Render results as the documented JSON report string (design §7). */

--- a/packages/core/src/reporter/sarif.ts
+++ b/packages/core/src/reporter/sarif.ts
@@ -18,7 +18,7 @@ interface SarifResult {
   ruleIndex: number;
   level: SarifLevel;
   message: { text: string };
-  locations?: { physicalLocation: { artifactLocation: { uri: string } } }[];
+  locations?: { physicalLocation: { artifactLocation: { uri: string }; region?: { startLine: number } } }[];
   partialFingerprints: Record<string, string>;
 }
 
@@ -50,7 +50,14 @@ export function formatSarifReport(results: Result[], config: Config, meta: { ver
       partialFingerprints: { 'svelteVitals/v1': `${r.id}:${r.route ?? 'project'}` }
     };
     if (r.location) {
-      result.locations = [{ physicalLocation: { artifactLocation: { uri: r.location } } }];
+      result.locations = [
+        {
+          physicalLocation: {
+            artifactLocation: { uri: r.location },
+            ...(r.line !== undefined ? { region: { startLine: r.line } } : {})
+          }
+        }
+      ];
     }
     return result;
   });

--- a/packages/core/src/reporter/sarif.ts
+++ b/packages/core/src/reporter/sarif.ts
@@ -47,7 +47,9 @@ export function formatSarifReport(results: Result[], config: Config, meta: { ver
       ruleIndex: ruleIndex.get(r.id)!,
       level: severityToSarifLevel(effectiveSeverity(r, config)),
       message: { text: messageText(r) },
-      partialFingerprints: { 'svelteVitals/v1': `${r.id}:${r.route ?? 'project'}` }
+      partialFingerprints: {
+        'svelteVitals/v1': `${r.id}:${r.route ?? 'project'}${r.line !== undefined ? ':' + r.line : ''}`
+      }
     };
     if (r.location) {
       result.locations = [

--- a/packages/core/src/reporter/sarif.ts
+++ b/packages/core/src/reporter/sarif.ts
@@ -48,7 +48,7 @@ export function formatSarifReport(results: Result[], config: Config, meta: { ver
       level: severityToSarifLevel(effectiveSeverity(r, config)),
       message: { text: messageText(r) },
       partialFingerprints: {
-        'svelteVitals/v1': `${r.id}:${r.route ?? 'project'}${r.line !== undefined ? ':' + r.line : ''}`
+        'svelteVitals/v1': `${r.id}:${r.route ?? 'project'}${r.line !== undefined ? `:${r.location ?? ''}:${r.line}` : ''}`
       }
     };
     if (r.location) {

--- a/packages/core/src/rule.ts
+++ b/packages/core/src/rule.ts
@@ -1,9 +1,12 @@
 import type { Category, Config, Detection, Fix, Project, Result, Scope, Severity, TreatDynamicAs } from './types.js';
 import type { ResolvedHead } from './head.js';
+import type { ResolvedImages } from './images.js';
 
 /** Input given to every rule. Mode-independent: rules see only ResolvedHead[] (design §8, §10). */
 export interface RuleContext {
   heads: ResolvedHead[];
+  /** Per-route <img> elements for Performance rules (absent in modes that don't collect them). */
+  images?: ResolvedImages[];
   project: Project;
   config: Config;
 }

--- a/packages/core/src/rules/index.ts
+++ b/packages/core/src/rules/index.ts
@@ -9,6 +9,7 @@ import {
   seo008JsonLd
 } from './seo/seo002-005-008.js';
 import { seo006Robots, seo007Sitemap, seo009HtmlLang } from './seo/project-rules.js';
+import { perf001ImageDimensions, perf002ImageLoading } from './perf/images.js';
 
 export const allRules: Rule[] = [
   seo001Title,
@@ -19,7 +20,9 @@ export const allRules: Rule[] = [
   seo006Robots,
   seo007Sitemap,
   seo008JsonLd,
-  seo009HtmlLang
+  seo009HtmlLang,
+  perf001ImageDimensions,
+  perf002ImageLoading
 ];
 
 export {
@@ -31,7 +34,9 @@ export {
   seo006Robots,
   seo007Sitemap,
   seo008JsonLd,
-  seo009HtmlLang
+  seo009HtmlLang,
+  perf001ImageDimensions,
+  perf002ImageLoading
 };
 
 export interface RuleInfo {

--- a/packages/core/src/rules/perf/image-rule.ts
+++ b/packages/core/src/rules/perf/image-rule.ts
@@ -1,0 +1,67 @@
+import type { Fix, Result, Severity } from '../../types.js';
+import type { ImageInfo } from '../../images.js';
+import { docsUrlFor, type Rule, type RuleContext } from '../../rule.js';
+
+export interface ImageRuleOptions {
+  id: string;
+  title: string;
+  severity: Severity;
+  /** Noun phrase for messages, e.g. '<img> width/height'. */
+  label: string;
+  recommendation: string;
+  rationale: string;
+  fix?: Fix;
+  /** Returns true when the image satisfies the rule (passes). */
+  ok: (img: ImageInfo) => boolean;
+}
+
+/** Build a route-scoped Performance rule that checks each <img> against `ok` (issue #10). */
+export function imageRule(opts: ImageRuleOptions): Rule {
+  const docsUrl = docsUrlFor(opts.id);
+  return {
+    id: opts.id,
+    title: opts.title,
+    category: 'performance',
+    severity: opts.severity,
+    scope: 'route',
+    rationale: opts.rationale,
+    ...(opts.fix ? { fix: opts.fix } : {}),
+    async check(ctx: RuleContext): Promise<Result[]> {
+      const out: Result[] = [];
+      for (const route of ctx.images ?? []) {
+        const bad = route.images.filter((img) => !opts.ok(img));
+        if (bad.length === 0) {
+          // One passing result per route seeds it at 100 for the per-category score.
+          out.push({
+            id: opts.id,
+            category: 'performance',
+            severity: opts.severity,
+            detection: { presence: 'own', value: 'static' },
+            route: route.route,
+            message: opts.label,
+            recommendation: opts.recommendation,
+            docsUrl,
+            ...(opts.fix ? { fix: { ...opts.fix } } : {})
+          });
+          continue;
+        }
+        for (const img of bad) {
+          out.push({
+            id: opts.id,
+            category: 'performance',
+            severity: opts.severity,
+            detection: { presence: 'none', value: 'absent' },
+            route: route.route,
+            location: img.file,
+            line: img.line,
+            message: `Missing ${opts.label}`,
+            recommendation: opts.recommendation,
+            docsUrl,
+            ...(opts.fix ? { fix: { ...opts.fix } } : {})
+          });
+        }
+      }
+      return out;
+    }
+  };
+}

--- a/packages/core/src/rules/perf/image-rule.ts
+++ b/packages/core/src/rules/perf/image-rule.ts
@@ -29,9 +29,12 @@ export function imageRule(opts: ImageRuleOptions): Rule {
     async check(ctx: RuleContext): Promise<Result[]> {
       const out: Result[] = [];
       for (const route of ctx.images ?? []) {
+        // A route with no <img> has no Performance signal: emit nothing so it is
+        // neither penalized nor seeded (a zero-image project hides the category).
+        if (route.images.length === 0) continue;
         const bad = route.images.filter((img) => !opts.ok(img));
         if (bad.length === 0) {
-          // One passing result per route seeds it at 100 for the per-category score.
+          // One passing result per imaged route seeds it at 100 for the per-category score.
           out.push({
             id: opts.id,
             category: 'performance',

--- a/packages/core/src/rules/perf/image-rule.ts
+++ b/packages/core/src/rules/perf/image-rule.ts
@@ -34,7 +34,8 @@ export function imageRule(opts: ImageRuleOptions): Rule {
         if (route.images.length === 0) continue;
         const bad = route.images.filter((img) => !opts.ok(img));
         if (bad.length === 0) {
-          // One passing result per imaged route seeds it at 100 for the per-category score.
+          // One passing result per imaged route seeds it at 100 for the per-category
+          // score. A passing result carries no `fix` — there is nothing to remediate.
           out.push({
             id: opts.id,
             category: 'performance',
@@ -43,8 +44,7 @@ export function imageRule(opts: ImageRuleOptions): Rule {
             route: route.route,
             message: opts.label,
             recommendation: opts.recommendation,
-            docsUrl,
-            ...(opts.fix ? { fix: { ...opts.fix } } : {})
+            docsUrl
           });
           continue;
         }

--- a/packages/core/src/rules/perf/image-rule.ts
+++ b/packages/core/src/rules/perf/image-rule.ts
@@ -53,7 +53,7 @@ export function imageRule(opts: ImageRuleOptions): Rule {
             detection: { presence: 'none', value: 'absent' },
             route: route.route,
             location: img.file,
-            line: img.line,
+            ...(img.line > 0 ? { line: img.line } : {}),
             message: `Missing ${opts.label}`,
             recommendation: opts.recommendation,
             docsUrl,

--- a/packages/core/src/rules/perf/images.ts
+++ b/packages/core/src/rules/perf/images.ts
@@ -1,0 +1,33 @@
+import { imageRule } from './image-rule.js';
+
+export const perf001ImageDimensions = imageRule({
+  id: 'PERF001',
+  title: 'Image dimensions',
+  severity: 'warning',
+  label: '<img> width/height',
+  recommendation: 'Set explicit width and height on <img> to reserve space and avoid layout shift (CLS).',
+  rationale:
+    'An <img> without explicit width and height triggers layout shift (CLS) as it loads, hurting Core Web Vitals and visual stability.',
+  fix: {
+    description: 'Add explicit width and height attributes to the <img>.',
+    snippet: '<img src="/hero.jpg" width="1200" height="630" alt="…" />',
+    lang: 'svelte'
+  },
+  ok: (img) => img.hasWidth && img.hasHeight
+});
+
+export const perf002ImageLoading = imageRule({
+  id: 'PERF002',
+  title: 'Image loading hint',
+  severity: 'info',
+  label: '<img> loading attribute',
+  recommendation: 'Set loading="lazy" for offscreen images; keep the LCP image eager (consider fetchpriority="high").',
+  rationale:
+    'A loading attribute lets the browser defer offscreen images; without it images load eagerly and can delay more important content. Static analysis cannot tell which image is the LCP, so this is advisory.',
+  fix: {
+    description: 'Add loading="lazy" to offscreen <img> elements (leave the LCP/hero image eager).',
+    snippet: '<img src="/thumb.jpg" width="320" height="240" loading="lazy" alt="…" />',
+    lang: 'svelte'
+  },
+  ok: (img) => img.hasLoading
+});

--- a/packages/core/src/rules/seo/head-tag-rule.ts
+++ b/packages/core/src/rules/seo/head-tag-rule.ts
@@ -44,6 +44,7 @@ export function headTagRule(opts: HeadTagRuleOptions): Rule {
               : opts.label;
         return {
           id: opts.id,
+          category: 'seo',
           severity: opts.severity,
           detection,
           route: head.route,

--- a/packages/core/src/rules/seo/project-rules.ts
+++ b/packages/core/src/rules/seo/project-rules.ts
@@ -24,6 +24,7 @@ export const seo006Robots: Rule = {
     return [
       {
         id: 'SEO006',
+        category: 'seo',
         severity: 'warning',
         detection,
         message: ctx.project.hasRobotsTxt ? 'robots.txt' : 'Missing robots.txt',
@@ -56,6 +57,7 @@ export const seo007Sitemap: Rule = {
     return [
       {
         id: 'SEO007',
+        category: 'seo',
         severity: 'warning',
         detection,
         message: ctx.project.hasSitemap ? 'sitemap.xml' : 'Missing sitemap.xml',
@@ -93,6 +95,7 @@ export const seo009HtmlLang: Rule = {
     return [
       {
         id: 'SEO009',
+        category: 'seo',
         severity: 'warning',
         detection,
         message,

--- a/packages/core/src/rules/seo/seo001-title.ts
+++ b/packages/core/src/rules/seo/seo001-title.ts
@@ -43,6 +43,7 @@ export const seo001Title: Rule = {
       const detection = detectTitle(head);
       return {
         id: 'SEO001',
+        category: 'seo',
         severity: 'critical',
         detection,
         route: head.route,

--- a/packages/core/src/scoring/score.ts
+++ b/packages/core/src/scoring/score.ts
@@ -1,4 +1,4 @@
-import type { Config, Result, Severity } from '../types.js';
+import type { Category, Config, Result, Severity } from '../types.js';
 import { isPenalized } from '../rule.js';
 import { effectiveSeverity } from '../summary.js';
 
@@ -80,4 +80,18 @@ export function computeScore(results: Result[], config: Config, options: ScoreOp
   const score = capBinds ? CRITICAL_CAP : uncapped;
 
   return { score: clamp(score), scoreModel: { routeAverage, sitePenalty, criticalCap } };
+}
+
+/** Compute an independent score per category present in `results` (issue #10). */
+export function scoresByCategory(results: Result[], config: Config): Partial<Record<Category, ScoreResult>> {
+  const byCat = new Map<Category, Result[]>();
+  for (const r of results) {
+    const cat = r.category ?? 'seo';
+    let bucket = byCat.get(cat);
+    if (!bucket) byCat.set(cat, (bucket = []));
+    bucket.push(r);
+  }
+  const out: Partial<Record<Category, ScoreResult>> = {};
+  for (const [cat, rs] of byCat) out[cat] = computeScore(rs, config);
+  return out;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -59,6 +59,10 @@ export interface Result {
   docsUrl?: string;
   /** Agent-actionable remediation (issue #18). */
   fix?: Fix;
+  /** Vitals category this finding belongs to (default 'seo' when absent). */
+  category?: Category;
+  /** 1-based source line for element-level findings (e.g. a specific <img>). */
+  line?: number;
 }
 
 export type Scope = 'route' | 'project';

--- a/packages/core/test/agent-report.test.ts
+++ b/packages/core/test/agent-report.test.ts
@@ -34,7 +34,17 @@ describe('formatAgentReport', () => {
   it('groups performance findings and uses a category-neutral heading', () => {
     const withPerf: Result[] = [
       ...results,
-      { id: 'PERF001', category: 'performance', severity: 'warning', detection: { presence: 'none', value: 'absent' }, route: '/blog', location: 'src/routes/blog/+page.svelte', line: 42, message: 'Missing <img> width/height', fix: { description: 'Add width/height.', snippet: '<img width="1" height="1" />', lang: 'svelte' } }
+      {
+        id: 'PERF001',
+        category: 'performance',
+        severity: 'warning',
+        detection: { presence: 'none', value: 'absent' },
+        route: '/blog',
+        location: 'src/routes/blog/+page.svelte',
+        line: 42,
+        message: 'Missing <img> width/height',
+        fix: { description: 'Add width/height.', snippet: '<img width="1" height="1" />', lang: 'svelte' }
+      }
     ];
     const md = formatAgentReport(withPerf, config);
     expect(md).toContain('PERF001');

--- a/packages/core/test/agent-report.test.ts
+++ b/packages/core/test/agent-report.test.ts
@@ -31,6 +31,16 @@ const results: Result[] = [
 ];
 
 describe('formatAgentReport', () => {
+  it('groups performance findings and uses a category-neutral heading', () => {
+    const withPerf: Result[] = [
+      ...results,
+      { id: 'PERF001', category: 'performance', severity: 'warning', detection: { presence: 'none', value: 'absent' }, route: '/blog', location: 'src/routes/blog/+page.svelte', line: 42, message: 'Missing <img> width/height', fix: { description: 'Add width/height.', snippet: '<img width="1" height="1" />', lang: 'svelte' } }
+    ];
+    const md = formatAgentReport(withPerf, config);
+    expect(md).toContain('PERF001');
+    expect(md).toMatch(/^# svelte-vitals/m); // heading no longer says "SEO fixes"
+  });
+
   it('lists only failing findings, grouped, with fix snippet and acceptance', () => {
     const md = formatAgentReport(results, config);
     expect(md).toContain('## src/routes/a/+page.svelte');

--- a/packages/core/test/console-report.test.ts
+++ b/packages/core/test/console-report.test.ts
@@ -36,7 +36,16 @@ describe('formatConsoleReport', () => {
   it('adds a Performance score section when performance findings exist', () => {
     const withPerf: Result[] = [
       ...results,
-      { id: 'PERF001', category: 'performance', severity: 'warning', detection: { presence: 'none', value: 'absent' }, route: '/blog', location: 'src/routes/blog/+page.svelte', line: 42, message: 'Missing <img> width/height' }
+      {
+        id: 'PERF001',
+        category: 'performance',
+        severity: 'warning',
+        detection: { presence: 'none', value: 'absent' },
+        route: '/blog',
+        location: 'src/routes/blog/+page.svelte',
+        line: 42,
+        message: 'Missing <img> width/height'
+      }
     ];
     const out = formatConsoleReport(withPerf, config);
     expect(out).toMatch(/SEO Score: \d+\/100/);

--- a/packages/core/test/console-report.test.ts
+++ b/packages/core/test/console-report.test.ts
@@ -33,4 +33,15 @@ describe('formatConsoleReport', () => {
     expect(out).toContain('By route');
     expect(out).toMatch(/\/a\s+\d+/);
   });
+  it('adds a Performance score section when performance findings exist', () => {
+    const withPerf: Result[] = [
+      ...results,
+      { id: 'PERF001', category: 'performance', severity: 'warning', detection: { presence: 'none', value: 'absent' }, route: '/blog', location: 'src/routes/blog/+page.svelte', line: 42, message: 'Missing <img> width/height' }
+    ];
+    const out = formatConsoleReport(withPerf, config);
+    expect(out).toMatch(/SEO Score: \d+\/100/);
+    expect(out).toMatch(/Performance Score: \d+\/100/);
+    expect(out).toContain('PERF001');
+    expect(out).toContain('src/routes/blog/+page.svelte:42');
+  });
 });

--- a/packages/core/test/github-report.test.ts
+++ b/packages/core/test/github-report.test.ts
@@ -62,6 +62,23 @@ describe('formatGithubReport', () => {
     expect(out).toContain('::Missing title: needed Add <title>, set it.%0ASecond line');
   });
 
+  it('uses result.line in the annotation when present', () => {
+    const results: Result[] = [
+      {
+        id: 'PERF001',
+        category: 'performance',
+        severity: 'warning',
+        detection: { presence: 'none', value: 'absent' },
+        route: '/blog',
+        location: 'src/routes/blog/+page.svelte',
+        line: 42,
+        message: 'Missing <img> width/height'
+      }
+    ];
+    const out = formatGithubReport(results, config);
+    expect(out).toContain('line=42');
+  });
+
   it('returns an empty string when there are no penalized findings', () => {
     const passing: Result[] = [
       {

--- a/packages/core/test/json-report.test.ts
+++ b/packages/core/test/json-report.test.ts
@@ -23,6 +23,19 @@ const results: Result[] = [
 ];
 
 describe('formatJsonReport', () => {
+  it('exposes a per-category scores map and tags issues with category', () => {
+    const withPerf: Result[] = [
+      ...results,
+      { id: 'PERF001', category: 'performance', severity: 'warning', detection: { presence: 'none', value: 'absent' }, route: '/blog', location: 'src/routes/blog/+page.svelte', line: 42, message: 'Missing <img> width/height' }
+    ];
+    const json = JSON.parse(formatJsonReport(withPerf, config, { version: '0.1.0' }));
+    expect(json.categories.seo.score).toBeTypeOf('number');
+    expect(json.categories.performance.score).toBeTypeOf('number');
+    const blog = json.routes.find((r: { route: string }) => r.route === '/blog');
+    expect(blog.issues[0].category).toBe('performance');
+    expect(blog.issues[0].line).toBe(42);
+  });
+
   it('emits the documented shape with only penalized findings', () => {
     const json = JSON.parse(formatJsonReport(results, config, { version: '0.1.0' }));
     expect(json.version).toBe('0.1.0');

--- a/packages/core/test/json-report.test.ts
+++ b/packages/core/test/json-report.test.ts
@@ -26,7 +26,16 @@ describe('formatJsonReport', () => {
   it('exposes a per-category scores map and tags issues with category', () => {
     const withPerf: Result[] = [
       ...results,
-      { id: 'PERF001', category: 'performance', severity: 'warning', detection: { presence: 'none', value: 'absent' }, route: '/blog', location: 'src/routes/blog/+page.svelte', line: 42, message: 'Missing <img> width/height' }
+      {
+        id: 'PERF001',
+        category: 'performance',
+        severity: 'warning',
+        detection: { presence: 'none', value: 'absent' },
+        route: '/blog',
+        location: 'src/routes/blog/+page.svelte',
+        line: 42,
+        message: 'Missing <img> width/height'
+      }
     ];
     const json = JSON.parse(formatJsonReport(withPerf, config, { version: '0.1.0' }));
     expect(json.categories.seo.score).toBeTypeOf('number');

--- a/packages/core/test/perf-rules.test.ts
+++ b/packages/core/test/perf-rules.test.ts
@@ -4,7 +4,12 @@ import type { ResolvedImages } from '../src/images.js';
 
 const config = defaultConfig;
 const img = (over: Partial<{ hasWidth: boolean; hasHeight: boolean; hasLoading: boolean }>) => ({
-  hasWidth: true, hasHeight: true, hasLoading: true, line: 7, file: 'src/routes/+page.svelte', ...over
+  hasWidth: true,
+  hasHeight: true,
+  hasLoading: true,
+  line: 7,
+  file: 'src/routes/+page.svelte',
+  ...over
 });
 const ctxWith = (images: ResolvedImages[]) => ({ heads: [], images, project: defaultProject, config });
 

--- a/packages/core/test/perf-rules.test.ts
+++ b/packages/core/test/perf-rules.test.ts
@@ -46,6 +46,22 @@ describe('PERF001 image dimensions', () => {
   });
 });
 
+describe('PERF001 image line omission when unknown (line: 0)', () => {
+  it('omits line property when img.line === 0', async () => {
+    const imgNoLine = { hasWidth: false, hasHeight: true, hasLoading: true, line: 0, file: 'src/routes/+page.svelte' };
+    const ctx = ctxWith([{ route: '/a', images: [imgNoLine] }]);
+    const [r] = await perf001ImageDimensions.check(ctx);
+    expect('line' in r!).toBe(false);
+    expect(r!.line).toBeUndefined();
+  });
+
+  it('still sets line when img.line > 0', async () => {
+    const ctx = ctxWith([{ route: '/a', images: [img({ hasWidth: false })] }]);
+    const [r] = await perf001ImageDimensions.check(ctx);
+    expect(r!.line).toBe(7);
+  });
+});
+
 describe('PERF002 image loading', () => {
   it('flags a missing loading attribute as info', async () => {
     const ctx = ctxWith([{ route: '/a', images: [img({ hasLoading: false })] }]);

--- a/packages/core/test/perf-rules.test.ts
+++ b/packages/core/test/perf-rules.test.ts
@@ -31,8 +31,14 @@ describe('PERF001 image dimensions', () => {
     expect(r!.detection).toEqual({ presence: 'own', value: 'static' }); // a seeding pass result
   });
 
-  it('emits one passing result for a route with no images', async () => {
+  it('emits nothing for a route with no images (no Performance signal)', async () => {
     const ctx = ctxWith([{ route: '/empty', images: [] }]);
+    const results = await perf001ImageDimensions.check(ctx);
+    expect(results).toHaveLength(0);
+  });
+
+  it('seeds a single passing result for an imaged route whose images all pass', async () => {
+    const ctx = ctxWith([{ route: '/a', images: [img({})] }]);
     const results = await perf001ImageDimensions.check(ctx);
     expect(results).toHaveLength(1);
     expect(results[0]!.detection.presence).toBe('own');

--- a/packages/core/test/perf-rules.test.ts
+++ b/packages/core/test/perf-rules.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { perf001ImageDimensions, perf002ImageLoading, defaultProject, defaultConfig } from '../src/index.js';
+import type { ResolvedImages } from '../src/images.js';
+
+const config = defaultConfig;
+const img = (over: Partial<{ hasWidth: boolean; hasHeight: boolean; hasLoading: boolean }>) => ({
+  hasWidth: true, hasHeight: true, hasLoading: true, line: 7, file: 'src/routes/+page.svelte', ...over
+});
+const ctxWith = (images: ResolvedImages[]) => ({ heads: [], images, project: defaultProject, config });
+
+describe('PERF001 image dimensions', () => {
+  it('flags an <img> missing width or height, with file and line', async () => {
+    const ctx = ctxWith([{ route: '/a', images: [img({ hasWidth: false })] }]);
+    const [r] = await perf001ImageDimensions.check(ctx);
+    expect(r!.category).toBe('performance');
+    expect(r!.severity).toBe('warning');
+    expect(r!.route).toBe('/a');
+    expect(r!.location).toBe('src/routes/+page.svelte');
+    expect(r!.line).toBe(7);
+    expect(r!.detection).toEqual({ presence: 'none', value: 'absent' });
+  });
+
+  it('passes an <img> with both dimensions (dynamic counts as present)', async () => {
+    const ctx = ctxWith([{ route: '/a', images: [img({})] }]);
+    const [r] = await perf001ImageDimensions.check(ctx);
+    expect(r!.detection).toEqual({ presence: 'own', value: 'static' }); // a seeding pass result
+  });
+
+  it('emits one passing result for a route with no images', async () => {
+    const ctx = ctxWith([{ route: '/empty', images: [] }]);
+    const results = await perf001ImageDimensions.check(ctx);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.detection.presence).toBe('own');
+  });
+
+  it('emits one finding per offending image', async () => {
+    const ctx = ctxWith([{ route: '/a', images: [img({ hasWidth: false }), img({ hasHeight: false })] }]);
+    const results = await perf001ImageDimensions.check(ctx);
+    expect(results).toHaveLength(2);
+    expect(results.every((r) => r.detection.presence === 'none')).toBe(true);
+  });
+});
+
+describe('PERF002 image loading', () => {
+  it('flags a missing loading attribute as info', async () => {
+    const ctx = ctxWith([{ route: '/a', images: [img({ hasLoading: false })] }]);
+    const [r] = await perf002ImageLoading.check(ctx);
+    expect(r!.severity).toBe('info');
+    expect(r!.category).toBe('performance');
+    expect(r!.detection.presence).toBe('none');
+  });
+});

--- a/packages/core/test/perf-rules.test.ts
+++ b/packages/core/test/perf-rules.test.ts
@@ -42,6 +42,8 @@ describe('PERF001 image dimensions', () => {
     const results = await perf001ImageDimensions.check(ctx);
     expect(results).toHaveLength(1);
     expect(results[0]!.detection.presence).toBe('own');
+    // A passing seed has nothing to remediate, so it carries no fix.
+    expect('fix' in results[0]!).toBe(false);
   });
 
   it('emits one finding per offending image', async () => {

--- a/packages/core/test/rule-category.test.ts
+++ b/packages/core/test/rule-category.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { allRules, defaultProject, defaultConfig, type ResolvedHead } from '../src/index.js';
+
+const head: ResolvedHead = { route: '/x', source: 'static', file: 'src/routes/x/+page.svelte', tags: [] };
+const ctx = { heads: [head], project: defaultProject, config: defaultConfig };
+
+describe('rule results carry a category', () => {
+  it('every SEO rule tags its results category "seo"', async () => {
+    for (const rule of allRules) {
+      const results = await rule.check(ctx);
+      for (const r of results) expect(r.category, rule.id).toBe('seo');
+    }
+  });
+});

--- a/packages/core/test/sarif-report.test.ts
+++ b/packages/core/test/sarif-report.test.ts
@@ -76,6 +76,23 @@ describe('formatSarifReport', () => {
     expect(run.results[1].partialFingerprints['svelteVitals/v1']).toBe('SEO006:project');
   });
 
+  it('uses result.line as startLine when present', () => {
+    const withLine: Result[] = [
+      {
+        id: 'PERF001',
+        category: 'performance',
+        severity: 'warning',
+        detection: { presence: 'none', value: 'absent' },
+        route: '/blog',
+        location: 'src/routes/blog/+page.svelte',
+        line: 42,
+        message: 'Missing <img> width/height'
+      }
+    ];
+    const run = JSON.parse(formatSarifReport(withLine, config, { version: '0.0.0' })).runs[0];
+    expect(run.results[0].locations[0].physicalLocation.region.startLine).toBe(42);
+  });
+
   it('emits a valid empty log when there are no penalized findings', () => {
     const passing: Result[] = [results[2]!];
     const sarif = JSON.parse(formatSarifReport(passing, config, { version: '0.0.0' }));

--- a/packages/core/test/sarif-report.test.ts
+++ b/packages/core/test/sarif-report.test.ts
@@ -119,9 +119,46 @@ describe('formatSarifReport', () => {
     const run = JSON.parse(formatSarifReport(twoImages, config, { version: '0.0.0' })).runs[0];
     const fp0 = run.results[0].partialFingerprints['svelteVitals/v1'];
     const fp1 = run.results[1].partialFingerprints['svelteVitals/v1'];
-    expect(fp0).toBe('PERF001:/blog:10');
-    expect(fp1).toBe('PERF001:/blog:20');
+    expect(fp0).toBe('PERF001:/blog:src/routes/blog/+page.svelte:10');
+    expect(fp1).toBe('PERF001:/blog:src/routes/blog/+page.svelte:20');
     expect(fp0).not.toBe(fp1);
+  });
+
+  it('produces distinct partialFingerprints for same (id, route, line) but different location (file)', () => {
+    const sameLineDiffFile: Result[] = [
+      {
+        id: 'PERF001',
+        category: 'performance',
+        severity: 'warning',
+        detection: { presence: 'none', value: 'absent' },
+        route: '/blog',
+        location: 'src/routes/blog/+page.svelte',
+        line: 5,
+        message: 'Missing <img> width/height in page'
+      },
+      {
+        id: 'PERF001',
+        category: 'performance',
+        severity: 'warning',
+        detection: { presence: 'none', value: 'absent' },
+        route: '/blog',
+        location: 'src/routes/blog/Card.svelte',
+        line: 5,
+        message: 'Missing <img> width/height in card'
+      }
+    ];
+    const run = JSON.parse(formatSarifReport(sameLineDiffFile, config, { version: '0.0.0' })).runs[0];
+    const fp0 = run.results[0].partialFingerprints['svelteVitals/v1'];
+    const fp1 = run.results[1].partialFingerprints['svelteVitals/v1'];
+    expect(fp0).toBe('PERF001:/blog:src/routes/blog/+page.svelte:5');
+    expect(fp1).toBe('PERF001:/blog:src/routes/blog/Card.svelte:5');
+    expect(fp0).not.toBe(fp1);
+  });
+
+  it('SEO fingerprints (no line) are unchanged by the location-in-fingerprint change', () => {
+    const run = JSON.parse(formatSarifReport(results, config, { version: '0.0.0' })).runs[0];
+    expect(run.results[0].partialFingerprints['svelteVitals/v1']).toBe('SEO001:/none');
+    expect(run.results[1].partialFingerprints['svelteVitals/v1']).toBe('SEO006:project');
   });
 
   it('emits a valid empty log when there are no penalized findings', () => {

--- a/packages/core/test/sarif-report.test.ts
+++ b/packages/core/test/sarif-report.test.ts
@@ -93,6 +93,37 @@ describe('formatSarifReport', () => {
     expect(run.results[0].locations[0].physicalLocation.region.startLine).toBe(42);
   });
 
+  it('produces distinct partialFingerprints for same (id, route) but different line', () => {
+    const twoImages: Result[] = [
+      {
+        id: 'PERF001',
+        category: 'performance',
+        severity: 'warning',
+        detection: { presence: 'none', value: 'absent' },
+        route: '/blog',
+        location: 'src/routes/blog/+page.svelte',
+        line: 10,
+        message: 'Missing <img> width/height at line 10'
+      },
+      {
+        id: 'PERF001',
+        category: 'performance',
+        severity: 'warning',
+        detection: { presence: 'none', value: 'absent' },
+        route: '/blog',
+        location: 'src/routes/blog/+page.svelte',
+        line: 20,
+        message: 'Missing <img> width/height at line 20'
+      }
+    ];
+    const run = JSON.parse(formatSarifReport(twoImages, config, { version: '0.0.0' })).runs[0];
+    const fp0 = run.results[0].partialFingerprints['svelteVitals/v1'];
+    const fp1 = run.results[1].partialFingerprints['svelteVitals/v1'];
+    expect(fp0).toBe('PERF001:/blog:10');
+    expect(fp1).toBe('PERF001:/blog:20');
+    expect(fp0).not.toBe(fp1);
+  });
+
   it('emits a valid empty log when there are no penalized findings', () => {
     const passing: Result[] = [results[2]!];
     const sarif = JSON.parse(formatSarifReport(passing, config, { version: '0.0.0' }));

--- a/packages/core/test/score.test.ts
+++ b/packages/core/test/score.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeScore, defineConfig, type Result } from '../src/index.js';
+import { computeScore, defineConfig, scoresByCategory, type Result } from '../src/index.js';
 
 const pass = (id: string, route: string): Result => ({
   id,
@@ -102,5 +102,31 @@ describe('computeScore (§12 worked example)', () => {
     // single route seeded at 100 not present; routeAverage falls back to 100; site penalty counted once (5) -> 95
     expect(computeScore(results, defineConfig({})).scoreModel.sitePenalty).toBe(5);
     expect(computeScore(results, defineConfig({})).score).toBe(95);
+  });
+});
+
+describe('scoresByCategory', () => {
+  it('scores each category independently', () => {
+    const config = defineConfig({});
+    const results = [
+      { id: 'SEO001', category: 'seo', severity: 'critical', detection: { presence: 'none', value: 'absent' }, route: '/a', message: 'x' },
+      { id: 'PERF001', category: 'performance', severity: 'warning', detection: { presence: 'none', value: 'absent' }, route: '/a', message: 'y' },
+      { id: 'PERF001', category: 'performance', severity: 'warning', detection: { presence: 'own', value: 'static' }, route: '/b', message: 'ok' }
+    ] as const;
+    const byCat = scoresByCategory(results as never, config);
+    expect(byCat.seo).toBeDefined();
+    expect(byCat.performance).toBeDefined();
+    // SEO has a critical on its only route → capped/low; performance has one bad route and one clean route.
+    expect(byCat.performance!.score).toBeGreaterThan(byCat.seo!.score);
+  });
+
+  it('treats a missing category as seo', () => {
+    const config = defineConfig({});
+    const byCat = scoresByCategory(
+      [{ id: 'SEO001', severity: 'warning', detection: { presence: 'none', value: 'absent' }, route: '/a', message: 'x' }] as never,
+      config
+    );
+    expect(byCat.seo).toBeDefined();
+    expect(byCat.performance).toBeUndefined();
   });
 });

--- a/packages/core/test/score.test.ts
+++ b/packages/core/test/score.test.ts
@@ -109,9 +109,30 @@ describe('scoresByCategory', () => {
   it('scores each category independently', () => {
     const config = defineConfig({});
     const results = [
-      { id: 'SEO001', category: 'seo', severity: 'critical', detection: { presence: 'none', value: 'absent' }, route: '/a', message: 'x' },
-      { id: 'PERF001', category: 'performance', severity: 'warning', detection: { presence: 'none', value: 'absent' }, route: '/a', message: 'y' },
-      { id: 'PERF001', category: 'performance', severity: 'warning', detection: { presence: 'own', value: 'static' }, route: '/b', message: 'ok' }
+      {
+        id: 'SEO001',
+        category: 'seo',
+        severity: 'critical',
+        detection: { presence: 'none', value: 'absent' },
+        route: '/a',
+        message: 'x'
+      },
+      {
+        id: 'PERF001',
+        category: 'performance',
+        severity: 'warning',
+        detection: { presence: 'none', value: 'absent' },
+        route: '/a',
+        message: 'y'
+      },
+      {
+        id: 'PERF001',
+        category: 'performance',
+        severity: 'warning',
+        detection: { presence: 'own', value: 'static' },
+        route: '/b',
+        message: 'ok'
+      }
     ] as const;
     const byCat = scoresByCategory(results as never, config);
     expect(byCat.seo).toBeDefined();
@@ -123,7 +144,15 @@ describe('scoresByCategory', () => {
   it('treats a missing category as seo', () => {
     const config = defineConfig({});
     const byCat = scoresByCategory(
-      [{ id: 'SEO001', severity: 'warning', detection: { presence: 'none', value: 'absent' }, route: '/a', message: 'x' }] as never,
+      [
+        {
+          id: 'SEO001',
+          severity: 'warning',
+          detection: { presence: 'none', value: 'absent' },
+          route: '/a',
+          message: 'x'
+        }
+      ] as never,
       config
     );
     expect(byCat.seo).toBeDefined();

--- a/packages/vite/test/analyze.test.ts
+++ b/packages/vite/test/analyze.test.ts
@@ -35,7 +35,7 @@ describe('analyze', () => {
     const json = JSON.parse(r.jsonReport);
     expect(json.siteIssues.map((i: { id: string }) => i.id)).not.toContain('SEO009');
     // console report must carry the plugin-mode label and not the static-mode label
-    expect(r.consoleReport).toContain('SEO (rendered / plugin)');
+    expect(r.consoleReport).toContain('Svelte Vitals  (rendered / plugin)');
     expect(r.consoleReport).not.toContain('static mode');
   });
 

--- a/packages/vite/test/analyze.test.ts
+++ b/packages/vite/test/analyze.test.ts
@@ -35,7 +35,7 @@ describe('analyze', () => {
     const json = JSON.parse(r.jsonReport);
     expect(json.siteIssues.map((i: { id: string }) => i.id)).not.toContain('SEO009');
     // console report must carry the plugin-mode label and not the static-mode label
-    expect(r.consoleReport).toContain('Svelte Vitals  (rendered / plugin)');
+    expect(r.consoleReport).toContain('Svelte Vitals  ·  rendered / plugin');
     expect(r.consoleReport).not.toContain('static mode');
   });
 


### PR DESCRIPTION
First Vitals category beyond SEO, plus the multi-category foundation later categories reuse. Implements the **Performance v0.4** item of #10 (static-analysis only; no runtime Core Web Vitals).

## What's new

- **PERF001 — image dimensions (`warning`)**: an `<img>` missing explicit `width`/`height` (CLS risk). A dynamically-bound dimension (`width={w}`) counts as present and passes.
- **PERF002 — image loading hint (`info`)**: an `<img>` with no `loading` attribute (advisory; static analysis can't know the LCP image, so it never fails the build).
- One finding **per offending `<img>`**, with `location` (file) + `line`.

## Multi-category foundation

- `Result.category` + `line`; image IR (`ImageInfo`/`ResolvedImages`) + `RuleContext.images`; an `imageRule` factory.
- `scoresByCategory` — per-category scores by reusing the existing route-average `computeScore`.
- **Category-aware reporters**: console shows a per-category score line (`SEO Score:` / `Performance Score:`); json adds a `categories` map and tags issues with `category`/`line`; agent uses a category-neutral heading; github/sarif carry the finding line.
- CLI provider collects heads and `<img>` in a **single walk** of each route's layout chain (`collectRoutes`) — one read + parse per file (a layout image surfaces per child route, like inherited head findings).

## Additivity

The change is additive: a missing `category` defaults to `'seo'`, the json top-level `score` stays the SEO subset, and the Performance reporting only adds sections. **All existing SEO findings, scores, and output are unchanged.**

## Scope

Static mode only; `@svelte-vitals/vite` untouched. Per #10's plan and the 1.0 philosophy, `preload`/adapter/large-import checks, plugin-mode images, and the combined weighted Health Report are **later 0.x increments** (1.0 is the polished culmination, not where new integration lands).

## Validation

- `pnpm -r test` — **240 passed** (core 89, vite 31, cli 111, mcp 9)
- `pnpm -r typecheck`, `pnpm build`, `pnpm lint`, publint + attw (esm-only) — green

## Notes for reviewers

- Built subagent-driven: 6 tasks, each spec+quality reviewed, plus a whole-branch review.
- **Performance category only appears when the project has `<img>` elements.** PERF rules emit nothing for an image-less route, so a zero-image project hides the Performance section entirely (rather than reporting a hollow `Performance Score: 100/100`), and the console `Passed` list is no longer padded with per-route PERF passes for image-less routes. Routes whose images all pass still seed a `100` for the per-category score.
- SARIF `partialFingerprints` are disambiguated by `line` (and `location`) so multiple per-route image findings don't collapse into one code-scanning alert (SEO fingerprints unchanged).

### Review follow-up (addressed in this branch)

- **Single-pass collection** — heads and images are now gathered in one walk of each route's layout chain (`collectRoutes`), parsing every `.svelte` file once instead of twice (the head and image providers previously each walked + parsed the whole chain independently).
- **Image-less routes** — no longer emit passing seeds (the zero-image behavior described above).
- Console header tidied to `Svelte Vitals  ·  <mode>`; the unused `_config` parameter was removed by the single-pass refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Performance category with image-dimension checks (`width`/`height`) and `loading` attribute advisories
  * Multi-category reporting system now groups findings by category with independent per-category scores
  * Category-aware output in console, JSON, GitHub, and SARIF reporters

* **Documentation**
  * Updated roadmap reflecting Performance v0.4 and upcoming categories before v1.0 release

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
