### PR TITLE
feat(cli): resolve layout breakouts (+page@ / +layout@) (#12)

### DIFF
--- a/.changeset/layout-breakouts.md
+++ b/.changeset/layout-breakouts.md
@@ -1,0 +1,9 @@
+---
+'svelte-vitals': minor
+---
+
+Resolve SvelteKit layout breakouts in static (CLI) mode (#12). `+page@.svelte` /
+`+page@segment.svelte` pages are now enumerated (previously skipped entirely),
+and the layout chain honors `+page@` / `+layout@` resets — so a route that breaks
+out inherits the correct layouts instead of the full ancestor chain. The route
+URL is unchanged (the `@segment` only affects layout inheritance).

--- a/README.md
+++ b/README.md
@@ -85,10 +85,6 @@ This makes svelte-vitals usable as a CI gate. See the [CLI guide](https://oekazu
 
 svelte-vitals resolves the **effective `<head>`** of every route — walking the layout chain (`+layout.svelte` → … → `+page.svelte`) and parsing `<svelte:head>` with the official `svelte/compiler`. Its design goal is **no false negatives**: a dynamic title like `<title>{data.title}</title>` (the correct SvelteKit pattern) is **never** flagged as missing — it passes with a `↯` marker, and only genuinely missing or empty metadata is penalized.
 
-### Known limitations
-
-- **Layout breakouts are not resolved** ([#12](https://github.com/oekazuma/svelte-vitals/issues/12)). The static-mode resolver walks the full `+layout.svelte` chain and does not yet account for SvelteKit's layout reset/breakout files (`+page@.svelte`, `+page@segment.svelte`, `+layout@.svelte`). A route that breaks out of its layout chain may therefore be composed against the wrong set of layouts (or skipped). This is rare in practice; until proper breakout resolution lands, scope the run to the routes you trust with `--route`, or check the affected pages in **plugin mode** (`@svelte-vitals/vite`), which inspects the real prerendered HTML and is unaffected.
-
 ## Roadmap
 
 The project advances along two axes: **mode maturity** and **category coverage**. SEO is the first category; more follow.

--- a/docs/superpowers/specs/2026-06-29-layout-breakouts-design.md
+++ b/docs/superpowers/specs/2026-06-29-layout-breakouts-design.md
@@ -46,9 +46,13 @@ returns `Map<dirRel, filename>` (a directory has one layout). Built once per run
 `chainFiles(pageRel, layouts)` returns `[{rel,isPage:false}...root-first, {rel:pageRel,isPage:true}]`:
 
 - `parseAt(filename)` → the `@`-segment (`''` for `@`, `null` for no `@`).
-- `atTarget(filename, dirSegs)` → directory segments to attach to: `null` (default
-  = own dir), `[]` (root), or the prefix up to the **last** segment equal to the
-  `@`-segment (not found → fall back to default, never crash).
+- `atTarget(filename, dirSegs, strictAncestor?)` → directory segments to attach to:
+  `null` (default = own dir), `[]` (root), or the prefix up to the **last** segment
+  equal to the `@`-segment (not found → fall back to default, never crash).
+  `strictAncestor` (used for `+layout@seg` resets) excludes the file's own dir
+  segment from the search — a layout cannot be its own parent, so `+layout@b` in
+  `…/b` must target an **outer** `b`. The page leaf keeps the full search (a page
+  may legitimately attach to its own directory's layout).
 - `buildChain(attachSegs)` walks upward from the attach dir: find the nearest
   layout at-or-above the current dir, prepend it, then continue from its parent —
   **unless that layout is itself `+layout@seg`**, in which case jump to `seg`'s
@@ -65,9 +69,11 @@ and drops `(group)` segments — URL unchanged by breakouts.
 
 - `chainFiles` unit (with a layout map): default chain unchanged; `+page@`
   (root), `+page@seg`, `+page@(group)`, `+page@[param]`; `+layout@` reset skips an
-  intermediate layout; unknown `@seg` falls back; cycle guard.
+  intermediate layout; `+layout@seg` resolves a strict ancestor even when `seg`
+  repeats its own dir name; unknown `@seg` falls back; cycle guard.
 - `deriveRoute`: `+page@(app).svelte` etc. yield the directory's route.
-- `enumerateRoutePages`: `+page@x.svelte` is enumerated.
+- `enumerateRoutePages`: `+page@x.svelte` is enumerated; leading-dot dirs are
+  ignored (memory runtime mirrors tinyglobby `dot:false`).
 - Integration (`collectRoutes`, memory runtime): a breakout page inherits the
   reset chain (correct inherited vs skipped tags).
 - Full `pnpm -r test` + typecheck + lint green.

--- a/docs/superpowers/specs/2026-06-29-layout-breakouts-design.md
+++ b/docs/superpowers/specs/2026-06-29-layout-breakouts-design.md
@@ -1,0 +1,78 @@
+# Layout breakouts — `+page@` / `+layout@` resolution
+
+**Date:** 2026-06-29
+**Status:** Approved (per maintainer)
+**Packages:** `@svelte-vitals/cli` (static route resolver)
+**Issue:** #12
+
+## Goal
+
+Resolve SvelteKit layout **breakouts** in the static (CLI) provider so analysis
+matches the real layout hierarchy. Two gaps today:
+
+1. **Breakout pages are not even enumerated.** `enumerateRoutePages` globs
+   `**/+page.svelte`, which never matches `+page@.svelte` / `+page@x.svelte`, so
+   those routes get **zero analysis**.
+2. **`chainFiles` ignores `@`.** It always includes every ancestor `+layout.svelte`,
+   so a route that breaks out inherits the wrong layouts (false inherited tags).
+
+## SvelteKit semantics (from kit/advanced-routing)
+
+- `+page@seg.svelte` resets the page's layout to the `+layout.svelte` in the
+  ancestor directory whose segment name is `seg` (`@` = the **root** layout).
+  `seg` matches a literal path segment, including groups `(app)` and params `[id]`.
+  Layouts between `seg` and the page are skipped.
+- `+layout@seg.svelte` resets **that layout's** parent the same way; its own
+  children then inherit through the reset chain.
+- The route URL is derived from the directory only — `@seg` never affects the URL.
+
+Example (`(app)/item/[id]/embed/+page@(app).svelte`) inherits root +
+`(app)/+layout.svelte` + the page, skipping `item` and `[id]` layouts.
+
+## Design (`packages/cli/src/providers/source/`)
+
+### Enumeration (`project.ts`)
+
+`enumerateRoutePages` globs both `**/+page.svelte` and `**/+page@*.svelte`, merged
+and sorted.
+
+### Layout index (`routes.ts`)
+
+`collectLayouts(rt, cwd)` globs `**/+layout.svelte` + `**/+layout@*.svelte` and
+returns `Map<dirRel, filename>` (a directory has one layout). Built once per run.
+
+### Breakout-aware chain (`routes.ts`, now pure)
+
+`chainFiles(pageRel, layouts)` returns `[{rel,isPage:false}...root-first, {rel:pageRel,isPage:true}]`:
+
+- `parseAt(filename)` → the `@`-segment (`''` for `@`, `null` for no `@`).
+- `atTarget(filename, dirSegs)` → directory segments to attach to: `null` (default
+  = own dir), `[]` (root), or the prefix up to the **last** segment equal to the
+  `@`-segment (not found → fall back to default, never crash).
+- `buildChain(attachSegs)` walks upward from the attach dir: find the nearest
+  layout at-or-above the current dir, prepend it, then continue from its parent —
+  **unless that layout is itself `+layout@seg`**, in which case jump to `seg`'s
+  dir. A `seen` set guards against cycles.
+- The page's own `@` chooses the initial `attachSegs`.
+
+`deriveRoute(pageRel)` strips from the last `/+page` (so `+page@x.svelte` works)
+and drops `(group)` segments — URL unchanged by breakouts.
+
+`collectRoutes` builds the layout index once and passes it to each `resolveRoute`
+(which becomes sync-chain + per-file read, no per-ancestor `exists()`).
+
+## Testing
+
+- `chainFiles` unit (with a layout map): default chain unchanged; `+page@`
+  (root), `+page@seg`, `+page@(group)`, `+page@[param]`; `+layout@` reset skips an
+  intermediate layout; unknown `@seg` falls back; cycle guard.
+- `deriveRoute`: `+page@(app).svelte` etc. yield the directory's route.
+- `enumerateRoutePages`: `+page@x.svelte` is enumerated.
+- Integration (`collectRoutes`, memory runtime): a breakout page inherits the
+  reset chain (correct inherited vs skipped tags).
+- Full `pnpm -r test` + typecheck + lint green.
+
+## Out of scope
+
+- Rendered (vite) mode already reads final HTML, so breakouts don't apply there.
+- Param-matcher / encoding edge cases unrelated to layout inheritance.

--- a/packages/cli/src/providers/source/project.ts
+++ b/packages/cli/src/providers/source/project.ts
@@ -47,10 +47,13 @@ export async function detectProject(rt: Runtime, cwd: string): Promise<void> {
   );
 }
 
-/** Enumerate route page files relative to the project root (design §5). */
+/** Enumerate route page files relative to the project root (design §5, #12: incl. +page@ breakouts). */
 export async function enumerateRoutePages(rt: Runtime, cwd: string): Promise<string[]> {
-  const pages = await rt.glob(`${ROUTES_DIR}/**/+page.svelte`, cwd);
-  return pages.sort();
+  const [plain, breakout] = await Promise.all([
+    rt.glob(`${ROUTES_DIR}/**/+page.svelte`, cwd),
+    rt.glob(`${ROUTES_DIR}/**/+page@*.svelte`, cwd)
+  ]);
+  return [...new Set([...plain, ...breakout])].sort();
 }
 
 async function existsAny(rt: Runtime, cwd: string, paths: readonly string[]): Promise<boolean> {

--- a/packages/cli/src/providers/source/routes.ts
+++ b/packages/cli/src/providers/source/routes.ts
@@ -50,12 +50,18 @@ function parseAt(rel: string): string | null {
  * Directory segments a `@`-leaf attaches to: null = default (own dir), [] = root,
  * else the prefix up to the LAST segment equal to the `@`-segment (null when the
  * segment is unknown → caller falls back to the default, never crashes).
+ *
+ * `strictAncestor` excludes the file's own directory segment from the search:
+ * a `+layout@seg` resets to a STRICT ancestor (a layout cannot be its own parent),
+ * so a `+layout@b` in `…/b` must target an outer `b`, never itself. A page leaf may
+ * legitimately attach to its own directory's layout, so it keeps the full search.
  */
-function atTarget(rel: string, dirSegs: string[]): string[] | null {
+function atTarget(rel: string, dirSegs: string[], strictAncestor = false): string[] | null {
   const at = parseAt(rel);
   if (at === null) return null; // no breakout
   if (at === '') return []; // root layout
-  const i = dirSegs.lastIndexOf(at);
+  const haystack = strictAncestor ? dirSegs.slice(0, -1) : dirSegs;
+  const i = haystack.lastIndexOf(at);
   return i >= 0 ? dirSegs.slice(0, i + 1) : null;
 }
 
@@ -101,7 +107,7 @@ export function chainFiles(pageRel: string, layouts: Map<string, string>): Array
     if (!found || seen.has(found.rel)) break;
     seen.add(found.rel);
     chain.unshift(found.rel);
-    const reset = atTarget(found.rel, found.segs);
+    const reset = atTarget(found.rel, found.segs, true);
     // default (or unknown segment) → parent is strictly above the layout's dir;
     // a `+layout@seg` that names a strict ancestor jumps straight to it.
     dir = reset !== null && reset.length < found.segs.length ? reset : found.segs.slice(0, -1);

--- a/packages/cli/src/providers/source/routes.ts
+++ b/packages/cli/src/providers/source/routes.ts
@@ -22,35 +22,93 @@ function isGroupSegment(segment: string): boolean {
   return /^\(.+\)$/.test(segment);
 }
 
-/** Derive the route path from a +page.svelte path, dropping (group) dirs (design §5). */
-export function deriveRoute(pageRel: string): string {
-  const inner = pageRel.slice(`${ROUTES_DIR}/`.length, -'/+page.svelte'.length);
-  const segments = inner.length === 0 ? [] : inner.split('/').filter((s) => !isGroupSegment(s));
-  return '/' + segments.join('/');
+/** Directory of a route file (everything before the trailing `/+page…` or `/+layout…`). */
+function dirOf(rel: string): string {
+  const i = rel.lastIndexOf('/');
+  return i >= 0 ? rel.slice(0, i) : '';
+}
+
+/** Segments of a directory under src/routes, e.g. 'src/routes/(app)/item' → ['(app)','item']. */
+function dirSegments(dir: string): string[] {
+  const extra = dir.slice(ROUTES_DIR.length); // '' or '/(app)/item'
+  return extra.length === 0 ? [] : extra.split('/').filter(Boolean);
+}
+
+/** Directory rel path for a list of segments. */
+function dirKey(segs: string[]): string {
+  return segs.length === 0 ? ROUTES_DIR : `${ROUTES_DIR}/${segs.join('/')}`;
+}
+
+/** The `@`-segment of a +page@/+layout@ file: '' for `@`, the name for `@seg`, or null when there is no `@`. */
+function parseAt(rel: string): string | null {
+  const file = rel.slice(rel.lastIndexOf('/') + 1);
+  const m = /^\+(?:page|layout)@(.*)\.svelte$/.exec(file);
+  return m ? m[1]! : null;
 }
 
 /**
- * Build the layout chain (root → leaf) for a route, then append the page itself.
- * All layout levels are resolved (design §5); +layout@/+page@ breakouts are not.
+ * Directory segments a `@`-leaf attaches to: null = default (own dir), [] = root,
+ * else the prefix up to the LAST segment equal to the `@`-segment (null when the
+ * segment is unknown → caller falls back to the default, never crashes).
  */
-export async function chainFiles(
-  rt: Runtime,
-  cwd: string,
-  pageRel: string
-): Promise<Array<{ rel: string; isPage: boolean }>> {
-  const dir = pageRel.slice(0, -'/+page.svelte'.length); // 'src/routes/blog/[slug]'
-  const extra = dir.slice(ROUTES_DIR.length); // '' or '/blog/[slug]'
-  const segments = extra.length === 0 ? [] : extra.split('/').filter(Boolean);
+function atTarget(rel: string, dirSegs: string[]): string[] | null {
+  const at = parseAt(rel);
+  if (at === null) return null; // no breakout
+  if (at === '') return []; // root layout
+  const i = dirSegs.lastIndexOf(at);
+  return i >= 0 ? dirSegs.slice(0, i + 1) : null;
+}
 
-  const files: Array<{ rel: string; isPage: boolean }> = [];
-  let prefix = ROUTES_DIR;
-  for (let i = 0; i <= segments.length; i++) {
-    if (i > 0) prefix = `${prefix}/${segments[i - 1]}`;
-    const layout = `${prefix}/+layout.svelte`;
-    if (await rt.exists(rt.join(cwd, layout))) files.push({ rel: layout, isPage: false });
+/** Derive the route path from a +page(@…).svelte path, dropping (group) dirs (design §5; #12). */
+export function deriveRoute(pageRel: string): string {
+  const segments = dirSegments(dirOf(pageRel)).filter((s) => !isGroupSegment(s));
+  return '/' + segments.join('/');
+}
+
+/** Index every +layout.svelte / +layout@*.svelte by its directory (one layout per dir) (#12). */
+export async function collectLayouts(rt: Runtime, cwd: string): Promise<Map<string, string>> {
+  const [plain, breakout] = await Promise.all([
+    rt.glob(`${ROUTES_DIR}/**/+layout.svelte`, cwd),
+    rt.glob(`${ROUTES_DIR}/**/+layout@*.svelte`, cwd)
+  ]);
+  const map = new Map<string, string>();
+  for (const rel of [...plain, ...breakout]) map.set(dirOf(rel), rel);
+  return map;
+}
+
+/** Nearest layout at or above `segs` (walking the prefix down to root), or null. */
+function layoutAtOrAbove(segs: string[], layouts: Map<string, string>): { segs: string[]; rel: string } | null {
+  for (let j = segs.length; j >= 0; j--) {
+    const rel = layouts.get(dirKey(segs.slice(0, j)));
+    if (rel) return { segs: segs.slice(0, j), rel };
   }
-  files.push({ rel: pageRel, isPage: true });
-  return files;
+  return null;
+}
+
+/**
+ * Build the breakout-aware layout chain (root → leaf) then append the page (#12).
+ * The page's own `@` chooses where to attach; each layout's own `@` can reset its
+ * parent. A `seen` set guards against cycles.
+ */
+export function chainFiles(pageRel: string, layouts: Map<string, string>): Array<{ rel: string; isPage: boolean }> {
+  const pageSegs = dirSegments(dirOf(pageRel));
+  let dir: string[] | null = atTarget(pageRel, pageSegs) ?? pageSegs;
+
+  const chain: string[] = [];
+  const seen = new Set<string>();
+  while (dir !== null) {
+    const found = layoutAtOrAbove(dir, layouts);
+    if (!found || seen.has(found.rel)) break;
+    seen.add(found.rel);
+    chain.unshift(found.rel);
+    const reset = atTarget(found.rel, found.segs);
+    // default (or unknown segment) → parent is strictly above the layout's dir;
+    // a `+layout@seg` that names a strict ancestor jumps straight to it.
+    dir = reset !== null && reset.length < found.segs.length ? reset : found.segs.slice(0, -1);
+    if (dir.length === 0 && found.segs.length === 0) dir = null; // passed root
+  }
+
+  return [...chain.map((rel) => ({ rel, isPage: false })), { rel: pageRel, isPage: true }];
 }
 
 /** Per-route facts produced by a single walk of the layout chain. */
@@ -65,8 +123,14 @@ interface RouteFacts {
  * parsed a single time, yielding both the composed head (child overrides parent)
  * and the route's <img> facts. Heads and images therefore share one parse pass.
  */
-async function resolveRoute(rt: Runtime, cwd: string, pageRel: string, config: Config): Promise<RouteFacts> {
-  const files = await chainFiles(rt, cwd, pageRel);
+async function resolveRoute(
+  rt: Runtime,
+  cwd: string,
+  pageRel: string,
+  config: Config,
+  layouts: Map<string, string>
+): Promise<RouteFacts> {
+  const files = chainFiles(pageRel, layouts);
   const composed = new Map<string, HeadTag>();
   let broadOwn = false;
   let broadInherited = false;
@@ -122,8 +186,8 @@ export async function collectRoutes(
   cwd: string,
   config: Config = defaultConfig
 ): Promise<{ heads: ResolvedHead[]; images: ResolvedImages[]; headings: ResolvedHeadings[] }> {
-  const pages = await enumerateRoutePages(rt, cwd);
-  const facts = await Promise.all(pages.map((page) => resolveRoute(rt, cwd, page, config)));
+  const [pages, layouts] = await Promise.all([enumerateRoutePages(rt, cwd), collectLayouts(rt, cwd)]);
+  const facts = await Promise.all(pages.map((page) => resolveRoute(rt, cwd, page, config, layouts)));
   return {
     heads: facts.map((f) => f.head),
     images: facts.map((f) => f.images),

--- a/packages/cli/test/helpers/memory-runtime.ts
+++ b/packages/cli/test/helpers/memory-runtime.ts
@@ -26,10 +26,24 @@ export function createMemoryRuntime(files: Record<string, string>): Runtime {
 }
 
 function globToRegExp(pattern: string): RegExp {
-  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&');
-  const body = escaped
-    .replace(/\*\*\//g, '(?:.*/)?')
-    .replace(/\*\*/g, '.*')
-    .replace(/\*/g, '[^/]*');
+  // Tokenize char-by-char so `**/` expands to "any depth" without the later `*`
+  // pass corrupting the inserted regex (the previous string-replace approach only
+  // matched a single nested segment).
+  let body = '';
+  for (let i = 0; i < pattern.length; i++) {
+    if (pattern.startsWith('**/', i)) {
+      body += '(?:[^/]+/)*'; // zero or more full path segments
+      i += 2;
+    } else if (pattern.startsWith('**', i)) {
+      body += '.*';
+      i += 1;
+    } else if (pattern[i] === '*') {
+      body += '[^/]*';
+    } else if (/[.+^${}()|[\]\\]/.test(pattern[i]!)) {
+      body += `\\${pattern[i]}`;
+    } else {
+      body += pattern[i];
+    }
+  }
   return new RegExp(`^${body}$`);
 }

--- a/packages/cli/test/helpers/memory-runtime.ts
+++ b/packages/cli/test/helpers/memory-runtime.ts
@@ -32,7 +32,9 @@ function globToRegExp(pattern: string): RegExp {
   let body = '';
   for (let i = 0; i < pattern.length; i++) {
     if (pattern.startsWith('**/', i)) {
-      body += '(?:[^/]+/)*'; // zero or more full path segments
+      // zero or more full path segments, excluding leading-dot dirs to match the
+      // real runtime glob (tinyglobby runs with dot:false, so it skips hidden dirs).
+      body += '(?:(?!\\.)[^/]+/)*';
       i += 2;
     } else if (pattern.startsWith('**', i)) {
       body += '.*';

--- a/packages/cli/test/layout-breakouts.test.ts
+++ b/packages/cli/test/layout-breakouts.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { chainFiles, deriveRoute, collectRoutes } from '../src/providers/source/routes.js';
+import { enumerateRoutePages } from '../src/providers/source/project.js';
+import { createMemoryRuntime } from './helpers/memory-runtime.js';
+
+const L = (dir: string, file = '+layout.svelte') => [dir, `${dir}/${file}`] as const;
+
+// Layout index for the (app)/item/[id]/embed example from the SvelteKit docs.
+const layouts = new Map<string, string>([
+  L('src/routes'),
+  L('src/routes/(app)'),
+  L('src/routes/(app)/item'),
+  L('src/routes/(app)/item/[id]')
+]);
+const rels = (page: string, map = layouts) => chainFiles(page, map).map((f) => f.rel);
+
+describe('chainFiles — breakout resolution (#12)', () => {
+  it('default page inherits the full ancestor layout chain', () => {
+    expect(rels('src/routes/(app)/item/[id]/embed/+page.svelte')).toEqual([
+      'src/routes/+layout.svelte',
+      'src/routes/(app)/+layout.svelte',
+      'src/routes/(app)/item/+layout.svelte',
+      'src/routes/(app)/item/[id]/+layout.svelte',
+      'src/routes/(app)/item/[id]/embed/+page.svelte'
+    ]);
+  });
+
+  it('+page@ resets to the root layout only', () => {
+    expect(rels('src/routes/(app)/item/[id]/embed/+page@.svelte')).toEqual([
+      'src/routes/+layout.svelte',
+      'src/routes/(app)/item/[id]/embed/+page@.svelte'
+    ]);
+  });
+
+  it('+page@(group) resets to the group layout', () => {
+    expect(rels('src/routes/(app)/item/[id]/embed/+page@(app).svelte')).toEqual([
+      'src/routes/+layout.svelte',
+      'src/routes/(app)/+layout.svelte',
+      'src/routes/(app)/item/[id]/embed/+page@(app).svelte'
+    ]);
+  });
+
+  it('+page@segment resets to that named ancestor layout (skips deeper layouts)', () => {
+    expect(rels('src/routes/(app)/item/[id]/embed/+page@item.svelte')).toEqual([
+      'src/routes/+layout.svelte',
+      'src/routes/(app)/+layout.svelte',
+      'src/routes/(app)/item/+layout.svelte',
+      'src/routes/(app)/item/[id]/embed/+page@item.svelte'
+    ]);
+  });
+
+  it('+layout@ on an intermediate layout skips its parent for all children', () => {
+    // (app)/item/+layout@.svelte resets to root, so (app)/+layout.svelte is skipped.
+    const map = new Map<string, string>([
+      L('src/routes'),
+      L('src/routes/(app)'),
+      L('src/routes/(app)/item', '+layout@.svelte'),
+      L('src/routes/(app)/item/[id]')
+    ]);
+    expect(rels('src/routes/(app)/item/[id]/+page.svelte', map)).toEqual([
+      'src/routes/+layout.svelte',
+      'src/routes/(app)/item/+layout@.svelte',
+      'src/routes/(app)/item/[id]/+layout.svelte',
+      'src/routes/(app)/item/[id]/+page.svelte'
+    ]);
+  });
+
+  it('falls back to the default chain when the @segment is unknown', () => {
+    expect(rels('src/routes/(app)/item/+page@nope.svelte')).toEqual([
+      'src/routes/+layout.svelte',
+      'src/routes/(app)/+layout.svelte',
+      'src/routes/(app)/item/+layout.svelte',
+      'src/routes/(app)/item/+page@nope.svelte'
+    ]);
+  });
+});
+
+describe('deriveRoute — breakout filenames (#12)', () => {
+  it('derives the URL from the directory, ignoring @ and (groups)', () => {
+    expect(deriveRoute('src/routes/(app)/item/[id]/embed/+page@(app).svelte')).toBe('/item/[id]/embed');
+    expect(deriveRoute('src/routes/+page@.svelte')).toBe('/');
+  });
+});
+
+describe('enumerateRoutePages — includes +page@ breakouts (#12)', () => {
+  it('enumerates both +page.svelte and +page@x.svelte', async () => {
+    const rt = createMemoryRuntime({
+      'src/routes/+page.svelte': 'x',
+      'src/routes/(app)/item/+page@.svelte': 'y'
+    });
+    expect(await enumerateRoutePages(rt, '')).toEqual([
+      'src/routes/(app)/item/+page@.svelte',
+      'src/routes/+page.svelte'
+    ]);
+  });
+});
+
+describe('collectRoutes — breakout page does not inherit skipped layout tags (#12)', () => {
+  it('a +page@ (root) page ignores the group layout title', async () => {
+    const rt = createMemoryRuntime({
+      'src/routes/+layout.svelte': '<svelte:head><meta name="description" content="root" /></svelte:head>',
+      'src/routes/(app)/+layout.svelte': '<svelte:head><title>App Layout Title</title></svelte:head>',
+      'src/routes/(app)/page/+page@.svelte': '<h1>Breakout</h1>'
+    });
+    const { heads } = await collectRoutes(rt, '');
+    const head = heads.find((h) => h.route === '/page')!;
+    // Inherits the root layout's description, but NOT the (app) layout's title.
+    expect(head.tags.some((t) => t.kind === 'meta' && t.name === 'description')).toBe(true);
+    expect(head.tags.some((t) => t.kind === 'title')).toBe(false);
+  });
+});

--- a/packages/cli/test/layout-breakouts.test.ts
+++ b/packages/cli/test/layout-breakouts.test.ts
@@ -73,6 +73,23 @@ describe('chainFiles — breakout resolution (#12)', () => {
       'src/routes/(app)/item/+page@nope.svelte'
     ]);
   });
+
+  it('+layout@seg resolves a STRICT ancestor, even when the segment name repeats its own dir', () => {
+    // b/a/b/+layout@b must reset to the OUTER ancestor `src/routes/b`, not its own dir,
+    // so the intermediate b/a/+layout.svelte is skipped. `@` targets strict ancestors only.
+    const map = new Map<string, string>([
+      L('src/routes/b'),
+      L('src/routes/b/a'),
+      L('src/routes/b/a/b', '+layout@b.svelte'),
+      L('src/routes/b/a/b/c')
+    ]);
+    expect(rels('src/routes/b/a/b/c/+page.svelte', map)).toEqual([
+      'src/routes/b/+layout.svelte',
+      'src/routes/b/a/b/+layout@b.svelte',
+      'src/routes/b/a/b/c/+layout.svelte',
+      'src/routes/b/a/b/c/+page.svelte'
+    ]);
+  });
 });
 
 describe('deriveRoute — breakout filenames (#12)', () => {
@@ -92,6 +109,14 @@ describe('enumerateRoutePages — includes +page@ breakouts (#12)', () => {
       'src/routes/(app)/item/+page@.svelte',
       'src/routes/+page.svelte'
     ]);
+  });
+
+  it('ignores leading-dot directories, matching the real runtime glob (tinyglobby dot:false)', async () => {
+    const rt = createMemoryRuntime({
+      'src/routes/+page.svelte': 'x',
+      'src/routes/.well-known/+page.svelte': 'y'
+    });
+    expect(await enumerateRoutePages(rt, '')).toEqual(['src/routes/+page.svelte']);
   });
 });
 


### PR DESCRIPTION
Resolves the layout-breakout known limitation (#12) in static (CLI) mode.

## Problem

1. **Breakout pages were never analyzed.** `enumerateRoutePages` globbed only `**/+page.svelte`, which doesn't match `+page@.svelte` / `+page@segment.svelte` — those routes got **zero analysis**.
2. **The layout chain ignored `@` resets.** `chainFiles` always included every ancestor `+layout.svelte`, so a route that breaks out inherited the wrong layouts (false inherited tags) — or none.

## Change (`packages/cli/src/providers/source/`)

- **`enumerateRoutePages`** now also globs `**/+page@*.svelte`.
- **`collectLayouts`** (new) indexes `+layout.svelte` / `+layout@*.svelte` by directory, built once per run.
- **`chainFiles`** is now a pure, breakout-aware walk: the page's `@` chooses the attach point; each layout's own `@` can reset its parent; a `seen` set guards cycles; an unknown `@segment` falls back to the default chain.
- **`deriveRoute`** strips from the last `/+page`, so `+page@(app).svelte` maps to the directory's URL (breakouts never change the URL).
- Per SvelteKit semantics (kit/advanced-routing): `@` = root layout, `@(group)` / `@segment` / `@[param]` attach to that directory's layout, skipping deeper ones.

Also fixes the in-memory **test runtime** glob so `**/` matches any depth (it previously matched a single nested segment, which masked multi-level routes).

Rendered (vite) mode is unaffected — it already reads the final prerendered HTML.

## Tests

- `chainFiles` breakout matrix: default chain, `+page@` (root), `+page@(group)`, `+page@segment`, `+layout@` reset (skips an intermediate layout), unknown `@segment` fallback.
- `deriveRoute` with `@` filenames; `enumerateRoutePages` includes `+page@`; a `collectRoutes` integration where a breakout page ignores the skipped layout's tags.

`pnpm -r test` (**473**: core 217 / vite 76 / cli 171 / mcp 9), `pnpm -r typecheck`, `pnpm lint`, `pnpm --filter docs build` — all green. README known-limitation removed.

Closes #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Static CLI route processing now recognizes breakout page and layout patterns, including `+page@...` and `+layout@...` files.
  * Route URLs continue to be derived without breakout markers, while layout inheritance now follows the intended reset and ancestor behavior.

* **Bug Fixes**
  * Fixed missing enumeration of breakout pages in static mode.
  * Fixed incorrect layout chaining so pages inherit the correct layouts, including cases with grouped or reset layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->