### PR TITLE
feat(cli): --diff / --staged to gate findings on changed files

### DIFF
--- a/.changeset/workflow-diff-staged.md
+++ b/.changeset/workflow-diff-staged.md
@@ -1,0 +1,14 @@
+---
+'svelte-vitals': minor
+---
+
+Add `--diff` and `--staged` to scope findings to changed files (#69) — run
+svelte-vitals as a pre-commit hook or PR check that gates only what just changed:
+
+- `--staged` — report only findings in files staged for commit.
+- `--diff [ref]` — report only findings in files changed vs `ref` (default
+  `HEAD`; e.g. `--diff main` for branch changes).
+
+Findings are filtered to those located in the changed files, then flow through
+scoring, the reporters, and the `--fail-on` / `--min-health` gates. If git can't
+answer (not a repo / unavailable), it warns and analyzes everything.

--- a/docs/src/content/docs/guides/cli.md
+++ b/docs/src/content/docs/guides/cli.md
@@ -72,6 +72,25 @@ Only analyze routes whose path matches the given glob pattern.
 svelte-vitals --route "/blog/**"
 ```
 
+### `--diff [ref]`
+
+Report only findings located in files **changed** versus `ref` (default `HEAD`, i.e. uncommitted changes). Compares against the **merge-base** with `ref`, and includes untracked (new) files — so `--diff main` is "what this branch changed". Great as a PR check.
+
+```bash
+svelte-vitals --diff          # uncommitted changes vs HEAD
+svelte-vitals --diff main     # everything this branch changed vs main
+```
+
+### `--staged`
+
+Report only findings in files **staged** for commit (`git diff --cached`). Ideal as a pre-commit hook to gate just what you're about to commit. Takes precedence over `--diff`.
+
+```bash
+svelte-vitals --staged --fail-on warning
+```
+
+> Both flags filter findings by their source-file location and assume the project root is the git root. If git is unavailable (or the ref is invalid), svelte-vitals warns and analyzes the whole project.
+
 ### `--by-route`
 
 Print a per-route score breakdown in the console output.

--- a/docs/superpowers/specs/2026-06-30-workflow-diff-staged-design.md
+++ b/docs/superpowers/specs/2026-06-30-workflow-diff-staged-design.md
@@ -18,10 +18,15 @@ pre-existing findings across the whole app. The signature agent-native workflow.
 
 ### Changed-file resolution (`changed-files.ts`)
 
-`getChangedFiles(cwd, { staged?, base? })` runs git via `node:child_process`
-(`git diff --name-only --diff-filter=d [--cached] [base]`) and returns a `Set`
-of repo-relative POSIX paths, or `undefined` on any failure (not a git repo, git
-missing, etc.). Deleted files are excluded (`--diff-filter=d`).
+`getChangedFiles(cwd, { staged?, base? })` runs git via `node:child_process` and
+returns a `Set` of repo-relative POSIX paths, or `undefined` on any failure (not a
+git repo, git missing, bad ref). Deleted files are excluded (`--diff-filter=d`).
+
+- `--staged`: `git diff --name-only --cached --diff-filter=d`.
+- `--diff`: `git diff --name-only --diff-filter=d --merge-base <base>` (so
+  `--diff main` is branch-introduced changes, not files only changed on `main`),
+  **unioned with** `git ls-files --others --exclude-standard` (untracked/new files
+  — a "gate what changed" run must catch brand-new components).
 
 ### Filtering (`run()` in `index.ts`)
 
@@ -41,9 +46,9 @@ v1 assumes project root == git root (the common case); documented.
 
 ## CLI surface
 
-- mri: `diff` (string — `--diff` alone → `''` ⇒ default base; `--diff main` →
-  `'main'`), `staged` (boolean). `resolveArgs` maps to
-  `RunOptions.diff?: string | true` and `staged?: boolean`. `--staged` wins if both.
+- mri: `diff` (string — `--diff` alone → `''`; `--diff main` → `'main'`), `staged`
+  (boolean). `resolveArgs` maps to `RunOptions.diffBase?: string` (bare `--diff` →
+  `'HEAD'`; `undefined` = no gating) and `staged?: boolean`. `--staged` wins if both.
 - HELP + exit codes documented. Changeset `svelte-vitals` minor.
 
 ## Testing

--- a/docs/superpowers/specs/2026-06-30-workflow-diff-staged-design.md
+++ b/docs/superpowers/specs/2026-06-30-workflow-diff-staged-design.md
@@ -1,0 +1,61 @@
+# Workflow ergonomics — `--diff` / `--staged` (changed-file gating)
+
+**Date:** 2026-06-30
+**Status:** Approved (per maintainer; next slice of #69)
+**Packages:** `@svelte-vitals/cli` only (no core/rule changes)
+
+## Goal
+
+Let the CLI gate **only the files that changed** — so it can run as a pre-commit
+hook or PR check that catches "what the agent just wrote" without drowning in
+pre-existing findings across the whole app. The signature agent-native workflow.
+
+- `--staged` — report only findings in files staged for commit (`git diff --cached`).
+- `--diff [ref]` — report only findings in files changed vs `ref` (working tree;
+  default `HEAD` = uncommitted changes; e.g. `--diff main` for branch changes).
+
+## Design (CLI-only)
+
+### Changed-file resolution (`changed-files.ts`)
+
+`getChangedFiles(cwd, { staged?, base? })` runs git via `node:child_process`
+(`git diff --name-only --diff-filter=d [--cached] [base]`) and returns a `Set`
+of repo-relative POSIX paths, or `undefined` on any failure (not a git repo, git
+missing, etc.). Deleted files are excluded (`--diff-filter=d`).
+
+### Filtering (`run()` in `index.ts`)
+
+`run()` already calls `analyzeProject()` (shared with MCP — left untouched, no
+git there). After analysis, when `--staged`/`--diff` is set:
+
+1. Resolve the changed set; if `undefined`, print a warning and analyze everything
+   (don't silently pass).
+2. `filterToChangedFiles(results, changed)` keeps results whose `location` is in
+   the set. Findings without a `location` (project-scoped, e.g. robots/sitemap)
+   and passing "seed" results (no location) are dropped — the gate reports issues
+   **in the changed files**. The filtered results flow through scoring, summary,
+   reporters, and the fail-on/min-health gates unchanged.
+
+Path note: `location` is project-root-relative; git paths are repo-root-relative.
+v1 assumes project root == git root (the common case); documented.
+
+## CLI surface
+
+- mri: `diff` (string — `--diff` alone → `''` ⇒ default base; `--diff main` →
+  `'main'`), `staged` (boolean). `resolveArgs` maps to
+  `RunOptions.diff?: string | true` and `staged?: boolean`. `--staged` wins if both.
+- HELP + exit codes documented. Changeset `svelte-vitals` minor.
+
+## Testing
+
+- `filterToChangedFiles` (pure): keeps location-in-set, drops location-less and
+  out-of-set.
+- `resolveArgs`: `--diff`, `--diff main`, `--staged` produce the right options.
+- (git `getChangedFiles` is integration-only; kept thin and not unit-tested.)
+- Full `pnpm -r test` + typecheck + lint green.
+
+## Out of scope
+
+- Layout-chain awareness (a changed `+layout.svelte` surfacing affected routes
+  whose finding `location` is the `+page`). v1 matches by finding `location` only.
+- Per-rule agent-ready fix prompts (separate slice).

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -13,6 +13,8 @@ Options:
   --meta-components <names>   Comma-separated component names that emit head metadata
   --treat-dynamic-as <mode>   pass | warn | fail (default: pass)
   --route <glob>              Only analyze routes matching this glob
+  --diff [ref]                Report only findings in files changed vs ref (default HEAD; e.g. --diff main)
+  --staged                    Report only findings in files staged for commit (pre-commit gate)
   --by-route                  Show per-route score breakdown in console output
   --reporter <fmt>            console | json | agent | sarif | github | html (auto: agent under AI-agent envs, github under GitHub Actions)
   --out-file <path>           Output path for --reporter html (default: svelte-vitals-report.html; '-' for stdout)
@@ -35,7 +37,7 @@ const VERSION = readPackageVersion();
 async function main(): Promise<void> {
   const argv = mri(process.argv.slice(2), {
     alias: { h: 'help', v: 'version' },
-    boolean: ['by-route', 'json', 'fail-on-warning'],
+    boolean: ['by-route', 'json', 'fail-on-warning', 'staged'],
     string: [
       'meta-components',
       'treat-dynamic-as',
@@ -45,7 +47,8 @@ async function main(): Promise<void> {
       'rules',
       'ignore',
       'min-health',
-      'out-file'
+      'out-file',
+      'diff'
     ]
   });
 

--- a/packages/cli/src/changed-files.ts
+++ b/packages/cli/src/changed-files.ts
@@ -1,0 +1,40 @@
+import { execFileSync } from 'node:child_process';
+import type { Result } from '@svelte-vitals/core';
+
+export interface ChangedFilesOptions {
+  /** Report only files staged for commit (`git diff --cached`). */
+  staged?: boolean;
+  /** Compare the working tree against this ref (default 'HEAD'). Ignored when `staged`. */
+  base?: string;
+}
+
+/**
+ * Repo-relative POSIX paths changed per the options, or `undefined` when git can't
+ * answer (not a repo, git missing, bad ref). Deleted files are excluded — there is
+ * nothing left to analyze. Used to scope `--diff` / `--staged` runs.
+ */
+export function getChangedFiles(cwd: string, opts: ChangedFilesOptions): Set<string> | undefined {
+  const args = opts.staged
+    ? ['diff', '--name-only', '--cached', '--diff-filter=d']
+    : ['diff', '--name-only', '--diff-filter=d', opts.base ?? 'HEAD'];
+  try {
+    const out = execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    return new Set(
+      out
+        .split('\n')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Keep only findings located in a changed file. Results without a `location`
+ * (project-scoped findings, passing seeds) are dropped — the gate reports issues
+ * *in* the changed files.
+ */
+export function filterToChangedFiles(results: Result[], changed: Set<string>): Result[] {
+  return results.filter((r) => r.location !== undefined && changed.has(r.location));
+}

--- a/packages/cli/src/changed-files.ts
+++ b/packages/cli/src/changed-files.ts
@@ -4,27 +4,33 @@ import type { Result } from '@svelte-vitals/core';
 export interface ChangedFilesOptions {
   /** Report only files staged for commit (`git diff --cached`). */
   staged?: boolean;
-  /** Compare the working tree against this ref (default 'HEAD'). Ignored when `staged`. */
+  /** Compare the working tree against the merge-base with this ref (default 'HEAD'). Ignored when `staged`. */
   base?: string;
+}
+
+function git(args: string[], cwd: string): string[] {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).split('\n');
 }
 
 /**
  * Repo-relative POSIX paths changed per the options, or `undefined` when git can't
  * answer (not a repo, git missing, bad ref). Deleted files are excluded — there is
  * nothing left to analyze. Used to scope `--diff` / `--staged` runs.
+ *
+ * For `--diff`, the working tree is compared against the **merge-base** with `base`
+ * (so `--diff main` is "what this branch changed", not files that only moved on
+ * `main`), and untracked (new) files are unioned in — a "gate what changed" run
+ * must catch brand-new components too.
  */
 export function getChangedFiles(cwd: string, opts: ChangedFilesOptions): Set<string> | undefined {
-  const args = opts.staged
-    ? ['diff', '--name-only', '--cached', '--diff-filter=d']
-    : ['diff', '--name-only', '--diff-filter=d', opts.base ?? 'HEAD'];
   try {
-    const out = execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
-    return new Set(
-      out
-        .split('\n')
-        .map((s) => s.trim())
-        .filter(Boolean)
-    );
+    const files = opts.staged
+      ? git(['diff', '--name-only', '--cached', '--diff-filter=d'], cwd)
+      : [
+          ...git(['diff', '--name-only', '--diff-filter=d', '--merge-base', opts.base ?? 'HEAD'], cwd),
+          ...git(['ls-files', '--others', '--exclude-standard'], cwd) // untracked / new files
+        ];
+    return new Set(files.map((s) => s.trim()).filter(Boolean));
   } catch {
     return undefined;
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -26,6 +26,7 @@ import { collectComponentFacts } from './providers/source/components.js';
 import { detectProject, ProjectError, collectProjectFacts } from './providers/source/project.js';
 import { readPackageVersion } from './version.js';
 import { resolveReporter, isAutoDetectedAgent, isAutoDetectedGithub, type ReporterName } from './reporter-resolve.js';
+import { getChangedFiles, filterToChangedFiles } from './changed-files.js';
 
 export interface RunOptions {
   cwd?: string;
@@ -47,6 +48,10 @@ export interface RunOptions {
   outFile?: string;
   /** Injected file writer for --reporter html (defaults to node:fs writeFileSync). Mainly for tests. */
   writeFile?: (path: string, content: string) => void;
+  /** Report only findings in files changed vs a ref (true = HEAD/uncommitted; string = that ref). */
+  diff?: string | boolean;
+  /** Report only findings in files staged for commit. Takes precedence over `diff`. */
+  staged?: boolean;
 }
 
 export function routeMatcher(glob: string | undefined): (route: string) => boolean {
@@ -147,7 +152,24 @@ export async function run(opts: RunOptions = {}): Promise<number> {
   }
 
   try {
-    const { results, config, version } = analysis;
+    const { config, version } = analysis;
+    let results = analysis.results;
+
+    // --staged / --diff: scope findings to the changed files (gate "what the agent wrote").
+    if (opts.staged || opts.diff) {
+      const cwd = opts.cwd ?? process.cwd();
+      const changed = opts.staged
+        ? getChangedFiles(cwd, { staged: true })
+        : getChangedFiles(cwd, { base: typeof opts.diff === 'string' ? opts.diff : undefined });
+      if (changed === undefined) {
+        errorLog(
+          'svelte-vitals: could not determine changed files (not a git repo or git unavailable); analyzing all.'
+        );
+      } else {
+        results = filterToChangedFiles(results, changed);
+      }
+    }
+
     const env = opts.env ?? process.env;
     const reporter = resolveReporter(opts.reporter, env);
     if (reporter === 'agent' && isAutoDetectedAgent(opts.reporter, env)) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -48,9 +48,9 @@ export interface RunOptions {
   outFile?: string;
   /** Injected file writer for --reporter html (defaults to node:fs writeFileSync). Mainly for tests. */
   writeFile?: (path: string, content: string) => void;
-  /** Report only findings in files changed vs a ref (true = HEAD/uncommitted; string = that ref). */
-  diff?: string | boolean;
-  /** Report only findings in files staged for commit. Takes precedence over `diff`. */
+  /** Report only findings in files changed vs the merge-base with this ref ('HEAD' = uncommitted). Undefined = no gating. */
+  diffBase?: string;
+  /** Report only findings in files staged for commit. Takes precedence over `diffBase`. */
   staged?: boolean;
 }
 
@@ -156,14 +156,14 @@ export async function run(opts: RunOptions = {}): Promise<number> {
     let results = analysis.results;
 
     // --staged / --diff: scope findings to the changed files (gate "what the agent wrote").
-    if (opts.staged || opts.diff) {
+    if (opts.staged || opts.diffBase !== undefined) {
       const cwd = opts.cwd ?? process.cwd();
       const changed = opts.staged
         ? getChangedFiles(cwd, { staged: true })
-        : getChangedFiles(cwd, { base: typeof opts.diff === 'string' ? opts.diff : undefined });
+        : getChangedFiles(cwd, { base: opts.diffBase });
       if (changed === undefined) {
         errorLog(
-          'svelte-vitals: could not determine changed files (not a git repo or git unavailable); analyzing all.'
+          'svelte-vitals: could not determine changed files (not a git repo, git unavailable, or bad ref); analyzing all.'
         );
       } else {
         results = filterToChangedFiles(results, changed);

--- a/packages/cli/src/resolve-args.ts
+++ b/packages/cli/src/resolve-args.ts
@@ -49,8 +49,8 @@ export function resolveArgs(argv: mri.Argv): ResolvedArgs {
 
   const route = typeof argv.route === 'string' ? argv.route : undefined;
 
-  // --diff (string): `--diff` alone → '' (default base HEAD); `--diff main` → 'main'.
-  const diff = typeof argv.diff === 'string' ? argv.diff || true : undefined;
+  // --diff (string): `--diff` alone → '' ⇒ default base 'HEAD'; `--diff main` → 'main'.
+  const diffBase = typeof argv.diff === 'string' ? argv.diff || 'HEAD' : undefined;
   const staged = Boolean(argv.staged);
 
   const allow = toList(argv.rules);
@@ -96,7 +96,7 @@ export function resolveArgs(argv: mri.Argv): ResolvedArgs {
       byRoute: Boolean(argv['by-route']),
       failOn,
       rules: buildRulesConfig(allow, ignore),
-      ...(diff !== undefined ? { diff } : {}),
+      ...(diffBase !== undefined ? { diffBase } : {}),
       ...(staged ? { staged } : {})
     },
     warnings,

--- a/packages/cli/src/resolve-args.ts
+++ b/packages/cli/src/resolve-args.ts
@@ -49,6 +49,10 @@ export function resolveArgs(argv: mri.Argv): ResolvedArgs {
 
   const route = typeof argv.route === 'string' ? argv.route : undefined;
 
+  // --diff (string): `--diff` alone → '' (default base HEAD); `--diff main` → 'main'.
+  const diff = typeof argv.diff === 'string' ? argv.diff || true : undefined;
+  const staged = Boolean(argv.staged);
+
   const allow = toList(argv.rules);
   const ignore = toList(argv.ignore);
   const unknown = findUnknownRuleIds([...allow, ...ignore]);
@@ -91,7 +95,9 @@ export function resolveArgs(argv: mri.Argv): ResolvedArgs {
       outFile: typeof argv['out-file'] === 'string' ? argv['out-file'] : undefined,
       byRoute: Boolean(argv['by-route']),
       failOn,
-      rules: buildRulesConfig(allow, ignore)
+      rules: buildRulesConfig(allow, ignore),
+      ...(diff !== undefined ? { diff } : {}),
+      ...(staged ? { staged } : {})
     },
     warnings,
     errors

--- a/packages/cli/test/changed-files.test.ts
+++ b/packages/cli/test/changed-files.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { filterToChangedFiles } from '../src/changed-files.js';
+import type { Result } from '@svelte-vitals/core';
+
+const r = (over: Partial<Result>): Result => ({
+  id: 'X',
+  severity: 'warning',
+  detection: { presence: 'none', value: 'absent' },
+  message: 'm',
+  ...over
+});
+
+describe('filterToChangedFiles', () => {
+  const results: Result[] = [
+    r({ id: 'A', location: 'src/lib/Changed.svelte' }),
+    r({ id: 'B', location: 'src/lib/Untouched.svelte' }),
+    r({ id: 'C' }), // project-scoped / passing seed: no location
+    r({ id: 'D', location: 'src/routes/+page.svelte' })
+  ];
+
+  it('keeps only findings located in a changed file', () => {
+    const changed = new Set(['src/lib/Changed.svelte', 'src/routes/+page.svelte']);
+    expect(filterToChangedFiles(results, changed).map((x) => x.id)).toEqual(['A', 'D']);
+  });
+
+  it('drops location-less findings (project-scoped / seeds)', () => {
+    expect(filterToChangedFiles(results, new Set(['src/lib/Changed.svelte'])).map((x) => x.id)).toEqual(['A']);
+  });
+
+  it('returns nothing when no result is in the changed set', () => {
+    expect(filterToChangedFiles(results, new Set(['src/other.svelte']))).toEqual([]);
+  });
+});

--- a/packages/cli/test/resolve-args.test.ts
+++ b/packages/cli/test/resolve-args.test.ts
@@ -6,8 +6,8 @@ import { resolveArgs } from '../src/resolve-args.js';
 function resolve(...args: string[]) {
   const argv = mri(args, {
     alias: { h: 'help', v: 'version' },
-    boolean: ['by-route', 'json', 'fail-on-warning'],
-    string: ['meta-components', 'treat-dynamic-as', 'route', 'fail-on', 'reporter', 'rules', 'ignore']
+    boolean: ['by-route', 'json', 'fail-on-warning', 'staged'],
+    string: ['meta-components', 'treat-dynamic-as', 'route', 'fail-on', 'reporter', 'rules', 'ignore', 'diff']
   });
   return resolveArgs(argv);
 }
@@ -65,5 +65,17 @@ describe('resolveArgs', () => {
   it('maps --json to the json reporter', () => {
     const { options } = resolve('--json');
     expect(options?.reporter).toBe('json');
+  });
+
+  it('maps --staged and --diff to changed-file options', () => {
+    expect(resolve('--staged').options?.staged).toBe(true);
+    expect(resolve('--diff').options?.diff).toBe(true); // bare --diff → default base (HEAD)
+    expect(resolve('--diff', 'main').options?.diff).toBe('main');
+  });
+
+  it('omits diff/staged when not passed', () => {
+    const { options } = resolve('--json');
+    expect(options?.diff).toBeUndefined();
+    expect(options?.staged).toBeUndefined();
   });
 });

--- a/packages/cli/test/resolve-args.test.ts
+++ b/packages/cli/test/resolve-args.test.ts
@@ -69,13 +69,13 @@ describe('resolveArgs', () => {
 
   it('maps --staged and --diff to changed-file options', () => {
     expect(resolve('--staged').options?.staged).toBe(true);
-    expect(resolve('--diff').options?.diff).toBe(true); // bare --diff → default base (HEAD)
-    expect(resolve('--diff', 'main').options?.diff).toBe('main');
+    expect(resolve('--diff').options?.diffBase).toBe('HEAD'); // bare --diff → default base
+    expect(resolve('--diff', 'main').options?.diffBase).toBe('main');
   });
 
-  it('omits diff/staged when not passed', () => {
+  it('omits diffBase/staged when not passed', () => {
     const { options } = resolve('--json');
-    expect(options?.diff).toBeUndefined();
+    expect(options?.diffBase).toBeUndefined();
     expect(options?.staged).toBeUndefined();
   });
 });

--- a/packages/cli/test/run-diff.test.ts
+++ b/packages/cli/test/run-diff.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+// Mock the git layer so run()'s --diff/--staged gating is testable without a real repo.
+vi.mock('../src/changed-files.js', async (orig) => {
+  const actual = await orig<typeof import('../src/changed-files.js')>();
+  return { ...actual, getChangedFiles: vi.fn() };
+});
+
+import { run } from '../src/index.js';
+import { getChangedFiles } from '../src/changed-files.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixtureDir = join(here, 'fixtures', 'basic-project');
+const CLEAN_ENV: NodeJS.ProcessEnv = {};
+const mockGet = vi.mocked(getChangedFiles);
+
+function capture() {
+  const out: string[] = [];
+  const err: string[] = [];
+  return { out, err, log: (l: string) => out.push(l), errorLog: (l: string) => err.push(l) };
+}
+
+describe('run() --diff / --staged gating', () => {
+  beforeEach(() => mockGet.mockReset());
+
+  it('passes (exit 0) when no changed file has a finding', async () => {
+    mockGet.mockReturnValue(new Set(['README.md'])); // a changed file with no svelte-vitals findings
+    const cap = capture();
+    const code = await run({ cwd: fixtureDir, diffBase: 'HEAD', log: cap.log, errorLog: cap.errorLog, env: CLEAN_ENV });
+    expect(code).toBe(0);
+    expect(cap.out.join('\n')).not.toContain('SEO001');
+  });
+
+  it('--staged queries staged files and takes precedence over diffBase', async () => {
+    mockGet.mockReturnValue(new Set());
+    const cap = capture();
+    await run({
+      cwd: fixtureDir,
+      staged: true,
+      diffBase: 'main',
+      log: cap.log,
+      errorLog: cap.errorLog,
+      env: CLEAN_ENV
+    });
+    expect(mockGet).toHaveBeenCalledWith(fixtureDir, { staged: true });
+  });
+
+  it('warns and analyzes everything when git cannot answer', async () => {
+    mockGet.mockReturnValue(undefined);
+    const cap = capture();
+    const code = await run({ cwd: fixtureDir, diffBase: 'HEAD', log: cap.log, errorLog: cap.errorLog, env: CLEAN_ENV });
+    expect(cap.err.join('\n')).toContain('could not determine changed files');
+    expect(code).toBe(1); // same as an unscoped run — findings still surface
+    expect(cap.out.join('\n')).toContain('SEO001');
+  });
+});


### PR DESCRIPTION
The "Workflow ergonomics" slice of #69 — run svelte-vitals as a **pre-commit hook or PR check that gates only what changed** ("what the agent just wrote"), instead of drowning in pre-existing findings across the whole app.

## New flags (CLI-only)

- `--staged` — report only findings in files staged for commit (`git diff --cached`).
- `--diff [ref]` — report only findings in files changed vs `ref` (default `HEAD` = uncommitted; e.g. `--diff main` for branch changes).

## How it works

- New `changed-files.ts`: `getChangedFiles(cwd, {staged|base})` runs git via `child_process` (`git diff --name-only --diff-filter=d …`) and returns repo-relative paths, or `undefined` on any failure. `filterToChangedFiles(results, changed)` keeps findings whose `location` is a changed file (project-scoped findings and passing seeds — no `location` — are dropped).
- `run()` applies the filter **after** analysis, so scoring, the reporters, and the `--fail-on` / `--min-health` gates all operate on the scoped set. `analyzeProject` (shared with MCP) is untouched — no git there.
- Git unavailable / not a repo → warns and analyzes everything (never silently passes).

No core or rule changes.

## Tests / docs

- `filterToChangedFiles` (keeps location-in-set, drops location-less / out-of-set) + `resolveArgs` (`--diff`, `--diff main`, `--staged`). (`getChangedFiles` is git-integration, kept thin.)
- HELP, changeset, design spec.

`pnpm -r test` (**525**: core 237 / vite 76 / cli 203 / mcp 9), `pnpm -r typecheck`, `pnpm lint` — all green.

## Notes / out of scope

- Matches by finding `location`; a changed `+layout.svelte` surfacing affected routes (whose finding location is the `+page`) is layout-chain-aware work left for later.
- v1 assumes project root == git root (the common case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI options to limit results to changed files: `--diff [ref]` and `--staged`.
  * `--diff` targets files changed against a reference (default `HEAD`); `--staged` targets staged changes and takes precedence.

* **Bug Fixes**
  * Findings now respect the selected change scope across console, JSON, SARIF, GitHub, and HTML outputs.
  * If Git can’t determine changed files, the CLI warns and falls back to analyzing the full project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->