### PR TITLE
feat(vite): collect rendered-mode <img> for image-rule parity

### DIFF
--- a/.changeset/rendered-image-collection.md
+++ b/.changeset/rendered-image-collection.md
@@ -1,0 +1,8 @@
+---
+'@svelte-vitals/vite': minor
+---
+
+Collect `<img>` elements in rendered (vite) mode so the image rules — PERF001,
+PERF002, PERF005, PERF006, and SEO025 — now run during build analysis and in the
+dev hook, not only in static (CLI) mode (#61). Previously the vite plugin
+silently skipped every image/alt check.

--- a/docs/superpowers/specs/2026-06-29-rendered-image-collection-design.md
+++ b/docs/superpowers/specs/2026-06-29-rendered-image-collection-design.md
@@ -19,20 +19,21 @@ silently skipped every image/alt check (`ctx.images` was unset).
   (`image-rule.ts`, `perf005`). Only the CLI provider populates `ctx.images`
   (`collectImages` in `parse.ts` → `routes.ts` → `cli/index.ts`).
 - The rendered provider (`parse-html.ts`) parses the whole document already
-  (node-html-parser) but only reads `<head>`; `analyze.ts` and the dev
-  `handle.ts` build `ctx` without `images`.
+  (node-html-parser) and already scans `<body>` for headings (SEO027), but does
+  not collect `<img>`; `analyze.ts` and the dev `handle.ts` build `ctx` without
+  `images`.
 - `ImageInfo` = `{ hasWidth, hasHeight, hasLoading, hasAlt, lazy, hasSrcset, line, file }`.
 
 ## Design
 
 ### Capture (`parse-html.ts`)
 
-Add `images` to `ParsedHtmlHead`. Collect every `<img>` in the document
-(document order, so PERF005's "first image" heuristic matches the static
-provider):
+Add `images` to `ParsedHtmlHead`. Collect every `<img>` in the **body** (scoped
+like the heading scan, so a stray `<head><img>` is ignored; document order, so
+PERF005's "first image" heuristic matches the static provider):
 
 ```ts
-images: root.querySelectorAll('img').map((img) => ({
+images: (root.querySelector('body') ?? root).querySelectorAll('img').map((img) => ({
   hasWidth: img.hasAttribute('width'),
   hasHeight: img.hasAttribute('height'),
   hasLoading: img.hasAttribute('loading'),

--- a/docs/superpowers/specs/2026-06-29-rendered-image-collection-design.md
+++ b/docs/superpowers/specs/2026-06-29-rendered-image-collection-design.md
@@ -1,0 +1,77 @@
+# Rendered-mode image collection — image-rule parity (vite)
+
+**Date:** 2026-06-29
+**Status:** Approved (1 PR, per maintainer)
+**Packages:** `@svelte-vitals/vite` (rendered provider + dev hook), `@svelte-vitals/core` (none — rules unchanged)
+**Issue:** #61 (SEO025 rendered-mode parity)
+
+## Goal
+
+Collect `<img>` elements in the **rendered (vite) provider** so the existing
+image rules — **PERF001, PERF002, PERF005, PERF006, SEO025** — fire in rendered
+mode (build analysis and the dev hook), not only in static (CLI) mode. No new
+rules and no core changes; this closes a coverage gap where the vite plugin
+silently skipped every image/alt check (`ctx.images` was unset).
+
+## Background
+
+- Image rules iterate `ctx.images ?? []` and no-op when it is unset
+  (`image-rule.ts`, `perf005`). Only the CLI provider populates `ctx.images`
+  (`collectImages` in `parse.ts` → `routes.ts` → `cli/index.ts`).
+- The rendered provider (`parse-html.ts`) parses the whole document already
+  (node-html-parser) but only reads `<head>`; `analyze.ts` and the dev
+  `handle.ts` build `ctx` without `images`.
+- `ImageInfo` = `{ hasWidth, hasHeight, hasLoading, hasAlt, lazy, hasSrcset, line, file }`.
+
+## Design
+
+### Capture (`parse-html.ts`)
+
+Add `images` to `ParsedHtmlHead`. Collect every `<img>` in the document
+(document order, so PERF005's "first image" heuristic matches the static
+provider):
+
+```ts
+images: root.querySelectorAll('img').map((img) => ({
+  hasWidth: img.hasAttribute('width'),
+  hasHeight: img.hasAttribute('height'),
+  hasLoading: img.hasAttribute('loading'),
+  hasAlt: img.hasAttribute('alt'),
+  lazy: img.getAttribute('loading') === 'lazy',
+  hasSrcset: img.hasAttribute('srcset'),
+  line: 0 // rendered mode does not track source lines
+}));
+```
+
+Returned shape: `Omit<ImageInfo, 'file'>[]` — the caller fills `file`.
+
+### Threading
+
+- **`collect.ts`** (`collectRenderedHeads`): return `images: ResolvedImages[]`,
+  one per route, `file` = the HTML rel path, mirroring how headings are threaded.
+- **`analyze.ts`**: pass `images` into the rule context.
+- **`hooks/handle.ts`**: build `images` from `parseHtmlHead(...).images` (file =
+  route) and pass it into `runRules` context, so the dev overlay also reports
+  image findings.
+
+## Behavior change
+
+PERF001/002/005/006 and SEO025 now emit in rendered mode. Rendered fixtures that
+contain an `<img>` without dimensions/alt/srcset will newly report — update those
+fixtures (additive) or accept the finding where it is correct. Pages with no
+`<img>` are unaffected (image rules skip imageless routes).
+
+## Testing
+
+- `parse-html` unit: an `<img>` in the body is collected with the right flags;
+  document order preserved; a page with no `<img>` yields `images: []`.
+- `collect`: rendered route exposes `ResolvedImages` with `file` set.
+- Cross-check: a rendered page with `<img>` missing width/height now trips
+  PERF001; missing alt trips SEO025 (integration via `runRules` or the dev hook).
+- Full `pnpm -r test` + typecheck + lint + docs build green; fixtures updated as
+  needed (no assertions loosened).
+
+## Out of scope
+
+- Source-line numbers for rendered images (stays `line: 0`).
+- The remaining #61 items (charset value, hreflang reciprocity, pixel-width).

--- a/packages/core/src/rules/perf/perf005-lcp-image.ts
+++ b/packages/core/src/rules/perf/perf005-lcp-image.ts
@@ -7,9 +7,9 @@ const recommendation =
 
 /**
  * PERF005 — LCP image not lazy-loaded. Lazy-loading the largest contentful paint
- * image delays it. Static analysis approximates the LCP as the first <img> in
- * document order for the route; if that image is loading="lazy", flag it.
- * CLI/static only (the rendered provider does not collect <img>).
+ * image delays it. Analysis approximates the LCP as the first <img> in document
+ * order for the route; if that image is loading="lazy", flag it. Runs in both
+ * static (CLI) and rendered (vite) mode, since both providers collect <img>.
  */
 export const perf005LcpImage: Rule = {
   id: 'PERF005',

--- a/packages/core/src/rules/seo/seo025-image-alt.ts
+++ b/packages/core/src/rules/seo/seo025-image-alt.ts
@@ -1,8 +1,8 @@
 import { imageRule } from '../perf/image-rule.js';
 
 /**
- * SEO025 — Image alt text. Reuses the <img> collection (CLI/static only; rendered
- * mode does not collect images, so the rule no-ops there, like PERF001/002).
+ * SEO025 — Image alt text. Reuses the <img> collection from both providers — the
+ * static (CLI) source parser and the rendered (vite) HTML parser — like PERF001/002.
  * Presence only: an explicit empty `alt=""` is a valid decorative-image signal and
  * passes; a spread `{...rest}` may supply alt, so it is not flagged.
  */

--- a/packages/vite/src/analyze.ts
+++ b/packages/vite/src/analyze.ts
@@ -42,10 +42,10 @@ export async function analyze(
     failOn: options.failOn ?? 'critical'
   });
 
-  const { heads, headings, htmlLang } = await collectRenderedHeads(prerenderPagesDir);
+  const { heads, headings, images, htmlLang } = await collectRenderedHeads(prerenderPagesDir);
   const project = await collectRenderedProject(cwd, htmlLang);
   const results = applyRuleSeverities(
-    await runRules(selectRules(allRules, config), { heads, headings, project, config }),
+    await runRules(selectRules(allRules, config), { heads, headings, images, project, config }),
     config
   );
 

--- a/packages/vite/src/hooks/handle.ts
+++ b/packages/vite/src/hooks/handle.ts
@@ -10,6 +10,7 @@ import {
   type Project,
   type ResolvedHead,
   type ResolvedHeadings,
+  type ResolvedImages,
   type Result,
   type Rule
 } from '@svelte-vitals/core';
@@ -60,16 +61,20 @@ async function analyzeAndWarn(
   lastSignature: Map<string, string>
 ): Promise<void> {
   try {
-    const { tags, htmlLang, headings: levels } = parseHtmlHead(html);
+    const { tags, htmlLang, headings: levels, images: imgs } = parseHtmlHead(html);
     const head: ResolvedHead = { route, source: 'rendered', tags, file: route };
     // Rendered mode does not track source lines (line 0 = unknown); file is the route.
     const headings: ResolvedHeadings[] = [
       { route, headings: levels.map((level) => ({ level, line: 0, file: route })) }
     ];
+    const images: ResolvedImages[] = [{ route, images: imgs.map((img) => ({ ...img, file: route })) }];
     // robots/sitemap are not page-scoped, so mark them present to suppress SEO006/SEO007;
     // htmlLang comes from the rendered document so SEO009 is evaluated against reality.
     const project: Project = { hasRobotsTxt: true, hasSitemap: true, htmlLang };
-    const results = applyRuleSeverities(await runRules(rules, { heads: [head], headings, project, config }), config);
+    const results = applyRuleSeverities(
+      await runRules(rules, { heads: [head], headings, images, project, config }),
+      config
+    );
 
     const signature = findingSignature(results, config);
     if (lastSignature.get(route) === signature) return;

--- a/packages/vite/src/providers/rendered/collect.ts
+++ b/packages/vite/src/providers/rendered/collect.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { glob } from 'tinyglobby';
-import type { ResolvedHead, ResolvedHeadings, Value } from '@svelte-vitals/core';
+import type { ResolvedHead, ResolvedHeadings, ResolvedImages, Value } from '@svelte-vitals/core';
 import { parseHtmlHead } from './parse-html.js';
 
 /** Map a prerendered HTML path (relative to pages/, POSIX) to its route. */
@@ -15,6 +15,7 @@ export function deriveRouteFromHtmlPath(relPath: string): string {
 export interface CollectedHeads {
   heads: ResolvedHead[];
   headings: ResolvedHeadings[];
+  images: ResolvedImages[];
   htmlLang: { presence: 'own' | 'none'; value: Value };
 }
 
@@ -29,6 +30,7 @@ export async function collectRenderedHeads(prerenderPagesDir: string): Promise<C
 
   const heads: ResolvedHead[] = [];
   const headings: ResolvedHeadings[] = [];
+  const images: ResolvedImages[] = [];
   let htmlLang: CollectedHeads['htmlLang'] = { presence: 'none', value: 'absent' };
 
   for (const { rel, parsed } of parsedFiles) {
@@ -45,7 +47,8 @@ export async function collectRenderedHeads(prerenderPagesDir: string): Promise<C
       // Rendered mode does not track source lines (line 0 = unknown); file is the HTML path.
       headings: parsed.headings.map((level) => ({ level, line: 0, file: rel }))
     });
+    images.push({ route, images: parsed.images.map((img) => ({ ...img, file: rel })) });
   }
 
-  return { heads, headings, htmlLang };
+  return { heads, headings, images, htmlLang };
 }

--- a/packages/vite/src/providers/rendered/parse-html.ts
+++ b/packages/vite/src/providers/rendered/parse-html.ts
@@ -1,5 +1,5 @@
 import { parse, HTMLElement } from 'node-html-parser';
-import type { HeadTag, Value } from '@svelte-vitals/core';
+import type { HeadTag, ImageInfo, Value } from '@svelte-vitals/core';
 
 function attrValue(v: string | undefined): Value {
   return v !== undefined && v.trim().length > 0 ? 'static' : 'absent';
@@ -10,6 +10,8 @@ export interface ParsedHtmlHead {
   htmlLang: { presence: 'own' | 'none'; value: Value };
   /** Page-body heading levels (the `n` in <hn>) found in the document (SEO027). */
   headings: number[];
+  /** Page <img> elements (the caller fills `file`); enables the image rules in rendered mode. */
+  images: Omit<ImageInfo, 'file'>[];
 }
 
 /** Parse a fully-rendered HTML document's <head> into normalized head tags. */
@@ -126,5 +128,17 @@ export function parseHtmlHead(html: string): ParsedHtmlHead {
   };
   collectHeadings(root.querySelector('body') ?? root);
 
-  return { tags, htmlLang, headings };
+  // Page <img> elements (PERF001/002/005/006, SEO025). Document order so PERF005's
+  // "first image ≈ LCP" heuristic matches the static provider. line 0 = unknown.
+  const images = root.querySelectorAll('img').map((img) => ({
+    hasWidth: img.hasAttribute('width'),
+    hasHeight: img.hasAttribute('height'),
+    hasLoading: img.hasAttribute('loading'),
+    hasAlt: img.hasAttribute('alt'),
+    lazy: img.getAttribute('loading') === 'lazy',
+    hasSrcset: img.hasAttribute('srcset'),
+    line: 0
+  }));
+
+  return { tags, htmlLang, headings, images };
 }

--- a/packages/vite/src/providers/rendered/parse-html.ts
+++ b/packages/vite/src/providers/rendered/parse-html.ts
@@ -128,9 +128,10 @@ export function parseHtmlHead(html: string): ParsedHtmlHead {
   };
   collectHeadings(root.querySelector('body') ?? root);
 
-  // Page <img> elements (PERF001/002/005/006, SEO025). Document order so PERF005's
+  // Page <img> elements (PERF001/002/005/006, SEO025). Scope to <body> (like the
+  // heading scan) so a stray <head><img> isn't reported. Document order so PERF005's
   // "first image ≈ LCP" heuristic matches the static provider. line 0 = unknown.
-  const images = root.querySelectorAll('img').map((img) => ({
+  const images = (root.querySelector('body') ?? root).querySelectorAll('img').map((img) => ({
     hasWidth: img.hasAttribute('width'),
     hasHeight: img.hasAttribute('height'),
     hasLoading: img.hasAttribute('loading'),

--- a/packages/vite/test/dev-handle.test.ts
+++ b/packages/vite/test/dev-handle.test.ts
@@ -44,6 +44,10 @@ const PAGE_OK =
 // rendered body through the dev hook.
 const PAGE_TWO_H1 = PAGE_OK.replace('</body>', '<h1>Second heading</h1></body>');
 
+// PAGE_OK with a body <img> missing alt + dimensions — proves the dev hook now
+// threads rendered images into the rule context (image rules were CLI-only before).
+const PAGE_BAD_IMG = PAGE_OK.replace('</body>', '<img src="/photo.jpg"></body>');
+
 afterEach(() => vi.restoreAllMocks());
 
 describe('svelteVitalsHandle', () => {
@@ -73,6 +77,17 @@ describe('svelteVitalsHandle', () => {
     const out = warn.mock.calls.map((c) => String(c[0])).join('\n');
     expect(out).toContain('[svelte-vitals] /two-h1');
     expect(out).toContain('SEO027');
+  });
+
+  it('warns about a rendered <img> missing alt/dimensions (image rules in rendered mode)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const handle = svelteVitalsHandle();
+    await handle({ event: fakeEvent('/img', '/img'), resolve: resolveWith([PAGE_BAD_IMG]) });
+    await flush();
+    const out = warn.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(out).toContain('[svelte-vitals] /img');
+    expect(out).toContain('SEO025'); // missing alt
+    expect(out).toContain('PERF001'); // missing width/height
   });
 
   it('returns each chunk unchanged', async () => {

--- a/packages/vite/test/parse-html.test.ts
+++ b/packages/vite/test/parse-html.test.ts
@@ -154,6 +154,31 @@ describe('parse-html: static-gaps capture (SEO024/026/027)', () => {
   });
 });
 
+describe('parse-html: image capture (rendered image-rule parity)', () => {
+  const doc = (body: string) =>
+    `<!doctype html><html lang="en"><head><title>t</title></head><body>${body}</body></html>`;
+
+  it('collects <img> attribute flags from the body', () => {
+    const { images } = parseHtmlHead(
+      doc('<img src="/a.jpg" width="8" height="6" loading="lazy" srcset="/a-2x.jpg 2x" alt="A" />')
+    );
+    expect(images).toEqual([
+      { hasWidth: true, hasHeight: true, hasLoading: true, hasAlt: true, lazy: true, hasSrcset: true, line: 0 }
+    ]);
+  });
+
+  it('records false flags for a bare <img> and preserves document order', () => {
+    const { images } = parseHtmlHead(doc('<img src="/first.jpg" alt="x" /><img src="/second.jpg" />'));
+    expect(images).toHaveLength(2);
+    expect(images[0]!.hasAlt).toBe(true);
+    expect(images[1]!).toMatchObject({ hasWidth: false, hasAlt: false, lazy: false, hasSrcset: false });
+  });
+
+  it('reports no images for a page without <img>', () => {
+    expect(parseHtmlHead(doc('<h1>t</h1>')).images).toEqual([]);
+  });
+});
+
 describe('parse-html: script capture (PERF007/008)', () => {
   it('marks a sync <script src> in head as blocking', () => {
     const { tags } = parseHtmlHead(html('<script src="/a.js"></script>'));

--- a/packages/vite/test/parse-html.test.ts
+++ b/packages/vite/test/parse-html.test.ts
@@ -177,6 +177,15 @@ describe('parse-html: image capture (rendered image-rule parity)', () => {
   it('reports no images for a page without <img>', () => {
     expect(parseHtmlHead(doc('<h1>t</h1>')).images).toEqual([]);
   });
+
+  it('ignores an <img> outside <body> (body-scoped, like headings)', () => {
+    const html =
+      '<!doctype html><html lang="en"><head><title>t</title><img src="/head.jpg"></head>' +
+      '<body><img src="/body.jpg" alt="x" /></body></html>';
+    const { images } = parseHtmlHead(html);
+    expect(images).toHaveLength(1);
+    expect(images[0]!.hasAlt).toBe(true); // the body image, not the head one
+  });
 });
 
 describe('parse-html: script capture (PERF007/008)', () => {


### PR DESCRIPTION
Closes the **SEO025 rendered-mode parity** item in #61.

## Problem

The rendered (vite) provider parsed only `<head>`, so it never populated `ctx.images`. Every image rule — **PERF001, PERF002, PERF005, PERF006, SEO025** — iterates `ctx.images ?? []` and therefore **silently no-op'd in build analysis and the dev hook**. Image/alt checks only worked in static (CLI) mode.

## Change

- **`parse-html.ts`** now collects `<img>` from the rendered body (document order, so PERF005's "first image ≈ LCP" heuristic matches the static provider; `line: 0` since rendered mode has no source lines). Returns `Omit<ImageInfo, 'file'>[]`.
- **`collect.ts`** (build) and **`hooks/handle.ts`** (dev) thread `ResolvedImages` into the rule context (`file` = HTML path / route).

No core or rule changes — pure coverage parity. Pages without `<img>` are unaffected (image rules skip imageless routes).

## Tests

- `parse-html` image capture: attribute flags, document order, empty page.
- Dev-hook integration: a bare `<img>` in the body now warns **SEO025** (missing alt) and **PERF001** (missing dimensions).

`pnpm -r test` (**463**: core 217 / vite 75 / cli 162 / mcp 9), `pnpm -r typecheck`, `pnpm lint`, `pnpm --filter docs build` (93 pages) — all green. No existing fixtures tripped (vite fixtures have no `<img>`).

Still tracked in #61: charset value policing, hreflang reciprocity, pixel-width measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image checks now run in rendered/Vite mode during build and dev analysis, matching static mode.
  * Missing image dimensions, alt text, lazy-loading, and srcset issues can now be reported for rendered pages.

* **Bug Fixes**
  * Fixed a gap where rendered pages could silently skip image-related warnings.
  * Pages without images are unaffected, and results preserve document order for consistent reporting.

* **Tests**
  * Added coverage for rendered image detection and the new warning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->