### PR TITLE
feat(core): PERF003/PERF004 resource-hint checks

### DIFF
--- a/.changeset/perf-resource-hints.md
+++ b/.changeset/perf-resource-hints.md
@@ -1,0 +1,12 @@
+---
+'@svelte-vitals/core': minor
+'svelte-vitals': minor
+'@svelte-vitals/vite': minor
+---
+
+Add two static resource-hint Performance checks: PERF003 flags a `<link rel="preload">`
+with no `as` attribute (the browser ignores or double-fetches it), and PERF004 flags a
+`<link rel="preload" as="font">` with no `crossorigin` (the font preload is wasted and the
+file downloads twice). Both surface in the CLI, the static report, and the vite plugin /
+dev UI. Static mode evaluates hints in `<svelte:head>`; resource hints in `app.html` are
+covered in plugin/rendered mode.

--- a/.changeset/perf-resource-hints.md
+++ b/.changeset/perf-resource-hints.md
@@ -2,6 +2,7 @@
 '@svelte-vitals/core': minor
 'svelte-vitals': minor
 '@svelte-vitals/vite': minor
+'@svelte-vitals/mcp': minor
 ---
 
 Add two static resource-hint Performance checks: PERF003 flags a `<link rel="preload">`

--- a/docs/src/content/docs/ja/rules/perf003.md
+++ b/docs/src/content/docs/ja/rules/perf003.md
@@ -1,0 +1,22 @@
+---
+title: PERF003 · preload に as がない
+description: すべての <link rel="preload"> は as 属性を指定すべきです。
+---
+
+**重大度:** warning
+
+## チェック内容
+
+すべての `<link rel="preload">` は、リソース種別を示す `as` 属性（`style`・`script`・`font`・`image` など）を持つ必要があります。`as` のない preload は検出されます。
+
+## なぜ重要か
+
+`as` 属性のない `<link rel="preload">` はブラウザに無視される（または二重にフェッチされる）ため、preload が無駄になります。
+
+## 修正方法
+
+リソース種別に合った `as` 属性を追加します：
+
+```html
+<link rel="preload" href="/app.css" as="style" />
+```

--- a/docs/src/content/docs/ja/rules/perf004.md
+++ b/docs/src/content/docs/ja/rules/perf004.md
@@ -1,0 +1,22 @@
+---
+title: PERF004 · フォント preload に crossorigin がない
+description: フォントの preload は crossorigin を指定しないと使われません。
+---
+
+**重大度:** warning
+
+## チェック内容
+
+すべての `<link rel="preload" as="font">` は `crossorigin` 属性を含む必要があります。これがないフォント preload は検出されます。
+
+## なぜ重要か
+
+`crossorigin` のないフォント preload は実際の（CORS）フォントリクエストと一致しないため、preload したファイルは使われず、フォントが二重にダウンロードされます。
+
+## 修正方法
+
+フォントの preload に `crossorigin` を追加します：
+
+```html
+<link rel="preload" href="/inter.woff2" as="font" type="font/woff2" crossorigin />
+```

--- a/docs/src/content/docs/rules/perf003.md
+++ b/docs/src/content/docs/rules/perf003.md
@@ -1,0 +1,22 @@
+---
+title: PERF003 · Preload missing as
+description: Every <link rel="preload"> should declare an as attribute.
+---
+
+**Severity:** warning
+
+## What it checks
+
+Every `<link rel="preload">` must have an `as` attribute naming the resource type (`style`, `script`, `font`, `image`, …). A preload without `as` is flagged.
+
+## Why it matters
+
+A `<link rel="preload">` without an `as` attribute is ignored by the browser (or fetched a second time), wasting the preload.
+
+## How to fix
+
+Add an `as` attribute matching the resource type:
+
+```html
+<link rel="preload" href="/app.css" as="style" />
+```

--- a/docs/src/content/docs/rules/perf004.md
+++ b/docs/src/content/docs/rules/perf004.md
@@ -1,0 +1,22 @@
+---
+title: PERF004 · Font preload missing crossorigin
+description: A font preload must set crossorigin so the preloaded file is actually used.
+---
+
+**Severity:** warning
+
+## What it checks
+
+Every `<link rel="preload" as="font">` must include the `crossorigin` attribute. A font preload without it is flagged.
+
+## Why it matters
+
+A font preload without `crossorigin` does not match the actual (CORS) font request, so the preloaded file is never used and the font downloads twice.
+
+## How to fix
+
+Add `crossorigin` to the font preload:
+
+```html
+<link rel="preload" href="/inter.woff2" as="font" type="font/woff2" crossorigin />
+```

