### PR TITLE
feat: Accessibility v0.5 — aggregate Svelte compiler a11y warnings (#10)

### DIFF
--- a/.changeset/a11y-v0.5.md
+++ b/.changeset/a11y-v0.5.md
@@ -1,0 +1,10 @@
+---
+'svelte-vitals': minor
+---
+
+Add the Accessibility category (v0.5, #10): aggregates the Svelte compiler's `a11y_*`
+warnings (e.g. `a11y_missing_attribute`, `a11y_label_has_associated_control`) into the
+report as a scored `a11y` category, reusing the Performance v0.4 multi-category
+foundation. Findings use the Svelte code as the rule id and link to Svelte's docs;
+`--ignore <a11y_code>` disables a specific code. Per-file compile results are cached, and
+a file that fails to compile is skipped rather than failing the run.

--- a/README.md
+++ b/README.md
@@ -148,10 +148,11 @@ The project advances along two axes: **mode maturity** and **category coverage**
 - **Dev overlay** (`@svelte-vitals/vite`) — warns in-place while developing via `transformPageChunk`, so dynamic routes are seen with real values as pages are visited.
 - **MCP server** (`@svelte-vitals/mcp`) — exposes `analyze` and `explain_rule` tools over stdio so an agent can run analysis in its tool loop and receive structured, fixable findings.
 - **Performance checks** (`0.4`) — static `<img>` analysis: `width`/`height` (CLS) and a `loading` advisory, scored as a separate Performance category alongside SEO.
+- **Accessibility checks** (`0.5`) — aggregates the Svelte compiler's `a11y_*` warnings (alt text, label association, ARIA, …) into a scored Accessibility category.
 
 **Upcoming**
 
-- **More categories** ([#10](https://github.com/oekazuma/svelte-vitals/issues/10)) — Accessibility and Upgrade checks, then a combined weighted Health Report — all landing across `0.x` ahead of the `1.0` polish.
+- **More categories** ([#10](https://github.com/oekazuma/svelte-vitals/issues/10)) — Upgrade checks, then a combined weighted Health Report — landing across `0.x` ahead of the `1.0` polish.
 
 See the design document for the full vision.
 

--- a/docs/superpowers/plans/2026-06-22-a11y-v0.5.md
+++ b/docs/superpowers/plans/2026-06-22-a11y-v0.5.md
@@ -1,0 +1,405 @@
+# Accessibility v0.5 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an Accessibility category that aggregates the Svelte compiler's `a11y_*` warnings into the report as `category: 'a11y'` findings, reusing the Performance v0.4 multi-category foundation (per-category scores + category-aware reporters).
+
+**Architecture:** A new CLI-side collector (`packages/cli/src/providers/source/a11y.ts`) compiles each route's `+page.svelte` + `+layout.svelte` chain with `svelte/compiler`'s `compile(src, { generate: false })`, maps `a11y_*` warnings to `Result`s (id = the Svelte code), and emits a passing seed per warning-free route (so the per-category score seeds at 100). `analyzeProject` merges these into the result set; scoring/reporters already handle a new category generically.
+
+**Tech Stack:** TypeScript (ESM-only), `svelte/compiler` (`compile`), `vitest`, pnpm workspaces.
+
+## Global Constraints
+
+- **ESM-only**, `tsup` `format: ['esm']`, `target: 'es2022'`; never add CJS (#20).
+- **`@svelte-vitals/core` stays runtime-agnostic** — `svelte/compiler` (`compile`) is used ONLY in `packages/cli` (like the existing `parse.ts`); core gains no `svelte/compiler` dependency.
+- **id = the Svelte warning code verbatim** (e.g. `a11y_missing_attribute`) — an external-origin id alongside `SEO00N`/`PERF00N`.
+- **Severity uniform `warning`** in v0.5; `config.rules[code]` severity overrides still apply via the existing `applyRuleSeverities`.
+- **Resilience**: a per-file `compile()` that throws is swallowed (skip a11y for that file); never fail the run because of a11y collection.
+- **Additive**: existing SEO/Performance findings, scores, and reporter output must not change. All existing tests stay green.
+- **`--ignore <a11y_code>` (deny) controls a11y**; the `--rules` allow-list governs the built-in SEO/PERF rules (a11y is a separate signal source — documented limitation for v0.5).
+- Commit trailer: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+### Task 1: a11y collector (`collectA11y`)
+
+**Files:**
+- Modify: `packages/cli/src/providers/source/routes.ts` (export `chainFiles`)
+- Create: `packages/cli/src/providers/source/a11y.ts`
+- Test: `packages/cli/test/a11y.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `chainFiles(rt, cwd, pageRel): Promise<Array<{ rel: string; isPage: boolean }>>` and `deriveRoute(pageRel): string` (both from `routes.js`); `enumerateRoutePages(rt, cwd)` from `project.js`; `Result`, `Config`, `Runtime`, `defaultConfig` from `@svelte-vitals/core`.
+- Produces: `function collectA11y(rt: Runtime, cwd: string, config?: Config): Promise<Result[]>` — per-route a11y findings (one fail `Result` per non-ignored warning; one passing seed `Result` per warning-free route).
+
+- [ ] **Step 1: Export `chainFiles` from `routes.ts`.** It is currently a module-private `async function chainFiles(...)`. Change its declaration to `export async function chainFiles(...)` (signature unchanged). `deriveRoute` is already exported.
+
+- [ ] **Step 2: Write the failing test** — `packages/cli/test/a11y.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { collectA11y } from '../src/providers/source/a11y.js';
+import { createMemoryRuntime } from './helpers/memory-runtime.js';
+import { defineConfig } from '@svelte-vitals/core';
+
+const config = defineConfig({});
+
+describe('collectA11y', () => {
+  it('maps a Svelte a11y warning to an a11y finding (code as id, line, docsUrl)', async () => {
+    const rt = createMemoryRuntime({
+      'src/routes/+page.svelte': `<h1>Home</h1>\n<img src="/a.png" />`
+    });
+    const results = await collectA11y(rt, '', config);
+    const finding = results.find((r) => r.id === 'a11y_missing_attribute');
+    expect(finding).toBeDefined();
+    expect(finding!.category).toBe('a11y');
+    expect(finding!.severity).toBe('warning');
+    expect(finding!.route).toBe('/');
+    expect(finding!.location).toBe('src/routes/+page.svelte');
+    expect(finding!.line).toBe(2);
+    expect(finding!.detection).toEqual({ presence: 'none', value: 'absent' });
+    expect(finding!.docsUrl).toBe('https://svelte.dev/e/a11y_missing_attribute');
+    // message is the first line only (no trailing docs URL line)
+    expect(finding!.message).not.toContain('https://');
+  });
+
+  it('emits one passing seed for a route with no a11y warnings', async () => {
+    const rt = createMemoryRuntime({ 'src/routes/+page.svelte': `<h1>Home</h1>` });
+    const results = await collectA11y(rt, '', config);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.id).toBe('a11y');
+    expect(results[0]!.category).toBe('a11y');
+    expect(results[0]!.detection).toEqual({ presence: 'own', value: 'static' });
+    expect(results[0]!.route).toBe('/');
+  });
+
+  it('surfaces a layout a11y warning on the child route', async () => {
+    const rt = createMemoryRuntime({
+      'src/routes/+layout.svelte': `<img src="/logo.png" />\n<slot />`,
+      'src/routes/about/+page.svelte': `<h1>About</h1>`
+    });
+    const results = await collectA11y(rt, '', config);
+    const about = results.filter((r) => r.route === '/about' && r.id === 'a11y_missing_attribute');
+    expect(about).toHaveLength(1);
+    expect(about[0]!.location).toBe('src/routes/+layout.svelte');
+  });
+
+  it('skips a code disabled via config.rules', async () => {
+    const rt = createMemoryRuntime({ 'src/routes/+page.svelte': `<img src="/a.png" />` });
+    const off = defineConfig({ rules: { a11y_missing_attribute: 'off' } });
+    const results = await collectA11y(rt, '', off);
+    expect(results.some((r) => r.id === 'a11y_missing_attribute')).toBe(false);
+    // with its only warning ignored, the route seeds as passing
+    expect(results).toEqual([expect.objectContaining({ id: 'a11y', route: '/' })]);
+  });
+
+  it('does not throw when a file fails to compile (skips a11y for it)', async () => {
+    const rt = createMemoryRuntime({ 'src/routes/+page.svelte': `<div {#bad}></div>` });
+    const results = await collectA11y(rt, '', config);
+    // no throw; the unparseable route simply yields a seed (no a11y findings)
+    expect(results.every((r) => r.category === 'a11y')).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 3: Run it to verify it fails**
+
+Run: `pnpm --filter svelte-vitals test -- a11y`
+Expected: FAIL — cannot find `../src/providers/source/a11y.js`.
+
+- [ ] **Step 4: Implement `packages/cli/src/providers/source/a11y.ts`:**
+
+```ts
+import { compile } from 'svelte/compiler';
+import type { Config, Result, Runtime } from '@svelte-vitals/core';
+import { defaultConfig } from '@svelte-vitals/core';
+import { enumerateRoutePages } from './project.js';
+import { chainFiles, deriveRoute } from './routes.js';
+
+interface A11yWarning {
+  code: string;
+  /** First line of the Svelte message (the trailing docs-URL line is stripped). */
+  message: string;
+  /** 1-based source line, or 0 if unknown. */
+  line: number;
+}
+
+function firstLine(message: string): string {
+  return message.split('\n')[0] ?? message;
+}
+
+/** Compile one file and return its mapped a11y warnings. Resilient: returns [] if compile throws. */
+function fileA11y(source: string, rel: string): A11yWarning[] {
+  let warnings: ReadonlyArray<{ code?: string; message?: string; start?: { line?: number } }> = [];
+  try {
+    ({ warnings = [] } = compile(source, { generate: false, filename: rel }) as {
+      warnings?: ReadonlyArray<{ code?: string; message?: string; start?: { line?: number } }>;
+    });
+  } catch {
+    return [];
+  }
+  const out: A11yWarning[] = [];
+  for (const w of warnings) {
+    if (typeof w.code === 'string' && w.code.startsWith('a11y')) {
+      out.push({
+        code: w.code,
+        message: firstLine(w.message ?? w.code),
+        line: typeof w.start?.line === 'number' ? w.start.line : 0
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Aggregate the Svelte compiler's a11y warnings into per-route findings (issue #10,
+ * Accessibility v0.5). Each route's +page.svelte and +layout.svelte chain is compiled
+ * (cached per file); each a11y warning becomes a fail Result keyed by its Svelte code,
+ * and a warning-free route emits one passing seed so the a11y score anchors at 100.
+ */
+export async function collectA11y(rt: Runtime, cwd: string, config: Config = defaultConfig): Promise<Result[]> {
+  const pages = await enumerateRoutePages(rt, cwd);
+  const cache = new Map<string, A11yWarning[]>();
+  const results: Result[] = [];
+
+  for (const page of pages) {
+    const files = await chainFiles(rt, cwd, page);
+    const route = deriveRoute(page);
+    const fails: Result[] = [];
+
+    for (const { rel } of files) {
+      let warns = cache.get(rel);
+      if (!warns) {
+        const source = await rt.readFile(rt.join(cwd, rel));
+        warns = fileA11y(source, rel);
+        cache.set(rel, warns);
+      }
+      for (const w of warns) {
+        if (config.rules[w.code] === 'off') continue;
+        fails.push({
+          id: w.code,
+          category: 'a11y',
+          severity: 'warning',
+          detection: { presence: 'none', value: 'absent' },
+          route,
+          location: rel,
+          ...(w.line > 0 ? { line: w.line } : {}),
+          message: w.message,
+          docsUrl: `https://svelte.dev/e/${w.code}`
+        });
+      }
+    }
+
+    if (fails.length === 0) {
+      // One passing seed per warning-free route anchors the a11y category score at 100.
+      results.push({
+        id: 'a11y',
+        category: 'a11y',
+        severity: 'warning',
+        detection: { presence: 'own', value: 'static' },
+        route,
+        message: 'Accessibility'
+      });
+    } else {
+      results.push(...fails);
+    }
+  }
+
+  return results;
+}
+```
+
+> Notes: the loop is sequential (`for…of` with `await`) so the per-file `cache` is race-free and each unique file is compiled exactly once even when shared by many routes. `generate: false` skips codegen (analysis + warnings only). The `as {…}` cast keeps us tolerant of the compiler's warning type across Svelte minor versions while reading only `code`/`message`/`start.line`.
+
+- [ ] **Step 5: Run the a11y test**
+
+Run: `pnpm --filter svelte-vitals test -- a11y`
+Expected: PASS (all five cases). If the `line` assertion (`2`) is off, confirm Svelte reports the `<img>` on line 2 of the fixture (`\n` before it) and adjust the fixture/assertion to match real output — do not weaken to `>= 0`.
+
+- [ ] **Step 6: Typecheck + commit**
+
+Run: `pnpm --filter svelte-vitals typecheck`
+
+```bash
+git add packages/cli/src/providers/source/routes.ts packages/cli/src/providers/source/a11y.ts packages/cli/test/a11y.test.ts
+git commit -m "feat(cli): aggregate Svelte compiler a11y warnings (#10)"
+```
+
+---
+
+### Task 2: known-id validation + pipeline wiring
+
+**Files:**
+- Modify: `packages/cli/src/rules-config.ts` (accept `a11y_*` ids as known)
+- Modify: `packages/cli/src/index.ts` (`analyzeProject` merges a11y results)
+- Test: `packages/cli/test/rules-config.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `collectA11y` (Task 1).
+- Produces: `findUnknownRuleIds` treats `a11y_*` ids as known; `analyzeProject` includes a11y results in its `Result[]`.
+
+- [ ] **Step 1: Write the failing test** — add to `packages/cli/test/rules-config.test.ts`:
+
+```ts
+it('treats a11y_* codes as known rule ids', () => {
+  expect(findUnknownRuleIds(['a11y_missing_attribute'])).toEqual([]);
+  // a genuinely unknown id is still reported
+  expect(findUnknownRuleIds(['NOPE999'])).toEqual(['NOPE999']);
+});
+```
+
+> Confirm `findUnknownRuleIds` is imported in that test file; it is used by existing cases, so the import exists.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `pnpm --filter svelte-vitals test -- rules-config`
+Expected: FAIL — `a11y_missing_attribute` is reported as unknown.
+
+- [ ] **Step 3: Update `findUnknownRuleIds`** in `packages/cli/src/rules-config.ts`:
+
+```ts
+/** Rule ids passed to --rules/--ignore that aren't part of the built-in registry. */
+export function findUnknownRuleIds(ids: string[]): string[] {
+  // a11y_* ids are Svelte compiler warning codes (Accessibility category, #10);
+  // they are accepted dynamically rather than enumerated in the built-in registry.
+  return [...new Set(ids.filter((id) => !KNOWN_IDS.has(id) && !id.startsWith('a11y')))];
+}
+```
+
+- [ ] **Step 4: Run the rules-config test**
+
+Run: `pnpm --filter svelte-vitals test -- rules-config`
+Expected: PASS.
+
+- [ ] **Step 5: Wire `collectA11y` into `analyzeProject`** in `packages/cli/src/index.ts`. Add the import and merge a11y results (filtered by the same `routeMatcher`) before `applyRuleSeverities`:
+
+```ts
+import { collectA11y } from './providers/source/a11y.js';
+```
+Replace the results line:
+```ts
+  const project = await collectProjectFacts(rt, cwd);
+  const rules = selectRules(allRules, config);
+  const a11y = (await collectA11y(rt, cwd, config)).filter((r) => r.route === undefined || matches(r.route));
+  const ruleResults = await runRules(rules, { heads, images, project, config });
+  const results = applyRuleSeverities([...ruleResults, ...a11y], config);
+  return { results, config, version: readPackageVersion() };
+```
+
+> `applyRuleSeverities` applies any `config.rules[code]` severity override to the merged a11y results (keyed by `result.id`); codes set to `'off'` were already dropped inside `collectA11y`.
+
+- [ ] **Step 6: Run the full CLI suite + typecheck**
+
+Run: `pnpm --filter svelte-vitals test` then `pnpm --filter svelte-vitals typecheck`
+Expected: PASS. The new `/img` route etc. already exist; adding a11y results may add new findings to broad assertions — if an existing `run.test.ts` count assertion shifts because a11y findings now appear, inspect it: most `run.test` assertions target SEO specifics and should be unaffected. If `--json` `summary` counts in a test now include a11y warnings, update that assertion to the correct value and note why. Do not weaken assertions.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/cli/src/rules-config.ts packages/cli/src/index.ts packages/cli/test/rules-config.test.ts
+git commit -m "feat(cli): accept a11y_* ids and merge a11y findings into analysis (#10)"
+```
+
+---
+
+### Task 3: e2e, README, changeset, full verification
+
+**Files:**
+- Modify: `packages/cli/test/run.test.ts` (e2e a11y assertion)
+- Modify: `README.md` (roadmap)
+- Create: `.changeset/a11y-v0.5.md`
+
+**Interfaces:** none (integration + docs/release).
+
+- [ ] **Step 1: Confirm the e2e fixture has an a11y trigger.** The fixture route `packages/cli/test/fixtures/basic-project/src/routes/img/+page.svelte` was added in Performance v0.4 as:
+```svelte
+<svelte:head><title>{data.title}</title></svelte:head>
+<img src="/hero.png" alt="hero" />
+```
+That `<img>` HAS `alt`, so it triggers no `a11y_missing_attribute`. Read the file; if it has `alt`, **remove the `alt` attribute** so it triggers `a11y_missing_attribute` (and keep the dynamic title so SEO counts are unchanged):
+```svelte
+<svelte:head><title>{data.title}</title></svelte:head>
+<img src="/hero.png" />
+```
+> Removing `alt` does not change SEO/Performance assertions (PERF still flags the missing dimensions as before; the dynamic title still passes SEO). If a Performance assertion referenced this image's findings, it is unaffected (PERF001/PERF002 still fire on the dimension/loading attrs).
+
+- [ ] **Step 2: Write the failing e2e assertion** — add to `packages/cli/test/run.test.ts` (reuse the file's `capture()`, `CLEAN_ENV`, `fixtureDir`):
+
+```ts
+it('reports an Accessibility finding for an <img> without alt', async () => {
+  const cap = capture();
+  await run({ cwd: fixtureDir, reporter: 'json', log: cap.log, errorLog: cap.errorLog, env: CLEAN_ENV });
+  const json = JSON.parse(cap.out.join('\n'));
+  expect(json.categories.a11y).toBeDefined();
+  const img = json.routes.find((r: { route: string }) => r.route === '/img');
+  expect(img.issues.some((i: { id: string }) => i.id === 'a11y_missing_attribute')).toBe(true);
+});
+```
+
+- [ ] **Step 3: Run it**
+
+Run: `pnpm --filter svelte-vitals test -- run`
+Expected: PASS. Fix any count drift in other `run.test` assertions caused by the removed `alt` / new a11y findings, updating to correct values (not weakening).
+
+- [ ] **Step 4: Run the full CLI suite** to catch drift in other suites (e.g. `source-provider.test`, json/console expectations):
+
+Run: `pnpm --filter svelte-vitals test`
+Expected: PASS (update any legitimately-shifted assertion).
+
+- [ ] **Step 5: Update the README roadmap.** In `README.md`, under **Shipped**, add:
+
+```md
+- **Accessibility checks** (`0.5`) — aggregates the Svelte compiler's `a11y_*` warnings (alt text, label association, ARIA, …) into a scored Accessibility category.
+```
+And reword the **Upcoming** #10 bullet to drop Accessibility:
+
+```md
+- **More categories** ([#10](https://github.com/oekazuma/svelte-vitals/issues/10)) — Upgrade checks, then a combined weighted Health Report — landing across `0.x` ahead of the `1.0` polish.
+```
+
+- [ ] **Step 6: Add the changeset** — `.changeset/a11y-v0.5.md`:
+
+```md
+---
+'svelte-vitals': minor
+---
+
+Add the Accessibility category (v0.5, #10): aggregates the Svelte compiler's `a11y_*`
+warnings (e.g. `a11y_missing_attribute`, `a11y_label_has_associated_control`) into the
+report as a scored `a11y` category, reusing the Performance v0.4 multi-category
+foundation. Findings use the Svelte code as the rule id and link to Svelte's docs;
+`--ignore <a11y_code>` disables a specific code. Per-file compile results are cached, and
+a file that fails to compile is skipped rather than failing the run.
+```
+
+> Only `svelte-vitals` (the CLI) changes — the a11y collector and `findUnknownRuleIds` both live in `packages/cli`. `@svelte-vitals/core` is unchanged (the multi-category foundation already shipped in v0.4). Confirm `git diff --name-only` touches no `packages/core/src` before finalizing the changeset; if it does, add the appropriate core bump.
+
+- [ ] **Step 7: Full repo verification**
+
+Run: `pnpm -r typecheck && pnpm -r test && pnpm build && pnpm lint && pnpm check:publint`
+Expected: all green. (Run `pnpm format` first if prettier flags formatting. For attw, if the local root-owned npm cache blocks `check:publish`'s `npm pack`, verify attw via `npm_config_cache="$TMPDIR/npmcache" pnpm --workspace-concurrency=1 --filter @svelte-vitals/core --filter @svelte-vitals/vite --filter svelte-vitals --filter @svelte-vitals/mcp exec attw --pack . --profile esm-only`, as in #20.) For any pnpm "no TTY" modules-dir error, prefix `CI=true`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/cli/test/fixtures/basic-project/src/routes/img/+page.svelte packages/cli/test/run.test.ts README.md .changeset/a11y-v0.5.md
+git commit -m "docs(a11y): ship Accessibility v0.5, roadmap + changeset (#10)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Aggregate Svelte compiler `a11y_*` warnings → Task 1 (`fileA11y`/`collectA11y`). ✅
+- id = Svelte code; severity warning; detection shape; location/line; message first-line; docsUrl → Task 1. ✅
+- Per-route chain collection + seed + per-file compile cache + compile-throw resilience → Task 1. ✅
+- Config: `--ignore` code skipped in collector; severity override via `applyRuleSeverities`; `findUnknownRuleIds` accepts `a11y_*` → Tasks 1 & 2. ✅
+- Scoring/reporters reuse (no changes) → verified by Task 3 e2e (`categories.a11y` in json). ✅
+- core stays free of `svelte/compiler` (collector in cli) → Task 1 file location. ✅
+- README roadmap + changeset (cli minor only) → Task 3. ✅
+- Out of scope (eslint-plugin-svelte, per-code severity tiers, plugin-mode, Health Report) → not implemented. ✅
+
+**Placeholder scan:** No "TBD"/"add error handling"-style gaps; full code in every code step. The line-number and count-drift steps give concrete verification + adjustment instructions, not placeholders. The changeset step's "confirm core untouched" is a guard, not a deferral.
+
+**Type consistency:** `collectA11y(rt, cwd, config?) → Promise<Result[]>` defined in Task 1, consumed in Task 2's `analyzeProject`. `chainFiles`/`deriveRoute` exported in Task 1, imported by `a11y.ts`. Findings use `category: 'a11y'` and the `Result` shape (`id`, `severity`, `detection`, `route`, `location`, `line?`, `message`, `docsUrl`) consistent with the core `Result` type and the Performance findings. `findUnknownRuleIds` signature unchanged (Task 2 only changes the predicate body).

--- a/docs/superpowers/plans/2026-06-22-a11y-v0.5.md
+++ b/docs/superpowers/plans/2026-06-22-a11y-v0.5.md
@@ -24,11 +24,13 @@
 ### Task 1: a11y collector (`collectA11y`)
 
 **Files:**
+
 - Modify: `packages/cli/src/providers/source/routes.ts` (export `chainFiles`)
 - Create: `packages/cli/src/providers/source/a11y.ts`
 - Test: `packages/cli/test/a11y.test.ts` (new)
 
 **Interfaces:**
+
 - Consumes: `chainFiles(rt, cwd, pageRel): Promise<Array<{ rel: string; isPage: boolean }>>` and `deriveRoute(pageRel): string` (both from `routes.js`); `enumerateRoutePages(rt, cwd)` from `project.js`; `Result`, `Config`, `Runtime`, `defaultConfig` from `@svelte-vitals/core`.
 - Produces: `function collectA11y(rt: Runtime, cwd: string, config?: Config): Promise<Result[]>` — per-route a11y findings (one fail `Result` per non-ignored warning; one passing seed `Result` per warning-free route).
 
@@ -230,11 +232,13 @@ git commit -m "feat(cli): aggregate Svelte compiler a11y warnings (#10)"
 ### Task 2: known-id validation + pipeline wiring
 
 **Files:**
+
 - Modify: `packages/cli/src/rules-config.ts` (accept `a11y_*` ids as known)
 - Modify: `packages/cli/src/index.ts` (`analyzeProject` merges a11y results)
 - Test: `packages/cli/test/rules-config.test.ts` (extend)
 
 **Interfaces:**
+
 - Consumes: `collectA11y` (Task 1).
 - Produces: `findUnknownRuleIds` treats `a11y_*` ids as known; `analyzeProject` includes a11y results in its `Result[]`.
 
@@ -276,14 +280,16 @@ Expected: PASS.
 ```ts
 import { collectA11y } from './providers/source/a11y.js';
 ```
+
 Replace the results line:
+
 ```ts
-  const project = await collectProjectFacts(rt, cwd);
-  const rules = selectRules(allRules, config);
-  const a11y = (await collectA11y(rt, cwd, config)).filter((r) => r.route === undefined || matches(r.route));
-  const ruleResults = await runRules(rules, { heads, images, project, config });
-  const results = applyRuleSeverities([...ruleResults, ...a11y], config);
-  return { results, config, version: readPackageVersion() };
+const project = await collectProjectFacts(rt, cwd);
+const rules = selectRules(allRules, config);
+const a11y = (await collectA11y(rt, cwd, config)).filter((r) => r.route === undefined || matches(r.route));
+const ruleResults = await runRules(rules, { heads, images, project, config });
+const results = applyRuleSeverities([...ruleResults, ...a11y], config);
+return { results, config, version: readPackageVersion() };
 ```
 
 > `applyRuleSeverities` applies any `config.rules[code]` severity override to the merged a11y results (keyed by `result.id`); codes set to `'off'` were already dropped inside `collectA11y`.
@@ -305,6 +311,7 @@ git commit -m "feat(cli): accept a11y_* ids and merge a11y findings into analysi
 ### Task 3: e2e, README, changeset, full verification
 
 **Files:**
+
 - Modify: `packages/cli/test/run.test.ts` (e2e a11y assertion)
 - Modify: `README.md` (roadmap)
 - Create: `.changeset/a11y-v0.5.md`
@@ -312,15 +319,19 @@ git commit -m "feat(cli): accept a11y_* ids and merge a11y findings into analysi
 **Interfaces:** none (integration + docs/release).
 
 - [ ] **Step 1: Confirm the e2e fixture has an a11y trigger.** The fixture route `packages/cli/test/fixtures/basic-project/src/routes/img/+page.svelte` was added in Performance v0.4 as:
+
 ```svelte
 <svelte:head><title>{data.title}</title></svelte:head>
 <img src="/hero.png" alt="hero" />
 ```
+
 That `<img>` HAS `alt`, so it triggers no `a11y_missing_attribute`. Read the file; if it has `alt`, **remove the `alt` attribute** so it triggers `a11y_missing_attribute` (and keep the dynamic title so SEO counts are unchanged):
+
 ```svelte
 <svelte:head><title>{data.title}</title></svelte:head>
 <img src="/hero.png" />
 ```
+
 > Removing `alt` does not change SEO/Performance assertions (PERF still flags the missing dimensions as before; the dynamic title still passes SEO). If a Performance assertion referenced this image's findings, it is unaffected (PERF001/PERF002 still fire on the dimension/loading attrs).
 
 - [ ] **Step 2: Write the failing e2e assertion** — add to `packages/cli/test/run.test.ts` (reuse the file's `capture()`, `CLEAN_ENV`, `fixtureDir`):
@@ -351,6 +362,7 @@ Expected: PASS (update any legitimately-shifted assertion).
 ```md
 - **Accessibility checks** (`0.5`) — aggregates the Svelte compiler's `a11y_*` warnings (alt text, label association, ARIA, …) into a scored Accessibility category.
 ```
+
 And reword the **Upcoming** #10 bullet to drop Accessibility:
 
 ```md
@@ -391,6 +403,7 @@ git commit -m "docs(a11y): ship Accessibility v0.5, roadmap + changeset (#10)"
 ## Self-Review
 
 **Spec coverage:**
+
 - Aggregate Svelte compiler `a11y_*` warnings → Task 1 (`fileA11y`/`collectA11y`). ✅
 - id = Svelte code; severity warning; detection shape; location/line; message first-line; docsUrl → Task 1. ✅
 - Per-route chain collection + seed + per-file compile cache + compile-throw resilience → Task 1. ✅

--- a/docs/superpowers/specs/2026-06-22-a11y-v0.5-design.md
+++ b/docs/superpowers/specs/2026-06-22-a11y-v0.5-design.md
@@ -38,9 +38,9 @@ A new CLI-side `sourceA11yProvider` (in `packages/cli/src/providers/source/`), a
 
 - Enumerate route pages; for each route, walk its `chainFiles` (page + layout chain).
 - For each chain file, obtain its a11y warnings; map each to a fail `Result` (tagged with that file as `location`).
-- If a route's chain yields **no** a11y warnings, emit one **passing seed** result (`detection { presence: 'own', value: 'static' }`, `id: 'a11y'`, message e.g. `Accessibility`) so the route seeds at 100 in the a11y category score — exactly as `imageRule` seeds the Performance score.
-- **Cache compile results per file** (`Map<relPath, A11yWarning[]>`): a layout shared by many routes is compiled once. `compile()` is heavier than `parse()`, so this matters on large projects.
-- **Resilience**: wrap each per-file `compile()` in try/catch. If `compile()` throws (e.g. an analysis-phase error `parse()` tolerated), skip a11y for that file rather than failing the run — SEO/Performance already parsed it. (A genuinely unparseable project still fails earlier in the pipeline as today.)
+- If a route's chain compiles cleanly and yields **no** a11y warnings, emit one **passing seed** result (`detection { presence: 'own', value: 'static' }`, `id: 'a11y'`, message e.g. `Accessibility`) so the route seeds at 100 in the a11y category score — exactly as `imageRule` seeds the Performance score.
+- **Cache compile results per file** (`Map<relPath, FileA11y>`, where `FileA11y` carries both the mapped warnings and an `ok` flag): a layout shared by many routes is compiled once. `compile()` is heavier than `parse()`, so this matters on large projects.
+- **Resilience**: wrap each per-file `compile()` in try/catch. If `compile()` throws (e.g. an analysis-phase error `parse()` tolerated), skip a11y for that file rather than failing the run — SEO/Performance already parsed it. A route whose chain has an unparseable file **and no other findings** is left _unchecked_: it emits **no seed** and is excluded from the category average, so an uncompilable route can never report a false 100. (Findings from sibling files that did compile are still surfaced. A genuinely unparseable project still fails earlier in the pipeline as today.)
 
 `compile()` (the Svelte compiler) lives in the CLI package only, like the existing `parse.ts`; `@svelte-vitals/core` stays runtime-agnostic and free of `svelte/compiler`.
 
@@ -75,11 +75,11 @@ The same `routeMatcher(opts.route)` filter applies, consistent with heads/images
 
 ## Error handling
 
-Per-file `compile()` failures are swallowed (skip a11y for that file). No new top-level failure modes; the existing project-detection / parse error paths (exit 2) are unchanged.
+Per-file `compile()` failures are swallowed (skip a11y for that file; an otherwise-finding-free route is excluded from the category rather than seeded). No new top-level failure modes; the existing project-detection / parse error paths (exit 2) are unchanged.
 
 ## Testing (TDD)
 
-- **cli**: warning→Result mapping (code as id, line from `start.line`, docsUrl derived, message first-line); per-route seed when a route has no a11y warnings; compile cached per file (a shared layout compiled once — assert via a spy/counter or by observing identical findings without recompute); `config.rules[code]==='off'` drops that code's findings; a file that fails `compile()` is skipped without throwing.
+- **cli**: warning→Result mapping (code as id, line from `start.line`, docsUrl derived, message first-line); per-route seed when a route has no a11y warnings; compile cached per file (a shared layout compiled once — assert via a spy/counter or by observing identical findings without recompute); `config.rules[code]==='off'` drops that code's findings; a file that fails `compile()` is skipped without throwing, and a route left with no findings is excluded (no false seed) rather than reported as passing.
 - **cli rules-config**: `findUnknownRuleIds(['a11y_missing_attribute'])` returns `[]` (a11y\_\* treated as known); a genuinely unknown id still reported.
 - **e2e** (`run.test.ts`): a fixture route whose `<img>` lacks `alt` produces an `a11y_missing_attribute` finding under `categories.a11y` in the json report; the dynamic-title fixture convention keeps SEO counts stable.
 - All existing SEO/Performance tests stay green (a11y is additive; the seed/score path mirrors Performance).

--- a/docs/superpowers/specs/2026-06-22-a11y-v0.5-design.md
+++ b/docs/superpowers/specs/2026-06-22-a11y-v0.5-design.md
@@ -1,0 +1,97 @@
+# Design: Accessibility v0.5 (second Vitals category)
+
+Issue: [#10](https://github.com/oekazuma/svelte-vitals/issues/10) (roadmap epic). This spec covers **only Accessibility v0.5** — the second category beyond SEO — built on the multi-category foundation shipped in Performance v0.4.
+
+## Goal
+
+Add an **Accessibility** category that **aggregates the Svelte compiler's a11y warnings** into the app-quality report, rather than reinventing accessibility checks. The Svelte compiler already ships a mature, maintained a11y warning set (`a11y_missing_attribute`, `a11y_label_has_associated_control`, `a11y_click_events_have_key_events`, …); v0.5 surfaces these as `category: 'a11y'` findings, scored and reported through the existing per-category machinery.
+
+Static-analysis-only; static mode (CLI) first.
+
+## Why aggregation
+
+Verified against Svelte 5.56.3: `compile(source, { generate: false, filename })` returns `warnings: Array<{ code, message, start: { line, column, character } }>`. a11y warnings have `code` prefixed `a11y_`, the `message` ends with a `https://svelte.dev/e/<code>` docs link, and `start.line` is a ready 1-based line. This gives broad, accurate coverage with **zero new dependencies** (svelte is already a dependency) and no rule logic to maintain as Svelte evolves its a11y set.
+
+## Scope (v0.5)
+
+- Collect Svelte compiler a11y warnings (`code` starts with `a11y_`) for each route's `+page.svelte` and its `+layout.svelte` chain, and surface them as `a11y` findings.
+- Reuse the v0.4 multi-category foundation: `Result.category`, `scoresByCategory`, category-aware reporters. The Accessibility score and section appear automatically.
+
+**Out of scope for v0.5** (later increments, tracked under #10): eslint-plugin-svelte aggregation, per-code severity differentiation (all a11y warnings are `warning` in v0.5), plugin-mode a11y, and the combined weighted Health Report.
+
+## Findings: warning → Result mapping
+
+Each collected a11y warning maps to one `Result`:
+
+- `id` = the Svelte code verbatim (e.g. `a11y_missing_attribute`) — an external-origin id alongside `SEO00N`/`PERF00N`.
+- `category: 'a11y'`.
+- `severity: 'warning'` (uniform in v0.5; per-rule severity overrides via config still apply — see Config).
+- `detection: { presence: 'none', value: 'absent' }` (penalized — consistent with how PERF fail findings reuse the detection shape).
+- `location` = the `.svelte` file the warning is in; `line` = `warning.start.line` (omit when not a positive number, consistent with PERF).
+- `message` = the first line of `warning.message` (the trailing `https://svelte.dev/e/...` line is stripped).
+- `docsUrl` = `https://svelte.dev/e/${code}`.
+- No `fix` (accessibility fixes are contextual; the docs URL carries guidance).
+
+## Collection model (mirrors Performance v0.4)
+
+A new CLI-side `sourceA11yProvider` (in `packages/cli/src/providers/source/`), analogous to `sourceImageProvider`:
+
+- Enumerate route pages; for each route, walk its `chainFiles` (page + layout chain).
+- For each chain file, obtain its a11y warnings; map each to a fail `Result` (tagged with that file as `location`).
+- If a route's chain yields **no** a11y warnings, emit one **passing seed** result (`detection { presence: 'own', value: 'static' }`, `id: 'a11y'`, message e.g. `Accessibility`) so the route seeds at 100 in the a11y category score — exactly as `imageRule` seeds the Performance score.
+- **Cache compile results per file** (`Map<relPath, A11yWarning[]>`): a layout shared by many routes is compiled once. `compile()` is heavier than `parse()`, so this matters on large projects.
+- **Resilience**: wrap each per-file `compile()` in try/catch. If `compile()` throws (e.g. an analysis-phase error `parse()` tolerated), skip a11y for that file rather than failing the run — SEO/Performance already parsed it. (A genuinely unparseable project still fails earlier in the pipeline as today.)
+
+`compile()` (the Svelte compiler) lives in the CLI package only, like the existing `parse.ts`; `@svelte-vitals/core` stays runtime-agnostic and free of `svelte/compiler`.
+
+The seed result uses the literal id `'a11y'`; the per-warning fail results use the Svelte codes. The seed is never penalized, so its id only needs to be stable and non-colliding with a real code.
+
+## Config integration
+
+- **Disable a code**: `--ignore a11y_missing_attribute` sets `config.rules['a11y_missing_attribute'] = 'off'`. The collector skips emitting findings for codes set to `'off'` (it reads `config.rules`). (`selectRules` only governs `Rule[]`; a11y findings come from the collector, so the collector enforces the skip.)
+- **Severity override**: `config.rules[code]` set to `info`/`warning`/`critical` is applied by the existing `applyRuleSeverities` (keyed by `result.id`) — works for a11y results for free.
+- **Known-id validation**: extend `findUnknownRuleIds` (in `packages/cli/src/rules-config.ts`) to treat any `a11y_`-prefixed id as known, so `--rules`/`--ignore a11y_*` does not error. (`knownRuleIds()` for help text still lists the built-in `SEO/PERF` rule ids plus a short note that `a11y_*` codes are accepted.)
+
+## Scoring & reporters
+
+No reporter/scoring changes needed — the v0.4 foundation handles a new category generically:
+
+- `scoresByCategory` buckets by `r.category` and computes an independent `a11y` score via the existing route-average `computeScore` (no `critical` a11y rule, so the cap never binds).
+- console already enumerates `a11y` in `CATEGORY_ORDER`/`CATEGORY_LABEL` (`'Accessibility'`), so an `Accessibility Score: N/100` line and findings appear automatically; json's `categories` map gains an `a11y` entry; agent/sarif/github carry the findings with their `line`.
+
+`summary`/`hasFailureAtOrAbove`/exit codes unchanged: a11y warnings count as `warning`, so under the default `--fail-on=critical` they do not fail the build.
+
+## Pipeline wiring
+
+In `packages/cli/src/index.ts` `analyzeProject`: after collecting heads, images, and project facts, also collect a11y results and merge them into the result set before `applyRuleSeverities`:
+
+```
+const a11y = (await sourceA11yProvider.collect(rt, cwd, config)).filter((r) => r.route === undefined || matches(r.route));
+const results = applyRuleSeverities([...await runRules(rules, { heads, images, project, config }), ...a11y], config);
+```
+
+The same `routeMatcher(opts.route)` filter applies, consistent with heads/images.
+
+## Error handling
+
+Per-file `compile()` failures are swallowed (skip a11y for that file). No new top-level failure modes; the existing project-detection / parse error paths (exit 2) are unchanged.
+
+## Testing (TDD)
+
+- **cli**: warning→Result mapping (code as id, line from `start.line`, docsUrl derived, message first-line); per-route seed when a route has no a11y warnings; compile cached per file (a shared layout compiled once — assert via a spy/counter or by observing identical findings without recompute); `config.rules[code]==='off'` drops that code's findings; a file that fails `compile()` is skipped without throwing.
+- **cli rules-config**: `findUnknownRuleIds(['a11y_missing_attribute'])` returns `[]` (a11y_* treated as known); a genuinely unknown id still reported.
+- **e2e** (`run.test.ts`): a fixture route whose `<img>` lacks `alt` produces an `a11y_missing_attribute` finding under `categories.a11y` in the json report; the dynamic-title fixture convention keeps SEO counts stable.
+- All existing SEO/Performance tests stay green (a11y is additive; the seed/score path mirrors Performance).
+
+## Roadmap / release
+
+- README roadmap: note Accessibility checks shipping at `0.5` (aggregating Svelte compiler a11y warnings); keep Upgrade and the combined Health Report as upcoming 0.x increments before the 1.0 polish.
+- Changeset: `@svelte-vitals/core` patch (only if `findUnknownRuleIds` or a shared helper moves to core — otherwise core unchanged) and `svelte-vitals` minor (the a11y collector + rules-config change). Confirm at implementation time which packages actually change; if core is untouched, omit it from the changeset.
+
+## Non-goals / follow-ups
+
+- eslint-plugin-svelte aggregation (a second signal source).
+- Per-code severity tiers (some a11y codes as `info`).
+- Plugin-mode (`@svelte-vitals/vite`) a11y on rendered HTML.
+- `explain_rule`/MCP coverage of a11y codes (they are external; the finding's `docsUrl` already links Svelte's docs).
+- The weighted combined Health Report — a later 0.x increment, not 1.0 work.

--- a/docs/superpowers/specs/2026-06-22-a11y-v0.5-design.md
+++ b/docs/superpowers/specs/2026-06-22-a11y-v0.5-design.md
@@ -79,7 +79,7 @@ Per-file `compile()` failures are swallowed (skip a11y for that file). No new to
 ## Testing (TDD)
 
 - **cli**: warning→Result mapping (code as id, line from `start.line`, docsUrl derived, message first-line); per-route seed when a route has no a11y warnings; compile cached per file (a shared layout compiled once — assert via a spy/counter or by observing identical findings without recompute); `config.rules[code]==='off'` drops that code's findings; a file that fails `compile()` is skipped without throwing.
-- **cli rules-config**: `findUnknownRuleIds(['a11y_missing_attribute'])` returns `[]` (a11y_* treated as known); a genuinely unknown id still reported.
+- **cli rules-config**: `findUnknownRuleIds(['a11y_missing_attribute'])` returns `[]` (a11y\_\* treated as known); a genuinely unknown id still reported.
 - **e2e** (`run.test.ts`): a fixture route whose `<img>` lacks `alt` produces an `a11y_missing_attribute` finding under `categories.a11y` in the json report; the dynamic-title fixture convention keeps SEO counts stable.
 - All existing SEO/Performance tests stay green (a11y is additive; the seed/score path mirrors Performance).
 

--- a/docs/superpowers/specs/2026-06-22-a11y-v0.5-design.md
+++ b/docs/superpowers/specs/2026-06-22-a11y-v0.5-design.md
@@ -51,6 +51,7 @@ The seed result uses the literal id `'a11y'`; the per-warning fail results use t
 - **Disable a code**: `--ignore a11y_missing_attribute` sets `config.rules['a11y_missing_attribute'] = 'off'`. The collector skips emitting findings for codes set to `'off'` (it reads `config.rules`). (`selectRules` only governs `Rule[]`; a11y findings come from the collector, so the collector enforces the skip.)
 - **Severity override**: `config.rules[code]` set to `info`/`warning`/`critical` is applied by the existing `applyRuleSeverities` (keyed by `result.id`) — works for a11y results for free.
 - **Known-id validation**: extend `findUnknownRuleIds` (in `packages/cli/src/rules-config.ts`) to treat any `a11y_`-prefixed id as known, so `--rules`/`--ignore a11y_*` does not error. (`knownRuleIds()` for help text still lists the built-in `SEO/PERF` rule ids plus a short note that `a11y_*` codes are accepted.)
+- **Allow-list (`--rules`) scopes a11y too**: a `--rules` allow-list that contains no `a11y_*` code suppresses the whole Accessibility category (so `--rules SEO001` yields only SEO001, not leaked a11y seeds/findings). `buildRulesConfig` signals this with an `a11y_category: 'off'` sentinel in the rules map, which `collectA11y` honors with an early return. An allow-list that includes an `a11y_*` code keeps a11y on. (This supersedes an earlier draft that treated the allow-list as governing only the built-in rules; aligning it keeps `--rules` intuitive and the MCP allow-list test green.)
 
 ## Scoring & reporters
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,6 +19,7 @@ import {
 import { createNodeRuntime } from './runtime/node.js';
 import { collectRoutes } from './providers/source/routes.js';
 import { detectProject, ProjectError, collectProjectFacts } from './providers/source/project.js';
+import { collectA11y } from './providers/source/a11y.js';
 import { readPackageVersion } from './version.js';
 import { resolveReporter, isAutoDetectedAgent, isAutoDetectedGithub, type ReporterName } from './reporter-resolve.js';
 
@@ -92,7 +93,9 @@ export async function analyzeProject(opts: AnalyzeOptions = {}): Promise<Analyze
   const images = collected.images.filter((i) => matches(i.route));
   const project = await collectProjectFacts(rt, cwd);
   const rules = selectRules(allRules, config);
-  const results = applyRuleSeverities(await runRules(rules, { heads, images, project, config }), config);
+  const a11y = (await collectA11y(rt, cwd, config)).filter((r) => r.route === undefined || matches(r.route));
+  const ruleResults = await runRules(rules, { heads, images, project, config });
+  const results = applyRuleSeverities([...ruleResults, ...a11y], config);
   return { results, config, version: readPackageVersion() };
 }
 

--- a/packages/cli/src/providers/source/a11y.ts
+++ b/packages/cli/src/providers/source/a11y.ts
@@ -28,7 +28,7 @@ function fileA11y(source: string, rel: string): A11yWarning[] {
   }
   const out: A11yWarning[] = [];
   for (const w of warnings) {
-    if (typeof w.code === 'string' && w.code.startsWith('a11y')) {
+    if (typeof w.code === 'string' && w.code.startsWith('a11y_')) {
       out.push({
         code: w.code,
         message: firstLine(w.message ?? w.code),

--- a/packages/cli/src/providers/source/a11y.ts
+++ b/packages/cli/src/providers/source/a11y.ts
@@ -1,0 +1,97 @@
+import { compile } from 'svelte/compiler';
+import type { Config, Result, Runtime } from '@svelte-vitals/core';
+import { defaultConfig } from '@svelte-vitals/core';
+import { enumerateRoutePages } from './project.js';
+import { chainFiles, deriveRoute } from './routes.js';
+
+interface A11yWarning {
+  code: string;
+  /** First line of the Svelte message (the trailing docs-URL line is stripped). */
+  message: string;
+  /** 1-based source line, or 0 if unknown. */
+  line: number;
+}
+
+function firstLine(message: string): string {
+  return message.split('\n')[0] ?? message;
+}
+
+/** Compile one file and return its mapped a11y warnings. Resilient: returns [] if compile throws. */
+function fileA11y(source: string, rel: string): A11yWarning[] {
+  let warnings: ReadonlyArray<{ code?: string; message?: string; start?: { line?: number } }> = [];
+  try {
+    ({ warnings = [] } = compile(source, { generate: false, filename: rel }) as {
+      warnings?: ReadonlyArray<{ code?: string; message?: string; start?: { line?: number } }>;
+    });
+  } catch {
+    return [];
+  }
+  const out: A11yWarning[] = [];
+  for (const w of warnings) {
+    if (typeof w.code === 'string' && w.code.startsWith('a11y')) {
+      out.push({
+        code: w.code,
+        message: firstLine(w.message ?? w.code),
+        line: typeof w.start?.line === 'number' ? w.start.line : 0
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Aggregate the Svelte compiler's a11y warnings into per-route findings (issue #10,
+ * Accessibility v0.5). Each route's +page.svelte and +layout.svelte chain is compiled
+ * (cached per file); each a11y warning becomes a fail Result keyed by its Svelte code,
+ * and a warning-free route emits one passing seed so the a11y score anchors at 100.
+ */
+export async function collectA11y(rt: Runtime, cwd: string, config: Config = defaultConfig): Promise<Result[]> {
+  const pages = await enumerateRoutePages(rt, cwd);
+  const cache = new Map<string, A11yWarning[]>();
+  const results: Result[] = [];
+
+  for (const page of pages) {
+    const files = await chainFiles(rt, cwd, page);
+    const route = deriveRoute(page);
+    const fails: Result[] = [];
+
+    for (const { rel } of files) {
+      let warns = cache.get(rel);
+      if (!warns) {
+        const source = await rt.readFile(rt.join(cwd, rel));
+        warns = fileA11y(source, rel);
+        cache.set(rel, warns);
+      }
+      for (const w of warns) {
+        if (config.rules[w.code] === 'off') continue;
+        fails.push({
+          id: w.code,
+          category: 'a11y',
+          severity: 'warning',
+          detection: { presence: 'none', value: 'absent' },
+          route,
+          location: rel,
+          ...(w.line > 0 ? { line: w.line } : {}),
+          message: w.message,
+          docsUrl: `https://svelte.dev/e/${w.code}`
+        });
+      }
+    }
+
+    if (fails.length === 0) {
+      // One passing seed per warning-free route anchors the a11y category score at 100.
+      results.push({
+        id: 'a11y',
+        category: 'a11y',
+        severity: 'warning',
+        detection: { presence: 'own', value: 'static' },
+        route,
+        message: 'Accessibility'
+      });
+    } else {
+      results.push(...fails);
+    }
+  }
+
+  return results;
+}

--- a/packages/cli/src/providers/source/a11y.ts
+++ b/packages/cli/src/providers/source/a11y.ts
@@ -3,6 +3,7 @@ import type { Config, Result, Runtime } from '@svelte-vitals/core';
 import { defaultConfig } from '@svelte-vitals/core';
 import { enumerateRoutePages } from './project.js';
 import { chainFiles, deriveRoute } from './routes.js';
+import { A11Y_CATEGORY_KEY, A11Y_CODE_PREFIX } from '../../rules-config.js';
 
 interface A11yWarning {
   code: string;
@@ -12,31 +13,39 @@ interface A11yWarning {
   line: number;
 }
 
+/**
+ * The a11y outcome of compiling one file. `ok: false` means the compiler threw
+ * (unparseable source) — distinct from `ok: true` with no warnings (compiled clean).
+ * The distinction matters: an unparseable route must NOT be seeded as passing.
+ */
+interface FileA11y {
+  ok: boolean;
+  warnings: A11yWarning[];
+}
+
 function firstLine(message: string): string {
   return message.split('\n')[0] ?? message;
 }
 
-/** Compile one file and return its mapped a11y warnings. Resilient: returns [] if compile throws. */
-function fileA11y(source: string, rel: string): A11yWarning[] {
-  let warnings: ReadonlyArray<{ code?: string; message?: string; start?: { line?: number } }>;
+/** Compile one file and return its mapped a11y warnings. Resilient: `ok: false` if compile throws. */
+function fileA11y(source: string, rel: string): FileA11y {
+  let warnings: ReturnType<typeof compile>['warnings'];
   try {
-    ({ warnings = [] } = compile(source, { generate: false, filename: rel }) as {
-      warnings?: ReadonlyArray<{ code?: string; message?: string; start?: { line?: number } }>;
-    });
+    ({ warnings } = compile(source, { generate: false, filename: rel }));
   } catch {
-    return [];
+    return { ok: false, warnings: [] };
   }
   const out: A11yWarning[] = [];
   for (const w of warnings) {
-    if (typeof w.code === 'string' && w.code.startsWith('a11y_')) {
+    if (w.code.startsWith(A11Y_CODE_PREFIX)) {
       out.push({
         code: w.code,
-        message: firstLine(w.message ?? w.code),
-        line: typeof w.start?.line === 'number' ? w.start.line : 0
+        message: firstLine(w.message),
+        line: w.start?.line ?? 0
       });
     }
   }
-  return out;
+  return { ok: true, warnings: out };
 }
 
 /**
@@ -44,27 +53,33 @@ function fileA11y(source: string, rel: string): A11yWarning[] {
  * Accessibility v0.5). Each route's +page.svelte and +layout.svelte chain is compiled
  * (cached per file); each a11y warning becomes a fail Result keyed by its Svelte code,
  * and a warning-free route emits one passing seed so the a11y score anchors at 100.
+ *
+ * A route whose chain has an unparseable file and no other findings is left
+ * *unchecked*: it emits nothing and is excluded from the category average, rather
+ * than being falsely seeded as passing.
  */
 export async function collectA11y(rt: Runtime, cwd: string, config: Config = defaultConfig): Promise<Result[]> {
   // Sentinel set by buildRulesConfig when the allow-list contains no a11y codes.
-  if (config.rules['a11y_category'] === 'off') return [];
+  if (config.rules[A11Y_CATEGORY_KEY] === 'off') return [];
   const pages = await enumerateRoutePages(rt, cwd);
-  const cache = new Map<string, A11yWarning[]>();
+  const cache = new Map<string, FileA11y>();
   const results: Result[] = [];
 
   for (const page of pages) {
     const files = await chainFiles(rt, cwd, page);
     const route = deriveRoute(page);
     const fails: Result[] = [];
+    let compiledAll = true;
 
     for (const { rel } of files) {
-      let warns = cache.get(rel);
-      if (!warns) {
+      let entry = cache.get(rel);
+      if (!entry) {
         const source = await rt.readFile(rt.join(cwd, rel));
-        warns = fileA11y(source, rel);
-        cache.set(rel, warns);
+        entry = fileA11y(source, rel);
+        cache.set(rel, entry);
       }
-      for (const w of warns) {
+      if (!entry.ok) compiledAll = false;
+      for (const w of entry.warnings) {
         if (config.rules[w.code] === 'off') continue;
         fails.push({
           id: w.code,
@@ -80,7 +95,9 @@ export async function collectA11y(rt: Runtime, cwd: string, config: Config = def
       }
     }
 
-    if (fails.length === 0) {
+    if (fails.length > 0) {
+      results.push(...fails);
+    } else if (compiledAll) {
       // One passing seed per warning-free route anchors the a11y category score at 100.
       results.push({
         id: 'a11y',
@@ -90,9 +107,9 @@ export async function collectA11y(rt: Runtime, cwd: string, config: Config = def
         route,
         message: 'Accessibility'
       });
-    } else {
-      results.push(...fails);
     }
+    // else: a file in the chain failed to compile and nothing was found — leave the
+    // route unchecked (no seed) so an unparseable route can't report a false 100.
   }
 
   return results;

--- a/packages/cli/src/providers/source/a11y.ts
+++ b/packages/cli/src/providers/source/a11y.ts
@@ -18,7 +18,7 @@ function firstLine(message: string): string {
 
 /** Compile one file and return its mapped a11y warnings. Resilient: returns [] if compile throws. */
 function fileA11y(source: string, rel: string): A11yWarning[] {
-  let warnings: ReadonlyArray<{ code?: string; message?: string; start?: { line?: number } }> = [];
+  let warnings: ReadonlyArray<{ code?: string; message?: string; start?: { line?: number } }>;
   try {
     ({ warnings = [] } = compile(source, { generate: false, filename: rel }) as {
       warnings?: ReadonlyArray<{ code?: string; message?: string; start?: { line?: number } }>;
@@ -46,6 +46,8 @@ function fileA11y(source: string, rel: string): A11yWarning[] {
  * and a warning-free route emits one passing seed so the a11y score anchors at 100.
  */
 export async function collectA11y(rt: Runtime, cwd: string, config: Config = defaultConfig): Promise<Result[]> {
+  // Sentinel set by buildRulesConfig when the allow-list contains no a11y codes.
+  if (config.rules['a11y_category'] === 'off') return [];
   const pages = await enumerateRoutePages(rt, cwd);
   const cache = new Map<string, A11yWarning[]>();
   const results: Result[] = [];

--- a/packages/cli/src/providers/source/routes.ts
+++ b/packages/cli/src/providers/source/routes.ts
@@ -31,7 +31,11 @@ export function deriveRoute(pageRel: string): string {
  * Build the layout chain (root → leaf) for a route, then append the page itself.
  * All layout levels are resolved (design §5); +layout@/+page@ breakouts are not.
  */
-export async function chainFiles(rt: Runtime, cwd: string, pageRel: string): Promise<Array<{ rel: string; isPage: boolean }>> {
+export async function chainFiles(
+  rt: Runtime,
+  cwd: string,
+  pageRel: string
+): Promise<Array<{ rel: string; isPage: boolean }>> {
   const dir = pageRel.slice(0, -'/+page.svelte'.length); // 'src/routes/blog/[slug]'
   const extra = dir.slice(ROUTES_DIR.length); // '' or '/blog/[slug]'
   const segments = extra.length === 0 ? [] : extra.split('/').filter(Boolean);

--- a/packages/cli/src/providers/source/routes.ts
+++ b/packages/cli/src/providers/source/routes.ts
@@ -31,7 +31,7 @@ export function deriveRoute(pageRel: string): string {
  * Build the layout chain (root → leaf) for a route, then append the page itself.
  * All layout levels are resolved (design §5); +layout@/+page@ breakouts are not.
  */
-async function chainFiles(rt: Runtime, cwd: string, pageRel: string): Promise<Array<{ rel: string; isPage: boolean }>> {
+export async function chainFiles(rt: Runtime, cwd: string, pageRel: string): Promise<Array<{ rel: string; isPage: boolean }>> {
   const dir = pageRel.slice(0, -'/+page.svelte'.length); // 'src/routes/blog/[slug]'
   const extra = dir.slice(ROUTES_DIR.length); // '' or '/blog/[slug]'
   const segments = extra.length === 0 ? [] : extra.split('/').filter(Boolean);

--- a/packages/cli/src/rules-config.ts
+++ b/packages/cli/src/rules-config.ts
@@ -2,11 +2,27 @@ import { allRules, type RuleSetting } from '@svelte-vitals/core';
 
 const KNOWN_IDS = new Set(allRules.map((r) => r.id));
 
+/** Prefix of every Svelte compiler a11y warning code (Accessibility category, #10). */
+export const A11Y_CODE_PREFIX = 'a11y_';
+
+/**
+ * Internal sentinel key written into the rules map to suppress the whole
+ * Accessibility category (see buildRulesConfig). It shares the rules-map
+ * namespace but is not a user-settable rule id — findUnknownRuleIds rejects it.
+ *
+ * NOTE (#10): this is a deliberate stopgap. The v0.6 follow-up replaces it with a
+ * typed per-category config so category toggles no longer ride the rules map.
+ */
+export const A11Y_CATEGORY_KEY = 'a11y_category';
+
 /** Rule ids passed to --rules/--ignore that aren't part of the built-in registry. */
 export function findUnknownRuleIds(ids: string[]): string[] {
   // a11y_* ids are Svelte compiler warning codes (Accessibility category, #10);
   // they are accepted dynamically rather than enumerated in the built-in registry.
-  return [...new Set(ids.filter((id) => !KNOWN_IDS.has(id) && !(id.startsWith('a11y_') && id !== 'a11y_category')))];
+  // The internal a11y_category sentinel is NOT user-settable, so it stays "unknown".
+  return [
+    ...new Set(ids.filter((id) => !KNOWN_IDS.has(id) && !(id.startsWith(A11Y_CODE_PREFIX) && id !== A11Y_CATEGORY_KEY)))
+  ];
 }
 
 /** All built-in rule ids, sorted — for help and error messages. */
@@ -20,16 +36,16 @@ export function knownRuleIds(): string[] {
  * Callers should reject unknown ids first (see findUnknownRuleIds) so a typo in
  * --rules can't silently disable every rule.
  *
- * When the allow-list is non-empty and contains no `a11y_*` entries, a sentinel
- * key `'a11y_category'` is set to `'off'`; `collectA11y` checks this key to
- * suppress the entire Accessibility category.
+ * When the allow-list is non-empty and contains no `a11y_*` entries, the
+ * `A11Y_CATEGORY_KEY` sentinel is set to `'off'`; `collectA11y` checks this key
+ * to suppress the entire Accessibility category.
  */
 export function buildRulesConfig(allow: string[], ignore: string[]): Record<string, RuleSetting> {
   const rules: Record<string, RuleSetting> = {};
   if (allow.length > 0) {
     for (const r of allRules) if (!allow.includes(r.id)) rules[r.id] = 'off';
     // If the allow-list contains no a11y codes, suppress the Accessibility category.
-    if (!allow.some((id) => id.startsWith('a11y_'))) rules['a11y_category'] = 'off';
+    if (!allow.some((id) => id.startsWith(A11Y_CODE_PREFIX))) rules[A11Y_CATEGORY_KEY] = 'off';
   }
   for (const id of ignore) rules[id] = 'off';
   return rules;

--- a/packages/cli/src/rules-config.ts
+++ b/packages/cli/src/rules-config.ts
@@ -6,7 +6,7 @@ const KNOWN_IDS = new Set(allRules.map((r) => r.id));
 export function findUnknownRuleIds(ids: string[]): string[] {
   // a11y_* ids are Svelte compiler warning codes (Accessibility category, #10);
   // they are accepted dynamically rather than enumerated in the built-in registry.
-  return [...new Set(ids.filter((id) => !KNOWN_IDS.has(id) && !id.startsWith('a11y')))];
+  return [...new Set(ids.filter((id) => !KNOWN_IDS.has(id) && !(id.startsWith('a11y_') && id !== 'a11y_category')))];
 }
 
 /** All built-in rule ids, sorted — for help and error messages. */

--- a/packages/cli/src/rules-config.ts
+++ b/packages/cli/src/rules-config.ts
@@ -19,11 +19,17 @@ export function knownRuleIds(): string[] {
  * (--ignore). An allow-list disables every rule not listed; deny always wins.
  * Callers should reject unknown ids first (see findUnknownRuleIds) so a typo in
  * --rules can't silently disable every rule.
+ *
+ * When the allow-list is non-empty and contains no `a11y_*` entries, a sentinel
+ * key `'a11y_category'` is set to `'off'`; `collectA11y` checks this key to
+ * suppress the entire Accessibility category.
  */
 export function buildRulesConfig(allow: string[], ignore: string[]): Record<string, RuleSetting> {
   const rules: Record<string, RuleSetting> = {};
   if (allow.length > 0) {
     for (const r of allRules) if (!allow.includes(r.id)) rules[r.id] = 'off';
+    // If the allow-list contains no a11y codes, suppress the Accessibility category.
+    if (!allow.some((id) => id.startsWith('a11y_'))) rules['a11y_category'] = 'off';
   }
   for (const id of ignore) rules[id] = 'off';
   return rules;

--- a/packages/cli/src/rules-config.ts
+++ b/packages/cli/src/rules-config.ts
@@ -4,7 +4,9 @@ const KNOWN_IDS = new Set(allRules.map((r) => r.id));
 
 /** Rule ids passed to --rules/--ignore that aren't part of the built-in registry. */
 export function findUnknownRuleIds(ids: string[]): string[] {
-  return [...new Set(ids.filter((id) => !KNOWN_IDS.has(id)))];
+  // a11y_* ids are Svelte compiler warning codes (Accessibility category, #10);
+  // they are accepted dynamically rather than enumerated in the built-in registry.
+  return [...new Set(ids.filter((id) => !KNOWN_IDS.has(id) && !id.startsWith('a11y')))];
 }
 
 /** All built-in rule ids, sorted — for help and error messages. */

--- a/packages/cli/test/a11y.test.ts
+++ b/packages/cli/test/a11y.test.ts
@@ -54,13 +54,26 @@ describe('collectA11y', () => {
     expect(results).toEqual([expect.objectContaining({ id: 'a11y', route: '/' })]);
   });
 
-  it('does not throw when a file fails to compile (skips a11y for it)', async () => {
+  it('leaves an unparseable route unchecked (no false passing seed)', async () => {
     const rt = createMemoryRuntime({ 'src/routes/+page.svelte': `<div {#bad}></div>` });
     const results = await collectA11y(rt, '', config);
-    // no throw; the unparseable route simply yields a seed (no a11y findings)
-    expect(results).toHaveLength(1);
-    expect(results[0]!.id).toBe('a11y');
-    expect(results.every((r) => r.category === 'a11y')).toBe(true);
+    // no throw, and the unchecked route is excluded from the category rather than
+    // seeded as passing — an uncompilable route must not report a false 100.
+    expect(results).toEqual([]);
+  });
+
+  it('still surfaces findings from compiled files when a sibling file fails to compile', async () => {
+    const rt = createMemoryRuntime({
+      // layout has a real a11y issue; the page is unparseable
+      'src/routes/+layout.svelte': `<img src="/logo.png" />\n<slot />`,
+      'src/routes/broken/+page.svelte': `<div {#bad}></div>`
+    });
+    const results = await collectA11y(rt, '', config);
+    const finding = results.find((r) => r.id === 'a11y_missing_attribute');
+    expect(finding).toBeDefined();
+    expect(finding!.location).toBe('src/routes/+layout.svelte');
+    // the broken route is reported via its layout finding, not seeded as passing
+    expect(results.some((r) => r.id === 'a11y')).toBe(false);
   });
 
   it('returns [] when a11y_category sentinel is off (allow-list with no a11y code)', async () => {

--- a/packages/cli/test/a11y.test.ts
+++ b/packages/cli/test/a11y.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { collectA11y } from '../src/providers/source/a11y.js';
+import { createMemoryRuntime } from './helpers/memory-runtime.js';
+import { defineConfig } from '@svelte-vitals/core';
+
+const config = defineConfig({});
+
+describe('collectA11y', () => {
+  it('maps a Svelte a11y warning to an a11y finding (code as id, line, docsUrl)', async () => {
+    const rt = createMemoryRuntime({
+      'src/routes/+page.svelte': `<h1>Home</h1>\n<img src="/a.png" />`
+    });
+    const results = await collectA11y(rt, '', config);
+    const finding = results.find((r) => r.id === 'a11y_missing_attribute');
+    expect(finding).toBeDefined();
+    expect(finding!.category).toBe('a11y');
+    expect(finding!.severity).toBe('warning');
+    expect(finding!.route).toBe('/');
+    expect(finding!.location).toBe('src/routes/+page.svelte');
+    expect(finding!.line).toBe(2);
+    expect(finding!.detection).toEqual({ presence: 'none', value: 'absent' });
+    expect(finding!.docsUrl).toBe('https://svelte.dev/e/a11y_missing_attribute');
+    // message is the first line only (no trailing docs URL line)
+    expect(finding!.message).not.toContain('https://');
+  });
+
+  it('emits one passing seed for a route with no a11y warnings', async () => {
+    const rt = createMemoryRuntime({ 'src/routes/+page.svelte': `<h1>Home</h1>` });
+    const results = await collectA11y(rt, '', config);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.id).toBe('a11y');
+    expect(results[0]!.category).toBe('a11y');
+    expect(results[0]!.detection).toEqual({ presence: 'own', value: 'static' });
+    expect(results[0]!.route).toBe('/');
+  });
+
+  it('surfaces a layout a11y warning on the child route', async () => {
+    const rt = createMemoryRuntime({
+      'src/routes/+layout.svelte': `<img src="/logo.png" />\n<slot />`,
+      'src/routes/about/+page.svelte': `<h1>About</h1>`
+    });
+    const results = await collectA11y(rt, '', config);
+    const about = results.filter((r) => r.route === '/about' && r.id === 'a11y_missing_attribute');
+    expect(about).toHaveLength(1);
+    expect(about[0]!.location).toBe('src/routes/+layout.svelte');
+  });
+
+  it('skips a code disabled via config.rules', async () => {
+    const rt = createMemoryRuntime({ 'src/routes/+page.svelte': `<img src="/a.png" />` });
+    const off = defineConfig({ rules: { a11y_missing_attribute: 'off' } });
+    const results = await collectA11y(rt, '', off);
+    expect(results.some((r) => r.id === 'a11y_missing_attribute')).toBe(false);
+    // with its only warning ignored, the route seeds as passing
+    expect(results).toEqual([expect.objectContaining({ id: 'a11y', route: '/' })]);
+  });
+
+  it('does not throw when a file fails to compile (skips a11y for it)', async () => {
+    const rt = createMemoryRuntime({ 'src/routes/+page.svelte': `<div {#bad}></div>` });
+    const results = await collectA11y(rt, '', config);
+    // no throw; the unparseable route simply yields a seed (no a11y findings)
+    expect(results.every((r) => r.category === 'a11y')).toBe(true);
+  });
+});

--- a/packages/cli/test/a11y.test.ts
+++ b/packages/cli/test/a11y.test.ts
@@ -60,4 +60,12 @@ describe('collectA11y', () => {
     // no throw; the unparseable route simply yields a seed (no a11y findings)
     expect(results.every((r) => r.category === 'a11y')).toBe(true);
   });
+
+  it('returns [] when a11y_category sentinel is off (allow-list with no a11y code)', async () => {
+    // A route with a missing alt attribute would normally yield a11y_missing_attribute.
+    const rt = createMemoryRuntime({ 'src/routes/+page.svelte': `<img src="/a.png" />` });
+    const suppressed = defineConfig({ rules: { a11y_category: 'off' } });
+    const results = await collectA11y(rt, '', suppressed);
+    expect(results).toEqual([]);
+  });
 });

--- a/packages/cli/test/a11y.test.ts
+++ b/packages/cli/test/a11y.test.ts
@@ -58,6 +58,8 @@ describe('collectA11y', () => {
     const rt = createMemoryRuntime({ 'src/routes/+page.svelte': `<div {#bad}></div>` });
     const results = await collectA11y(rt, '', config);
     // no throw; the unparseable route simply yields a seed (no a11y findings)
+    expect(results).toHaveLength(1);
+    expect(results[0]!.id).toBe('a11y');
     expect(results.every((r) => r.category === 'a11y')).toBe(true);
   });
 

--- a/packages/cli/test/fixtures/basic-project/src/routes/img/+page.svelte
+++ b/packages/cli/test/fixtures/basic-project/src/routes/img/+page.svelte
@@ -3,4 +3,4 @@
 </script>
 
 <svelte:head><title>{data.title}</title></svelte:head>
-<img src="/hero.png" alt="hero" />
+<img src="/hero.png" />

--- a/packages/cli/test/rules-config.test.ts
+++ b/packages/cli/test/rules-config.test.ts
@@ -44,3 +44,11 @@ describe('knownRuleIds', () => {
     expect(ids).toEqual([...ids].sort());
   });
 });
+
+describe('findUnknownRuleIds a11y', () => {
+  it('treats a11y_* codes as known rule ids', () => {
+    expect(findUnknownRuleIds(['a11y_missing_attribute'])).toEqual([]);
+    // a genuinely unknown id is still reported
+    expect(findUnknownRuleIds(['NOPE999'])).toEqual(['NOPE999']);
+  });
+});

--- a/packages/cli/test/rules-config.test.ts
+++ b/packages/cli/test/rules-config.test.ts
@@ -52,3 +52,23 @@ describe('findUnknownRuleIds a11y', () => {
     expect(findUnknownRuleIds(['NOPE999'])).toEqual(['NOPE999']);
   });
 });
+
+describe('buildRulesConfig a11y_category sentinel', () => {
+  it('sets a11y_category to off when allow-list has no a11y code', () => {
+    const cfg = buildRulesConfig(['SEO001'], []);
+    expect(cfg['a11y_category']).toBe('off');
+  });
+
+  it('does NOT set a11y_category when allow-list includes an a11y code', () => {
+    const cfg = buildRulesConfig(['SEO001', 'a11y_missing_attribute'], []);
+    expect(cfg['a11y_category']).toBeUndefined();
+  });
+
+  it('does NOT set a11y_category when allow-list is empty (no --rules flag)', () => {
+    expect(buildRulesConfig([], [])['a11y_category']).toBeUndefined();
+  });
+
+  it('does NOT set a11y_category when only ignore-list is given', () => {
+    expect(buildRulesConfig([], ['a11y_missing_attribute'])['a11y_category']).toBeUndefined();
+  });
+});

--- a/packages/cli/test/run.test.ts
+++ b/packages/cli/test/run.test.ts
@@ -127,6 +127,17 @@ describe('run() performance rules', () => {
   });
 });
 
+describe('run() accessibility rules', () => {
+  it('reports an Accessibility finding for an <img> without alt', async () => {
+    const cap = capture();
+    await run({ cwd: fixtureDir, reporter: 'json', log: cap.log, errorLog: cap.errorLog, env: CLEAN_ENV });
+    const json = JSON.parse(cap.out.join('\n'));
+    expect(json.categories.a11y).toBeDefined();
+    const img = json.routes.find((r: { route: string }) => r.route === '/img');
+    expect(img.issues.some((i: { id: string }) => i.id === 'a11y_missing_attribute')).toBe(true);
+  });
+});
+
 describe('run() agent reporter', () => {
   it('emits the agent Markdown report when reporter is agent', async () => {
     const cap = capture();

--- a/packages/cli/test/run.test.ts
+++ b/packages/cli/test/run.test.ts
@@ -134,6 +134,7 @@ describe('run() accessibility rules', () => {
     const json = JSON.parse(cap.out.join('\n'));
     expect(json.categories.a11y).toBeDefined();
     const img = json.routes.find((r: { route: string }) => r.route === '/img');
+    expect(img).toBeDefined();
     expect(img.issues.some((i: { id: string }) => i.id === 'a11y_missing_attribute')).toBe(true);
   });
 });


### PR DESCRIPTION
Second Vitals category from #10, built on the multi-category foundation shipped in Performance v0.4. **Aggregates the Svelte compiler's `a11y_*` warnings** into a scored Accessibility category rather than reinventing a11y checks.

## What's new

- A CLI collector compiles each route's `+page.svelte` + `+layout.svelte` chain (`compile(src, { generate: false })`) and maps `a11y_*` warnings (e.g. `a11y_missing_attribute`, `a11y_label_has_associated_control`) to `category: 'a11y'` findings — `id` = the Svelte code, `severity: 'warning'`, with `location`, `line`, and a `https://svelte.dev/e/<code>` docs link.
- Per-file compile results are **cached** (a shared layout compiles once); a file that fails to compile is **skipped** rather than failing the run.
- A passing **seed** per warning-free route anchors the Accessibility score at 100 (mirrors Performance).

## Reused, not rebuilt

Scoring and reporters are unchanged — the Performance v0.4 multi-category foundation (`Result.category`, `scoresByCategory`, category-aware reporters) surfaces the Accessibility score/section automatically. **`@svelte-vitals/core` is untouched**; all changes are in the CLI.

## Config

- `--ignore <a11y_code>` disables a specific code.
- Severity overrides via config apply through the existing `applyRuleSeverities`.
- `findUnknownRuleIds` accepts `a11y_*` ids.
- A `--rules` allow-list with no `a11y_*` code **suppresses the whole Accessibility category** (so `--rules SEO001` yields only SEO001, no leaked a11y) — via an `a11y_category` sentinel honored by the collector.

## Validation

- `pnpm -r test` — **247 passed** (incl. collector mapping/seed/cache/resilience, the allow-list sentinel, and an e2e `a11y_missing_attribute` on `/img`).
- `pnpm -r typecheck`, `pnpm build`, `pnpm lint`, publint + attw (esm-only) — green.

## Notes for reviewers

- Built subagent-driven: 3 tasks (each spec+quality reviewed) + a whole-branch review (verdict: ready to merge; the reviewer ran the real compiler to confirm the scoring path and sentinel non-collision).
- One deliberate deviation, approved during review: the spec originally treated the `--rules` allow-list as governing only built-in rules, but that leaked a11y seeds and broke an MCP allow-list test; the allow-list now scopes a11y too (sentinel mechanism). The spec was updated to match.
- Known v0.6 follow-up: replace the rules-map sentinel with a typed per-category config before adding more compiler-based categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Accessibility checks (v0.5): Reports Svelte compiler accessibility warnings found in routes
  * Support for `--ignore <a11y_code>` to suppress specific accessibility findings
  * Per-file caching and graceful handling of compilation failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->