### PR TITLE
feat(vite): live UI dashboard (svelteVitals({ ui: true }))

### DIFF
--- a/.changeset/vite-live-ui.md
+++ b/.changeset/vite-live-ui.md
@@ -1,0 +1,9 @@
+---
+'@svelte-vitals/vite': minor
+---
+
+Add a live UI dashboard: `svelteVitals({ ui: true })` serves a svelte-vitals report at
+`/__svelte-vitals/` during `vite dev`, fed by `svelteVitalsHandle`, that updates live as you
+navigate. It reuses the same renderer as the CLI's `--reporter html`. Dev-only and
+rendered-based (SEO `<head>` rules for visited routes); the dev overlay's behavior is
+unchanged when the UI is not enabled.

--- a/docs/src/content/docs/guides/dev-overlay.md
+++ b/docs/src/content/docs/guides/dev-overlay.md
@@ -60,3 +60,20 @@ export const handle = sequence(
 - Only the rendered HTML `<head>` is analyzed — the same data the browser receives. Source-level dynamic values (e.g. `{data.title}`) are always resolved by the time the handle sees them, so `treatDynamicAs` is not applicable here.
 - `failOn` is not used: the handle reports findings but never gates the request.
 - Set `SVELTE_VITALS_DEBUG=true` to surface any internal analysis errors to the terminal.
+
+## Live UI dashboard
+
+Enable a live dashboard at `/__svelte-vitals/` during `vite dev` — the same report the CLI's `--reporter html` produces, updating in place as you navigate your app.
+
+```js
+// vite.config.{js,ts}
+import { svelteVitals } from '@svelte-vitals/vite';
+
+export default {
+  plugins: [svelteVitals({ ui: true }) /* , sveltekit() */]
+};
+```
+
+It is fed by the dev handle (the same one the overlay above uses), so keep `svelteVitalsHandle()` in `src/hooks.server.ts`. Open `http://localhost:5173/__svelte-vitals/` and browse your app: each visited route's rendered `<head>` is analyzed and the dashboard updates live.
+
+Like the overlay, this is dev-only and rendered-based: it covers the SEO `<head>` rules for the routes you visit. For a whole-project report (all routes, Performance, site checks), run `npx svelte-vitals` or `--reporter html`.

--- a/docs/src/content/docs/guides/dev-overlay.md
+++ b/docs/src/content/docs/guides/dev-overlay.md
@@ -76,4 +76,4 @@ export default {
 
 It is fed by the dev handle (the same one the overlay above uses), so keep `svelteVitalsHandle()` in `src/hooks.server.ts`. Open `http://localhost:5173/__svelte-vitals/` and browse your app: each visited route's rendered `<head>` is analyzed and the dashboard updates live.
 
-Like the overlay, this is dev-only and rendered-based: it covers the SEO `<head>` rules for the routes you visit. For a whole-project report (all routes, Performance, site checks), run `npx svelte-vitals` or `--reporter html`.
+Like the overlay, this is dev-only and rendered-based: it covers the SEO `<head>` rules for the routes you visit. For a whole-project report (all routes, Performance, site checks), run `npx svelte-vitals` or `npx svelte-vitals --reporter html`.

--- a/docs/src/content/docs/guides/dev-overlay.md
+++ b/docs/src/content/docs/guides/dev-overlay.md
@@ -76,4 +76,6 @@ export default {
 
 It is fed by the dev handle (the same one the overlay above uses), so keep `svelteVitalsHandle()` in `src/hooks.server.ts`. Open `http://localhost:5173/__svelte-vitals/` and browse your app: each visited route's rendered `<head>` is analyzed and the dashboard updates live.
 
+Live updates only flow over a loopback origin (`localhost`, `127.0.0.1`, `[::1]`). When you run `vite dev --host` and open the app via a LAN IP, the handle skips the ingest POST (a guard against a spoofed `Host` header), so the dashboard stays empty — open it from `localhost` instead. Set `SVELTE_VITALS_DEBUG=true` to log when an ingest is skipped.
+
 Like the overlay, this is dev-only and rendered-based: it covers the SEO `<head>` rules for the routes you visit. For a whole-project report (all routes, Performance, site checks), run `npx svelte-vitals` or `npx svelte-vitals --reporter html`.

--- a/docs/src/content/docs/ja/guides/dev-overlay.md
+++ b/docs/src/content/docs/ja/guides/dev-overlay.md
@@ -60,3 +60,20 @@ export const handle = sequence(
 - 分析されるのはレンダリングされた HTML の `<head>` のみです — ブラウザが受け取るデータと同じです。ソースレベルの動的な値（例：`{data.title}`）はハンドルが見る時点で常に解決されているため、`treatDynamicAs` はここでは適用されません。
 - `failOn` は使用されません：このハンドルは検出結果を報告するだけで、リクエストをゲートしません。
 - 内部分析エラーをターミナルに表示するには `SVELTE_VITALS_DEBUG=true` を設定してください。
+
+## ライブ UI ダッシュボード
+
+`vite dev` 中に `/__svelte-vitals/` でライブダッシュボードを表示します。CLI の `--reporter html` と同じレポートが、アプリを操作するたびにその場で更新されます。
+
+```js
+// vite.config.{js,ts}
+import { svelteVitals } from '@svelte-vitals/vite';
+
+export default {
+  plugins: [svelteVitals({ ui: true }) /* , sveltekit() */]
+};
+```
+
+これは dev handle（上記オーバーレイと同じもの）から供給されるため、`src/hooks.server.ts` の `svelteVitalsHandle()` はそのまま残してください。`http://localhost:5173/__svelte-vitals/` を開いてアプリを操作すると、訪問した各ルートのレンダリング済み `<head>` が解析され、ダッシュボードがライブ更新されます。
+
+オーバーレイと同様、これは dev 専用かつレンダリングベースで、訪問したルートの SEO `<head>` ルールを対象とします。プロジェクト全体のレポート（全ルート・パフォーマンス・サイト全体のチェック）が必要な場合は `npx svelte-vitals` または `--reporter html` を実行してください。

--- a/docs/src/content/docs/ja/guides/dev-overlay.md
+++ b/docs/src/content/docs/ja/guides/dev-overlay.md
@@ -76,4 +76,4 @@ export default {
 
 これは dev handle（上記オーバーレイと同じもの）から供給されるため、`src/hooks.server.ts` の `svelteVitalsHandle()` はそのまま残してください。`http://localhost:5173/__svelte-vitals/` を開いてアプリを操作すると、訪問した各ルートのレンダリング済み `<head>` が解析され、ダッシュボードがライブ更新されます。
 
-オーバーレイと同様、これは dev 専用かつレンダリングベースで、訪問したルートの SEO `<head>` ルールを対象とします。プロジェクト全体のレポート（全ルート・パフォーマンス・サイト全体のチェック）が必要な場合は `npx svelte-vitals` または `--reporter html` を実行してください。
+オーバーレイと同様、これは dev 専用かつレンダリングベースで、訪問したルートの SEO `<head>` ルールを対象とします。プロジェクト全体のレポート（全ルート・パフォーマンス・サイト全体のチェック）が必要な場合は `npx svelte-vitals` または `npx svelte-vitals --reporter html` を実行してください。

--- a/docs/src/content/docs/ja/guides/dev-overlay.md
+++ b/docs/src/content/docs/ja/guides/dev-overlay.md
@@ -76,4 +76,6 @@ export default {
 
 これは dev handle（上記オーバーレイと同じもの）から供給されるため、`src/hooks.server.ts` の `svelteVitalsHandle()` はそのまま残してください。`http://localhost:5173/__svelte-vitals/` を開いてアプリを操作すると、訪問した各ルートのレンダリング済み `<head>` が解析され、ダッシュボードがライブ更新されます。
 
+ライブ更新はループバックオリジン（`localhost`・`127.0.0.1`・`[::1]`）でのみ流れます。`vite dev --host` で LAN の IP からアプリを開いた場合、ハンドルは ingest の POST をスキップする（`Host` ヘッダー偽装への防御）ため、ダッシュボードは空のままになります。その場合は `localhost` から開いてください。`SVELTE_VITALS_DEBUG=true` を設定すると、ingest がスキップされた際にログが出力されます。
+
 オーバーレイと同様、これは dev 専用かつレンダリングベースで、訪問したルートの SEO `<head>` ルールを対象とします。プロジェクト全体のレポート（全ルート・パフォーマンス・サイト全体のチェック）が必要な場合は `npx svelte-vitals` または `npx svelte-vitals --reporter html` を実行してください。

--- a/docs/superpowers/plans/2026-06-23-vite-live-ui.md
+++ b/docs/superpowers/plans/2026-06-23-vite-live-ui.md
@@ -1,0 +1,787 @@
+# Vite Live UI Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `svelteVitals({ ui: true })` serves a live svelte-vitals dashboard at `/__svelte-vitals/` during `vite dev`, fed by the existing `svelteVitalsHandle`, reusing the core `buildHtmlDocument` renderer.
+
+**Architecture:** The SvelteKit `handle` (SSR) analyzes each visited page's rendered `<head>` and, when the UI is enabled, POSTs the findings to the dev server. The Vite plugin's dev-server middleware keeps an in-memory store, serves `buildHtmlDocument(...)` (plus an injected live-update script) at `/__svelte-vitals/`, and pushes SSE `update` events so the page re-renders without a full reload. Handle↔plugin talk over HTTP (they may be different module instances), not shared module state.
+
+**Tech Stack:** TypeScript, ESM-only (tsup, `target: es2022`), vitest, Vite dev middleware (connect), SSE, `fetch` (Node 18+ global).
+
+## Global Constraints
+
+- ESM-only; no CJS. `@svelte-vitals/core` is **not modified** — the UI consumes `buildHtmlDocument` / `buildJsonReport` from it.
+- All server/serve/SSE/store/injection code lives in `@svelte-vitals/vite`. **No dependency on the CLI package.** No new runtime dependencies (use Node built-ins + `vite` peer types).
+- The dashboard is served only in **dev** (`apply: 'serve'`); the existing build-time plugin (`apply: 'build'`) is unchanged.
+- Handle↔plugin coupling is **HTTP over the dev server's own origin**, gated by `process.env.SVELTE_VITALS_UI`. Dev-overlay-only users (flag unset) see **no behavior change** — no POST.
+- `buildHtmlDocument` is reused **verbatim**; the live behavior is a `<script data-live>` injected before `</body>` by the vite side.
+- Coverage is the rendered model (same as the dev overlay): **SEO `<head>` rules**, visited routes only; Performance image rules and project-wide checks are out of scope for the live UI.
+- Dev tooling must never break a request: the handle's ingest POST is fire-and-forget with all errors swallowed.
+
+### Reference: existing signatures (read-only — already in the codebase)
+
+```ts
+// @svelte-vitals/core
+function buildJsonReport(results: Result[], config: Config, meta: { version: string }): JsonReport
+function buildHtmlDocument(report: JsonReport, meta: { version: string }): string
+function defineConfig(partial): Config
+type Result = { id: string; message: string; category?: Category; detection: {...}; location?: string; route?: string; severity?: Severity; ... }
+
+// packages/vite/src/hooks/handle.ts (current)
+//   analyzeAndWarn(html, route, rules, config, lastSignature) — computes `results`, dedupes by signature, console.warn's formatDevReport
+//   svelteVitalsHandle(options) returns a SvelteKit Handle; DEV-only; uses transformPageChunk to capture rendered HTML
+
+// packages/vite/src/plugin.ts (current)
+//   svelteVitals(options: SvelteVitalsOptions): Plugin  — apply:'build', closeBundle gates the build
+//   readPackageVersion() from './version.js'
+```
+
+---
+
+### Task 1: Findings store
+
+An in-memory store the dev middleware owns: findings keyed by route, a flattened snapshot for `buildJsonReport`, and change subscriptions for SSE.
+
+**Files:**
+- Create: `packages/vite/src/ui/store.ts`
+- Test: `packages/vite/test/ui-store.test.ts`
+
+**Interfaces:**
+- Consumes: `type Result` from `@svelte-vitals/core`.
+- Produces:
+  - `interface FindingsStore { set(route: string, results: Result[]): void; snapshot(): Result[]; subscribe(fn: () => void): () => void; }`
+  - `function createStore(): FindingsStore`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/vite/test/ui-store.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { createStore } from '../src/ui/store.js';
+import type { Result } from '@svelte-vitals/core';
+
+const r = (id: string, route?: string): Result =>
+  ({ id, message: id, category: 'seo', detection: { presence: 'none', value: 'absent' }, route, severity: 'critical' }) as Result;
+
+describe('createStore', () => {
+  it('flattens results across routes in snapshot()', () => {
+    const s = createStore();
+    s.set('/a', [r('SEO001', '/a')]);
+    s.set('/b', [r('SEO002', '/b')]);
+    expect(s.snapshot().map((x) => x.id).sort()).toEqual(['SEO001', 'SEO002']);
+  });
+
+  it('replaces (not appends) a route on re-set', () => {
+    const s = createStore();
+    s.set('/a', [r('SEO001', '/a')]);
+    s.set('/a', [r('SEO002', '/a')]);
+    expect(s.snapshot().map((x) => x.id)).toEqual(['SEO002']);
+  });
+
+  it('stamps the route onto results missing one', () => {
+    const s = createStore();
+    s.set('/a', [r('SEO001')]); // no route on the result
+    expect(s.snapshot()[0]!.route).toBe('/a');
+  });
+
+  it('notifies subscribers on set and supports unsubscribe', () => {
+    const s = createStore();
+    const fn = vi.fn();
+    const off = s.subscribe(fn);
+    s.set('/a', [r('SEO001', '/a')]);
+    expect(fn).toHaveBeenCalledTimes(1);
+    off();
+    s.set('/b', [r('SEO002', '/b')]);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/vite && pnpm vitest run test/ui-store.test.ts`
+Expected: FAIL — `../src/ui/store.js` does not exist.
+
+- [ ] **Step 3: Implement the store**
+
+Create `packages/vite/src/ui/store.ts`:
+
+```ts
+import type { Result } from '@svelte-vitals/core';
+
+/** In-memory findings store for the dev UI. Owned by the dev-server middleware. */
+export interface FindingsStore {
+  /** Replace a route's findings (route stamped onto results missing one) and notify subscribers. */
+  set(route: string, results: Result[]): void;
+  /** All findings across routes, flattened — feed straight into buildJsonReport. */
+  snapshot(): Result[];
+  /** Subscribe to change notifications; returns an unsubscribe function. */
+  subscribe(fn: () => void): () => void;
+}
+
+export function createStore(): FindingsStore {
+  const byRoute = new Map<string, Result[]>();
+  const subs = new Set<() => void>();
+  return {
+    set(route, results) {
+      byRoute.set(
+        route,
+        results.map((r) => (r.route ? r : { ...r, route }))
+      );
+      for (const fn of subs) fn();
+    },
+    snapshot() {
+      return [...byRoute.values()].flat();
+    },
+    subscribe(fn) {
+      subs.add(fn);
+      return () => subs.delete(fn);
+    }
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/vite && pnpm vitest run test/ui-store.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/vite/src/ui/store.ts packages/vite/test/ui-store.test.ts
+git commit -m "feat(vite): findings store for the live UI"
+```
+
+---
+
+### Task 2: Dashboard renderer (reuse buildHtmlDocument + inject live script)
+
+Build the served HTML: the core `buildHtmlDocument` output with a `<script data-live>` injected before `</body>` that subscribes to SSE and swaps the `.wrap` content on update.
+
+**Files:**
+- Create: `packages/vite/src/ui/serve.ts`
+- Test: `packages/vite/test/ui-serve.test.ts`
+
+**Interfaces:**
+- Consumes: `buildHtmlDocument`, `buildJsonReport`, `type Config`, `type Result` from `@svelte-vitals/core`.
+- Produces: `function renderDashboard(results: Result[], config: Config, meta: { version: string }): string`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/vite/test/ui-serve.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { renderDashboard } from '../src/ui/serve.js';
+import { defineConfig, type Result } from '@svelte-vitals/core';
+
+const config = defineConfig({});
+const results: Result[] = [
+  { id: 'SEO001', message: 'Missing <title>', category: 'seo', detection: { presence: 'none', value: 'absent' }, route: '/a', location: 'a/+page.svelte', severity: 'critical' } as Result
+];
+
+describe('renderDashboard', () => {
+  const html = renderDashboard(results, config, { version: '9.9.9' });
+
+  it('reuses buildHtmlDocument (full doc with the finding)', () => {
+    expect(html.startsWith('<!doctype html>')).toBe(true);
+    expect(html).toContain('SEO001');
+  });
+
+  it('injects a live-update script before </body>', () => {
+    expect(html).toContain('data-live');
+    expect(html).toContain("EventSource('/__svelte-vitals/events')");
+    // injected before the closing body tag
+    expect(html.indexOf('data-live')).toBeLessThan(html.indexOf('</body>'));
+  });
+
+  it('renders an empty snapshot without throwing', () => {
+    expect(() => renderDashboard([], config, { version: '0' })).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/vite && pnpm vitest run test/ui-serve.test.ts`
+Expected: FAIL — `../src/ui/serve.js` does not exist.
+
+- [ ] **Step 3: Implement the renderer**
+
+Create `packages/vite/src/ui/serve.ts`:
+
+```ts
+import { buildHtmlDocument, buildJsonReport, type Config, type Result } from '@svelte-vitals/core';
+
+// Injected only by the live UI (not part of the shared core renderer). On an SSE
+// `update`, re-fetch the dashboard, swap the `.wrap` element, and re-run the core
+// init script (freshly appended <script> executes) so the gauge/filters rebind.
+const LIVE_SCRIPT = `<script data-live>
+(function(){
+  var es=new EventSource('/__svelte-vitals/events');
+  es.addEventListener('update',function(){
+    fetch('/__svelte-vitals/').then(function(r){return r.text();}).then(function(html){
+      var doc=new DOMParser().parseFromString(html,'text/html');
+      var next=doc.querySelector('.wrap'),cur=document.querySelector('.wrap');
+      if(next&&cur)cur.replaceWith(next);
+      var scripts=doc.querySelectorAll('body > script:not([data-live])');
+      var core=scripts[scripts.length-1];
+      if(core){var s=document.createElement('script');s.textContent=core.textContent;document.body.appendChild(s);s.remove();}
+    }).catch(function(){});
+  });
+})();
+</script>`;
+
+/** The dashboard HTML: the core report document plus the injected live-update script. */
+export function renderDashboard(results: Result[], config: Config, meta: { version: string }): string {
+  const html = buildHtmlDocument(buildJsonReport(results, config, meta), meta);
+  return html.replace('</body>', LIVE_SCRIPT + '</body>');
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/vite && pnpm vitest run test/ui-serve.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/vite/src/ui/serve.ts packages/vite/test/ui-serve.test.ts
+git commit -m "feat(vite): dashboard renderer reusing buildHtmlDocument + live script"
+```
+
+---
+
+### Task 3: Dev-server middleware (`/`, `/ingest`, `/events`)
+
+Wire the store + renderer onto a Vite dev server: serve the dashboard, accept ingested findings, and stream SSE updates.
+
+**Files:**
+- Create: `packages/vite/src/ui/middleware.ts`
+- Test: `packages/vite/test/ui-middleware.test.ts`
+
+**Interfaces:**
+- Consumes: `createStore` (Task 1), `renderDashboard` (Task 2); `type Config` from `@svelte-vitals/core`; Vite `ViteDevServer` type; Node `IncomingMessage`/`ServerResponse`.
+- Produces: `function installUiMiddleware(server: ViteDevServer, config: Config, version: string): void`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/vite/test/ui-middleware.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { installUiMiddleware } from '../src/ui/middleware.js';
+import { defineConfig } from '@svelte-vitals/core';
+
+// Capture the handler that installUiMiddleware registers on server.middlewares.use(path, fn).
+function setup() {
+  let handler: (req: any, res: any, next: () => void) => void = () => {};
+  const server = { middlewares: { use: (_path: string, fn: typeof handler) => (handler = fn) } } as any;
+  installUiMiddleware(server, defineConfig({}), '9.9.9');
+  return { call: (req: any, res: any) => handler(req, res, () => {}) };
+}
+function res() {
+  return { statusCode: 0, headers: {} as Record<string, string>, chunks: [] as string[], setHeader(k: string, v: string) { this.headers[k] = v; }, writeHead(c: number, h?: Record<string, string>) { this.statusCode = c; Object.assign(this.headers, h ?? {}); }, write(c: string) { this.chunks.push(c); }, end(c?: string) { if (c) this.chunks.push(c); } };
+}
+function postReq(url: string) { return Object.assign(new EventEmitter(), { method: 'POST', url }); }
+function getReq(url: string) { return Object.assign(new EventEmitter(), { method: 'GET', url }); }
+
+const ingestBody = JSON.stringify({
+  route: '/a',
+  results: [{ id: 'SEO001', message: 'Missing <title>', category: 'seo', detection: { presence: 'none', value: 'absent' }, route: '/a', severity: 'critical' }]
+});
+
+describe('installUiMiddleware', () => {
+  it('serves the dashboard at / reflecting ingested findings', async () => {
+    const { call } = setup();
+    const ir = res();
+    const ireq = postReq('/ingest');
+    call(ireq, ir);
+    ireq.emit('data', Buffer.from(ingestBody));
+    ireq.emit('end');
+    await new Promise((r) => setTimeout(r, 0));
+    const gr = res();
+    call(getReq('/'), gr);
+    const html = gr.chunks.join('');
+    expect(html).toContain('SEO001');
+    expect(gr.headers['Content-Type']).toContain('text/html');
+  });
+
+  it('streams an SSE update when findings are ingested', async () => {
+    const { call } = setup();
+    const sse = res();
+    call(getReq('/events'), sse);
+    expect(sse.headers['Content-Type']).toContain('text/event-stream');
+    const ireq = postReq('/ingest');
+    call(ireq, res());
+    ireq.emit('data', Buffer.from(ingestBody));
+    ireq.emit('end');
+    await new Promise((r) => setTimeout(r, 0));
+    expect(sse.chunks.join('')).toContain('event: update');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/vite && pnpm vitest run test/ui-middleware.test.ts`
+Expected: FAIL — `../src/ui/middleware.js` does not exist.
+
+- [ ] **Step 3: Implement the middleware**
+
+Create `packages/vite/src/ui/middleware.ts`:
+
+```ts
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { ViteDevServer } from 'vite';
+import type { Config } from '@svelte-vitals/core';
+import { createStore } from './store.js';
+import { renderDashboard } from './serve.js';
+
+/** Mount the dev UI at /__svelte-vitals/ : GET / (dashboard), POST /ingest, GET /events (SSE). */
+export function installUiMiddleware(server: ViteDevServer, config: Config, version: string): void {
+  const store = createStore();
+  const clients = new Set<ServerResponse>();
+
+  store.subscribe(() => {
+    for (const res of clients) res.write('event: update\ndata: {}\n\n');
+  });
+
+  // connect strips the mount path, so req.url is relative ('/', '/ingest', '/events').
+  server.middlewares.use('/__svelte-vitals', (req: IncomingMessage, res: ServerResponse) => {
+    const url = req.url ?? '/';
+
+    if (req.method === 'POST' && url.startsWith('/ingest')) {
+      let body = '';
+      req.on('data', (c) => (body += c));
+      req.on('end', () => {
+        try {
+          const { route, results } = JSON.parse(body);
+          if (typeof route === 'string' && Array.isArray(results)) store.set(route, results);
+        } catch {
+          // ignore malformed ingest payloads — dev tooling must not crash the dev server
+        }
+        res.statusCode = 204;
+        res.end();
+      });
+      return;
+    }
+
+    if (url.startsWith('/events')) {
+      res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive'
+      });
+      res.write('\n');
+      clients.add(res);
+      req.on('close', () => clients.delete(res));
+      return;
+    }
+
+    res.setHeader('Content-Type', 'text/html');
+    res.end(renderDashboard(store.snapshot(), config, { version }));
+  });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/vite && pnpm vitest run test/ui-middleware.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/vite/src/ui/middleware.ts packages/vite/test/ui-middleware.test.ts
+git commit -m "feat(vite): dev-server middleware (dashboard, ingest, SSE)"
+```
+
+---
+
+### Task 4: Plugin `ui` option (serve the dashboard in dev)
+
+Add `ui?: boolean` to the plugin options. When set, `svelteVitals()` returns the existing build plugin **plus** a dev-only plugin whose `configureServer` installs the UI middleware and sets `process.env.SVELTE_VITALS_UI`.
+
+**Files:**
+- Modify: `packages/vite/src/plugin.ts`
+- Test: `packages/vite/test/ui-plugin.test.ts`
+
+**Interfaces:**
+- Consumes: `installUiMiddleware` (Task 3); `defineConfig` from `@svelte-vitals/core`; `readPackageVersion` from `./version.js`; Vite `Plugin`/`ViteDevServer`.
+- Produces: `SvelteVitalsOptions` gains `ui?: boolean`; `svelteVitals(options): Plugin | Plugin[]` (returns an array when `ui` is set, a single Plugin otherwise).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/vite/test/ui-plugin.test.ts`:
+
+```ts
+import { describe, it, expect, afterEach } from 'vitest';
+import type { Plugin, ViteDevServer } from 'vite';
+import { svelteVitals } from '../src/index.js';
+
+afterEach(() => {
+  delete process.env.SVELTE_VITALS_UI;
+});
+
+describe('svelteVitals({ ui })', () => {
+  it('returns a single plugin when ui is not set (unchanged)', () => {
+    const p = svelteVitals({});
+    expect(Array.isArray(p)).toBe(false);
+    expect((p as Plugin).name).toBe('svelte-vitals');
+  });
+
+  it('adds a dev-only UI plugin when ui:true', () => {
+    const plugins = svelteVitals({ ui: true }) as Plugin[];
+    expect(Array.isArray(plugins)).toBe(true);
+    const ui = plugins.find((p) => p.name === 'svelte-vitals:ui')!;
+    expect(ui).toBeDefined();
+    expect(ui.apply).toBe('serve');
+  });
+
+  it('configureServer installs middleware and sets the UI env flag', () => {
+    const plugins = svelteVitals({ ui: true }) as Plugin[];
+    const ui = plugins.find((p) => p.name === 'svelte-vitals:ui')!;
+    const used: string[] = [];
+    const server = { middlewares: { use: (path: string) => used.push(path) } } as unknown as ViteDevServer;
+    const hook = typeof ui.configureServer === 'function' ? ui.configureServer : ui.configureServer!.handler;
+    (hook as (s: ViteDevServer) => void).call({}, server);
+    expect(process.env.SVELTE_VITALS_UI).toBe('1');
+    expect(used).toContain('/__svelte-vitals');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/vite && pnpm vitest run test/ui-plugin.test.ts`
+Expected: FAIL — `ui` not handled; `svelteVitals({ui:true})` returns a single plugin.
+
+- [ ] **Step 3: Add the `ui` option and dev plugin**
+
+In `packages/vite/src/plugin.ts`:
+
+- Add to `SvelteVitalsOptions` (after `prerenderDir`):
+```ts
+  /** Serve a live dashboard at /__svelte-vitals/ during `vite dev` (requires svelteVitalsHandle in hooks.server.ts). */
+  ui?: boolean;
+```
+- Add imports at the top (alongside the existing imports):
+```ts
+import type { Plugin, ViteDevServer } from 'vite';
+import { defineConfig } from '@svelte-vitals/core';
+import { installUiMiddleware } from './ui/middleware.js';
+import { readPackageVersion } from './version.js';
+```
+(`type { Plugin }` may already be imported — keep a single import; add `ViteDevServer` to it. Remove any duplicate.)
+- Change the signature and wrap the return. The existing function body builds the build-time plugin object; keep it, name it `buildPlugin`, and return conditionally:
+
+```ts
+export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin | Plugin[] {
+  let root = options.cwd ?? process.cwd();
+  const buildPlugin: Plugin = {
+    name: 'svelte-vitals',
+    apply: 'build',
+    enforce: 'post',
+    configResolved(config) {
+      if (!options.cwd) root = config.root;
+    },
+    async closeBundle() {
+      // … existing closeBundle body unchanged …
+    }
+  };
+
+  if (!options.ui) return buildPlugin;
+
+  const uiPlugin: Plugin = {
+    name: 'svelte-vitals:ui',
+    apply: 'serve',
+    configureServer(server: ViteDevServer) {
+      process.env.SVELTE_VITALS_UI = '1';
+      const config = defineConfig({
+        treatDynamicAs: options.treatDynamicAs ?? 'pass',
+        metaComponents: options.metaComponents ?? [],
+        rules: options.rules ?? {},
+        failOn: options.failOn ?? 'critical'
+      });
+      installUiMiddleware(server, config, readPackageVersion());
+    }
+  };
+  return [buildPlugin, uiPlugin];
+}
+```
+
+> Keep the existing `closeBundle` body exactly as it is — only move it inside `buildPlugin` and wrap the return. Do not change build-time behavior.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/vite && pnpm vitest run test/ui-plugin.test.ts`
+Expected: PASS (3 tests).
+
+Also run the existing plugin tests to confirm no regression:
+Run: `cd packages/vite && pnpm vitest run test/plugin-options.test.ts test/plugin-error.test.ts`
+Expected: PASS (the no-`ui` path still returns a single Plugin).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/vite/src/plugin.ts packages/vite/test/ui-plugin.test.ts
+git commit -m "feat(vite): svelteVitals({ ui }) serves the dev dashboard"
+```
+
+---
+
+### Task 5: Handle feeds findings to the UI (env-gated ingest)
+
+When `process.env.SVELTE_VITALS_UI` is set, `svelteVitalsHandle` additionally POSTs each analyzed route's findings to the dev server's `/__svelte-vitals/ingest`. Terminal-warning behavior is unchanged; the POST is fire-and-forget.
+
+**Files:**
+- Modify: `packages/vite/src/hooks/handle.ts`
+- Test: `packages/vite/test/ui-ingest.test.ts`
+
+**Interfaces:**
+- Consumes: the ingest endpoint contract from Task 3 (`POST /__svelte-vitals/ingest` with `{ route, results }`).
+- Produces: no new exports; behavior change in `svelteVitalsHandle` gated by `SVELTE_VITALS_UI`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/vite/test/ui-ingest.test.ts`:
+
+```ts
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { Handle } from '@sveltejs/kit';
+import { svelteVitalsHandle } from '../src/hooks/index.js';
+
+function fakeEvent(routeId: string | null, pathname = '/') {
+  return { route: { id: routeId }, url: new URL(`http://localhost:5173${pathname}`) } as unknown as Parameters<
+    Parameters<Handle>[0]['resolve']
+  >[0];
+}
+function resolveWith(chunks: string[]) {
+  return (async (_event: unknown, opts?: { transformPageChunk?: (i: { html: string; done: boolean }) => unknown }) => {
+    const tpc = opts?.transformPageChunk;
+    if (tpc) for (let i = 0; i < chunks.length; i++) await tpc({ html: chunks[i]!, done: i === chunks.length - 1 });
+    return {} as unknown as Response;
+  }) as Parameters<Handle>[0]['resolve'];
+}
+const flush = () => new Promise((r) => setTimeout(r, 0));
+const PAGE_NO_TITLE = '<html lang="en"><head><meta name="description" content="x"></head><body></body></html>';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.SVELTE_VITALS_UI;
+});
+
+describe('handle ingest (UI feed)', () => {
+  it('POSTs findings to /__svelte-vitals/ingest when the UI env flag is set', async () => {
+    process.env.SVELTE_VITALS_UI = '1';
+    const fetchMock = vi.fn(async () => ({ ok: true }) as Response);
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const handle = svelteVitalsHandle();
+    await handle({ event: fakeEvent('/none', '/none'), resolve: resolveWith([PAGE_NO_TITLE]) });
+    await flush();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [urlArg, init] = fetchMock.mock.calls[0]!;
+    expect(String(urlArg)).toBe('http://localhost:5173/__svelte-vitals/ingest');
+    const sent = JSON.parse((init as RequestInit).body as string);
+    expect(sent.route).toBe('/none');
+    expect(Array.isArray(sent.results)).toBe(true);
+  });
+
+  it('does NOT POST when the UI env flag is unset', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true }) as Response);
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const handle = svelteVitalsHandle();
+    await handle({ event: fakeEvent('/none', '/none'), resolve: resolveWith([PAGE_NO_TITLE]) });
+    await flush();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/vite && pnpm vitest run test/ui-ingest.test.ts`
+Expected: FAIL — the handle does not POST.
+
+- [ ] **Step 3: Add the env-gated ingest POST**
+
+In `packages/vite/src/hooks/handle.ts`:
+
+- Add a fire-and-forget ingest helper above `analyzeAndWarn`:
+```ts
+async function postIngest(origin: string, route: string, results: Result[]): Promise<void> {
+  try {
+    await fetch(`${origin}/__svelte-vitals/ingest`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ route, results })
+    });
+  } catch {
+    // dev tooling must never break a request — swallow ingest failures
+  }
+}
+```
+- Import `Result` in the existing `@svelte-vitals/core` type import (add `type Result`).
+- Thread `origin` through `analyzeAndWarn`. Change its signature and the dedupe tail so it posts whenever a route's findings change:
+```ts
+async function analyzeAndWarn(
+  html: string,
+  route: string,
+  origin: string,
+  rules: Rule[],
+  config: Config,
+  lastSignature: Map<string, string>
+): Promise<void> {
+  try {
+    const { tags, htmlLang } = parseHtmlHead(html);
+    const head: ResolvedHead = { route, source: 'rendered', tags, file: route };
+    const project: Project = { hasRobotsTxt: true, hasSitemap: true, htmlLang };
+    const results = applyRuleSeverities(await runRules(rules, { heads: [head], project, config }), config);
+
+    const signature = findingSignature(results, config);
+    if (lastSignature.get(route) === signature) return;
+    lastSignature.set(route, signature);
+
+    const report = formatDevReport(route, results, config);
+    if (report) console.warn(report);
+    if (globalThis.process?.env?.SVELTE_VITALS_UI) void postIngest(origin, route, results);
+  } catch (err) {
+    if (globalThis.process?.env?.SVELTE_VITALS_DEBUG) {
+      console.warn('[svelte-vitals] dev analysis failed:', err);
+    }
+  }
+}
+```
+- Update the single call site inside the returned handle to pass `event.url.origin`:
+```ts
+        if (done) void analyzeAndWarn(buffer, event.route.id ?? event.url.pathname, event.url.origin, rules, config, lastSignature);
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/vite && pnpm vitest run test/ui-ingest.test.ts test/dev-handle.test.ts`
+Expected: PASS — ingest behavior gated by the flag; existing dev-handle warnings unaffected.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/vite/src/hooks/handle.ts packages/vite/test/ui-ingest.test.ts
+git commit -m "feat(vite): handle feeds findings to the live UI when enabled"
+```
+
+---
+
+### Task 6: Docs + changeset + full verification
+
+Document the live UI (docs site, en + ja) and add the release changeset, then run the full verification suite.
+
+**Files:**
+- Modify: `docs/src/content/docs/guides/dev-overlay.md` and `docs/src/content/docs/ja/guides/dev-overlay.md` (add a "Live UI" section)
+- Create: `.changeset/vite-live-ui.md`
+
+**Interfaces:** none (docs + release).
+
+- [ ] **Step 1: Add a "Live UI" section to the dev-overlay guide (en)**
+
+Open `docs/src/content/docs/guides/dev-overlay.md`, match its heading style/tone, and append:
+
+````md
+## Live UI dashboard
+
+Enable a live dashboard at `/__svelte-vitals/` during `vite dev` — the same report the CLI's `--reporter html` produces, updating in place as you navigate your app.
+
+```js
+// vite.config.{js,ts}
+import { svelteVitals } from '@svelte-vitals/vite';
+
+export default {
+  plugins: [svelteVitals({ ui: true }) /* , sveltekit() */]
+};
+```
+
+It is fed by the dev handle (the same one the overlay above uses), so keep `svelteVitalsHandle()` in `src/hooks.server.ts`. Open `http://localhost:5173/__svelte-vitals/` and browse your app: each visited route's rendered `<head>` is analyzed and the dashboard updates live.
+
+Like the overlay, this is dev-only and rendered-based: it covers the SEO `<head>` rules for the routes you visit. For a whole-project report (all routes, Performance, site checks), run `npx svelte-vitals` or `--reporter html`.
+````
+
+- [ ] **Step 2: Add the same section to the dev-overlay guide (ja)**
+
+Open `docs/src/content/docs/ja/guides/dev-overlay.md` and append the translated section:
+
+````md
+## ライブ UI ダッシュボード
+
+`vite dev` 中に `/__svelte-vitals/` でライブダッシュボードを表示します。CLI の `--reporter html` と同じレポートが、アプリを操作するたびにその場で更新されます。
+
+```js
+// vite.config.{js,ts}
+import { svelteVitals } from '@svelte-vitals/vite';
+
+export default {
+  plugins: [svelteVitals({ ui: true }) /* , sveltekit() */]
+};
+```
+
+これは dev handle（上記オーバーレイと同じもの）から供給されるため、`src/hooks.server.ts` の `svelteVitalsHandle()` はそのまま残してください。`http://localhost:5173/__svelte-vitals/` を開いてアプリを操作すると、訪問した各ルートのレンダリング済み `<head>` が解析され、ダッシュボードがライブ更新されます。
+
+オーバーレイと同様、これは dev 専用かつレンダリングベースで、訪問したルートの SEO `<head>` ルールを対象とします。プロジェクト全体のレポート（全ルート・パフォーマンス・サイト全体のチェック）が必要な場合は `npx svelte-vitals` または `--reporter html` を実行してください。
+````
+
+- [ ] **Step 3: Add the changeset**
+
+Create `.changeset/vite-live-ui.md`:
+
+```md
+---
+'@svelte-vitals/vite': minor
+---
+
+Add a live UI dashboard: `svelteVitals({ ui: true })` serves a svelte-vitals report at
+`/__svelte-vitals/` during `vite dev`, fed by `svelteVitalsHandle`, that updates live as you
+navigate. It reuses the same renderer as the CLI's `--reporter html`. Dev-only and
+rendered-based (SEO `<head>` rules for visited routes); the dev overlay's behavior is
+unchanged when the UI is not enabled.
+```
+
+- [ ] **Step 4: Full verification**
+
+Run from the repo root:
+
+```bash
+CI=true pnpm -r typecheck && CI=true pnpm -r test && pnpm build && CI=true pnpm --filter docs build && pnpm lint && pnpm check:publish
+```
+Expected: all green. (Run `pnpm format` first if prettier flags the new Markdown; re-run lint. `attw` inside `check:publish` may fail LOCALLY only — known pre-existing local-cache issue, CI-unaffected; if only attw/npm-pack fails and publint passes, treat it as the known issue.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/src/content/docs/guides/dev-overlay.md docs/src/content/docs/ja/guides/dev-overlay.md .changeset/vite-live-ui.md
+git commit -m "docs: document the live UI; changeset (@svelte-vitals/vite minor)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `svelteVitals({ ui: true })` serves `/__svelte-vitals/` in dev → Task 4. ✅
+- Reuse `buildHtmlDocument` verbatim + inject live script → Task 2. ✅
+- Handle↔plugin over HTTP, env-gated (`SVELTE_VITALS_UI`), no change when unset → Tasks 4 (sets env) + 5 (gated POST). ✅
+- In-memory store keyed by route, flattened snapshot, route-stamping → Task 1. ✅
+- Middleware `/`, `/ingest`, `/events` (SSE) → Task 3. ✅
+- Live-update script: SSE → re-fetch → swap `.wrap` → re-run core init → Task 2 (`LIVE_SCRIPT`). ✅
+- Core unchanged; vite-only; no cli dep; ESM-only → all tasks (core only imported). ✅
+- Rendered-model coverage caveats (SEO head, visited routes) → Task 6 docs state them. ✅
+- `@svelte-vitals/vite` minor changeset; no core changeset → Task 6. ✅
+- Docs en + ja → Task 6. ✅
+
+**Placeholder scan:** No "TBD"/"add error handling"/"similar to". The one prose carryover (Task 4 "existing closeBundle body unchanged") is explicit about preserving exact existing code rather than re-printing the unchanged ~30-line build body — intentional, since reprinting risks drift; the instruction is to move it verbatim. Every new code path has complete code.
+
+**Type consistency:** `createStore(): FindingsStore` (Task 1) is consumed by `installUiMiddleware` (Task 3). `renderDashboard(results, config, meta)` (Task 2) is consumed by Task 3. `installUiMiddleware(server, config, version)` (Task 3) is consumed by Task 4. `postIngest(origin, route, results)` and `analyzeAndWarn(html, route, origin, rules, config, lastSignature)` (Task 5) match the ingest contract `{ route, results }` from Task 3's middleware. `svelteVitals(): Plugin | Plugin[]` (Task 4) — the no-`ui` path returns a single `Plugin`, preserving existing callers/tests. The env flag string `'SVELTE_VITALS_UI'` and endpoint paths (`/__svelte-vitals`, `/ingest`, `/events`) are identical across Tasks 3, 4, 5.

--- a/docs/superpowers/plans/2026-06-23-vite-live-ui.md
+++ b/docs/superpowers/plans/2026-06-23-vite-live-ui.md
@@ -43,10 +43,12 @@ type Result = { id: string; message: string; category?: Category; detection: {..
 An in-memory store the dev middleware owns: findings keyed by route, a flattened snapshot for `buildJsonReport`, and change subscriptions for SSE.
 
 **Files:**
+
 - Create: `packages/vite/src/ui/store.ts`
 - Test: `packages/vite/test/ui-store.test.ts`
 
 **Interfaces:**
+
 - Consumes: `type Result` from `@svelte-vitals/core`.
 - Produces:
   - `interface FindingsStore { set(route: string, results: Result[]): void; snapshot(): Result[]; subscribe(fn: () => void): () => void; }`
@@ -62,14 +64,26 @@ import { createStore } from '../src/ui/store.js';
 import type { Result } from '@svelte-vitals/core';
 
 const r = (id: string, route?: string): Result =>
-  ({ id, message: id, category: 'seo', detection: { presence: 'none', value: 'absent' }, route, severity: 'critical' }) as Result;
+  ({
+    id,
+    message: id,
+    category: 'seo',
+    detection: { presence: 'none', value: 'absent' },
+    route,
+    severity: 'critical'
+  }) as Result;
 
 describe('createStore', () => {
   it('flattens results across routes in snapshot()', () => {
     const s = createStore();
     s.set('/a', [r('SEO001', '/a')]);
     s.set('/b', [r('SEO002', '/b')]);
-    expect(s.snapshot().map((x) => x.id).sort()).toEqual(['SEO001', 'SEO002']);
+    expect(
+      s
+        .snapshot()
+        .map((x) => x.id)
+        .sort()
+    ).toEqual(['SEO001', 'SEO002']);
   });
 
   it('replaces (not appends) a route on re-set', () => {
@@ -161,10 +175,12 @@ git commit -m "feat(vite): findings store for the live UI"
 Build the served HTML: the core `buildHtmlDocument` output with a `<script data-live>` injected before `</body>` that subscribes to SSE and swaps the `.wrap` content on update.
 
 **Files:**
+
 - Create: `packages/vite/src/ui/serve.ts`
 - Test: `packages/vite/test/ui-serve.test.ts`
 
 **Interfaces:**
+
 - Consumes: `buildHtmlDocument`, `buildJsonReport`, `type Config`, `type Result` from `@svelte-vitals/core`.
 - Produces: `function renderDashboard(results: Result[], config: Config, meta: { version: string }): string`
 
@@ -179,7 +195,15 @@ import { defineConfig, type Result } from '@svelte-vitals/core';
 
 const config = defineConfig({});
 const results: Result[] = [
-  { id: 'SEO001', message: 'Missing <title>', category: 'seo', detection: { presence: 'none', value: 'absent' }, route: '/a', location: 'a/+page.svelte', severity: 'critical' } as Result
+  {
+    id: 'SEO001',
+    message: 'Missing <title>',
+    category: 'seo',
+    detection: { presence: 'none', value: 'absent' },
+    route: '/a',
+    location: 'a/+page.svelte',
+    severity: 'critical'
+  } as Result
 ];
 
 describe('renderDashboard', () => {
@@ -260,10 +284,12 @@ git commit -m "feat(vite): dashboard renderer reusing buildHtmlDocument + live s
 Wire the store + renderer onto a Vite dev server: serve the dashboard, accept ingested findings, and stream SSE updates.
 
 **Files:**
+
 - Create: `packages/vite/src/ui/middleware.ts`
 - Test: `packages/vite/test/ui-middleware.test.ts`
 
 **Interfaces:**
+
 - Consumes: `createStore` (Task 1), `renderDashboard` (Task 2); `type Config` from `@svelte-vitals/core`; Vite `ViteDevServer` type; Node `IncomingMessage`/`ServerResponse`.
 - Produces: `function installUiMiddleware(server: ViteDevServer, config: Config, version: string): void`
 
@@ -285,14 +311,44 @@ function setup() {
   return { call: (req: any, res: any) => handler(req, res, () => {}) };
 }
 function res() {
-  return { statusCode: 0, headers: {} as Record<string, string>, chunks: [] as string[], setHeader(k: string, v: string) { this.headers[k] = v; }, writeHead(c: number, h?: Record<string, string>) { this.statusCode = c; Object.assign(this.headers, h ?? {}); }, write(c: string) { this.chunks.push(c); }, end(c?: string) { if (c) this.chunks.push(c); } };
+  return {
+    statusCode: 0,
+    headers: {} as Record<string, string>,
+    chunks: [] as string[],
+    setHeader(k: string, v: string) {
+      this.headers[k] = v;
+    },
+    writeHead(c: number, h?: Record<string, string>) {
+      this.statusCode = c;
+      Object.assign(this.headers, h ?? {});
+    },
+    write(c: string) {
+      this.chunks.push(c);
+    },
+    end(c?: string) {
+      if (c) this.chunks.push(c);
+    }
+  };
 }
-function postReq(url: string) { return Object.assign(new EventEmitter(), { method: 'POST', url }); }
-function getReq(url: string) { return Object.assign(new EventEmitter(), { method: 'GET', url }); }
+function postReq(url: string) {
+  return Object.assign(new EventEmitter(), { method: 'POST', url });
+}
+function getReq(url: string) {
+  return Object.assign(new EventEmitter(), { method: 'GET', url });
+}
 
 const ingestBody = JSON.stringify({
   route: '/a',
-  results: [{ id: 'SEO001', message: 'Missing <title>', category: 'seo', detection: { presence: 'none', value: 'absent' }, route: '/a', severity: 'critical' }]
+  results: [
+    {
+      id: 'SEO001',
+      message: 'Missing <title>',
+      category: 'seo',
+      detection: { presence: 'none', value: 'absent' },
+      route: '/a',
+      severity: 'critical'
+    }
+  ]
 });
 
 describe('installUiMiddleware', () => {
@@ -408,10 +464,12 @@ git commit -m "feat(vite): dev-server middleware (dashboard, ingest, SSE)"
 Add `ui?: boolean` to the plugin options. When set, `svelteVitals()` returns the existing build plugin **plus** a dev-only plugin whose `configureServer` installs the UI middleware and sets `process.env.SVELTE_VITALS_UI`.
 
 **Files:**
+
 - Modify: `packages/vite/src/plugin.ts`
 - Test: `packages/vite/test/ui-plugin.test.ts`
 
 **Interfaces:**
+
 - Consumes: `installUiMiddleware` (Task 3); `defineConfig` from `@svelte-vitals/core`; `readPackageVersion` from `./version.js`; Vite `Plugin`/`ViteDevServer`.
 - Produces: `SvelteVitalsOptions` gains `ui?: boolean`; `svelteVitals(options): Plugin | Plugin[]` (returns an array when `ui` is set, a single Plugin otherwise).
 
@@ -466,18 +524,23 @@ Expected: FAIL — `ui` not handled; `svelteVitals({ui:true})` returns a single 
 In `packages/vite/src/plugin.ts`:
 
 - Add to `SvelteVitalsOptions` (after `prerenderDir`):
+
 ```ts
   /** Serve a live dashboard at /__svelte-vitals/ during `vite dev` (requires svelteVitalsHandle in hooks.server.ts). */
   ui?: boolean;
 ```
+
 - Add imports at the top (alongside the existing imports):
+
 ```ts
 import type { Plugin, ViteDevServer } from 'vite';
 import { defineConfig } from '@svelte-vitals/core';
 import { installUiMiddleware } from './ui/middleware.js';
 import { readPackageVersion } from './version.js';
 ```
+
 (`type { Plugin }` may already be imported — keep a single import; add `ViteDevServer` to it. Remove any duplicate.)
+
 - Change the signature and wrap the return. The existing function body builds the build-time plugin object; keep it, name it `buildPlugin`, and return conditionally:
 
 ```ts
@@ -540,10 +603,12 @@ git commit -m "feat(vite): svelteVitals({ ui }) serves the dev dashboard"
 When `process.env.SVELTE_VITALS_UI` is set, `svelteVitalsHandle` additionally POSTs each analyzed route's findings to the dev server's `/__svelte-vitals/ingest`. Terminal-warning behavior is unchanged; the POST is fire-and-forget.
 
 **Files:**
+
 - Modify: `packages/vite/src/hooks/handle.ts`
 - Test: `packages/vite/test/ui-ingest.test.ts`
 
 **Interfaces:**
+
 - Consumes: the ingest endpoint contract from Task 3 (`POST /__svelte-vitals/ingest` with `{ route, results }`).
 - Produces: no new exports; behavior change in `svelteVitalsHandle` gated by `SVELTE_VITALS_UI`.
 
@@ -615,6 +680,7 @@ Expected: FAIL — the handle does not POST.
 In `packages/vite/src/hooks/handle.ts`:
 
 - Add a fire-and-forget ingest helper above `analyzeAndWarn`:
+
 ```ts
 async function postIngest(origin: string, route: string, results: Result[]): Promise<void> {
   try {
@@ -628,8 +694,10 @@ async function postIngest(origin: string, route: string, results: Result[]): Pro
   }
 }
 ```
+
 - Import `Result` in the existing `@svelte-vitals/core` type import (add `type Result`).
 - Thread `origin` through `analyzeAndWarn`. Change its signature and the dedupe tail so it posts whenever a route's findings change:
+
 ```ts
 async function analyzeAndWarn(
   html: string,
@@ -659,9 +727,12 @@ async function analyzeAndWarn(
   }
 }
 ```
+
 - Update the single call site inside the returned handle to pass `event.url.origin`:
+
 ```ts
-        if (done) void analyzeAndWarn(buffer, event.route.id ?? event.url.pathname, event.url.origin, rules, config, lastSignature);
+if (done)
+  void analyzeAndWarn(buffer, event.route.id ?? event.url.pathname, event.url.origin, rules, config, lastSignature);
 ```
 
 - [ ] **Step 4: Run tests to verify they pass**
@@ -683,6 +754,7 @@ git commit -m "feat(vite): handle feeds findings to the live UI when enabled"
 Document the live UI (docs site, en + ja) and add the release changeset, then run the full verification suite.
 
 **Files:**
+
 - Modify: `docs/src/content/docs/guides/dev-overlay.md` and `docs/src/content/docs/ja/guides/dev-overlay.md` (add a "Live UI" section)
 - Create: `.changeset/vite-live-ui.md`
 
@@ -757,6 +829,7 @@ Run from the repo root:
 ```bash
 CI=true pnpm -r typecheck && CI=true pnpm -r test && pnpm build && CI=true pnpm --filter docs build && pnpm lint && pnpm check:publish
 ```
+
 Expected: all green. (Run `pnpm format` first if prettier flags the new Markdown; re-run lint. `attw` inside `check:publish` may fail LOCALLY only — known pre-existing local-cache issue, CI-unaffected; if only attw/npm-pack fails and publint passes, treat it as the known issue.)
 
 - [ ] **Step 5: Commit**
@@ -771,6 +844,7 @@ git commit -m "docs: document the live UI; changeset (@svelte-vitals/vite minor)
 ## Self-Review
 
 **Spec coverage:**
+
 - `svelteVitals({ ui: true })` serves `/__svelte-vitals/` in dev → Task 4. ✅
 - Reuse `buildHtmlDocument` verbatim + inject live script → Task 2. ✅
 - Handle↔plugin over HTTP, env-gated (`SVELTE_VITALS_UI`), no change when unset → Tasks 4 (sets env) + 5 (gated POST). ✅

--- a/docs/superpowers/specs/2026-06-23-vite-live-ui-design.md
+++ b/docs/superpowers/specs/2026-06-23-vite-live-ui-design.md
@@ -50,8 +50,9 @@ These are deliberate v1 boundaries that keep B vite-native and dependency-free; 
 
 ```js
 // vite.config — serve the dashboard at /__svelte-vitals/ in dev
-svelteVitals({ ui: true })
+svelteVitals({ ui: true });
 ```
+
 ```ts
 // src/hooks.server.ts — already present for the dev overlay; feeds the UI
 export const handle = sequence(svelteVitalsHandle());

--- a/docs/superpowers/specs/2026-06-23-vite-live-ui-design.md
+++ b/docs/superpowers/specs/2026-06-23-vite-live-ui-design.md
@@ -1,0 +1,84 @@
+# Design: Vite live UI mode — toward 1.0
+
+Sub-project **B** of the "Lighthouse-like visualization" pillar. A `vitest --ui`-style live dashboard served by `@svelte-vitals/vite` during `vite dev`: as you navigate your app, each page's rendered `<head>` is analyzed and the dashboard updates live in the browser. It **reuses the core `buildHtmlDocument` renderer shipped in sub-project A** (PR #47) unchanged.
+
+(Sub-project A — the CLI `--reporter html` self-contained report — already shipped. This spec is B.)
+
+## Goal
+
+`svelteVitals({ ui: true })` in `vite.config` serves a live svelte-vitals dashboard at `/__svelte-vitals/` during dev. The existing `svelteVitalsHandle` (already added to `hooks.server.ts` for the dev overlay) feeds it findings as you browse, and the dashboard re-renders without a full reload. Same look as the CLI HTML report, because it is the same renderer.
+
+## Scope & coverage (honest, by the rendered model)
+
+The data source is **rendered HTML, navigation-driven** — the same model as the dev overlay. Consequences, stated up front:
+
+- Only **visited routes** appear; the dashboard accumulates as you browse (empty state invites navigation). Listing every route from the SvelteKit manifest is a **follow-up**, not v1.
+- Coverage matches the dev handle: **SEO `<head>` rules** evaluated against real rendered values. **Performance image rules and project-wide checks (robots/sitemap) are not covered** by this mode (the handle marks them present to suppress, and collects no image data) — consistent with the existing dev overlay. The dashboard's category breakdown therefore shows **SEO** for now.
+- **Health** is computed over the visited routes only (an evolving snapshot, not the whole-project score the CLI produces).
+
+These are deliberate v1 boundaries that keep B vite-native and dependency-free; the whole-project static analysis (the CLI's `analyzeProject`) is **not** pulled into vite.
+
+## Architecture & data flow
+
+`svelteVitalsHandle` (SSR, inside the dev server process) and the plugin's dev middleware run in the same Node process but may be **different module instances** (SvelteKit's SSR module runner vs the plugin's context). So they communicate over **HTTP on the dev server's own origin**, not a shared module singleton.
+
+1. **Navigate** → SvelteKit SSR → `svelteVitalsHandle` captures the rendered `<head>` via `transformPageChunk` and analyzes it (existing `analyzeAndWarn` logic).
+2. When the UI is enabled, the plugin sets `process.env.SVELTE_VITALS_UI` (dev only). The handle, seeing that flag, also **`POST`s the route's findings** to `${event.url.origin}/__svelte-vitals/ingest` (fire-and-forget, errors swallowed — dev tooling must never break a request). Dev-overlay-only users (flag unset) are unaffected: no POST, no behavior change.
+3. The plugin's `configureServer` middleware owns an **in-memory store** (`Map<route, Result[]>`, plus the resolved `Config` + version) and serves:
+   - `GET /__svelte-vitals/` → `buildHtmlDocument(buildJsonReport(allResults, config, { version }), { version })`, the dashboard page, **with a small live-update script injected before `</body>`**.
+   - `POST /__svelte-vitals/ingest` → parse `{ route, results }`, merge into the store (replace that route's entry), notify SSE subscribers.
+   - `GET /__svelte-vitals/events` → an **SSE** stream; emits an `update` event whenever the store changes.
+
+`buildJsonReport` groups results by `result.route` and computes Health, so the store keeps results keyed by route and concatenates them per request. Results already carry `route` (the build-time `analyze` path relies on it); the store stamps the ingest key onto any result missing one, so grouping is robust regardless.
+
+## Reuse of `buildHtmlDocument` (unchanged)
+
+`buildHtmlDocument` returns a full self-contained `<html>…</html>` document. The plugin reuses it **verbatim** and injects the live-update behavior by inserting a `<script>` immediately before the closing `</body>` in the served string. Core is not modified; the live script is a vite-side concern. The CLI static file (sub-project A) and the live UI thus render identically; only the live UI carries the extra injected script.
+
+**Live-update script (injected):** opens `EventSource('/__svelte-vitals/events')`; on `update`, fetches `/__svelte-vitals/` HTML, parses it, and swaps the `.wrap` element's contents into the current document, then re-runs the gauge/filter init (so scroll position and active filter survive — no full-page reload). On SSE error it falls back to nothing (the last render stays).
+
+## Components
+
+- **`packages/vite/src/ui/store.ts`** — the findings store: `set(route, results)`, `snapshot(): Result[]` (flattened), change subscription for SSE. Pure data; unit-testable.
+- **`packages/vite/src/ui/serve.ts`** — builds the served HTML: `renderDashboard(results, config, meta): string` = `buildHtmlDocument(buildJsonReport(...))` + injected live script. Pure; unit-testable.
+- **`packages/vite/src/ui/middleware.ts`** — wires the three routes (`/`, `/ingest`, `/events`) onto the vite dev server, backed by the store. Owns SSE subscriber management.
+- **`packages/vite/src/plugin.ts`** — gains a `ui?: boolean` option; when `ui` and in dev, a second plugin object (or `configureServer` + `apply` adjustment) installs the middleware and sets `process.env.SVELTE_VITALS_UI`. The existing build-time behavior is unchanged.
+- **`packages/vite/src/hooks/handle.ts`** — when `process.env.SVELTE_VITALS_UI` is set, additionally POSTs `{ route, results }` to the ingest endpoint (fire-and-forget). Terminal-warning behavior is unchanged.
+- Core: **no changes** — consumes `buildHtmlDocument` / `buildJsonReport` from `@svelte-vitals/core`.
+
+## Enable / setup (two files, same as the dev overlay)
+
+```js
+// vite.config — serve the dashboard at /__svelte-vitals/ in dev
+svelteVitals({ ui: true })
+```
+```ts
+// src/hooks.server.ts — already present for the dev overlay; feeds the UI
+export const handle = sequence(svelteVitalsHandle());
+```
+
+The build-time plugin (`apply: 'build'`) keeps gating builds; `ui` only affects `vite dev`.
+
+## Testing
+
+- **store** (`packages/vite/test/ui-store.test.ts`): `set`/`snapshot` flattens across routes; re-`set` of a route replaces (not appends); subscribers fire on change.
+- **serve** (`packages/vite/test/ui-serve.test.ts`): `renderDashboard` output contains the `buildHtmlDocument` markup (Health score, a finding) AND the injected live script (`EventSource('/__svelte-vitals/events')`); the injection sits before `</body>`.
+- **middleware** (`packages/vite/test/ui-middleware.test.ts`): a `POST /__svelte-vitals/ingest` then `GET /__svelte-vitals/` reflects the ingested route; `GET /__svelte-vitals/events` opens an SSE stream and an ingest emits an `update`. (Drive the connect handler directly with mock req/res; no real socket.)
+- **handle** (extend `packages/vite/test/…`): with `SVELTE_VITALS_UI` set, the handle issues the ingest POST; unset, it does not. (Mock `fetch`; assert call/no-call.)
+- Browser runtime behavior of the injected script is not unit-tested (string-presence + wiring only), matching sub-project A's approach.
+
+## Release
+
+`@svelte-vitals/vite` **minor** (new `ui` option + dev dashboard; handle gains opt-in ingest). No core change → no core changeset. `svelte-vitals` (CLI) unaffected.
+
+## Documentation
+
+Add a "Live UI" section to the docs site (en + ja) — a guide page or a section in the Plugin-mode / Dev-overlay guide — covering `svelteVitals({ ui: true })`, the `/__svelte-vitals/` URL, the two-file setup, and the rendered-model coverage caveats. Folded into the plan's final task.
+
+## Non-goals / follow-ups
+
+- **All-routes-from-manifest** upfront listing (v1 accumulates visited routes).
+- **Performance/image and site-wide (robots/sitemap) coverage** in the live UI — would need image collection in the rendered provider or a different analysis source.
+- **Whole-project static analysis in vite** (the CLI's `analyzeProject`) — intentionally not pulled in; would require extracting it to a shared lib.
+- Production serving, auth, multi-client coordination beyond simple SSE fan-out.
+- Syntax highlighting / dark mode (inherited from sub-project A's deferrals).

--- a/packages/vite/src/hooks/handle.ts
+++ b/packages/vite/src/hooks/handle.ts
@@ -29,7 +29,16 @@ function isLoopbackOrigin(origin: string): boolean {
 async function postIngest(origin: string, route: string, results: Result[]): Promise<void> {
   // `origin` comes from the request (Host header), so a spoofed Host must not
   // redirect this server-side POST to an arbitrary external host.
-  if (!isLoopbackOrigin(origin)) return;
+  if (!isLoopbackOrigin(origin)) {
+    // Accessing the app over LAN/--host yields a non-loopback origin, so the live
+    // UI silently stops updating — surface why when debugging is enabled.
+    if (globalThis.process?.env?.SVELTE_VITALS_DEBUG) {
+      console.warn(
+        `[svelte-vitals] live UI ingest skipped for non-loopback origin ${origin} — open the dashboard via localhost`
+      );
+    }
+    return;
+  }
   try {
     await fetch(`${origin}/__svelte-vitals/ingest`, {
       method: 'POST',

--- a/packages/vite/src/hooks/handle.ts
+++ b/packages/vite/src/hooks/handle.ts
@@ -9,15 +9,29 @@ import {
   type Config,
   type Project,
   type ResolvedHead,
+  type Result,
   type Rule
 } from '@svelte-vitals/core';
 import { parseHtmlHead } from '../providers/rendered/parse-html.js';
 import { findingSignature, formatDevReport } from './format.js';
 import type { SvelteVitalsHookOptions } from './options.js';
 
+async function postIngest(origin: string, route: string, results: Result[]): Promise<void> {
+  try {
+    await fetch(`${origin}/__svelte-vitals/ingest`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ route, results })
+    });
+  } catch {
+    // dev tooling must never break a request — swallow ingest failures
+  }
+}
+
 async function analyzeAndWarn(
   html: string,
   route: string,
+  origin: string,
   rules: Rule[],
   config: Config,
   lastSignature: Map<string, string>
@@ -36,6 +50,7 @@ async function analyzeAndWarn(
 
     const report = formatDevReport(route, results, config);
     if (report) console.warn(report);
+    if (globalThis.process?.env?.SVELTE_VITALS_UI) void postIngest(origin, route, results);
   } catch (err) {
     // Dev tooling must never break the request: swallow any parse/rule error.
     // Set SVELTE_VITALS_DEBUG to surface tool-internal errors while debugging.
@@ -74,7 +89,7 @@ export function svelteVitalsHandle(options: SvelteVitalsHookOptions = {}): Handl
         // Observe-only: return the chunk unchanged and never block the response on
         // analysis. We fire-and-forget on the final chunk; analyzeAndWarn swallows
         // its own errors, so the floating promise can never reject.
-        if (done) void analyzeAndWarn(buffer, event.route.id ?? event.url.pathname, rules, config, lastSignature);
+        if (done) void analyzeAndWarn(buffer, event.route.id ?? event.url.pathname, event.url.origin, rules, config, lastSignature);
         return html;
       }
     });

--- a/packages/vite/src/hooks/handle.ts
+++ b/packages/vite/src/hooks/handle.ts
@@ -16,7 +16,20 @@ import { parseHtmlHead } from '../providers/rendered/parse-html.js';
 import { findingSignature, formatDevReport } from './format.js';
 import type { SvelteVitalsHookOptions } from './options.js';
 
+/** Only the local dev server hosts the ingest endpoint, so never POST off-box. */
+function isLoopbackOrigin(origin: string): boolean {
+  try {
+    const host = new URL(origin).hostname;
+    return host === 'localhost' || host === '127.0.0.1' || host === '[::1]' || host === '::1';
+  } catch {
+    return false;
+  }
+}
+
 async function postIngest(origin: string, route: string, results: Result[]): Promise<void> {
+  // `origin` comes from the request (Host header), so a spoofed Host must not
+  // redirect this server-side POST to an arbitrary external host.
+  if (!isLoopbackOrigin(origin)) return;
   try {
     await fetch(`${origin}/__svelte-vitals/ingest`, {
       method: 'POST',
@@ -89,7 +102,15 @@ export function svelteVitalsHandle(options: SvelteVitalsHookOptions = {}): Handl
         // Observe-only: return the chunk unchanged and never block the response on
         // analysis. We fire-and-forget on the final chunk; analyzeAndWarn swallows
         // its own errors, so the floating promise can never reject.
-        if (done) void analyzeAndWarn(buffer, event.route.id ?? event.url.pathname, event.url.origin, rules, config, lastSignature);
+        if (done)
+          void analyzeAndWarn(
+            buffer,
+            event.route.id ?? event.url.pathname,
+            event.url.origin,
+            rules,
+            config,
+            lastSignature
+          );
         return html;
       }
     });

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -1,9 +1,12 @@
 import { existsSync } from 'node:fs';
 import { writeFile, mkdir } from 'node:fs/promises';
 import { join, isAbsolute, dirname } from 'node:path';
-import type { Plugin } from 'vite';
+import type { Plugin, ViteDevServer } from 'vite';
 import type { RuleSetting, Severity, TreatDynamicAs } from '@svelte-vitals/core';
+import { defineConfig } from '@svelte-vitals/core';
 import { analyze } from './analyze.js';
+import { installUiMiddleware } from './ui/middleware.js';
+import { readPackageVersion } from './version.js';
 
 export interface SvelteVitalsOptions {
   /** Project root (defaults to the Vite config root / cwd). */
@@ -19,14 +22,16 @@ export interface SvelteVitalsOptions {
   outFile?: string;
   /** Override the prerendered-pages directory (default: .svelte-kit/output/prerendered/pages). */
   prerenderDir?: string;
+  /** Serve a live dashboard at /__svelte-vitals/ during `vite dev` (requires svelteVitalsHandle in hooks.server.ts). */
+  ui?: boolean;
 }
 
 const DEFAULT_PRERENDER_DIR = '.svelte-kit/output/prerendered/pages';
 
 /** svelte-vitals Vite/SvelteKit plugin. */
-export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin {
+export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin | Plugin[] {
   let root = options.cwd ?? process.cwd();
-  return {
+  const buildPlugin: Plugin = {
     name: 'svelte-vitals',
     apply: 'build',
     enforce: 'post',
@@ -69,4 +74,22 @@ export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin {
       }
     }
   };
+
+  if (!options.ui) return buildPlugin;
+
+  const uiPlugin: Plugin = {
+    name: 'svelte-vitals:ui',
+    apply: 'serve',
+    configureServer(server: ViteDevServer) {
+      process.env.SVELTE_VITALS_UI = '1';
+      const config = defineConfig({
+        treatDynamicAs: options.treatDynamicAs ?? 'pass',
+        metaComponents: options.metaComponents ?? [],
+        rules: options.rules ?? {},
+        failOn: options.failOn ?? 'critical'
+      });
+      installUiMiddleware(server, config, readPackageVersion());
+    }
+  };
+  return [buildPlugin, uiPlugin];
 }

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -82,6 +82,11 @@ export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin | Plugin
     apply: 'serve',
     configureServer(server: ViteDevServer) {
       process.env.SVELTE_VITALS_UI = '1';
+      // Clear the flag when the dev server stops, so the handle doesn't keep
+      // POSTing to a no-longer-mounted endpoint after a restart / config flip.
+      server.httpServer?.once('close', () => {
+        delete process.env.SVELTE_VITALS_UI;
+      });
       const config = defineConfig({
         treatDynamicAs: options.treatDynamicAs ?? 'pass',
         metaComponents: options.metaComponents ?? [],

--- a/packages/vite/src/ui/middleware.ts
+++ b/packages/vite/src/ui/middleware.ts
@@ -1,0 +1,51 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { ViteDevServer } from 'vite';
+import type { Config } from '@svelte-vitals/core';
+import { createStore } from './store.js';
+import { renderDashboard } from './serve.js';
+
+/** Mount the dev UI at /__svelte-vitals/ : GET / (dashboard), POST /ingest, GET /events (SSE). */
+export function installUiMiddleware(server: ViteDevServer, config: Config, version: string): void {
+  const store = createStore();
+  const clients = new Set<ServerResponse>();
+
+  store.subscribe(() => {
+    for (const res of clients) res.write('event: update\ndata: {}\n\n');
+  });
+
+  // connect strips the mount path, so req.url is relative ('/', '/ingest', '/events').
+  server.middlewares.use('/__svelte-vitals', (req: IncomingMessage, res: ServerResponse) => {
+    const url = req.url ?? '/';
+
+    if (req.method === 'POST' && url.startsWith('/ingest')) {
+      let body = '';
+      req.on('data', (c) => (body += c));
+      req.on('end', () => {
+        try {
+          const { route, results } = JSON.parse(body);
+          if (typeof route === 'string' && Array.isArray(results)) store.set(route, results);
+        } catch {
+          // ignore malformed ingest payloads — dev tooling must not crash the dev server
+        }
+        res.statusCode = 204;
+        res.end();
+      });
+      return;
+    }
+
+    if (url.startsWith('/events')) {
+      res.writeHead(200, {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive'
+      });
+      res.write('\n');
+      clients.add(res);
+      req.on('close', () => clients.delete(res));
+      return;
+    }
+
+    res.setHeader('Content-Type', 'text/html');
+    res.end(renderDashboard(store.snapshot(), config, { version }));
+  });
+}

--- a/packages/vite/src/ui/middleware.ts
+++ b/packages/vite/src/ui/middleware.ts
@@ -1,8 +1,15 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { ViteDevServer } from 'vite';
-import type { Config } from '@svelte-vitals/core';
+import type { Config, Result } from '@svelte-vitals/core';
 import { createStore } from './store.js';
 import { renderDashboard } from './serve.js';
+
+/** Minimal shape the dashboard renderer relies on, so malformed ingest can't poison it. */
+function isResultLike(x: unknown): x is Result {
+  if (typeof x !== 'object' || x === null) return false;
+  const r = x as Record<string, unknown>;
+  return typeof r.id === 'string' && typeof r.detection === 'object' && r.detection !== null;
+}
 
 /** Mount the dev UI at /__svelte-vitals/ : GET / (dashboard), POST /ingest, GET /events (SSE). */
 export function installUiMiddleware(server: ViteDevServer, config: Config, version: string): void {
@@ -31,7 +38,9 @@ export function installUiMiddleware(server: ViteDevServer, config: Config, versi
       req.on('end', () => {
         try {
           const { route, results } = JSON.parse(body);
-          if (typeof route === 'string' && Array.isArray(results)) store.set(route, results);
+          if (typeof route === 'string' && Array.isArray(results)) {
+            store.set(route, results.filter(isResultLike));
+          }
         } catch {
           // ignore malformed ingest payloads — dev tooling must not crash the dev server
         }

--- a/packages/vite/src/ui/middleware.ts
+++ b/packages/vite/src/ui/middleware.ts
@@ -44,16 +44,25 @@ export function installUiMiddleware(server: ViteDevServer, config: Config, versi
     }
   });
 
+  // Open SSE connections keep the HTTP server from emitting 'close', so a `vite`
+  // restart/shutdown would hang until each client disconnects. End them ourselves.
+  server.httpServer?.once('close', () => {
+    for (const res of clients) res.end();
+    clients.clear();
+  });
+
   // connect strips the mount path, so req.url is relative ('/', '/ingest', '/events').
   server.middlewares.use('/__svelte-vitals', (req: IncomingMessage, res: ServerResponse) => {
     const url = req.url ?? '/';
 
     if (req.method === 'POST' && url.startsWith('/ingest')) {
-      let body = '';
-      req.on('data', (c) => (body += c));
+      // Collect raw Buffers and decode once: per-chunk toString() would corrupt a
+      // multibyte char split across a chunk boundary, dropping that route's findings.
+      const chunks: Buffer[] = [];
+      req.on('data', (c: Buffer) => chunks.push(c));
       req.on('end', () => {
         try {
-          const { route, results } = JSON.parse(body);
+          const { route, results } = JSON.parse(Buffer.concat(chunks).toString('utf8'));
           if (typeof route === 'string' && Array.isArray(results)) {
             store.set(route, results.filter(isResultLike));
           }

--- a/packages/vite/src/ui/middleware.ts
+++ b/packages/vite/src/ui/middleware.ts
@@ -10,7 +10,15 @@ export function installUiMiddleware(server: ViteDevServer, config: Config, versi
   const clients = new Set<ServerResponse>();
 
   store.subscribe(() => {
-    for (const res of clients) res.write('event: update\ndata: {}\n\n');
+    for (const res of clients) {
+      try {
+        res.write('event: update\ndata: {}\n\n');
+      } catch {
+        // a client socket can error between its close event and this write —
+        // drop it so one dead client never breaks the notify loop for the rest
+        clients.delete(res);
+      }
+    }
   });
 
   // connect strips the mount path, so req.url is relative ('/', '/ingest', '/events').

--- a/packages/vite/src/ui/middleware.ts
+++ b/packages/vite/src/ui/middleware.ts
@@ -4,11 +4,27 @@ import type { Config, Result } from '@svelte-vitals/core';
 import { createStore } from './store.js';
 import { renderDashboard } from './serve.js';
 
-/** Minimal shape the dashboard renderer relies on, so malformed ingest can't poison it. */
+const SEVERITIES = new Set(['critical', 'warning', 'info']);
+
+/**
+ * The fields the dashboard renderer dereferences, so malformed ingest can't crash it:
+ * `escapeHtml(id|message)` need strings, `effectiveSeverity`/`classify` read
+ * `detection.presence|value` and `severity`. Real engine findings always carry these.
+ */
 function isResultLike(x: unknown): x is Result {
   if (typeof x !== 'object' || x === null) return false;
   const r = x as Record<string, unknown>;
-  return typeof r.id === 'string' && typeof r.detection === 'object' && r.detection !== null;
+  const d = r.detection as Record<string, unknown> | undefined;
+  return (
+    typeof r.id === 'string' &&
+    typeof r.message === 'string' &&
+    typeof r.severity === 'string' &&
+    SEVERITIES.has(r.severity) &&
+    typeof d === 'object' &&
+    d !== null &&
+    typeof d.presence === 'string' &&
+    typeof d.value === 'string'
+  );
 }
 
 /** Mount the dev UI at /__svelte-vitals/ : GET / (dashboard), POST /ingest, GET /events (SSE). */

--- a/packages/vite/src/ui/serve.ts
+++ b/packages/vite/src/ui/serve.ts
@@ -1,0 +1,26 @@
+import { buildHtmlDocument, buildJsonReport, type Config, type Result } from '@svelte-vitals/core';
+
+// Injected only by the live UI (not part of the shared core renderer). On an SSE
+// `update`, re-fetch the dashboard, swap the `.wrap` element, and re-run the core
+// init script (freshly appended <script> executes) so the gauge/filters rebind.
+const LIVE_SCRIPT = `<script data-live>
+(function(){
+  var es=new EventSource('/__svelte-vitals/events');
+  es.addEventListener('update',function(){
+    fetch('/__svelte-vitals/').then(function(r){return r.text();}).then(function(html){
+      var doc=new DOMParser().parseFromString(html,'text/html');
+      var next=doc.querySelector('.wrap'),cur=document.querySelector('.wrap');
+      if(next&&cur)cur.replaceWith(next);
+      var scripts=doc.querySelectorAll('body > script:not([data-live])');
+      var core=scripts[scripts.length-1];
+      if(core){var s=document.createElement('script');s.textContent=core.textContent;document.body.appendChild(s);s.remove();}
+    }).catch(function(){});
+  });
+})();
+</script>`;
+
+/** The dashboard HTML: the core report document plus the injected live-update script. */
+export function renderDashboard(results: Result[], config: Config, meta: { version: string }): string {
+  const html = buildHtmlDocument(buildJsonReport(results, config, meta), meta);
+  return html.replace('</body>', LIVE_SCRIPT + '</body>');
+}

--- a/packages/vite/src/ui/store.ts
+++ b/packages/vite/src/ui/store.ts
@@ -1,0 +1,32 @@
+import type { Result } from '@svelte-vitals/core';
+
+/** In-memory findings store for the dev UI. Owned by the dev-server middleware. */
+export interface FindingsStore {
+  /** Replace a route's findings (route stamped onto results missing one) and notify subscribers. */
+  set(route: string, results: Result[]): void;
+  /** All findings across routes, flattened — feed straight into buildJsonReport. */
+  snapshot(): Result[];
+  /** Subscribe to change notifications; returns an unsubscribe function. */
+  subscribe(fn: () => void): () => void;
+}
+
+export function createStore(): FindingsStore {
+  const byRoute = new Map<string, Result[]>();
+  const subs = new Set<() => void>();
+  return {
+    set(route, results) {
+      byRoute.set(
+        route,
+        results.map((r) => (r.route ? r : { ...r, route }))
+      );
+      for (const fn of subs) fn();
+    },
+    snapshot() {
+      return [...byRoute.values()].flat();
+    },
+    subscribe(fn) {
+      subs.add(fn);
+      return () => subs.delete(fn);
+    }
+  };
+}

--- a/packages/vite/test/integration.test.ts
+++ b/packages/vite/test/integration.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { Plugin } from 'vite';
 import { svelteVitals } from '../src/index.js';
 
 describe('svelteVitals plugin', () => {
@@ -15,13 +16,13 @@ describe('svelteVitals plugin', () => {
   afterAll(async () => rm(cwd, { recursive: true, force: true }));
 
   it('is a build-only plugin named svelte-vitals', () => {
-    const p = svelteVitals({ cwd });
+    const p = svelteVitals({ cwd }) as Plugin;
     expect(p.name).toBe('svelte-vitals');
     expect(p.apply).toBe('build');
   });
 
   it('throws to fail the build when a critical finding exists (missing description on /)', async () => {
-    const p = svelteVitals({ cwd, report: false, failOn: 'critical' });
+    const p = svelteVitals({ cwd, report: false, failOn: 'critical' }) as Plugin;
     // closeBundle is a function on the plugin object
     const hook = typeof p.closeBundle === 'function' ? p.closeBundle : p.closeBundle?.handler;
     await expect((hook as () => Promise<void>).call({})).rejects.toThrow(/svelte-vitals: build failed/);
@@ -57,7 +58,7 @@ describe('svelteVitals plugin', () => {
           '</html>'
         ].join('')
       );
-      const p = svelteVitals({ cwd: cleanCwd, report: false, failOn: 'critical' });
+      const p = svelteVitals({ cwd: cleanCwd, report: false, failOn: 'critical' }) as Plugin;
       const hook = typeof p.closeBundle === 'function' ? p.closeBundle : p.closeBundle?.handler;
       await expect((hook as () => Promise<void>).call({})).resolves.toBeUndefined();
     } finally {

--- a/packages/vite/test/plugin-error.test.ts
+++ b/packages/vite/test/plugin-error.test.ts
@@ -35,7 +35,7 @@ describe('svelteVitals analysis failure', () => {
   });
 
   it('warns and skips the gate instead of failing the build when analysis throws', async () => {
-    const p = svelteVitals({ cwd, failOn: 'critical' });
+    const p = svelteVitals({ cwd, failOn: 'critical' }) as Plugin;
     await expect(closeBundleOf(p)()).resolves.toBeUndefined();
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy.mock.calls[0]![0]).toMatch(/analysis failed: boom/);

--- a/packages/vite/test/plugin-options.test.ts
+++ b/packages/vite/test/plugin-options.test.ts
@@ -32,7 +32,7 @@ describe('svelteVitals options', () => {
   });
 
   it('writes the JSON report to a relative outFile resolved against the project root', async () => {
-    const p = svelteVitals({ cwd, report: false, failOn: 'info', outFile: 'reports/seo.json' });
+    const p = svelteVitals({ cwd, report: false, failOn: 'info', outFile: 'reports/seo.json' }) as Plugin;
     // failOn:'info' would normally throw on findings; swallow so we can assert the file.
     await closeBundleOf(p)().catch(() => {});
     const written = await readFile(join(cwd, 'reports/seo.json'), 'utf8');
@@ -42,7 +42,7 @@ describe('svelteVitals options', () => {
 
   it("logs the JSON report to the console when report is 'json'", async () => {
     // Default failOn:'critical' throws after logging; the log fires first.
-    const p = svelteVitals({ cwd, report: 'json' });
+    const p = svelteVitals({ cwd, report: 'json' }) as Plugin;
     await closeBundleOf(p)().catch(() => {});
     expect(logSpy).toHaveBeenCalledTimes(1);
     const logged = logSpy.mock.calls[0]![0] as string;
@@ -52,7 +52,7 @@ describe('svelteVitals options', () => {
   it('is a no-op (no report, no throw) when the prerendered dir is absent', async () => {
     const empty = await mkdtemp(join(tmpdir(), 'sv-opt-empty-'));
     try {
-      const p = svelteVitals({ cwd: empty, failOn: 'critical' });
+      const p = svelteVitals({ cwd: empty, failOn: 'critical' }) as Plugin;
       await expect(closeBundleOf(p)()).resolves.toBeUndefined();
       expect(logSpy).not.toHaveBeenCalled();
     } finally {
@@ -62,7 +62,7 @@ describe('svelteVitals options', () => {
 
   it('respects an absolute outFile path unchanged', async () => {
     const abs = join(cwd, 'absolute-report.json');
-    const p = svelteVitals({ cwd, report: false, failOn: 'info', outFile: abs });
+    const p = svelteVitals({ cwd, report: false, failOn: 'info', outFile: abs }) as Plugin;
     await closeBundleOf(p)().catch(() => {});
     await expect(access(abs)).resolves.toBeUndefined();
   });

--- a/packages/vite/test/ui-ingest.test.ts
+++ b/packages/vite/test/ui-ingest.test.ts
@@ -50,4 +50,19 @@ describe('handle ingest (UI feed)', () => {
     await flush();
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it('does NOT POST to a non-loopback origin (spoofed Host)', async () => {
+    process.env.SVELTE_VITALS_UI = '1';
+    const fetchMock = vi.fn(async () => ({ ok: true }) as Response);
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const evilEvent = {
+      route: { id: '/none' },
+      url: new URL('http://evil.example.com/none')
+    } as unknown as Parameters<Parameters<Handle>[0]['resolve']>[0];
+    const handle = svelteVitalsHandle();
+    await handle({ event: evilEvent, resolve: resolveWith([PAGE_NO_TITLE]) });
+    await flush();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });

--- a/packages/vite/test/ui-ingest.test.ts
+++ b/packages/vite/test/ui-ingest.test.ts
@@ -25,7 +25,9 @@ afterEach(() => {
 describe('handle ingest (UI feed)', () => {
   it('POSTs findings to /__svelte-vitals/ingest when the UI env flag is set', async () => {
     process.env.SVELTE_VITALS_UI = '1';
-    const fetchMock = vi.fn(async () => ({ ok: true }) as Response);
+    const fetchMock = vi.fn<(url: string | URL, init?: RequestInit) => Promise<Response>>(
+      async () => ({ ok: true }) as Response
+    );
     vi.stubGlobal('fetch', fetchMock);
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     const handle = svelteVitalsHandle();

--- a/packages/vite/test/ui-ingest.test.ts
+++ b/packages/vite/test/ui-ingest.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { Handle } from '@sveltejs/kit';
+import { svelteVitalsHandle } from '../src/hooks/index.js';
+
+function fakeEvent(routeId: string | null, pathname = '/') {
+  return { route: { id: routeId }, url: new URL(`http://localhost:5173${pathname}`) } as unknown as Parameters<
+    Parameters<Handle>[0]['resolve']
+  >[0];
+}
+function resolveWith(chunks: string[]) {
+  return (async (_event: unknown, opts?: { transformPageChunk?: (i: { html: string; done: boolean }) => unknown }) => {
+    const tpc = opts?.transformPageChunk;
+    if (tpc) for (let i = 0; i < chunks.length; i++) await tpc({ html: chunks[i]!, done: i === chunks.length - 1 });
+    return {} as unknown as Response;
+  }) as Parameters<Handle>[0]['resolve'];
+}
+const flush = () => new Promise((r) => setTimeout(r, 0));
+const PAGE_NO_TITLE = '<html lang="en"><head><meta name="description" content="x"></head><body></body></html>';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.SVELTE_VITALS_UI;
+});
+
+describe('handle ingest (UI feed)', () => {
+  it('POSTs findings to /__svelte-vitals/ingest when the UI env flag is set', async () => {
+    process.env.SVELTE_VITALS_UI = '1';
+    const fetchMock = vi.fn(async () => ({ ok: true }) as Response);
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const handle = svelteVitalsHandle();
+    await handle({ event: fakeEvent('/none', '/none'), resolve: resolveWith([PAGE_NO_TITLE]) });
+    await flush();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [urlArg, init] = fetchMock.mock.calls[0]!;
+    expect(String(urlArg)).toBe('http://localhost:5173/__svelte-vitals/ingest');
+    const sent = JSON.parse((init as RequestInit).body as string);
+    expect(sent.route).toBe('/none');
+    expect(Array.isArray(sent.results)).toBe(true);
+  });
+
+  it('does NOT POST when the UI env flag is unset', async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true }) as Response);
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const handle = svelteVitalsHandle();
+    await handle({ event: fakeEvent('/none', '/none'), resolve: resolveWith([PAGE_NO_TITLE]) });
+    await flush();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/vite/test/ui-middleware.test.ts
+++ b/packages/vite/test/ui-middleware.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { installUiMiddleware } from '../src/ui/middleware.js';
 import { defineConfig } from '@svelte-vitals/core';

--- a/packages/vite/test/ui-middleware.test.ts
+++ b/packages/vite/test/ui-middleware.test.ts
@@ -108,7 +108,9 @@ describe('installUiMiddleware', () => {
         JSON.stringify({
           route: '/x',
           results: [
-            {},
+            {}, // not an object-shaped finding
+            { id: 'SEO002', detection: { presence: 'none', value: 'absent' } }, // missing message/severity
+            { id: 'SEO003', message: 'm', severity: 'bogus', detection: { presence: 'none', value: 'absent' } }, // invalid severity
             {
               id: 'SEO001',
               detection: { presence: 'none', value: 'absent' },
@@ -125,7 +127,9 @@ describe('installUiMiddleware', () => {
     const gr = res();
     call(getReq('/'), gr);
     const html = gr.chunks.join('');
-    expect(html.startsWith('<!doctype html>')).toBe(true); // did not crash on the {} entry
+    expect(html.startsWith('<!doctype html>')).toBe(true); // did not crash on the malformed entries
     expect(html).toContain('SEO001'); // the valid finding survived
+    expect(html).not.toContain('SEO002'); // missing message/severity → dropped
+    expect(html).not.toContain('SEO003'); // invalid severity → dropped
   });
 });

--- a/packages/vite/test/ui-middleware.test.ts
+++ b/packages/vite/test/ui-middleware.test.ts
@@ -97,4 +97,35 @@ describe('installUiMiddleware', () => {
     await new Promise((r) => setTimeout(r, 0));
     expect(sse.chunks.join('')).toContain('event: update');
   });
+
+  it('drops malformed finding objects so the dashboard still renders', async () => {
+    const { call } = setup();
+    const ireq = postReq('/ingest');
+    call(ireq, res());
+    ireq.emit(
+      'data',
+      Buffer.from(
+        JSON.stringify({
+          route: '/x',
+          results: [
+            {},
+            {
+              id: 'SEO001',
+              detection: { presence: 'none', value: 'absent' },
+              message: 'm',
+              category: 'seo',
+              severity: 'critical'
+            }
+          ]
+        })
+      )
+    );
+    ireq.emit('end');
+    await new Promise((r) => setTimeout(r, 0));
+    const gr = res();
+    call(getReq('/'), gr);
+    const html = gr.chunks.join('');
+    expect(html.startsWith('<!doctype html>')).toBe(true); // did not crash on the {} entry
+    expect(html).toContain('SEO001'); // the valid finding survived
+  });
 });

--- a/packages/vite/test/ui-middleware.test.ts
+++ b/packages/vite/test/ui-middleware.test.ts
@@ -1,24 +1,72 @@
 import { describe, it, expect } from 'vitest';
 import { EventEmitter } from 'node:events';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { ViteDevServer } from 'vite';
 import { installUiMiddleware } from '../src/ui/middleware.js';
 import { defineConfig } from '@svelte-vitals/core';
 
+type MiddlewareHandler = (req: IncomingMessage, res: ServerResponse, next: () => void) => void;
+
 // Capture the handler that installUiMiddleware registers on server.middlewares.use(path, fn).
 function setup() {
-  let handler: (req: any, res: any, next: () => void) => void = () => {};
-  const server = { middlewares: { use: (_path: string, fn: typeof handler) => (handler = fn) } } as any;
+  let handler: MiddlewareHandler = () => {};
+  const server = {
+    middlewares: { use: (_path: string, fn: MiddlewareHandler) => (handler = fn) }
+  } as unknown as ViteDevServer;
   installUiMiddleware(server, defineConfig({}), '9.9.9');
-  return { call: (req: any, res: any) => handler(req, res, () => {}) };
+  return {
+    call: (req: IncomingMessage, res: ServerResponse) => handler(req, res, () => {})
+  };
 }
-function res() {
-  return { statusCode: 0, headers: {} as Record<string, string>, chunks: [] as string[], setHeader(k: string, v: string) { this.headers[k] = v; }, writeHead(c: number, h?: Record<string, string>) { this.statusCode = c; Object.assign(this.headers, h ?? {}); }, write(c: string) { this.chunks.push(c); }, end(c?: string) { if (c) this.chunks.push(c); } };
+interface MockRes {
+  statusCode: number;
+  headers: Record<string, string>;
+  chunks: string[];
+  setHeader(k: string, v: string): void;
+  writeHead(c: number, h?: Record<string, string>): void;
+  write(c: string): void;
+  end(c?: string): void;
 }
-function postReq(url: string) { return Object.assign(new EventEmitter(), { method: 'POST', url }); }
-function getReq(url: string) { return Object.assign(new EventEmitter(), { method: 'GET', url }); }
+function res(): MockRes & ServerResponse {
+  const r: MockRes = {
+    statusCode: 0,
+    headers: {} as Record<string, string>,
+    chunks: [] as string[],
+    setHeader(k: string, v: string) {
+      r.headers[k] = v;
+    },
+    writeHead(c: number, h?: Record<string, string>) {
+      r.statusCode = c;
+      Object.assign(r.headers, h ?? {});
+    },
+    write(c: string) {
+      r.chunks.push(c);
+    },
+    end(c?: string) {
+      if (c) r.chunks.push(c);
+    }
+  };
+  return r as unknown as MockRes & ServerResponse;
+}
+function postReq(url: string): IncomingMessage {
+  return Object.assign(new EventEmitter(), { method: 'POST', url }) as unknown as IncomingMessage;
+}
+function getReq(url: string): IncomingMessage {
+  return Object.assign(new EventEmitter(), { method: 'GET', url }) as unknown as IncomingMessage;
+}
 
 const ingestBody = JSON.stringify({
   route: '/a',
-  results: [{ id: 'SEO001', message: 'Missing <title>', category: 'seo', detection: { presence: 'none', value: 'absent' }, route: '/a', severity: 'critical' }]
+  results: [
+    {
+      id: 'SEO001',
+      message: 'Missing <title>',
+      category: 'seo',
+      detection: { presence: 'none', value: 'absent' },
+      route: '/a',
+      severity: 'critical'
+    }
+  ]
 });
 
 describe('installUiMiddleware', () => {

--- a/packages/vite/test/ui-middleware.test.ts
+++ b/packages/vite/test/ui-middleware.test.ts
@@ -10,18 +10,22 @@ type MiddlewareHandler = (req: IncomingMessage, res: ServerResponse, next: () =>
 // Capture the handler that installUiMiddleware registers on server.middlewares.use(path, fn).
 function setup() {
   let handler: MiddlewareHandler = () => {};
+  const httpServer = new EventEmitter();
   const server = {
+    httpServer,
     middlewares: { use: (_path: string, fn: MiddlewareHandler) => (handler = fn) }
   } as unknown as ViteDevServer;
   installUiMiddleware(server, defineConfig({}), '9.9.9');
   return {
-    call: (req: IncomingMessage, res: ServerResponse) => handler(req, res, () => {})
+    call: (req: IncomingMessage, res: ServerResponse) => handler(req, res, () => {}),
+    closeServer: () => httpServer.emit('close')
   };
 }
 interface MockRes {
   statusCode: number;
   headers: Record<string, string>;
   chunks: string[];
+  ended: boolean;
   setHeader(k: string, v: string): void;
   writeHead(c: number, h?: Record<string, string>): void;
   write(c: string): void;
@@ -32,6 +36,7 @@ function res(): MockRes & ServerResponse {
     statusCode: 0,
     headers: {} as Record<string, string>,
     chunks: [] as string[],
+    ended: false,
     setHeader(k: string, v: string) {
       r.headers[k] = v;
     },
@@ -44,6 +49,7 @@ function res(): MockRes & ServerResponse {
     },
     end(c?: string) {
       if (c) r.chunks.push(c);
+      r.ended = true;
     }
   };
   return r as unknown as MockRes & ServerResponse;
@@ -131,5 +137,45 @@ describe('installUiMiddleware', () => {
     expect(html).toContain('SEO001'); // the valid finding survived
     expect(html).not.toContain('SEO002'); // missing message/severity → dropped
     expect(html).not.toContain('SEO003'); // invalid severity → dropped
+  });
+
+  it('decodes a multibyte ingest body split across chunk boundaries', async () => {
+    const { call } = setup();
+    // A finding message with a multibyte char; split the JSON bytes mid-character.
+    const payload = Buffer.from(
+      JSON.stringify({
+        route: '/x',
+        results: [
+          {
+            id: 'SEO001',
+            message: '日本語タイトルがありません',
+            category: 'seo',
+            detection: { presence: 'none', value: 'absent' },
+            severity: 'critical'
+          }
+        ]
+      }),
+      'utf8'
+    );
+    const split = payload.indexOf(Buffer.from('日', 'utf8')) + 1; // mid first multibyte char
+    const ireq = postReq('/ingest');
+    call(ireq, res());
+    ireq.emit('data', payload.subarray(0, split));
+    ireq.emit('data', payload.subarray(split));
+    ireq.emit('end');
+    await new Promise((r) => setTimeout(r, 0));
+    const gr = res();
+    call(getReq('/'), gr);
+    const html = gr.chunks.join('');
+    expect(html).toContain('SEO001'); // body parsed despite the split → finding survived
+  });
+
+  it('ends open SSE connections when the dev server closes', () => {
+    const { call, closeServer } = setup();
+    const sse = res();
+    call(getReq('/events'), sse);
+    expect(sse.ended).toBe(false);
+    closeServer();
+    expect(sse.ended).toBe(true); // connection released so httpServer.close() can finish
   });
 });

--- a/packages/vite/test/ui-middleware.test.ts
+++ b/packages/vite/test/ui-middleware.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { installUiMiddleware } from '../src/ui/middleware.js';
+import { defineConfig } from '@svelte-vitals/core';
+
+// Capture the handler that installUiMiddleware registers on server.middlewares.use(path, fn).
+function setup() {
+  let handler: (req: any, res: any, next: () => void) => void = () => {};
+  const server = { middlewares: { use: (_path: string, fn: typeof handler) => (handler = fn) } } as any;
+  installUiMiddleware(server, defineConfig({}), '9.9.9');
+  return { call: (req: any, res: any) => handler(req, res, () => {}) };
+}
+function res() {
+  return { statusCode: 0, headers: {} as Record<string, string>, chunks: [] as string[], setHeader(k: string, v: string) { this.headers[k] = v; }, writeHead(c: number, h?: Record<string, string>) { this.statusCode = c; Object.assign(this.headers, h ?? {}); }, write(c: string) { this.chunks.push(c); }, end(c?: string) { if (c) this.chunks.push(c); } };
+}
+function postReq(url: string) { return Object.assign(new EventEmitter(), { method: 'POST', url }); }
+function getReq(url: string) { return Object.assign(new EventEmitter(), { method: 'GET', url }); }
+
+const ingestBody = JSON.stringify({
+  route: '/a',
+  results: [{ id: 'SEO001', message: 'Missing <title>', category: 'seo', detection: { presence: 'none', value: 'absent' }, route: '/a', severity: 'critical' }]
+});
+
+describe('installUiMiddleware', () => {
+  it('serves the dashboard at / reflecting ingested findings', async () => {
+    const { call } = setup();
+    const ir = res();
+    const ireq = postReq('/ingest');
+    call(ireq, ir);
+    ireq.emit('data', Buffer.from(ingestBody));
+    ireq.emit('end');
+    await new Promise((r) => setTimeout(r, 0));
+    const gr = res();
+    call(getReq('/'), gr);
+    const html = gr.chunks.join('');
+    expect(html).toContain('SEO001');
+    expect(gr.headers['Content-Type']).toContain('text/html');
+  });
+
+  it('streams an SSE update when findings are ingested', async () => {
+    const { call } = setup();
+    const sse = res();
+    call(getReq('/events'), sse);
+    expect(sse.headers['Content-Type']).toContain('text/event-stream');
+    const ireq = postReq('/ingest');
+    call(ireq, res());
+    ireq.emit('data', Buffer.from(ingestBody));
+    ireq.emit('end');
+    await new Promise((r) => setTimeout(r, 0));
+    expect(sse.chunks.join('')).toContain('event: update');
+  });
+});

--- a/packages/vite/test/ui-plugin.test.ts
+++ b/packages/vite/test/ui-plugin.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import type { Plugin, ViteDevServer } from 'vite';
+import { svelteVitals } from '../src/index.js';
+
+afterEach(() => {
+  delete process.env.SVELTE_VITALS_UI;
+});
+
+describe('svelteVitals({ ui })', () => {
+  it('returns a single plugin when ui is not set (unchanged)', () => {
+    const p = svelteVitals({});
+    expect(Array.isArray(p)).toBe(false);
+    expect((p as Plugin).name).toBe('svelte-vitals');
+  });
+
+  it('adds a dev-only UI plugin when ui:true', () => {
+    const plugins = svelteVitals({ ui: true }) as Plugin[];
+    expect(Array.isArray(plugins)).toBe(true);
+    const ui = plugins.find((p) => p.name === 'svelte-vitals:ui')!;
+    expect(ui).toBeDefined();
+    expect(ui.apply).toBe('serve');
+  });
+
+  it('configureServer installs middleware and sets the UI env flag', () => {
+    const plugins = svelteVitals({ ui: true }) as Plugin[];
+    const ui = plugins.find((p) => p.name === 'svelte-vitals:ui')!;
+    const used: string[] = [];
+    const server = { middlewares: { use: (path: string) => used.push(path) } } as unknown as ViteDevServer;
+    const hook = typeof ui.configureServer === 'function' ? ui.configureServer : ui.configureServer!.handler;
+    (hook as (s: ViteDevServer) => void).call({}, server);
+    expect(process.env.SVELTE_VITALS_UI).toBe('1');
+    expect(used).toContain('/__svelte-vitals');
+  });
+});

--- a/packages/vite/test/ui-serve.test.ts
+++ b/packages/vite/test/ui-serve.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { renderDashboard } from '../src/ui/serve.js';
+import { defineConfig, type Result } from '@svelte-vitals/core';
+
+const config = defineConfig({});
+const results: Result[] = [
+  { id: 'SEO001', message: 'Missing <title>', category: 'seo', detection: { presence: 'none', value: 'absent' }, route: '/a', location: 'a/+page.svelte', severity: 'critical' } as Result
+];
+
+describe('renderDashboard', () => {
+  const html = renderDashboard(results, config, { version: '9.9.9' });
+
+  it('reuses buildHtmlDocument (full doc with the finding)', () => {
+    expect(html.startsWith('<!doctype html>')).toBe(true);
+    expect(html).toContain('SEO001');
+  });
+
+  it('injects a live-update script before </body>', () => {
+    expect(html).toContain('data-live');
+    expect(html).toContain("EventSource('/__svelte-vitals/events')");
+    // injected before the closing body tag
+    expect(html.indexOf('data-live')).toBeLessThan(html.indexOf('</body>'));
+  });
+
+  it('renders an empty snapshot without throwing', () => {
+    expect(() => renderDashboard([], config, { version: '0' })).not.toThrow();
+  });
+});

--- a/packages/vite/test/ui-serve.test.ts
+++ b/packages/vite/test/ui-serve.test.ts
@@ -4,7 +4,15 @@ import { defineConfig, type Result } from '@svelte-vitals/core';
 
 const config = defineConfig({});
 const results: Result[] = [
-  { id: 'SEO001', message: 'Missing <title>', category: 'seo', detection: { presence: 'none', value: 'absent' }, route: '/a', location: 'a/+page.svelte', severity: 'critical' } as Result
+  {
+    id: 'SEO001',
+    message: 'Missing <title>',
+    category: 'seo',
+    detection: { presence: 'none', value: 'absent' },
+    route: '/a',
+    location: 'a/+page.svelte',
+    severity: 'critical'
+  } as Result
 ];
 
 describe('renderDashboard', () => {

--- a/packages/vite/test/ui-store.test.ts
+++ b/packages/vite/test/ui-store.test.ts
@@ -3,14 +3,26 @@ import { createStore } from '../src/ui/store.js';
 import type { Result } from '@svelte-vitals/core';
 
 const r = (id: string, route?: string): Result =>
-  ({ id, message: id, category: 'seo', detection: { presence: 'none', value: 'absent' }, route, severity: 'critical' }) as Result;
+  ({
+    id,
+    message: id,
+    category: 'seo',
+    detection: { presence: 'none', value: 'absent' },
+    route,
+    severity: 'critical'
+  }) as Result;
 
 describe('createStore', () => {
   it('flattens results across routes in snapshot()', () => {
     const s = createStore();
     s.set('/a', [r('SEO001', '/a')]);
     s.set('/b', [r('SEO002', '/b')]);
-    expect(s.snapshot().map((x) => x.id).sort()).toEqual(['SEO001', 'SEO002']);
+    expect(
+      s
+        .snapshot()
+        .map((x) => x.id)
+        .sort()
+    ).toEqual(['SEO001', 'SEO002']);
   });
 
   it('replaces (not appends) a route on re-set', () => {

--- a/packages/vite/test/ui-store.test.ts
+++ b/packages/vite/test/ui-store.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createStore } from '../src/ui/store.js';
+import type { Result } from '@svelte-vitals/core';
+
+const r = (id: string, route?: string): Result =>
+  ({ id, message: id, category: 'seo', detection: { presence: 'none', value: 'absent' }, route, severity: 'critical' }) as Result;
+
+describe('createStore', () => {
+  it('flattens results across routes in snapshot()', () => {
+    const s = createStore();
+    s.set('/a', [r('SEO001', '/a')]);
+    s.set('/b', [r('SEO002', '/b')]);
+    expect(s.snapshot().map((x) => x.id).sort()).toEqual(['SEO001', 'SEO002']);
+  });
+
+  it('replaces (not appends) a route on re-set', () => {
+    const s = createStore();
+    s.set('/a', [r('SEO001', '/a')]);
+    s.set('/a', [r('SEO002', '/a')]);
+    expect(s.snapshot().map((x) => x.id)).toEqual(['SEO002']);
+  });
+
+  it('stamps the route onto results missing one', () => {
+    const s = createStore();
+    s.set('/a', [r('SEO001')]); // no route on the result
+    expect(s.snapshot()[0]!.route).toBe('/a');
+  });
+
+  it('notifies subscribers on set and supports unsubscribe', () => {
+    const s = createStore();
+    const fn = vi.fn();
+    const off = s.subscribe(fn);
+    s.set('/a', [r('SEO001', '/a')]);
+    expect(fn).toHaveBeenCalledTimes(1);
+    off();
+    s.set('/b', [r('SEO002', '/b')]);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Add a **live UI dashboard** to `@svelte-vitals/vite` — sub-project B of the "Lighthouse-like visualization" pillar. `svelteVitals({ ui: true })` serves a svelte-vitals report at `/__svelte-vitals/` during `vite dev` that updates live as you navigate, reusing the **same renderer** as the CLI's `--reporter html` (shipped in #47).

## How it works

- The existing `svelteVitalsHandle` (already in `hooks.server.ts` for the dev overlay) analyzes each visited page's rendered `<head>`. When the UI is enabled, it also **POSTs the route's findings** to the dev server (`/__svelte-vitals/ingest`) — fire-and-forget, errors swallowed.
- The plugin's dev middleware keeps an in-memory store and serves `buildHtmlDocument(buildJsonReport(...))` at `/__svelte-vitals/`, with a small **live-update script injected** before `</body>`. It pushes **SSE** `update` events; the page re-fetches and swaps `.wrap` in place (scroll/filters preserved, no full reload).
- Handle↔plugin talk over **HTTP on the dev server's origin** (they may be different module instances), gated by `process.env.SVELTE_VITALS_UI`.

## Setup (two files, same as the dev overlay)

```js
// vite.config — serve the dashboard in dev
svelteVitals({ ui: true })
```
```ts
// src/hooks.server.ts — already present for the dev overlay; feeds the UI
export const handle = sequence(svelteVitalsHandle());
```

Open `http://localhost:5173/__svelte-vitals/` and browse your app.

## Reuse / boundaries

- **`@svelte-vitals/core` is unchanged** — the UI only consumes `buildHtmlDocument` / `buildJsonReport`. `buildHtmlDocument` is reused **verbatim**; the live behavior is the injected `<script data-live>` only (vite-side).
- All server/serve/SSE/store/injection code lives in `@svelte-vitals/vite`. No dependency on the CLI. No new runtime dependencies (Node built-ins + vite peer types). ESM-only.
- **No behavior change when the UI is off**: `svelteVitals()` without `ui` returns the same single build plugin (byte-for-byte), and the handle does not POST when the flag is unset — dev-overlay-only users are unaffected.

## Scope (honest, rendered model)

Like the dev overlay, this is **dev-only and rendered-based**: it covers **SEO `<head>` rules** for the **routes you visit** (accumulates as you browse). Performance image rules and project-wide checks (robots/sitemap) aren't covered by this mode, and Health reflects visited routes. For a whole-project report, use `npx svelte-vitals` or `--reporter html`. (Manifest-all listing and deeper coverage are noted as follow-ups in the spec.)

## Release

`@svelte-vitals/vite` **minor** changeset only (no core/cli change).

## Validation

- `pnpm -r typecheck`, `pnpm -r test` (vite 45 incl. new store/serve/middleware/plugin/ingest tests; 287 total), `pnpm build`, `pnpm --filter docs build` (39 pages), `pnpm lint`, publint — all green.
- `attw` fails *locally only* (sandbox `npm pack`) — known pre-existing, CI-unaffected.

## Process

Built subagent-driven: 6 tasks (each spec + quality reviewed) + a whole-branch review on Opus (verdict: ready to merge). A cross-task typecheck/lint fix (the `Plugin | Plugin[]` return type rippling into existing vite tests, and a `no-explicit-any` in the new middleware test) and a final SSE-client-cleanup hardening were applied and re-verified. Docs: dev-overlay guide gains a "Live UI" section (en + ja).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dev-only live dashboard for Svelte Vitals in Vite, available at `/__svelte-vitals/` when enabled.
  * The dashboard updates automatically as you navigate during development and shows rendered page findings.
  * Added support for live updates via server-sent events.

* **Bug Fixes**
  * Improved build behavior so analysis issues no longer stop the build unexpectedly.
  * Made dev-server ingestion and streaming more resilient to malformed data and connection failures.

* **Documentation**
  * Updated English and Japanese guides with setup and usage details for the live dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->