--- a/docs/superpowers/plans/2026-06-25-perf-resource-hints.md
+++ b/docs/superpowers/plans/2026-06-25-perf-resource-hints.md
@@ -1,0 +1,640 @@
+# Deeper Performance: Resource-Hint Correctness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add PERF003 (a `<link rel="preload">` with no `as`) and PERF004 (a `<link rel="preload" as="font">` with no `crossorigin`) — two high-confidence, statically-analyzable resource-hint checks.
+
+**Architecture:** Extend the runtime-agnostic `HeadTag` with `as`/`hasAs`/`hasCrossorigin` (presence + the `as` keyword), populate them from both providers (CLI svelte/compiler + vite node-html-parser), and add a small head-link rule helper plus the two rules to the core engine. Rules are pure functions over `ResolvedHead.tags`.
+
+**Tech Stack:** TypeScript, ESM-only (tsup, `target: es2022`), vitest. No new dependencies.
+
+## Global Constraints
+
+- ESM-only; `@svelte-vitals/core` has **no `node:` imports**; rules are pure functions over resolved heads/images/project.
+- **No false negatives:** decide only on attribute presence + the `as` keyword (a fixed vocabulary, like `rel`). A dynamically-bound `as={x}` / `crossorigin={c}` counts as **present** (never flagged).
+- New checks decide purely on `as`/`hasAs`/`hasCrossorigin` — never on literal `href` values.
+- Both PERF003 and PERF004 are `warning` severity, `scope: 'route'`, `category: 'performance'`.
+- Scoring mirrors `imageRule`: a route with no `preload` link emits **nothing** (no Performance signal); a route whose relevant links all pass emits **one** passing result (seeds the route at 100); each failing link emits a finding with a `fix`.
+- Static-mode `<svelte:head>` head composition collapses multiple `<link rel="preload">` to one representative (last-wins) — a **documented v1 limitation**; rendered/plugin mode evaluates every preload. The rules are unaffected (they scan whatever `ResolvedHead.tags` contains).
+- Release: `@svelte-vitals/core` + `svelte-vitals` + `@svelte-vitals/vite` **minor**; `@svelte-vitals/mcp` cascades a patch.
+
+### Reference: existing types & patterns (read-only — already in the codebase)
+
+```ts
+// packages/core/src/head.ts
+interface HeadTag {
+  kind: 'title' | 'meta' | 'link' | 'jsonld';
+  name?: string; property?: string; rel?: string;
+  presence: 'own' | 'inherited';
+  value: 'static' | 'dynamic' | 'absent';
+  file?: string;
+}
+interface ResolvedHead { route: string; source: 'static'|'rendered'; tags: HeadTag[]; file: string; }
+
+// packages/core/src/rule.ts
+interface RuleContext { heads: ResolvedHead[]; images?: ResolvedImages[]; project: Project; config: Config; }
+interface Rule { id; title; category; severity; scope; rationale; fix?; check(ctx): Promise<Result[]>; }
+
+// packages/core/src/rules/perf/image-rule.ts — the pattern to mirror:
+//   pass result:  detection: { presence: 'own',  value: 'static' }
+//   fail result:  detection: { presence: 'none', value: 'absent' }, + fix
+//   no signal:    emit nothing (route with no relevant element)
+
+// CLI parse helpers (packages/cli/src/providers/source/parse.ts):
+//   findAttr(attributes, name): Node | undefined   — attribute presence
+//   attrText(attributes, name): string | undefined — literal text, undefined for dynamic ExpressionTag
+//   attrValue(attributes, name): Value             — 'static'|'dynamic'|'absent'
+```
+
+---
+
+### Task 1: Extend HeadTag + both providers with `as` / `hasAs` / `hasCrossorigin`
+
+Add the three optional fields to `HeadTag` and populate them from the CLI (source) and vite (rendered) link parsers. No rules yet — no behavior change, just richer head tags.
+
+**Files:**
+- Modify: `packages/core/src/head.ts` (HeadTag fields)
+- Modify: `packages/cli/src/providers/source/parse.ts` (link branch in `tagsFromHead`)
+- Modify: `packages/vite/src/providers/rendered/parse-html.ts` (link loop)
+- Test: `packages/cli/test/parse.test.ts` (or the existing parse test file — see Step 1) and `packages/vite/test/parse-html.test.ts`
+
+**Interfaces:**
+- Produces: `HeadTag.as?: string`, `HeadTag.hasAs?: boolean`, `HeadTag.hasCrossorigin?: boolean` — set only for `kind: 'link'`. `as` is the literal keyword (undefined when absent OR dynamically bound); `hasAs` is true when an `as` attribute is present at all (literal or dynamic); `hasCrossorigin` is true when a `crossorigin` attribute is present (literal or dynamic).
+
+- [ ] **Step 1: Write the failing provider tests**
+
+First find the existing parse tests:
+Run: `ls packages/cli/test | grep -i parse; ls packages/vite/test | grep -i parse`
+Expected: `packages/vite/test/parse-html.test.ts` exists. For CLI, append to whichever test exercises `parseHeadTags`/`parseFile` (grep: `grep -rl "parseHeadTags\|parseFile" packages/cli/test`). If none, create `packages/cli/test/parse-link-attrs.test.ts`.
+
+Append to the vite test `packages/vite/test/parse-html.test.ts`:
+
+```ts
+import { parseHtmlHead } from '../src/providers/rendered/parse-html.js';
+// (describe/it/expect already imported at the top of the file)
+
+describe('parse-html: link as/crossorigin', () => {
+  it('captures as + crossorigin presence on a font preload', () => {
+    const { tags } = parseHtmlHead(
+      '<html><head><link rel="preload" href="/i.woff2" as="font" type="font/woff2" crossorigin></head><body></body></html>'
+    );
+    const link = tags.find((t) => t.kind === 'link' && t.rel === 'preload')!;
+    expect(link.as).toBe('font');
+    expect(link.hasAs).toBe(true);
+    expect(link.hasCrossorigin).toBe(true);
+  });
+  it('leaves as/crossorigin unset when absent', () => {
+    const { tags } = parseHtmlHead('<html><head><link rel="preload" href="/a.js"></head><body></body></html>');
+    const link = tags.find((t) => t.kind === 'link' && t.rel === 'preload')!;
+    expect(link.as).toBeUndefined();
+    expect(link.hasAs).toBeUndefined();
+    expect(link.hasCrossorigin).toBeUndefined();
+  });
+});
+```
+
+Create `packages/cli/test/parse-link-attrs.test.ts` (adjust the import if a parse test already exists):
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { parseHeadTags } from '../src/providers/source/parse.js';
+
+const head = (inner: string) => `<svelte:head>${inner}</svelte:head>`;
+
+describe('parse: link as/crossorigin (static)', () => {
+  it('captures a literal as keyword + crossorigin presence', () => {
+    const tags = parseHeadTags(head('<link rel="preload" href="/i.woff2" as="font" crossorigin />'), 'x.svelte');
+    const link = tags.find((t) => t.kind === 'link' && t.rel === 'preload')!;
+    expect(link.as).toBe('font');
+    expect(link.hasAs).toBe(true);
+    expect(link.hasCrossorigin).toBe(true);
+  });
+  it('treats a dynamic as={x} as present but with no literal keyword', () => {
+    const tags = parseHeadTags(head('<link rel="preload" href="/a.js" as={kind} />'), 'x.svelte');
+    const link = tags.find((t) => t.kind === 'link' && t.rel === 'preload')!;
+    expect(link.hasAs).toBe(true); // present → PERF003 won't fire
+    expect(link.as).toBeUndefined(); // not a literal → PERF004 won't fire
+  });
+  it('leaves fields unset when the attributes are absent', () => {
+    const tags = parseHeadTags(head('<link rel="preload" href="/a.js" />'), 'x.svelte');
+    const link = tags.find((t) => t.kind === 'link' && t.rel === 'preload')!;
+    expect(link.hasAs).toBeUndefined();
+    expect(link.as).toBeUndefined();
+    expect(link.hasCrossorigin).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd packages/vite && pnpm vitest run test/parse-html.test.ts -t "link as/crossorigin"` then `cd ../cli && pnpm vitest run test/parse-link-attrs.test.ts`
+Expected: FAIL — `as`/`hasAs`/`hasCrossorigin` are not on the tags yet.
+
+- [ ] **Step 3: Add the fields to `HeadTag`**
+
+In `packages/core/src/head.ts`, inside `interface HeadTag`, after the `rel?: string;` line add:
+
+```ts
+  /** <link as="..."> keyword (e.g. 'font') when statically literal; undefined when absent or dynamically bound. */
+  as?: string;
+  /** True when a <link> has an `as` attribute at all (literal or dynamic). Distinguishes "no as" from "dynamic as". */
+  hasAs?: boolean;
+  /** True when a <link> has a `crossorigin` attribute (presence only; value is irrelevant to the checks). */
+  hasCrossorigin?: boolean;
+```
+
+- [ ] **Step 4: Populate them in the CLI parser**
+
+In `packages/cli/src/providers/source/parse.ts`, replace the `link` branch in `tagsFromHead` (currently):
+
+```ts
+    } else if (node.name === 'link') {
+      const rel = attrText(node.attributes, 'rel');
+      tags.push({ kind: 'link', ...(rel ? { rel } : {}), value: attrValue(node.attributes, 'href') });
+```
+
+with:
+
+```ts
+    } else if (node.name === 'link') {
+      const rel = attrText(node.attributes, 'rel');
+      const hasAs = findAttr(node.attributes, 'as') !== undefined;
+      const asLiteral = attrText(node.attributes, 'as'); // literal keyword, or undefined for dynamic/absent
+      const hasCrossorigin = findAttr(node.attributes, 'crossorigin') !== undefined;
+      tags.push({
+        kind: 'link',
+        ...(rel ? { rel } : {}),
+        value: attrValue(node.attributes, 'href'),
+        ...(hasAs ? { hasAs: true } : {}),
+        ...(asLiteral ? { as: asLiteral } : {}),
+        ...(hasCrossorigin ? { hasCrossorigin: true } : {})
+      });
+```
+
+(`findAttr` and `attrText` are already defined in this file.)
+
+- [ ] **Step 5: Populate them in the vite parser**
+
+In `packages/vite/src/providers/rendered/parse-html.ts`, replace the `link` loop body (currently):
+
+```ts
+  for (const link of head.querySelectorAll('link')) {
+    const rel = link.getAttribute('rel');
+    if (!rel) continue;
+    tags.push({ kind: 'link', rel, presence: 'own', value: attrValue(link.getAttribute('href')) });
+  }
+```
+
+with:
+
+```ts
+  for (const link of head.querySelectorAll('link')) {
+    const rel = link.getAttribute('rel');
+    if (!rel) continue;
+    const asAttr = link.getAttribute('as'); // rendered HTML: literal string or undefined
+    const hasCrossorigin = link.hasAttribute('crossorigin');
+    tags.push({
+      kind: 'link',
+      rel,
+      presence: 'own',
+      value: attrValue(link.getAttribute('href')),
+      ...(asAttr != null ? { hasAs: true, as: asAttr } : {}),
+      ...(hasCrossorigin ? { hasCrossorigin: true } : {})
+    });
+  }
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `cd packages/vite && pnpm vitest run test/parse-html.test.ts` then `cd ../cli && pnpm vitest run test/parse-link-attrs.test.ts`
+Expected: PASS. Also run the full core+cli+vite suites to confirm no regression: `cd /Users/oe.kazuma/localRepo/oss/svelte-vitals && CI=true pnpm --filter @svelte-vitals/core --filter svelte-vitals --filter @svelte-vitals/vite test`
+Expected: PASS (adding optional fields changes no existing behavior).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/head.ts packages/cli/src/providers/source/parse.ts packages/vite/src/providers/rendered/parse-html.ts packages/cli/test/parse-link-attrs.test.ts packages/vite/test/parse-html.test.ts
+git commit -m "feat(core,cli,vite): capture link as/crossorigin presence on head tags"
+```
+
+---
+
+### Task 2: Head-link rule helper + PERF003/PERF004 + docs
+
+Add a `linkRule` helper (mirroring `imageRule`), the two rules, register them, export them, and add their docs pages.
+
+**Files:**
+- Create: `packages/core/src/rules/perf/link-rule.ts`
+- Create: `packages/core/src/rules/perf/resource-hints.ts`
+- Modify: `packages/core/src/rules/index.ts` (register + export)
+- Modify: `packages/core/src/index.ts` (export the two rules)
+- Create: `docs/src/content/docs/rules/perf003.md`, `docs/src/content/docs/rules/perf004.md`, and `docs/src/content/docs/ja/rules/perf003.md`, `docs/src/content/docs/ja/rules/perf004.md`
+- Test: `packages/core/test/perf-resource-hints.test.ts`
+
+**Interfaces:**
+- Consumes: `HeadTag.as/hasAs/hasCrossorigin` (Task 1); `Rule`, `RuleContext`, `docsUrlFor` from `../../rule.js`; `HeadTag` from `../../head.js`; `Fix`, `Result`, `Severity` from `../../types.js`.
+- Produces: `linkRule(opts): Rule`; `perf003PreloadAs: Rule`; `perf004FontPreloadCrossorigin: Rule`.
+
+- [ ] **Step 1: Write the failing rule test**
+
+Create `packages/core/test/perf-resource-hints.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { perf003PreloadAs, perf004FontPreloadCrossorigin } from '../src/index.js';
+import { defineConfig } from '../src/types.js';
+import type { HeadTag, ResolvedHead } from '../src/head.js';
+import type { RuleContext } from '../src/rule.js';
+
+const headWith = (tags: Array<Partial<HeadTag>>): ResolvedHead => ({
+  route: '/x',
+  source: 'rendered',
+  file: 'x',
+  tags: tags.map((t) => ({ presence: 'own', value: 'static', ...t }) as HeadTag)
+});
+const ctx = (head: ResolvedHead): RuleContext => ({ heads: [head], project: {}, config: defineConfig({}) });
+const ids = (rs: Awaited<ReturnType<typeof perf003PreloadAs.check>>) => rs.map((r) => r.id);
+const failing = (rs: Awaited<ReturnType<typeof perf003PreloadAs.check>>) =>
+  rs.filter((r) => r.detection.presence === 'none');
+
+describe('PERF003 preload missing as', () => {
+  it('flags a preload link with no as', async () => {
+    const rs = await perf003PreloadAs.check(ctx(headWith([{ kind: 'link', rel: 'preload' }])));
+    expect(failing(rs)).toHaveLength(1);
+  });
+  it('passes a preload link that has an as', async () => {
+    const rs = await perf003PreloadAs.check(ctx(headWith([{ kind: 'link', rel: 'preload', hasAs: true, as: 'style' }])));
+    expect(failing(rs)).toHaveLength(0);
+    expect(rs).toHaveLength(1); // one passing result seeds the route
+  });
+  it('does not fire on a dynamically-bound as (present)', async () => {
+    const rs = await perf003PreloadAs.check(ctx(headWith([{ kind: 'link', rel: 'preload', hasAs: true }])));
+    expect(failing(rs)).toHaveLength(0);
+  });
+  it('emits nothing when there is no preload link', async () => {
+    const rs = await perf003PreloadAs.check(ctx(headWith([{ kind: 'link', rel: 'stylesheet' }])));
+    expect(rs).toHaveLength(0);
+  });
+});
+
+describe('PERF004 font preload missing crossorigin', () => {
+  it('flags as=font preload without crossorigin', async () => {
+    const rs = await perf004FontPreloadCrossorigin.check(
+      ctx(headWith([{ kind: 'link', rel: 'preload', hasAs: true, as: 'font' }]))
+    );
+    expect(failing(rs)).toHaveLength(1);
+  });
+  it('passes as=font preload with crossorigin', async () => {
+    const rs = await perf004FontPreloadCrossorigin.check(
+      ctx(headWith([{ kind: 'link', rel: 'preload', hasAs: true, as: 'font', hasCrossorigin: true }]))
+    );
+    expect(failing(rs)).toHaveLength(0);
+  });
+  it('ignores a non-font preload', async () => {
+    const rs = await perf004FontPreloadCrossorigin.check(
+      ctx(headWith([{ kind: 'link', rel: 'preload', hasAs: true, as: 'script' }]))
+    );
+    expect(rs).toHaveLength(0); // not relevant → no signal
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/core && pnpm vitest run test/perf-resource-hints.test.ts`
+Expected: FAIL — `perf003PreloadAs`/`perf004FontPreloadCrossorigin` not exported.
+
+- [ ] **Step 3: Create the `linkRule` helper**
+
+Create `packages/core/src/rules/perf/link-rule.ts`:
+
+```ts
+import type { Fix, Result, Severity } from '../../types.js';
+import type { HeadTag } from '../../head.js';
+import { docsUrlFor, type Rule, type RuleContext } from '../../rule.js';
+
+export interface LinkRuleOptions {
+  id: string;
+  title: string;
+  severity: Severity;
+  /** Noun phrase for messages, e.g. '`as` on a preloaded `<link>`'. */
+  label: string;
+  recommendation: string;
+  rationale: string;
+  fix?: Fix;
+  /** Which link tags this rule evaluates (e.g. rel === 'preload'). */
+  relevant: (tag: HeadTag) => boolean;
+  /** Returns true when a relevant link satisfies the rule (passes). */
+  ok: (tag: HeadTag) => boolean;
+}
+
+/** Build a route-scoped Performance rule that checks each relevant <link> in the effective head. */
+export function linkRule(opts: LinkRuleOptions): Rule {
+  const docsUrl = docsUrlFor(opts.id);
+  return {
+    id: opts.id,
+    title: opts.title,
+    category: 'performance',
+    severity: opts.severity,
+    scope: 'route',
+    rationale: opts.rationale,
+    ...(opts.fix ? { fix: opts.fix } : {}),
+    async check(ctx: RuleContext): Promise<Result[]> {
+      const out: Result[] = [];
+      for (const head of ctx.heads) {
+        const links = head.tags.filter((t) => t.kind === 'link' && opts.relevant(t));
+        // No relevant link on this route → no Performance signal (mirrors imageRule).
+        if (links.length === 0) continue;
+        const bad = links.filter((t) => !opts.ok(t));
+        if (bad.length === 0) {
+          // One passing result seeds the route at 100 for the per-category score.
+          out.push({
+            id: opts.id,
+            category: 'performance',
+            severity: opts.severity,
+            detection: { presence: 'own', value: 'static' },
+            route: head.route,
+            message: opts.label,
+            recommendation: opts.recommendation,
+            docsUrl
+          });
+          continue;
+        }
+        for (const _ of bad) {
+          out.push({
+            id: opts.id,
+            category: 'performance',
+            severity: opts.severity,
+            detection: { presence: 'none', value: 'absent' },
+            route: head.route,
+            location: head.file,
+            message: `Missing ${opts.label}`,
+            recommendation: opts.recommendation,
+            docsUrl,
+            ...(opts.fix ? { fix: { ...opts.fix } } : {})
+          });
+        }
+      }
+      return out;
+    }
+  };
+}
+```
+
+- [ ] **Step 4: Create the two rules**
+
+Create `packages/core/src/rules/perf/resource-hints.ts`:
+
+```ts
+import { linkRule } from './link-rule.js';
+
+export const perf003PreloadAs = linkRule({
+  id: 'PERF003',
+  title: 'Preload missing as',
+  severity: 'warning',
+  label: '`as` on a preloaded `<link>`',
+  recommendation: 'Add an `as` attribute to every `<link rel="preload">` so the browser knows the resource type and can prioritize it.',
+  rationale:
+    'A `<link rel="preload">` without an `as` attribute is ignored by the browser (or fetched a second time), wasting the preload.',
+  fix: {
+    description: 'Add an `as` attribute matching the resource type to the preload link.',
+    snippet: '<link rel="preload" href="/app.css" as="style" />',
+    lang: 'html'
+  },
+  relevant: (t) => t.rel === 'preload',
+  ok: (t) => t.hasAs === true
+});
+
+export const perf004FontPreloadCrossorigin = linkRule({
+  id: 'PERF004',
+  title: 'Font preload missing crossorigin',
+  severity: 'warning',
+  label: '`crossorigin` on a font preload',
+  recommendation: 'Add `crossorigin` to `<link rel="preload" as="font">` — fonts are fetched in CORS mode, so without it the preload fetches a second, unused copy.',
+  rationale:
+    'A font preload without `crossorigin` does not match the actual (CORS) font request, so the preloaded file is never used and the font downloads twice.',
+  fix: {
+    description: 'Add the `crossorigin` attribute to the font preload link.',
+    snippet: '<link rel="preload" href="/inter.woff2" as="font" type="font/woff2" crossorigin />',
+    lang: 'html'
+  },
+  relevant: (t) => t.rel === 'preload' && t.as === 'font',
+  ok: (t) => t.hasCrossorigin === true
+});
+```
+
+- [ ] **Step 5: Register + export the rules**
+
+In `packages/core/src/rules/index.ts`:
+- Add the import (after the `perf001ImageDimensions, perf002ImageLoading` import line):
+```ts
+import { perf003PreloadAs, perf004FontPreloadCrossorigin } from './perf/resource-hints.js';
+```
+- Add both to the `allRules` array (after `perf002ImageLoading`):
+```ts
+  perf002ImageLoading,
+  perf003PreloadAs,
+  perf004FontPreloadCrossorigin
+```
+- Add both to the re-export block (after `perf002ImageLoading`):
+```ts
+  perf002ImageLoading,
+  perf003PreloadAs,
+  perf004FontPreloadCrossorigin
+```
+
+In `packages/core/src/index.ts`, find the existing rules export (the line exporting `perf001ImageDimensions, perf002ImageLoading` from `./rules/index.js`) and add `perf003PreloadAs, perf004FontPreloadCrossorigin` to it. Also export the helper near the `imageRule` export:
+```ts
+export { linkRule } from './rules/perf/link-rule.js';
+```
+
+- [ ] **Step 6: Add the docs pages**
+
+Create `docs/src/content/docs/rules/perf003.md`:
+
+```md
+---
+title: PERF003 · Preload missing as
+description: Every <link rel="preload"> should declare an as attribute.
+---
+
+**Severity:** warning
+
+## What it checks
+
+Every `<link rel="preload">` must have an `as` attribute naming the resource type (`style`, `script`, `font`, `image`, …). A preload without `as` is flagged.
+
+## Why it matters
+
+A `<link rel="preload">` without an `as` attribute is ignored by the browser (or fetched a second time), wasting the preload.
+
+## How to fix
+
+Add an `as` attribute matching the resource type:
+
+```html
+<link rel="preload" href="/app.css" as="style" />
+```
+```
+
+Create `docs/src/content/docs/rules/perf004.md`:
+
+```md
+---
+title: PERF004 · Font preload missing crossorigin
+description: A font preload must set crossorigin so the preloaded file is actually used.
+---
+
+**Severity:** warning
+
+## What it checks
+
+Every `<link rel="preload" as="font">` must include the `crossorigin` attribute. A font preload without it is flagged.
+
+## Why it matters
+
+A font preload without `crossorigin` does not match the actual (CORS) font request, so the preloaded file is never used and the font downloads twice.
+
+## How to fix
+
+Add `crossorigin` to the font preload:
+
+```html
+<link rel="preload" href="/inter.woff2" as="font" type="font/woff2" crossorigin />
+```
+```
+
+Create `docs/src/content/docs/ja/rules/perf003.md`:
+
+```md
+---
+title: PERF003 · preload に as がない
+description: すべての <link rel="preload"> は as 属性を指定すべきです。
+---
+
+**重大度:** warning
+
+## チェック内容
+
+すべての `<link rel="preload">` は、リソース種別を示す `as` 属性（`style`・`script`・`font`・`image` など）を持つ必要があります。`as` のない preload は検出されます。
+
+## なぜ重要か
+
+`as` 属性のない `<link rel="preload">` はブラウザに無視される（または二重にフェッチされる）ため、preload が無駄になります。
+
+## 修正方法
+
+リソース種別に合った `as` 属性を追加します：
+
+```html
+<link rel="preload" href="/app.css" as="style" />
+```
+```
+
+Create `docs/src/content/docs/ja/rules/perf004.md`:
+
+```md
+---
+title: PERF004 · フォント preload に crossorigin がない
+description: フォントの preload は crossorigin を指定しないと使われません。
+---
+
+**重大度:** warning
+
+## チェック内容
+
+すべての `<link rel="preload" as="font">` は `crossorigin` 属性を含む必要があります。これがないフォント preload は検出されます。
+
+## なぜ重要か
+
+`crossorigin` のないフォント preload は実際の（CORS）フォントリクエストと一致しないため、preload したファイルは使われず、フォントが二重にダウンロードされます。
+
+## 修正方法
+
+フォントの preload に `crossorigin` を追加します：
+
+```html
+<link rel="preload" href="/inter.woff2" as="font" type="font/woff2" crossorigin />
+```
+```
+
+- [ ] **Step 7: Run the rule test + docs-link integrity + full suites**
+
+Run: `cd packages/core && pnpm vitest run test/perf-resource-hints.test.ts`
+Expected: PASS.
+
+Then the **full** core + cli + vite suites (adding rules to `allRules` can break rule-count / rule-list assertions — e.g. MCP/explain-rule tests, scoring snapshots, the docs-links integrity test):
+Run: `cd /Users/oe.kazuma/localRepo/oss/svelte-vitals && CI=true pnpm --filter @svelte-vitals/core --filter svelte-vitals --filter @svelte-vitals/vite --filter @svelte-vitals/mcp test`
+Expected: PASS. If any test asserts a fixed rule count or enumerates rule ids (search: `grep -rn "allRules\|PERF002\|toHaveLength" packages/*/test | grep -iE "length|count|perf"`), update it to include PERF003/PERF004. The docs-links test passes because the four pages were added in Step 6.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/core/src/rules/perf/link-rule.ts packages/core/src/rules/perf/resource-hints.ts packages/core/src/rules/index.ts packages/core/src/index.ts packages/core/test/perf-resource-hints.test.ts docs/src/content/docs/rules/perf003.md docs/src/content/docs/rules/perf004.md docs/src/content/docs/ja/rules/perf003.md docs/src/content/docs/ja/rules/perf004.md
+git commit -m "feat(core): add PERF003/PERF004 resource-hint rules + docs"
+```
+
+---
+
+### Task 3: Changeset + full verification
+
+**Files:**
+- Create: `.changeset/perf-resource-hints.md`
+
+**Interfaces:** none (release).
+
+- [ ] **Step 1: Add the changeset**
+
+Create `.changeset/perf-resource-hints.md`:
+
+```md
+---
+'@svelte-vitals/core': minor
+'svelte-vitals': minor
+'@svelte-vitals/vite': minor
+---
+
+Add two static resource-hint Performance checks: PERF003 flags a `<link rel="preload">`
+with no `as` attribute (the browser ignores or double-fetches it), and PERF004 flags a
+`<link rel="preload" as="font">` with no `crossorigin` (the font preload is wasted and the
+file downloads twice). Both surface in the CLI, the static report, and the vite plugin /
+dev UI. Static mode evaluates hints in `<svelte:head>`; resource hints in `app.html` are
+covered in plugin/rendered mode.
+```
+
+- [ ] **Step 2: Full verification**
+
+Run from the repo root:
+
+```bash
+CI=true pnpm -r typecheck && CI=true pnpm -r test && pnpm build && CI=true pnpm --filter docs build && pnpm lint && pnpm check:publish
+```
+Expected: all green. (Run `pnpm format` first if prettier flags the new Markdown; re-run lint. `attw` inside `check:publish` may fail LOCALLY only — known pre-existing local-cache issue, CI-unaffected; if only attw/npm-pack fails and publint passes, treat it as the known issue.) Confirm `pnpm --filter docs build` succeeds with the four new rule pages.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .changeset/perf-resource-hints.md
+git commit -m "chore: changeset for PERF003/PERF004 (core + cli + vite minor)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- PERF003 (preload missing `as`, warning, route-scoped) → Task 2. ✅
+- PERF004 (font preload missing `crossorigin`, warning, route-scoped) → Task 2. ✅
+- HeadTag `as` / `hasCrossorigin` (+ `hasAs` to distinguish dynamic-present from absent) → Task 1. ✅
+- Both providers populate the fields; dynamic binding counts as present → Task 1 (CLI uses `findAttr` for presence + `attrText` for literal; vite reads getAttribute/hasAttribute). ✅
+- Scoring mirrors imageRule (no-signal / pass-seeds / fail-with-fix) → Task 2 `linkRule`. ✅
+- No false negatives — decide on presence + `as` keyword only → Task 2 (`ok` reads `hasAs`/`hasCrossorigin`; `relevant` reads `rel`/`as`). ✅
+- Static-mode multi-preload limitation documented → spec + Global Constraints (rules unaffected). ✅
+- Docs pages PERF003/004 en + ja → Task 2 Step 6 (required by the docs-links integrity test). ✅
+- core + cli + vite minor changeset → Task 3. ✅
+
+**Placeholder scan:** No "TBD"/"add error handling"/"similar to". Every code step has complete code. The CLI parse-test import is hedged with an exact grep to locate the existing parse test; the create-file fallback is concrete.
+
+**Type consistency:** `HeadTag.as?: string` / `hasAs?: boolean` / `hasCrossorigin?: boolean` (Task 1) are read by `linkRule`'s `relevant`/`ok` and the two rules (Task 2). `linkRule(opts): Rule` with `relevant`/`ok: (tag: HeadTag) => boolean` matches both rule definitions. Result shape (`detection: {presence,value}`, `category:'performance'`, `route`, `message`, `recommendation`, `docsUrl`, optional `fix`) mirrors `imageRule` exactly. Rule ids `'PERF003'`/`'PERF004'` match the docs slugs `perf003`/`perf004` (lowercased by `docsUrlFor`) and the four created pages. `defineConfig` imported from `../src/types.js` in the test (matches its export site).
+
+**Note on the dynamic-`as` representation:** the spec says a dynamic `as` "counts as present"; this plan implements that precisely with `hasAs` (presence, incl. dynamic) separate from `as` (literal keyword only). PERF003 checks `hasAs`; PERF004 checks `as === 'font'`. So `as={x}` → `hasAs:true`, `as:undefined` → neither rule fires. This is a faithful refinement of the spec's stated behavior.

--- a/docs/superpowers/plans/2026-06-25-perf-resource-hints.md
+++ b/docs/superpowers/plans/2026-06-25-perf-resource-hints.md
@@ -24,16 +24,37 @@
 // packages/core/src/head.ts
 interface HeadTag {
   kind: 'title' | 'meta' | 'link' | 'jsonld';
-  name?: string; property?: string; rel?: string;
+  name?: string;
+  property?: string;
+  rel?: string;
   presence: 'own' | 'inherited';
   value: 'static' | 'dynamic' | 'absent';
   file?: string;
 }
-interface ResolvedHead { route: string; source: 'static'|'rendered'; tags: HeadTag[]; file: string; }
+interface ResolvedHead {
+  route: string;
+  source: 'static' | 'rendered';
+  tags: HeadTag[];
+  file: string;
+}
 
 // packages/core/src/rule.ts
-interface RuleContext { heads: ResolvedHead[]; images?: ResolvedImages[]; project: Project; config: Config; }
-interface Rule { id; title; category; severity; scope; rationale; fix?; check(ctx): Promise<Result[]>; }
+interface RuleContext {
+  heads: ResolvedHead[];
+  images?: ResolvedImages[];
+  project: Project;
+  config: Config;
+}
+interface Rule {
+  id;
+  title;
+  category;
+  severity;
+  scope;
+  rationale;
+  fix?;
+  check(ctx): Promise<Result[]>;
+}
 
 // packages/core/src/rules/perf/image-rule.ts — the pattern to mirror:
 //   pass result:  detection: { presence: 'own',  value: 'static' }
@@ -53,12 +74,14 @@ interface Rule { id; title; category; severity; scope; rationale; fix?; check(ct
 Add the three optional fields to `HeadTag` and populate them from the CLI (source) and vite (rendered) link parsers. No rules yet — no behavior change, just richer head tags.
 
 **Files:**
+
 - Modify: `packages/core/src/head.ts` (HeadTag fields)
 - Modify: `packages/cli/src/providers/source/parse.ts` (link branch in `tagsFromHead`)
 - Modify: `packages/vite/src/providers/rendered/parse-html.ts` (link loop)
 - Test: `packages/cli/test/parse.test.ts` (or the existing parse test file — see Step 1) and `packages/vite/test/parse-html.test.ts`
 
 **Interfaces:**
+
 - Produces: `HeadTag.as?: string`, `HeadTag.hasAs?: boolean`, `HeadTag.hasCrossorigin?: boolean` — set only for `kind: 'link'`. `as` is the literal keyword (undefined when absent OR dynamically bound); `hasAs` is true when an `as` attribute is present at all (literal or dynamic); `hasCrossorigin` is true when a `crossorigin` attribute is present (literal or dynamic).
 
 - [ ] **Step 1: Write the failing provider tests**
@@ -178,30 +201,30 @@ with:
 In `packages/vite/src/providers/rendered/parse-html.ts`, replace the `link` loop body (currently):
 
 ```ts
-  for (const link of head.querySelectorAll('link')) {
-    const rel = link.getAttribute('rel');
-    if (!rel) continue;
-    tags.push({ kind: 'link', rel, presence: 'own', value: attrValue(link.getAttribute('href')) });
-  }
+for (const link of head.querySelectorAll('link')) {
+  const rel = link.getAttribute('rel');
+  if (!rel) continue;
+  tags.push({ kind: 'link', rel, presence: 'own', value: attrValue(link.getAttribute('href')) });
+}
 ```
 
 with:
 
 ```ts
-  for (const link of head.querySelectorAll('link')) {
-    const rel = link.getAttribute('rel');
-    if (!rel) continue;
-    const asAttr = link.getAttribute('as'); // rendered HTML: literal string or undefined
-    const hasCrossorigin = link.hasAttribute('crossorigin');
-    tags.push({
-      kind: 'link',
-      rel,
-      presence: 'own',
-      value: attrValue(link.getAttribute('href')),
-      ...(asAttr != null ? { hasAs: true, as: asAttr } : {}),
-      ...(hasCrossorigin ? { hasCrossorigin: true } : {})
-    });
-  }
+for (const link of head.querySelectorAll('link')) {
+  const rel = link.getAttribute('rel');
+  if (!rel) continue;
+  const asAttr = link.getAttribute('as'); // rendered HTML: literal string or undefined
+  const hasCrossorigin = link.hasAttribute('crossorigin');
+  tags.push({
+    kind: 'link',
+    rel,
+    presence: 'own',
+    value: attrValue(link.getAttribute('href')),
+    ...(asAttr != null ? { hasAs: true, as: asAttr } : {}),
+    ...(hasCrossorigin ? { hasCrossorigin: true } : {})
+  });
+}
 ```
 
 - [ ] **Step 6: Run the tests to verify they pass**
@@ -224,6 +247,7 @@ git commit -m "feat(core,cli,vite): capture link as/crossorigin presence on head
 Add a `linkRule` helper (mirroring `imageRule`), the two rules, register them, export them, and add their docs pages.
 
 **Files:**
+
 - Create: `packages/core/src/rules/perf/link-rule.ts`
 - Create: `packages/core/src/rules/perf/resource-hints.ts`
 - Modify: `packages/core/src/rules/index.ts` (register + export)
@@ -232,6 +256,7 @@ Add a `linkRule` helper (mirroring `imageRule`), the two rules, register them, e
 - Test: `packages/core/test/perf-resource-hints.test.ts`
 
 **Interfaces:**
+
 - Consumes: `HeadTag.as/hasAs/hasCrossorigin` (Task 1); `Rule`, `RuleContext`, `docsUrlFor` from `../../rule.js`; `HeadTag` from `../../head.js`; `Fix`, `Result`, `Severity` from `../../types.js`.
 - Produces: `linkRule(opts): Rule`; `perf003PreloadAs: Rule`; `perf004FontPreloadCrossorigin: Rule`.
 
@@ -263,7 +288,9 @@ describe('PERF003 preload missing as', () => {
     expect(failing(rs)).toHaveLength(1);
   });
   it('passes a preload link that has an as', async () => {
-    const rs = await perf003PreloadAs.check(ctx(headWith([{ kind: 'link', rel: 'preload', hasAs: true, as: 'style' }])));
+    const rs = await perf003PreloadAs.check(
+      ctx(headWith([{ kind: 'link', rel: 'preload', hasAs: true, as: 'style' }]))
+    );
     expect(failing(rs)).toHaveLength(0);
     expect(rs).toHaveLength(1); // one passing result seeds the route
   });
@@ -393,7 +420,8 @@ export const perf003PreloadAs = linkRule({
   title: 'Preload missing as',
   severity: 'warning',
   label: '`as` on a preloaded `<link>`',
-  recommendation: 'Add an `as` attribute to every `<link rel="preload">` so the browser knows the resource type and can prioritize it.',
+  recommendation:
+    'Add an `as` attribute to every `<link rel="preload">` so the browser knows the resource type and can prioritize it.',
   rationale:
     'A `<link rel="preload">` without an `as` attribute is ignored by the browser (or fetched a second time), wasting the preload.',
   fix: {
@@ -410,7 +438,8 @@ export const perf004FontPreloadCrossorigin = linkRule({
   title: 'Font preload missing crossorigin',
   severity: 'warning',
   label: '`crossorigin` on a font preload',
-  recommendation: 'Add `crossorigin` to `<link rel="preload" as="font">` — fonts are fetched in CORS mode, so without it the preload fetches a second, unused copy.',
+  recommendation:
+    'Add `crossorigin` to `<link rel="preload" as="font">` — fonts are fetched in CORS mode, so without it the preload fetches a second, unused copy.',
   rationale:
     'A font preload without `crossorigin` does not match the actual (CORS) font request, so the preloaded file is never used and the font downloads twice.',
   fix: {
@@ -426,24 +455,27 @@ export const perf004FontPreloadCrossorigin = linkRule({
 - [ ] **Step 5: Register + export the rules**
 
 In `packages/core/src/rules/index.ts`:
+
 - Add the import (after the `perf001ImageDimensions, perf002ImageLoading` import line):
+
 ```ts
 import { perf003PreloadAs, perf004FontPreloadCrossorigin } from './perf/resource-hints.js';
 ```
+
 - Add both to the `allRules` array (after `perf002ImageLoading`):
+
 ```ts
-  perf002ImageLoading,
-  perf003PreloadAs,
-  perf004FontPreloadCrossorigin
+(perf002ImageLoading, perf003PreloadAs, perf004FontPreloadCrossorigin);
 ```
+
 - Add both to the re-export block (after `perf002ImageLoading`):
+
 ```ts
-  perf002ImageLoading,
-  perf003PreloadAs,
-  perf004FontPreloadCrossorigin
+(perf002ImageLoading, perf003PreloadAs, perf004FontPreloadCrossorigin);
 ```
 
 In `packages/core/src/index.ts`, find the existing rules export (the line exporting `perf001ImageDimensions, perf002ImageLoading` from `./rules/index.js`) and add `perf003PreloadAs, perf004FontPreloadCrossorigin` to it. Also export the helper near the `imageRule` export:
+
 ```ts
 export { linkRule } from './rules/perf/link-rule.js';
 ```
@@ -452,7 +484,7 @@ export { linkRule } from './rules/perf/link-rule.js';
 
 Create `docs/src/content/docs/rules/perf003.md`:
 
-```md
+````md
 ---
 title: PERF003 · Preload missing as
 description: Every <link rel="preload"> should declare an as attribute.
@@ -475,7 +507,9 @@ Add an `as` attribute matching the resource type:
 ```html
 <link rel="preload" href="/app.css" as="style" />
 ```
-```
+````
+
+````
 
 Create `docs/src/content/docs/rules/perf004.md`:
 
@@ -501,8 +535,9 @@ Add `crossorigin` to the font preload:
 
 ```html
 <link rel="preload" href="/inter.woff2" as="font" type="font/woff2" crossorigin />
-```
-```
+````
+
+````
 
 Create `docs/src/content/docs/ja/rules/perf003.md`:
 
@@ -528,8 +563,9 @@ description: すべての <link rel="preload"> は as 属性を指定すべき�
 
 ```html
 <link rel="preload" href="/app.css" as="style" />
-```
-```
+````
+
+````
 
 Create `docs/src/content/docs/ja/rules/perf004.md`:
 
@@ -555,8 +591,9 @@ description: フォントの preload は crossorigin を指定しないと使わ
 
 ```html
 <link rel="preload" href="/inter.woff2" as="font" type="font/woff2" crossorigin />
-```
-```
+````
+
+````
 
 - [ ] **Step 7: Run the rule test + docs-link integrity + full suites**
 
@@ -572,13 +609,14 @@ Expected: PASS. If any test asserts a fixed rule count or enumerates rule ids (s
 ```bash
 git add packages/core/src/rules/perf/link-rule.ts packages/core/src/rules/perf/resource-hints.ts packages/core/src/rules/index.ts packages/core/src/index.ts packages/core/test/perf-resource-hints.test.ts docs/src/content/docs/rules/perf003.md docs/src/content/docs/rules/perf004.md docs/src/content/docs/ja/rules/perf003.md docs/src/content/docs/ja/rules/perf004.md
 git commit -m "feat(core): add PERF003/PERF004 resource-hint rules + docs"
-```
+````
 
 ---
 
 ### Task 3: Changeset + full verification
 
 **Files:**
+
 - Create: `.changeset/perf-resource-hints.md`
 
 **Interfaces:** none (release).
@@ -609,6 +647,7 @@ Run from the repo root:
 ```bash
 CI=true pnpm -r typecheck && CI=true pnpm -r test && pnpm build && CI=true pnpm --filter docs build && pnpm lint && pnpm check:publish
 ```
+
 Expected: all green. (Run `pnpm format` first if prettier flags the new Markdown; re-run lint. `attw` inside `check:publish` may fail LOCALLY only — known pre-existing local-cache issue, CI-unaffected; if only attw/npm-pack fails and publint passes, treat it as the known issue.) Confirm `pnpm --filter docs build` succeeds with the four new rule pages.
 
 - [ ] **Step 3: Commit**
@@ -623,6 +662,7 @@ git commit -m "chore: changeset for PERF003/PERF004 (core + cli + vite minor)"
 ## Self-Review
 
 **Spec coverage:**
+
 - PERF003 (preload missing `as`, warning, route-scoped) → Task 2. ✅
 - PERF004 (font preload missing `crossorigin`, warning, route-scoped) → Task 2. ✅
 - HeadTag `as` / `hasCrossorigin` (+ `hasAs` to distinguish dynamic-present from absent) → Task 1. ✅

--- a/docs/superpowers/specs/2026-06-25-perf-resource-hints-design.md
+++ b/docs/superpowers/specs/2026-06-25-perf-resource-hints-design.md
@@ -1,0 +1,71 @@
+# Design: Deeper static Performance — resource-hint correctness
+
+The next increment of **pillar 1** (SEO + deep static Performance — the differentiated core). Today the Performance category has only PERF001 (`<img>` width/height → CLS) and PERF002 (`<img>` loading advisory). This adds two high-confidence, statically-analyzable checks for **resource-hint correctness** in the effective `<head>`: broken `preload` links that browsers ignore or double-fetch.
+
+## Goal
+
+Catch two concrete, well-known resource-hint bugs from the source / rendered `<head>`, before deploy, without a browser or runtime metrics:
+
+- **PERF003** — a `<link rel="preload">` with no `as` attribute. Without `as`, the browser can't assign a priority/destination; the preload is ignored or causes a double fetch.
+- **PERF004** — a `<link rel="preload" as="font">` with no `crossorigin` attribute. Fonts are always fetched in CORS mode, so a font preload without `crossorigin` fetches a *second*, unused copy — pure waste.
+
+Both are `warning` severity (a real, fixable waste — not merely advisory), route-scoped, and emit nothing for routes that have no `preload` link (no signal, like the image rules).
+
+## Why these two
+
+The constraints — runtime-agnostic core, no CSS parsing, no browser/LCP knowledge, and **no false negatives** (never flag a dynamic value) — rule out most "deep perf" ideas (`font-display` needs CSS parsing; LCP preload needs runtime knowledge; preconnect-for-external-fonts needs the literal `href` origin, which the model deliberately doesn't store). PERF003/PERF004 decide purely on **attribute presence** plus the `as` **keyword** (a fixed vocabulary like `rel`, not a user literal) — fully consistent with svelte-vitals' presence/value model and its no-false-negative guarantee.
+
+## Data model change (core)
+
+`HeadTag` (`packages/core/src/head.ts`) gains two optional fields, set only for `kind: 'link'`:
+
+- `as?: string` — the `as` keyword (`'font'`, `'script'`, `'style'`, `'image'`, …). A fixed vocabulary, safe to store (like `rel`). Absent when the `<link>` has no `as`.
+- `hasCrossorigin?: boolean` — whether the `<link>` carries a `crossorigin` attribute (presence only; the value, e.g. `anonymous`, is irrelevant to the checks).
+
+A dynamically-bound attribute (`as={x}` / `crossorigin={c}`) counts as **present** (so PERF003/004 never fire on it) — the same no-false-negative rule the image provider already uses for `width={w}`.
+
+## Providers (both modes populate the new fields)
+
+- **Static (CLI)** — `packages/cli/src/providers/source/parse.ts` (svelte/compiler walk of `<svelte:head>`): when building the `kind: 'link'` tag, also read `as` (keyword text, or mark present if dynamically bound) and set `hasCrossorigin` from attribute presence.
+- **Rendered (vite)** — `packages/vite/src/providers/rendered/parse-html.ts` (node-html-parser over the prerendered/dev `<head>`): on each `<link>`, read `getAttribute('as')` and `hasAttribute('crossorigin')`.
+
+Coverage note (honest, unchanged philosophy): static mode sees only hints written in `<svelte:head>`; resource hints placed in `app.html` are seen only in **rendered / plugin mode**. Both feed the same rule engine, so each check fires wherever the link tag is visible.
+
+## Rules (core, pure functions)
+
+Add a small **head-link rule** helper (`packages/core/src/rules/perf/link-rule.ts`), analogous to `imageRule`/`headTagRule`, that scans each route's head for `kind: 'link'` tags matching a predicate and checks each against `ok`:
+
+- It considers only routes whose head contains at least one **relevant** link (a `preload` link); routes with none emit nothing (no Performance signal — mirrors `imageRule`).
+- A route whose relevant links all pass emits one passing result (seeds the route at 100 for the per-category score); a failing link emits a finding with the fix.
+
+Rules:
+
+- `perf003PreloadAs` — relevant: `rel === 'preload'`; `ok`: `tag.as !== undefined` (has an `as`). Severity `warning`.
+- `perf004FontPreloadCrossorigin` — relevant: `rel === 'preload' && as === 'font'`; `ok`: `tag.hasCrossorigin === true`. Severity `warning`.
+
+Each carries `recommendation`, `rationale`, and a `fix` (description + snippet, `lang: 'svelte'`), like the existing rules. Register both in `allRules` (`packages/core/src/rules/index.ts`) and export them from the core index.
+
+Severity rationale: both are a *wasted/ineffective* hint (not a style preference), so `warning` — consistent with PERF001 (`warning`) and stronger than PERF002's `info` advisory.
+
+## Testing
+
+- **core rule tests** (`packages/core/test/perf-resource-hints.test.ts`): PERF003 flags a `preload` link with no `as`; passes one with `as`; PERF004 flags `preload as=font` without `crossorigin`, passes one with it; a route with no preload link emits nothing; a dynamically-bound `as`/`crossorigin` (present) is not flagged; a non-preload link (e.g. `stylesheet`, `preconnect`) is ignored by both.
+- **provider extraction tests**: CLI `parse.ts` test — a `<svelte:head>` `<link rel="preload" as="font" crossorigin>` yields a HeadTag with `as: 'font'`, `hasCrossorigin: true`; a dynamic `as={x}` yields a present `as`. vite `parse-html.ts` test — the same from rendered HTML.
+- **docs link integrity**: `packages/cli/test/docs-links.test.ts` already asserts every SEO/PERF rule has en + ja pages — PERF003/PERF004 pages must exist or it fails (so docs are part of this increment, below).
+
+## Documentation
+
+- Rule reference pages `docs/src/content/docs/rules/perf003.md` + `perf004.md` and their `ja/` counterparts (matching the existing PERF001/002 page template: title, severity, what it checks, why it matters, how to fix with a snippet).
+- No guide changes needed (the Performance category is already described).
+
+## Release
+
+`@svelte-vitals/core` + `svelte-vitals` + `@svelte-vitals/vite` **minor** (new findings surface in static mode, the CLI, and the vite plugin/dev UI). `@svelte-vitals/mcp` cascades a patch via `workspace:*`.
+
+## Non-goals / follow-ups
+
+- Checks needing the literal `href` origin: external-font-CSS missing `preconnect`, `preconnect` `crossorigin` correctness, dns-prefetch hygiene. (Would require storing link hrefs — a model/philosophy change.)
+- `font-display` / `@font-face` analysis — needs a CSS parser.
+- LCP-image `preload` / `fetchpriority` — needs runtime knowledge; only advisable, overlaps PERF002.
+- Render-blocking `<script>`/stylesheet analysis — SvelteKit manages these; noisy.
+- Responsive-image `srcset`/`sizes` deepening — a separate image-area increment.

--- a/docs/superpowers/specs/2026-06-25-perf-resource-hints-design.md
+++ b/docs/superpowers/specs/2026-06-25-perf-resource-hints-design.md
@@ -7,7 +7,7 @@ The next increment of **pillar 1** (SEO + deep static Performance — the differ
 Catch two concrete, well-known resource-hint bugs from the source / rendered `<head>`, before deploy, without a browser or runtime metrics:
 
 - **PERF003** — a `<link rel="preload">` with no `as` attribute. Without `as`, the browser can't assign a priority/destination; the preload is ignored or causes a double fetch.
-- **PERF004** — a `<link rel="preload" as="font">` with no `crossorigin` attribute. Fonts are always fetched in CORS mode, so a font preload without `crossorigin` fetches a *second*, unused copy — pure waste.
+- **PERF004** — a `<link rel="preload" as="font">` with no `crossorigin` attribute. Fonts are always fetched in CORS mode, so a font preload without `crossorigin` fetches a _second_, unused copy — pure waste.
 
 Both are `warning` severity (a real, fixable waste — not merely advisory), route-scoped, and emit nothing for routes that have no `preload` link (no signal, like the image rules).
 
@@ -47,7 +47,7 @@ Rules:
 
 Each carries `recommendation`, `rationale`, and a `fix` (description + snippet, `lang: 'svelte'`), like the existing rules. Register both in `allRules` (`packages/core/src/rules/index.ts`) and export them from the core index.
 
-Severity rationale: both are a *wasted/ineffective* hint (not a style preference), so `warning` — consistent with PERF001 (`warning`) and stronger than PERF002's `info` advisory.
+Severity rationale: both are a _wasted/ineffective_ hint (not a style preference), so `warning` — consistent with PERF001 (`warning`) and stronger than PERF002's `info` advisory.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-06-25-perf-resource-hints-design.md
+++ b/docs/superpowers/specs/2026-06-25-perf-resource-hints-design.md
@@ -31,6 +31,8 @@ A dynamically-bound attribute (`as={x}` / `crossorigin={c}`) counts as **present
 
 Coverage note (honest, unchanged philosophy): static mode sees only hints written in `<svelte:head>`; resource hints placed in `app.html` are seen only in **rendered / plugin mode**. Both feed the same rule engine, so each check fires wherever the link tag is visible.
 
+**Static-mode multi-`preload` limitation (v1):** the source-head composer (`packages/cli/src/providers/source/routes.ts`) collapses head tags into a singleton `Map` keyed by `link:${rel}` (correct for singleton tags like `canonical`), so multiple `<svelte:head>` `<link rel="preload">` tags collapse to one representative (last-wins) in static mode. **Rendered / plugin mode evaluates every preload** (its parser keeps a flat list). Since resource hints overwhelmingly live in `app.html` — invisible to static mode regardless — these rules are primarily a rendered/plugin-mode capability; the static-mode `<svelte:head>` case is a bonus with this documented limitation. De-duping multi-valued link tags in the static composer is a deferred follow-up; the rules themselves are unaffected (they scan whatever link tags `ResolvedHead.tags` contains).
+
 ## Rules (core, pure functions)
 
 Add a small **head-link rule** helper (`packages/core/src/rules/perf/link-rule.ts`), analogous to `imageRule`/`headTagRule`, that scans each route's head for `kind: 'link'` tags matching a predicate and checks each against `ok`:

--- a/packages/cli/src/providers/source/parse.ts
+++ b/packages/cli/src/providers/source/parse.ts
@@ -121,7 +121,17 @@ function tagsFromHead(head: Node): ParsedTag[] {
       });
     } else if (node.name === 'link') {
       const rel = attrText(node.attributes, 'rel');
-      tags.push({ kind: 'link', ...(rel ? { rel } : {}), value: attrValue(node.attributes, 'href') });
+      const hasAs = findAttr(node.attributes, 'as') !== undefined;
+      const asLiteral = attrText(node.attributes, 'as'); // literal keyword, or undefined for dynamic/absent
+      const hasCrossorigin = findAttr(node.attributes, 'crossorigin') !== undefined;
+      tags.push({
+        kind: 'link',
+        ...(rel ? { rel } : {}),
+        value: attrValue(node.attributes, 'href'),
+        ...(hasAs ? { hasAs: true } : {}),
+        ...(asLiteral ? { as: asLiteral } : {}),
+        ...(hasCrossorigin ? { hasCrossorigin: true } : {})
+      });
     } else if (node.name === 'script' && attrText(node.attributes, 'type') === 'application/ld+json') {
       tags.push({ kind: 'jsonld', value: valueFromNodes(node.fragment?.nodes ?? []) });
     }

--- a/packages/cli/test/parse-link-attrs.test.ts
+++ b/packages/cli/test/parse-link-attrs.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { parseHeadTags } from '../src/providers/source/parse.js';
+
+const head = (inner: string) => `<svelte:head>${inner}</svelte:head>`;
+
+describe('parse: link as/crossorigin (static)', () => {
+  it('captures a literal as keyword + crossorigin presence', () => {
+    const tags = parseHeadTags(head('<link rel="preload" href="/i.woff2" as="font" crossorigin />'), 'x.svelte');
+    const link = tags.find((t) => t.kind === 'link' && t.rel === 'preload')!;
+    expect(link.as).toBe('font');
+    expect(link.hasAs).toBe(true);
+    expect(link.hasCrossorigin).toBe(true);
+  });
+  it('treats a dynamic as={x} as present but with no literal keyword', () => {
+    const tags = parseHeadTags(head('<link rel="preload" href="/a.js" as={kind} />'), 'x.svelte');
+    const link = tags.find((t) => t.kind === 'link' && t.rel === 'preload')!;
+    expect(link.hasAs).toBe(true); // present → PERF003 won't fire
+    expect(link.as).toBeUndefined(); // not a literal → PERF004 won't fire
+  });
+  it('leaves fields unset when the attributes are absent', () => {
+    const tags = parseHeadTags(head('<link rel="preload" href="/a.js" />'), 'x.svelte');
+    const link = tags.find((t) => t.kind === 'link' && t.rel === 'preload')!;
+    expect(link.hasAs).toBeUndefined();
+    expect(link.as).toBeUndefined();
+    expect(link.hasCrossorigin).toBeUndefined();
+  });
+});

--- a/packages/core/src/head.ts
+++ b/packages/core/src/head.ts
@@ -15,6 +15,12 @@ export interface HeadTag {
   property?: string;
   /** <link rel="...">. */
   rel?: string;
+  /** <link as="..."> keyword (e.g. 'font') when statically literal; undefined when absent or dynamically bound. */
+  as?: string;
+  /** True when a <link> has an `as` attribute at all (literal or dynamic). Distinguishes "no as" from "dynamic as". */
+  hasAs?: boolean;
+  /** True when a <link> has a `crossorigin` attribute (presence only; value is irrelevant to the checks). */
+  hasCrossorigin?: boolean;
   /** Where this tag was set relative to the route. Never 'none' (absence = no tag). */
   presence: Exclude<Presence, 'none'>;
   /** Whether the tag's value is static/dynamic/absent (design §4). */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,11 +38,14 @@ export {
   seo008JsonLd,
   seo009HtmlLang,
   perf001ImageDimensions,
-  perf002ImageLoading
+  perf002ImageLoading,
+  perf003PreloadAs,
+  perf004FontPreloadCrossorigin
 } from './rules/index.js';
 export type { RuleInfo } from './rules/index.js';
 export { headTagRule } from './rules/seo/head-tag-rule.js';
 export { imageRule } from './rules/perf/image-rule.js';
+export { linkRule } from './rules/perf/link-rule.js';
 
 export type { Summary, Classification } from './summary.js';
 export { summarize, classify, hasFailureAtOrAbove, effectiveSeverity } from './summary.js';

--- a/packages/core/src/rules/index.ts
+++ b/packages/core/src/rules/index.ts
@@ -10,6 +10,7 @@ import {
 } from './seo/seo002-005-008.js';
 import { seo006Robots, seo007Sitemap, seo009HtmlLang } from './seo/project-rules.js';
 import { perf001ImageDimensions, perf002ImageLoading } from './perf/images.js';
+import { perf003PreloadAs, perf004FontPreloadCrossorigin } from './perf/resource-hints.js';
 
 export const allRules: Rule[] = [
   seo001Title,
@@ -22,7 +23,9 @@ export const allRules: Rule[] = [
   seo008JsonLd,
   seo009HtmlLang,
   perf001ImageDimensions,
-  perf002ImageLoading
+  perf002ImageLoading,
+  perf003PreloadAs,
+  perf004FontPreloadCrossorigin
 ];
 
 export {
@@ -36,7 +39,9 @@ export {
   seo008JsonLd,
   seo009HtmlLang,
   perf001ImageDimensions,
-  perf002ImageLoading
+  perf002ImageLoading,
+  perf003PreloadAs,
+  perf004FontPreloadCrossorigin
 };
 
 export interface RuleInfo {

--- a/packages/core/src/rules/perf/link-rule.ts
+++ b/packages/core/src/rules/perf/link-rule.ts
@@ -49,7 +49,7 @@ export function linkRule(opts: LinkRuleOptions): Rule {
           });
           continue;
         }
-        for (const _ of bad) {
+        for (let i = 0; i < bad.length; i++) {
           out.push({
             id: opts.id,
             category: 'performance',

--- a/packages/core/src/rules/perf/link-rule.ts
+++ b/packages/core/src/rules/perf/link-rule.ts
@@ -49,14 +49,17 @@ export function linkRule(opts: LinkRuleOptions): Rule {
           });
           continue;
         }
-        for (let i = 0; i < bad.length; i++) {
+        for (const tag of bad) {
           out.push({
             id: opts.id,
             category: 'performance',
             severity: opts.severity,
             detection: { presence: 'none', value: 'absent' },
             route: head.route,
-            location: head.file,
+            // Point at the file the link actually came from (a layout in static
+            // mode); fall back to the route's representative file when the tag
+            // carries no file (rendered mode).
+            location: tag.file ?? head.file,
             message: `Missing ${opts.label}`,
             recommendation: opts.recommendation,
             docsUrl,

--- a/packages/core/src/rules/perf/link-rule.ts
+++ b/packages/core/src/rules/perf/link-rule.ts
@@ -1,0 +1,70 @@
+import type { Fix, Result, Severity } from '../../types.js';
+import type { HeadTag } from '../../head.js';
+import { docsUrlFor, type Rule, type RuleContext } from '../../rule.js';
+
+export interface LinkRuleOptions {
+  id: string;
+  title: string;
+  severity: Severity;
+  /** Noun phrase for messages, e.g. '`as` on a preloaded `<link>`'. */
+  label: string;
+  recommendation: string;
+  rationale: string;
+  fix?: Fix;
+  /** Which link tags this rule evaluates (e.g. rel === 'preload'). */
+  relevant: (tag: HeadTag) => boolean;
+  /** Returns true when a relevant link satisfies the rule (passes). */
+  ok: (tag: HeadTag) => boolean;
+}
+
+/** Build a route-scoped Performance rule that checks each relevant <link> in the effective head. */
+export function linkRule(opts: LinkRuleOptions): Rule {
+  const docsUrl = docsUrlFor(opts.id);
+  return {
+    id: opts.id,
+    title: opts.title,
+    category: 'performance',
+    severity: opts.severity,
+    scope: 'route',
+    rationale: opts.rationale,
+    ...(opts.fix ? { fix: opts.fix } : {}),
+    async check(ctx: RuleContext): Promise<Result[]> {
+      const out: Result[] = [];
+      for (const head of ctx.heads) {
+        const links = head.tags.filter((t) => t.kind === 'link' && opts.relevant(t));
+        // No relevant link on this route → no Performance signal (mirrors imageRule).
+        if (links.length === 0) continue;
+        const bad = links.filter((t) => !opts.ok(t));
+        if (bad.length === 0) {
+          // One passing result seeds the route at 100 for the per-category score.
+          out.push({
+            id: opts.id,
+            category: 'performance',
+            severity: opts.severity,
+            detection: { presence: 'own', value: 'static' },
+            route: head.route,
+            message: opts.label,
+            recommendation: opts.recommendation,
+            docsUrl
+          });
+          continue;
+        }
+        for (const _ of bad) {
+          out.push({
+            id: opts.id,
+            category: 'performance',
+            severity: opts.severity,
+            detection: { presence: 'none', value: 'absent' },
+            route: head.route,
+            location: head.file,
+            message: `Missing ${opts.label}`,
+            recommendation: opts.recommendation,
+            docsUrl,
+            ...(opts.fix ? { fix: { ...opts.fix } } : {})
+          });
+        }
+      }
+      return out;
+    }
+  };
+}

--- a/packages/core/src/rules/perf/resource-hints.ts
+++ b/packages/core/src/rules/perf/resource-hints.ts
@@ -1,0 +1,35 @@
+import { linkRule } from './link-rule.js';
+
+export const perf003PreloadAs = linkRule({
+  id: 'PERF003',
+  title: 'Preload missing as',
+  severity: 'warning',
+  label: '`as` on a preloaded `<link>`',
+  recommendation: 'Add an `as` attribute to every `<link rel="preload">` so the browser knows the resource type and can prioritize it.',
+  rationale:
+    'A `<link rel="preload">` without an `as` attribute is ignored by the browser (or fetched a second time), wasting the preload.',
+  fix: {
+    description: 'Add an `as` attribute matching the resource type to the preload link.',
+    snippet: '<link rel="preload" href="/app.css" as="style" />',
+    lang: 'html'
+  },
+  relevant: (t) => t.rel === 'preload',
+  ok: (t) => t.hasAs === true
+});
+
+export const perf004FontPreloadCrossorigin = linkRule({
+  id: 'PERF004',
+  title: 'Font preload missing crossorigin',
+  severity: 'warning',
+  label: '`crossorigin` on a font preload',
+  recommendation: 'Add `crossorigin` to `<link rel="preload" as="font">` — fonts are fetched in CORS mode, so without it the preload fetches a second, unused copy.',
+  rationale:
+    'A font preload without `crossorigin` does not match the actual (CORS) font request, so the preloaded file is never used and the font downloads twice.',
+  fix: {
+    description: 'Add the `crossorigin` attribute to the font preload link.',
+    snippet: '<link rel="preload" href="/inter.woff2" as="font" type="font/woff2" crossorigin />',
+    lang: 'html'
+  },
+  relevant: (t) => t.rel === 'preload' && t.as === 'font',
+  ok: (t) => t.hasCrossorigin === true
+});

--- a/packages/core/src/rules/perf/resource-hints.ts
+++ b/packages/core/src/rules/perf/resource-hints.ts
@@ -5,7 +5,8 @@ export const perf003PreloadAs = linkRule({
   title: 'Preload missing as',
   severity: 'warning',
   label: '`as` on a preloaded `<link>`',
-  recommendation: 'Add an `as` attribute to every `<link rel="preload">` so the browser knows the resource type and can prioritize it.',
+  recommendation:
+    'Add an `as` attribute to every `<link rel="preload">` so the browser knows the resource type and can prioritize it.',
   rationale:
     'A `<link rel="preload">` without an `as` attribute is ignored by the browser (or fetched a second time), wasting the preload.',
   fix: {
@@ -22,7 +23,8 @@ export const perf004FontPreloadCrossorigin = linkRule({
   title: 'Font preload missing crossorigin',
   severity: 'warning',
   label: '`crossorigin` on a font preload',
-  recommendation: 'Add `crossorigin` to `<link rel="preload" as="font">` — fonts are fetched in CORS mode, so without it the preload fetches a second, unused copy.',
+  recommendation:
+    'Add `crossorigin` to `<link rel="preload" as="font">` — fonts are fetched in CORS mode, so without it the preload fetches a second, unused copy.',
   rationale:
     'A font preload without `crossorigin` does not match the actual (CORS) font request, so the preloaded file is never used and the font downloads twice.',
   fix: {

--- a/packages/core/test/perf-resource-hints.test.ts
+++ b/packages/core/test/perf-resource-hints.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { perf003PreloadAs, perf004FontPreloadCrossorigin } from '../src/index.js';
+import { defineConfig } from '../src/types.js';
+import type { HeadTag, ResolvedHead } from '../src/head.js';
+import type { RuleContext } from '../src/rule.js';
+
+const headWith = (tags: Array<Partial<HeadTag>>): ResolvedHead => ({
+  route: '/x',
+  source: 'rendered',
+  file: 'x',
+  tags: tags.map((t) => ({ presence: 'own', value: 'static', ...t }) as HeadTag)
+});
+const ctx = (head: ResolvedHead): RuleContext => ({ heads: [head], project: {}, config: defineConfig({}) });
+const ids = (rs: Awaited<ReturnType<typeof perf003PreloadAs.check>>) => rs.map((r) => r.id);
+const failing = (rs: Awaited<ReturnType<typeof perf003PreloadAs.check>>) =>
+  rs.filter((r) => r.detection.presence === 'none');
+
+describe('PERF003 preload missing as', () => {
+  it('flags a preload link with no as', async () => {
+    const rs = await perf003PreloadAs.check(ctx(headWith([{ kind: 'link', rel: 'preload' }])));
+    expect(failing(rs)).toHaveLength(1);
+  });
+  it('passes a preload link that has an as', async () => {
+    const rs = await perf003PreloadAs.check(ctx(headWith([{ kind: 'link', rel: 'preload', hasAs: true, as: 'style' }])));
+    expect(failing(rs)).toHaveLength(0);
+    expect(rs).toHaveLength(1); // one passing result seeds the route
+  });
+  it('does not fire on a dynamically-bound as (present)', async () => {
+    const rs = await perf003PreloadAs.check(ctx(headWith([{ kind: 'link', rel: 'preload', hasAs: true }])));
+    expect(failing(rs)).toHaveLength(0);
+  });
+  it('emits nothing when there is no preload link', async () => {
+    const rs = await perf003PreloadAs.check(ctx(headWith([{ kind: 'link', rel: 'stylesheet' }])));
+    expect(rs).toHaveLength(0);
+  });
+});
+
+describe('PERF004 font preload missing crossorigin', () => {
+  it('flags as=font preload without crossorigin', async () => {
+    const rs = await perf004FontPreloadCrossorigin.check(
+      ctx(headWith([{ kind: 'link', rel: 'preload', hasAs: true, as: 'font' }]))
+    );
+    expect(failing(rs)).toHaveLength(1);
+  });
+  it('passes as=font preload with crossorigin', async () => {
+    const rs = await perf004FontPreloadCrossorigin.check(
+      ctx(headWith([{ kind: 'link', rel: 'preload', hasAs: true, as: 'font', hasCrossorigin: true }]))
+    );
+    expect(failing(rs)).toHaveLength(0);
+  });
+  it('ignores a non-font preload', async () => {
+    const rs = await perf004FontPreloadCrossorigin.check(
+      ctx(headWith([{ kind: 'link', rel: 'preload', hasAs: true, as: 'script' }]))
+    );
+    expect(rs).toHaveLength(0); // not relevant → no signal
+  });
+});

--- a/packages/core/test/perf-resource-hints.test.ts
+++ b/packages/core/test/perf-resource-hints.test.ts
@@ -11,7 +11,6 @@ const headWith = (tags: Array<Partial<HeadTag>>): ResolvedHead => ({
   tags: tags.map((t) => ({ presence: 'own', value: 'static', ...t }) as HeadTag)
 });
 const ctx = (head: ResolvedHead): RuleContext => ({ heads: [head], project: {}, config: defineConfig({}) });
-const ids = (rs: Awaited<ReturnType<typeof perf003PreloadAs.check>>) => rs.map((r) => r.id);
 const failing = (rs: Awaited<ReturnType<typeof perf003PreloadAs.check>>) =>
   rs.filter((r) => r.detection.presence === 'none');
 

--- a/packages/core/test/perf-resource-hints.test.ts
+++ b/packages/core/test/perf-resource-hints.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { perf003PreloadAs, perf004FontPreloadCrossorigin } from '../src/index.js';
-import { defineConfig } from '../src/types.js';
+import { defineConfig, defaultProject } from '../src/types.js';
 import type { HeadTag, ResolvedHead } from '../src/head.js';
 import type { RuleContext } from '../src/rule.js';
 
@@ -10,7 +10,7 @@ const headWith = (tags: Array<Partial<HeadTag>>): ResolvedHead => ({
   file: 'x',
   tags: tags.map((t) => ({ presence: 'own', value: 'static', ...t }) as HeadTag)
 });
-const ctx = (head: ResolvedHead): RuleContext => ({ heads: [head], project: {}, config: defineConfig({}) });
+const ctx = (head: ResolvedHead): RuleContext => ({ heads: [head], project: defaultProject, config: defineConfig({}) });
 const failing = (rs: Awaited<ReturnType<typeof perf003PreloadAs.check>>) =>
   rs.filter((r) => r.detection.presence === 'none');
 
@@ -20,7 +20,9 @@ describe('PERF003 preload missing as', () => {
     expect(failing(rs)).toHaveLength(1);
   });
   it('passes a preload link that has an as', async () => {
-    const rs = await perf003PreloadAs.check(ctx(headWith([{ kind: 'link', rel: 'preload', hasAs: true, as: 'style' }])));
+    const rs = await perf003PreloadAs.check(
+      ctx(headWith([{ kind: 'link', rel: 'preload', hasAs: true, as: 'style' }]))
+    );
     expect(failing(rs)).toHaveLength(0);
     expect(rs).toHaveLength(1); // one passing result seeds the route
   });

--- a/packages/core/test/perf-resource-hints.test.ts
+++ b/packages/core/test/perf-resource-hints.test.ts
@@ -48,6 +48,7 @@ describe('PERF004 font preload missing crossorigin', () => {
       ctx(headWith([{ kind: 'link', rel: 'preload', hasAs: true, as: 'font', hasCrossorigin: true }]))
     );
     expect(failing(rs)).toHaveLength(0);
+    expect(rs).toHaveLength(1); // one passing result seeds the route
   });
   it('ignores a non-font preload', async () => {
     const rs = await perf004FontPreloadCrossorigin.check(

--- a/packages/vite/src/providers/rendered/parse-html.ts
+++ b/packages/vite/src/providers/rendered/parse-html.ts
@@ -35,7 +35,16 @@ export function parseHtmlHead(html: string): ParsedHtmlHead {
   for (const link of head.querySelectorAll('link')) {
     const rel = link.getAttribute('rel');
     if (!rel) continue;
-    tags.push({ kind: 'link', rel, presence: 'own', value: attrValue(link.getAttribute('href')) });
+    const asAttr = link.getAttribute('as'); // rendered HTML: literal string or undefined
+    const hasCrossorigin = link.hasAttribute('crossorigin');
+    tags.push({
+      kind: 'link',
+      rel,
+      presence: 'own',
+      value: attrValue(link.getAttribute('href')),
+      ...(asAttr != null ? { hasAs: true, as: asAttr } : {}),
+      ...(hasCrossorigin ? { hasCrossorigin: true } : {})
+    });
   }
 
   for (const script of head.querySelectorAll('script')) {

--- a/packages/vite/test/parse-html.test.ts
+++ b/packages/vite/test/parse-html.test.ts
@@ -39,3 +39,22 @@ describe('parseHtmlHead', () => {
     expect(parseHtmlHead(noLangHtml).htmlLang).toEqual({ presence: 'none', value: 'absent' });
   });
 });
+
+describe('parse-html: link as/crossorigin', () => {
+  it('captures as + crossorigin presence on a font preload', () => {
+    const { tags } = parseHtmlHead(
+      '<html><head><link rel="preload" href="/i.woff2" as="font" type="font/woff2" crossorigin></head><body></body></html>'
+    );
+    const link = tags.find((t) => t.kind === 'link' && t.rel === 'preload')!;
+    expect(link.as).toBe('font');
+    expect(link.hasAs).toBe(true);
+    expect(link.hasCrossorigin).toBe(true);
+  });
+  it('leaves as/crossorigin unset when absent', () => {
+    const { tags } = parseHtmlHead('<html><head><link rel="preload" href="/a.js"></head><body></body></html>');
+    const link = tags.find((t) => t.kind === 'link' && t.rel === 'preload')!;
+    expect(link.as).toBeUndefined();
+    expect(link.hasAs).toBeUndefined();
+    expect(link.hasCrossorigin).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Deepen the Performance category (pillar 1: SEO + deep static Performance) with two high-confidence, statically-analyzable resource-hint checks — beyond today's `<img>`-only PERF001/PERF002.

## New rules (both `warning`, route-scoped)

- **PERF003 — preload missing `as`**: a `<link rel="preload">` with no `as` attribute. Without `as` the browser can't assign a destination/priority, so the preload is ignored or causes a double fetch.
- **PERF004 — font preload missing `crossorigin`**: a `<link rel="preload" as="font">` with no `crossorigin`. Fonts are always fetched in CORS mode, so the preload doesn't match the real request — the file downloads twice and the preload is wasted.

## How it stays sound (no false negatives)

`HeadTag` gains `as` (the literal `as` keyword — a fixed vocabulary, like `rel`), `hasAs` (an `as` attribute is present at all), and `hasCrossorigin` (presence). The checks decide **only** on attribute presence + the `as` keyword — never on literal `href` values. A dynamically-bound `as={x}` / `crossorigin={c}` counts as **present**, so neither rule ever fires on a dynamic value (`as={x}` → `hasAs:true, as:undefined` → PERF003 passes, PERF004 not relevant).

## Architecture

- **core** (runtime-agnostic): the three `HeadTag` fields, a small `linkRule` helper (mirrors the existing `imageRule` scoring contract — no relevant link → no signal; all pass → seeds the route; each failing link → a finding with a fix), and the two rules.
- **Both providers populate the fields**: the CLI svelte/compiler parser (`findAttr` presence + `attrText` literal, so dynamic bindings are distinguished) and the vite node-html-parser (rendered HTML).
- Registered in `allRules`; all consumers (MCP `explain_rule`, scoring, the docs-link test) pick them up dynamically.

## Coverage (honest)

Static mode sees hints in `<svelte:head>`; resource hints in `app.html` are covered in **plugin / rendered mode** — so these rules are primarily a plugin/dev-UI capability. Static-mode head composition collapses multiple `<svelte:head>` `<link rel="preload">` to one representative (a documented v1 limitation; rendered mode evaluates every preload).

## Docs & release

- Rule reference pages **PERF003 / PERF004 (en + ja)**.
- `@svelte-vitals/core` + `svelte-vitals` + `@svelte-vitals/vite` **minor**; `@svelte-vitals/mcp` cascades a patch.

## Validation

- `pnpm -r typecheck`, `pnpm -r test` (core 125 / cli 127 / vite 51 / mcp 9), `pnpm build`, `pnpm --filter docs build` (43 pages incl. the 4 new), `pnpm lint`, publint — all green.
- `attw` fails *locally only* (sandbox `npm pack`) — known pre-existing, CI-unaffected.

## Process

Built subagent-driven: 3 tasks (each spec + quality reviewed) + a whole-branch review on Opus (verdict: ready to merge). A few per-task typecheck/lint follow-ups (test `Project` type, an unused loop var, prettier) were fixed in-branch and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new performance checks for preload links: one for missing `as`, and one for font preloads missing `crossorigin`.
  * These checks now appear in CLI output, static reports, and the Vite plugin UI.

* **Documentation**
  * Added new rule documentation in English and Japanese for both checks, including examples and guidance.

* **Bug Fixes**
  * Improved link parsing so preload attributes are recognized more accurately across static and rendered content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->