### PR TITLE
feat(core): CORRECT003 — $effect used as onMount

### DIFF
--- a/.changeset/correct003-effect-onmount.md
+++ b/.changeset/correct003-effect-onmount.md
@@ -1,0 +1,11 @@
+---
+'@svelte-vitals/core': minor
+'svelte-vitals': minor
+'@svelte-vitals/mcp': minor
+---
+
+Add **CORRECT003 (effect used as onMount)** — the Correctness/reactivity slice of
+#69. Flags an `$effect`/`$effect.pre` whose non-empty body reads no reactive value
+(no `$state`/`$derived`/`$props`, no store subscription, no bare function call), so
+it never re-runs and should be `onMount`. Reported under `correctness` (warning).
+`EffectFact` gains `mountOnly`.

--- a/docs/src/content/docs/ja/rules/correct003.md
+++ b/docs/src/content/docs/ja/rules/correct003.md
@@ -7,7 +7,7 @@ description: reactive 値を読まない $effect には onMount を使います�
 
 ## チェック内容
 
-空でない本体が reactive 値を一切読まない `$effect` / `$effect.pre` を検出します — `$state`・`$derived`・`$props` の参照、store 購読、ローカル関数呼び出しのいずれも無いものです。そのような effect はマウント後に一度だけ実行され、再実行されません。コンポーネントの instance スクリプトを静的(CLI)解析します。
+空でない本体が reactive 値を一切読まない `$effect` / `$effect.pre` を検出します — `$state`・`$derived`・`$props` の参照、store 購読、裸の関数呼び出し（`foo()`）のいずれも無いものです。そのような effect はマウント後に一度だけ実行され、再実行されません。コンポーネントの instance スクリプトを静的(CLI)解析します。
 
 ## なぜ重要か
 

--- a/docs/src/content/docs/ja/rules/correct003.md
+++ b/docs/src/content/docs/ja/rules/correct003.md
@@ -1,0 +1,26 @@
+---
+title: CORRECT003 · onMount 代わりの $effect
+description: reactive 値を読まない $effect には onMount を使います。
+---
+
+**重大度:** warning · **カテゴリ:** correctness
+
+## チェック内容
+
+空でない本体が reactive 値を一切読まない `$effect` / `$effect.pre` を検出します — `$state`・`$derived`・`$props` の参照、store 購読、ローカル関数呼び出しのいずれも無いものです。そのような effect はマウント後に一度だけ実行され、再実行されません。コンポーネントの instance スクリプトを静的(CLI)解析します。
+
+## なぜ重要か
+
+何にも反応しない `$effect` は実質 `onMount` です。`$effect` を使うとその意図が曖昧になり、リアクティビティの仕組みを誤用します。`onMount` なら「マウント時に一度だけ実行する」ことを直接表現できます。
+
+## 修正方法
+
+```svelte
+<script>
+  import { onMount } from 'svelte';
+  // $effect(() => { element.focus(); }); の代わりに
+  onMount(() => {
+    element.focus();
+  });
+</script>
+```

--- a/docs/src/content/docs/rules/correct003.md
+++ b/docs/src/content/docs/rules/correct003.md
@@ -1,0 +1,26 @@
+---
+title: CORRECT003 · Effect used as onMount
+description: Use onMount for an $effect that reads no reactive value.
+---
+
+**Severity:** warning · **Category:** correctness
+
+## What it checks
+
+Flags an `$effect` / `$effect.pre` whose non-empty body reads no reactive value — no `$state`, `$derived`, or `$props`, no store subscription, and no local function call. Such an effect runs once after mount and never re-runs. Checked by static (CLI) analysis of component instance scripts.
+
+## Why it matters
+
+An `$effect` that never reacts to anything is an `onMount` in disguise. Using `$effect` obscures that intent and misuses the reactivity system; `onMount` says "run this once when the component mounts" directly.
+
+## How to fix
+
+```svelte
+<script>
+  import { onMount } from 'svelte';
+  // Instead of: $effect(() => { element.focus(); });
+  onMount(() => {
+    element.focus();
+  });
+</script>
+```

--- a/docs/src/content/docs/rules/correct003.md
+++ b/docs/src/content/docs/rules/correct003.md
@@ -7,7 +7,7 @@ description: Use onMount for an $effect that reads no reactive value.
 
 ## What it checks
 
-Flags an `$effect` / `$effect.pre` whose non-empty body reads no reactive value — no `$state`, `$derived`, or `$props`, no store subscription, and no local function call. Such an effect runs once after mount and never re-runs. Checked by static (CLI) analysis of component instance scripts.
+Flags an `$effect` / `$effect.pre` whose non-empty body reads no reactive value — no `$state`, `$derived`, or `$props`, no store subscription, and no bare function call (`foo()`). Such an effect runs once after mount and never re-runs. Checked by static (CLI) analysis of component instance scripts.
 
 ## Why it matters
 

--- a/docs/superpowers/plans/2026-07-02-correct003-effect-as-onmount.md
+++ b/docs/superpowers/plans/2026-07-02-correct003-effect-as-onmount.md
@@ -39,12 +39,14 @@
 ### Task 1: Capture `EffectFact.mountOnly`
 
 **Files:**
+
 - Modify: `packages/core/src/component.ts` (add field after `assignsOnlyState`, line 20)
 - Modify: `packages/cli/src/providers/source/parse.ts` (helpers after `bodyOnlyAssignsState` ~line 420; instance block ~lines 543-557)
 - Modify: `packages/cli/test/parse-component-facts.test.ts` (3 `toEqual` fixups at the effect describe block; add capture tests)
 - Modify: `packages/core/test/correctness-rules.test.ts` (2 EffectFact literals at lines 48, 53)
 
 **Interfaces:**
+
 - Produces: `EffectFact.mountOnly: boolean`; `parseComponentFacts` sets it.
 - Consumes: existing `walkEstree`, `lineOf`, `isEffectCall`, `isStateDeclaration`.
 
@@ -53,8 +55,8 @@
 In `packages/core/src/component.ts`, inside `EffectFact`, after the `assignsOnlyState: boolean;` line (line 20), add:
 
 ```ts
-  /** True when this $effect has a NON-EMPTY body that reads no reactive value and makes no bare call — it never re-runs, so it should be onMount (CORRECT003). */
-  mountOnly: boolean;
+/** True when this $effect has a NON-EMPTY body that reads no reactive value and makes no bare call — it never re-runs, so it should be onMount (CORRECT003). */
+mountOnly: boolean;
 ```
 
 - [ ] **Step 2: Write the failing capture tests**
@@ -159,43 +161,44 @@ function bodyIsEmpty(fn: Node): boolean {
 In `parseComponentFacts`, the instance block currently reads:
 
 ```ts
-    const stateNames = new Set<string>();
-    walkEstree(program, (n) => {
-      if (n.type === 'VariableDeclarator' && n.init && isStateDeclaration(n.init) && n.id?.type === 'Identifier') {
-        stateNames.add(n.id.name);
-      }
-    });
-    walkEstree(program, (n) => {
-      if (n.type !== 'CallExpression' || !isEffectCall(n)) return;
-      const fn = n.arguments?.[0];
-      const isFn = fn?.type === 'ArrowFunctionExpression' || fn?.type === 'FunctionExpression';
-      effects.push({
-        line: lineOf(source, n.start),
-        assignsOnlyState: isFn ? bodyOnlyAssignsState(fn, stateNames) : false
-      });
-    });
+const stateNames = new Set<string>();
+walkEstree(program, (n) => {
+  if (n.type === 'VariableDeclarator' && n.init && isStateDeclaration(n.init) && n.id?.type === 'Identifier') {
+    stateNames.add(n.id.name);
+  }
+});
+walkEstree(program, (n) => {
+  if (n.type !== 'CallExpression' || !isEffectCall(n)) return;
+  const fn = n.arguments?.[0];
+  const isFn = fn?.type === 'ArrowFunctionExpression' || fn?.type === 'FunctionExpression';
+  effects.push({
+    line: lineOf(source, n.start),
+    assignsOnlyState: isFn ? bodyOnlyAssignsState(fn, stateNames) : false
+  });
+});
 ```
 
 Replace it with (adds a `reactiveNames` superset and the `mountOnly` field; `stateNames` unchanged):
 
 ```ts
-    const stateNames = new Set<string>();
-    const reactiveNames = new Set<string>();
-    walkEstree(program, (n) => {
-      if (n.type !== 'VariableDeclarator' || !n.init) return;
-      if (isStateDeclaration(n.init) && n.id?.type === 'Identifier') stateNames.add(n.id.name);
-      if (isStateDeclaration(n.init) || isDerivedDeclaration(n.init) || isPropsCall(n.init)) addBoundNames(n.id, reactiveNames);
-    });
-    walkEstree(program, (n) => {
-      if (n.type !== 'CallExpression' || !isEffectCall(n)) return;
-      const fn = n.arguments?.[0];
-      const isFn = fn?.type === 'ArrowFunctionExpression' || fn?.type === 'FunctionExpression';
-      effects.push({
-        line: lineOf(source, n.start),
-        assignsOnlyState: isFn ? bodyOnlyAssignsState(fn, stateNames) : false,
-        mountOnly: isFn ? !bodyIsEmpty(fn) && !bodyReadsReactive(fn, reactiveNames) : false
-      });
-    });
+const stateNames = new Set<string>();
+const reactiveNames = new Set<string>();
+walkEstree(program, (n) => {
+  if (n.type !== 'VariableDeclarator' || !n.init) return;
+  if (isStateDeclaration(n.init) && n.id?.type === 'Identifier') stateNames.add(n.id.name);
+  if (isStateDeclaration(n.init) || isDerivedDeclaration(n.init) || isPropsCall(n.init))
+    addBoundNames(n.id, reactiveNames);
+});
+walkEstree(program, (n) => {
+  if (n.type !== 'CallExpression' || !isEffectCall(n)) return;
+  const fn = n.arguments?.[0];
+  const isFn = fn?.type === 'ArrowFunctionExpression' || fn?.type === 'FunctionExpression';
+  effects.push({
+    line: lineOf(source, n.start),
+    assignsOnlyState: isFn ? bodyOnlyAssignsState(fn, stateNames) : false,
+    mountOnly: isFn ? !bodyIsEmpty(fn) && !bodyReadsReactive(fn, reactiveNames) : false
+  });
+});
 ```
 
 - [ ] **Step 6: Fix the existing effect `toEqual` assertions**
@@ -239,12 +242,14 @@ git commit -m "feat(cli): capture EffectFact.mountOnly for CORRECT003"
 ### Task 2: CORRECT003 rule + registration
 
 **Files:**
+
 - Modify: `packages/core/src/rules/correctness/correct001-002.ts` (add rule)
 - Modify: `packages/core/src/rules/index.ts` (import ~line 40; `allRules` ~line 86; re-export ~line 135)
 - Modify: `packages/core/src/index.ts` (re-export ~line 72)
 - Test: `packages/core/test/correctness-rules.test.ts` (add CORRECT003 describe block)
 
 **Interfaces:**
+
 - Consumes: `componentRule`; `EffectFact.mountOnly` (Task 1).
 - Produces: `export const correct003EffectAsOnMount: Rule`.
 
@@ -297,7 +302,9 @@ export const correct003EffectAsOnMount = componentRule({
     'An $effect that reads no reactive value runs once after mount and never re-runs — it is an onMount in disguise, which obscures intent and misuses the reactivity system.',
   applies: (c) => c.effects.length > 0,
   bad: (c) =>
-    c.effects.filter((e) => e.mountOnly).map((e) => ({ line: e.line, message: '$effect reads no reactive value — use onMount instead' }))
+    c.effects
+      .filter((e) => e.mountOnly)
+      .map((e) => ({ line: e.line, message: '$effect reads no reactive value — use onMount instead' }))
 });
 ```
 
@@ -340,6 +347,7 @@ git commit -m "feat(core): add CORRECT003 effect-used-as-onMount rule"
 ### Task 3: Docs + changeset
 
 **Files:**
+
 - Create: `docs/src/content/docs/rules/correct003.md`, `docs/src/content/docs/ja/rules/correct003.md`
 - Create: `.changeset/correct003-effect-onmount.md`
 
@@ -347,7 +355,7 @@ git commit -m "feat(core): add CORRECT003 effect-used-as-onMount rule"
 
 Create `docs/src/content/docs/rules/correct003.md`:
 
-```md
+````md
 ---
 title: CORRECT003 · Effect used as onMount
 description: Use onMount for an $effect that reads no reactive value.
@@ -374,7 +382,9 @@ An `$effect` that never reacts to anything is an `onMount` in disguise. Using `$
   });
 </script>
 ```
-```
+````
+
+````
 
 - [ ] **Step 2: Write the Japanese doc**
 
@@ -406,8 +416,9 @@ description: reactive 値を読まない $effect には onMount を使います�
     element.focus();
   });
 </script>
-```
-```
+````
+
+````
 
 - [ ] **Step 3: Write the changeset**
 
@@ -425,7 +436,7 @@ Add **CORRECT003 (effect used as onMount)** — the Correctness/reactivity slice
 (no `$state`/`$derived`/`$props`, no store subscription, no bare function call), so
 it never re-runs and should be `onMount`. Reported under `correctness` (warning).
 `EffectFact` gains `mountOnly`.
-```
+````
 
 - [ ] **Step 4: Verify docs build**
 
@@ -448,9 +459,11 @@ git commit -m "docs: CORRECT003 reference pages (en+ja) + changeset"
 - [ ] **Step 1: Build core, then run the whole suite / typecheck / lint / docs build**
 
 Run:
+
 ```bash
 pnpm -r build && pnpm -r test && pnpm -r typecheck && pnpm lint && pnpm --filter docs build
 ```
+
 Expected: all green. Core test count rises by 3 (CORRECT003 rule tests); cli by ~5 (mountOnly capture tests).
 
 - [ ] **Step 2: If lint reports formatting, fix and re-run**
@@ -470,6 +483,7 @@ git commit -m "chore: format CORRECT003 changes"
 ## Self-Review
 
 **Spec coverage:**
+
 - `EffectFact.mountOnly` field → Task 1 Step 1. ✓
 - Conservative reactive-read scan (reactive names + `$store` + bare call), empty-body exclusion, `$effect.pre`, reactiveNames = $state ∪ $derived ∪ $props → Task 1 Steps 4-5. ✓
 - Existing EffectFact `toEqual`/literal fixups → Task 1 Steps 6-7. ✓

--- a/docs/superpowers/plans/2026-07-02-correct003-effect-as-onmount.md
+++ b/docs/superpowers/plans/2026-07-02-correct003-effect-as-onmount.md
@@ -1,0 +1,484 @@
+# CORRECT003 — `$effect` used as `onMount` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add CORRECT003 — a `warning` correctness rule that flags an `$effect`/`$effect.pre` whose non-empty body reads no reactive value (so it never re-runs and should be `onMount`).
+
+**Architecture:** Add a computed `EffectFact.mountOnly` boolean (mirroring `assignsOnlyState`), set by the CLI parser from a conservative body scan against a `reactiveNames` set ($state ∪ $derived ∪ $props). The `componentRule` factory builds the rule; it no-ops in rendered mode.
+
+**Tech Stack:** TypeScript, Vitest, pnpm workspaces (`@svelte-vitals/core`, `@svelte-vitals/cli`), Astro Starlight docs, Changesets. Svelte compiler AST via `svelte/compiler`.
+
+## Global Constraints
+
+- Conservative "reads reactive" (→ NOT flagged) = body references a reactive name ($state/$state.raw/$derived/$derived.by/$props binding), OR reads a `$`-prefixed non-rune identifier (store), OR contains a bare-identifier `CallExpression` (`foo()`). Member calls (`el.focus()`, `console.log('x')`) are not suppressive by themselves.
+- `mountOnly` = the effect callback is an inline arrow/function AND its body is NON-EMPTY AND it reads no reactive value. Empty bodies (`() => {}`) are never flagged.
+- Both `$effect` and `$effect.pre` covered (existing `isEffectCall`).
+- `EffectFact.mountOnly` is a required field — existing `EffectFact` literals and `toEqual` assertions must add it or TS/tests break.
+- `assignsOnlyState` and `stateNames` (CORRECT002) are unchanged; `reactiveNames` is a separate superset.
+- Rule: `id 'CORRECT003'`, `category 'correctness'`, `severity 'warning'`, `scope 'component'`.
+- Verified: `walkEstree(node, visit)` visits the passed node itself then all children. Effect/rune collection runs only over the instance program (`ast.instance.content`).
+- Spec: `docs/superpowers/specs/2026-07-02-correct003-effect-as-onmount-design.md`.
+- Branch: `feat/correct003-effect-onmount` (created; spec committed).
+- Run commands from the repo root.
+
+---
+
+## File Structure
+
+- Modify: `packages/core/src/component.ts` — add `mountOnly` to `EffectFact`.
+- Modify: `packages/cli/src/providers/source/parse.ts` — reactiveNames + body helpers + populate `mountOnly`.
+- Modify: `packages/cli/test/parse-component-facts.test.ts` — fix 3 `toEqual` effect assertions; add capture tests.
+- Modify: `packages/core/test/correctness-rules.test.ts` — fix 2 `EffectFact` literals; add CORRECT003 rule tests (Task 2).
+- Modify: `packages/core/src/rules/correctness/correct001-002.ts` — add CORRECT003 (Task 2).
+- Modify: `packages/core/src/rules/index.ts`, `packages/core/src/index.ts` — register/export (Task 2).
+- Create: `docs/src/content/docs/rules/correct003.md`, `docs/src/content/docs/ja/rules/correct003.md` (Task 3).
+- Create: `.changeset/correct003-effect-onmount.md` (Task 3).
+
+---
+
+### Task 1: Capture `EffectFact.mountOnly`
+
+**Files:**
+- Modify: `packages/core/src/component.ts` (add field after `assignsOnlyState`, line 20)
+- Modify: `packages/cli/src/providers/source/parse.ts` (helpers after `bodyOnlyAssignsState` ~line 420; instance block ~lines 543-557)
+- Modify: `packages/cli/test/parse-component-facts.test.ts` (3 `toEqual` fixups at the effect describe block; add capture tests)
+- Modify: `packages/core/test/correctness-rules.test.ts` (2 EffectFact literals at lines 48, 53)
+
+**Interfaces:**
+- Produces: `EffectFact.mountOnly: boolean`; `parseComponentFacts` sets it.
+- Consumes: existing `walkEstree`, `lineOf`, `isEffectCall`, `isStateDeclaration`.
+
+- [ ] **Step 1: Add the field to `EffectFact`**
+
+In `packages/core/src/component.ts`, inside `EffectFact`, after the `assignsOnlyState: boolean;` line (line 20), add:
+
+```ts
+  /** True when this $effect has a NON-EMPTY body that reads no reactive value and makes no bare call — it never re-runs, so it should be onMount (CORRECT003). */
+  mountOnly: boolean;
+```
+
+- [ ] **Step 2: Write the failing capture tests**
+
+In `packages/cli/test/parse-component-facts.test.ts`, append a new describe block at the end of the file:
+
+```ts
+describe('parseComponentFacts — mount-only $effect (CORRECT003)', () => {
+  const facts = (script: string) => parseComponentFacts(`<script>${script}</script>`, 'C.svelte').effects;
+
+  it('marks an effect with only member-call side effects as mountOnly', () => {
+    expect(facts('$effect(() => { document.title = "Home"; });')[0]!.mountOnly).toBe(true);
+    expect(facts('$effect(() => { el.focus(); });')[0]!.mountOnly).toBe(true);
+    expect(facts('$effect(() => analytics.pageView());')[0]!.mountOnly).toBe(true);
+  });
+  it('is not mountOnly when the body reads reactive state/derived/props', () => {
+    expect(facts('let count = $state(0); $effect(() => { console.log(count); });')[0]!.mountOnly).toBe(false);
+    expect(facts('let d = $derived(1); $effect(() => { console.log(d); });')[0]!.mountOnly).toBe(false);
+    expect(facts('let { title } = $props(); $effect(() => { document.title = title; });')[0]!.mountOnly).toBe(false);
+  });
+  it('is not mountOnly for a store subscription or a bare call', () => {
+    expect(facts('$effect(() => { console.log($page); });')[0]!.mountOnly).toBe(false);
+    expect(facts('$effect(() => helper());')[0]!.mountOnly).toBe(false);
+  });
+  it('is not mountOnly for an empty body', () => {
+    expect(facts('$effect(() => {});')[0]!.mountOnly).toBe(false);
+  });
+  it('covers $effect.pre', () => {
+    expect(facts('$effect.pre(() => { el.focus(); });')[0]!.mountOnly).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 3: Run the capture tests to verify they fail**
+
+Run: `pnpm --filter svelte-vitals test parse-component-facts`
+Expected: FAIL — `mountOnly` is `undefined` (not computed yet). (Existing effect `toEqual` tests also fail now because the object gained no field yet — they are fixed in Step 6.)
+
+- [ ] **Step 4: Add the parser helpers**
+
+In `packages/cli/src/providers/source/parse.ts`, immediately after `bodyOnlyAssignsState` (after its closing brace, ~line 420), add:
+
+```ts
+/** `$derived(...)` or `$derived.by(...)` declaration form. */
+function isDerivedDeclaration(node: Node): boolean {
+  const c = node?.callee;
+  if (c?.type === 'Identifier') return c.name === '$derived';
+  if (c?.type === 'MemberExpression' && c.object?.type === 'Identifier' && c.object.name === '$derived') {
+    return c.property?.type === 'Identifier' && c.property.name === 'by';
+  }
+  return false;
+}
+
+/** A `$props()` call (the props rune). */
+function isPropsCall(node: Node): boolean {
+  return node?.type === 'CallExpression' && node.callee?.type === 'Identifier' && node.callee.name === '$props';
+}
+
+/** Add the names a declarator binds (Identifier or destructuring ObjectPattern) to `acc`. */
+function addBoundNames(id: Node, acc: Set<string>): void {
+  if (!id) return;
+  if (id.type === 'Identifier') acc.add(id.name);
+  else if (id.type === 'ObjectPattern') {
+    for (const p of id.properties ?? []) {
+      if (p?.type === 'Property' && p.value?.type === 'Identifier') acc.add(p.value.name);
+      else if (p?.type === 'RestElement' && p.argument?.type === 'Identifier') acc.add(p.argument.name);
+    }
+  }
+}
+
+const RUNE_NAMES = new Set(['$state', '$derived', '$effect', '$props', '$bindable', '$inspect', '$host']);
+
+/**
+ * Whether an $effect callback body reads a reactive value (CORRECT003, conservative):
+ * a reactive name, a `$`-prefixed store subscription, or any bare-identifier call.
+ */
+function bodyReadsReactive(fn: Node, reactiveNames: Set<string>): boolean {
+  let reads = false;
+  walkEstree(fn.body, (n: Node) => {
+    if (reads) return;
+    if (n?.type === 'Identifier') {
+      if (reactiveNames.has(n.name)) reads = true;
+      else if (n.name.startsWith('$') && !RUNE_NAMES.has(n.name)) reads = true;
+    } else if (n?.type === 'CallExpression' && n.callee?.type === 'Identifier') {
+      reads = true;
+    }
+  });
+  return reads;
+}
+
+/** Empty effect callback body (`() => {}` or no body). */
+function bodyIsEmpty(fn: Node): boolean {
+  const body = fn?.body;
+  if (!body) return true;
+  if (body.type === 'BlockStatement') return (body.body ?? []).length === 0;
+  return false;
+}
+```
+
+- [ ] **Step 5: Collect `reactiveNames` and populate `mountOnly`**
+
+In `parseComponentFacts`, the instance block currently reads:
+
+```ts
+    const stateNames = new Set<string>();
+    walkEstree(program, (n) => {
+      if (n.type === 'VariableDeclarator' && n.init && isStateDeclaration(n.init) && n.id?.type === 'Identifier') {
+        stateNames.add(n.id.name);
+      }
+    });
+    walkEstree(program, (n) => {
+      if (n.type !== 'CallExpression' || !isEffectCall(n)) return;
+      const fn = n.arguments?.[0];
+      const isFn = fn?.type === 'ArrowFunctionExpression' || fn?.type === 'FunctionExpression';
+      effects.push({
+        line: lineOf(source, n.start),
+        assignsOnlyState: isFn ? bodyOnlyAssignsState(fn, stateNames) : false
+      });
+    });
+```
+
+Replace it with (adds a `reactiveNames` superset and the `mountOnly` field; `stateNames` unchanged):
+
+```ts
+    const stateNames = new Set<string>();
+    const reactiveNames = new Set<string>();
+    walkEstree(program, (n) => {
+      if (n.type !== 'VariableDeclarator' || !n.init) return;
+      if (isStateDeclaration(n.init) && n.id?.type === 'Identifier') stateNames.add(n.id.name);
+      if (isStateDeclaration(n.init) || isDerivedDeclaration(n.init) || isPropsCall(n.init)) addBoundNames(n.id, reactiveNames);
+    });
+    walkEstree(program, (n) => {
+      if (n.type !== 'CallExpression' || !isEffectCall(n)) return;
+      const fn = n.arguments?.[0];
+      const isFn = fn?.type === 'ArrowFunctionExpression' || fn?.type === 'FunctionExpression';
+      effects.push({
+        line: lineOf(source, n.start),
+        assignsOnlyState: isFn ? bodyOnlyAssignsState(fn, stateNames) : false,
+        mountOnly: isFn ? !bodyIsEmpty(fn) && !bodyReadsReactive(fn, reactiveNames) : false
+      });
+    });
+```
+
+- [ ] **Step 6: Fix the existing effect `toEqual` assertions**
+
+In `packages/cli/test/parse-component-facts.test.ts`, the three full-object effect assertions must include `mountOnly: false` (all three effects read reactive state, so they are not mount-only):
+
+- `expect(e).toEqual([{ line: 1, assignsOnlyState: true }]);` (the "only assigns $state" test) → `expect(e).toEqual([{ line: 1, assignsOnlyState: true, mountOnly: false }]);`
+- `expect(e).toEqual([{ line: 1, assignsOnlyState: false }]);` (the "console.log(count)" test) → add `, mountOnly: false`
+- `expect(e).toEqual([{ line: 1, assignsOnlyState: true }]);` (the `$effect.pre` test) → add `, mountOnly: false`
+
+(The `expect(facts(...)).toEqual([])` no-effects assertion is unchanged.)
+
+- [ ] **Step 7: Fix the EffectFact literals in the core correctness tests**
+
+In `packages/core/test/correctness-rules.test.ts`, the two CORRECT002 test literals gain `mountOnly: false`:
+
+- `effects: [{ line: 5, assignsOnlyState: true }]` → `effects: [{ line: 5, assignsOnlyState: true, mountOnly: false }]`
+- `effects: [{ line: 5, assignsOnlyState: false }]` → `effects: [{ line: 5, assignsOnlyState: false, mountOnly: false }]`
+
+- [ ] **Step 8: Run capture tests + typecheck**
+
+Run: `pnpm --filter svelte-vitals test parse-component-facts`
+Expected: PASS (existing + new).
+Run: `pnpm --filter @svelte-vitals/core build && pnpm --filter @svelte-vitals/core typecheck && pnpm --filter svelte-vitals typecheck`
+Expected: no errors. (Core is rebuilt first because `EffectFact` changed and cli consumes core's dist.)
+
+- [ ] **Step 9: Run the core correctness suite to confirm the literal fixups**
+
+Run: `pnpm --filter @svelte-vitals/core test correctness-rules`
+Expected: PASS (existing CORRECT001/002 tests still green).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add packages/core/src/component.ts packages/cli/src/providers/source/parse.ts packages/cli/test/parse-component-facts.test.ts packages/core/test/correctness-rules.test.ts
+git commit -m "feat(cli): capture EffectFact.mountOnly for CORRECT003"
+```
+
+---
+
+### Task 2: CORRECT003 rule + registration
+
+**Files:**
+- Modify: `packages/core/src/rules/correctness/correct001-002.ts` (add rule)
+- Modify: `packages/core/src/rules/index.ts` (import ~line 40; `allRules` ~line 86; re-export ~line 135)
+- Modify: `packages/core/src/index.ts` (re-export ~line 72)
+- Test: `packages/core/test/correctness-rules.test.ts` (add CORRECT003 describe block)
+
+**Interfaces:**
+- Consumes: `componentRule`; `EffectFact.mountOnly` (Task 1).
+- Produces: `export const correct003EffectAsOnMount: Rule`.
+
+- [ ] **Step 1: Write the failing rule tests**
+
+In `packages/core/test/correctness-rules.test.ts`, add `correct003EffectAsOnMount` to the import from `../src/index.js`, then append at the end of the file:
+
+```ts
+describe('CORRECT003 effect used as onMount', () => {
+  it('flags a mount-only $effect', async () => {
+    const rs = await correct003EffectAsOnMount.check(
+      ctx([comp({ effects: [{ line: 4, assignsOnlyState: false, mountOnly: true }] })])
+    );
+    expect(fails(rs)).toHaveLength(1);
+    expect(rs[0]!.category).toBe('correctness');
+    expect(rs[0]!.message).toContain('onMount');
+  });
+  it('passes an $effect that reads reactive state', async () => {
+    const rs = await correct003EffectAsOnMount.check(
+      ctx([comp({ effects: [{ line: 4, assignsOnlyState: false, mountOnly: false }] })])
+    );
+    expect(fails(rs)).toHaveLength(0);
+    expect(rs).toHaveLength(1); // a passing seed (applies=true, no findings)
+  });
+  it('is no-signal when there are no effects', async () => {
+    const rs = await correct003EffectAsOnMount.check(ctx([comp({ effects: [] })]));
+    expect(rs).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @svelte-vitals/core test correctness-rules`
+Expected: FAIL — `correct003EffectAsOnMount` is not exported.
+
+- [ ] **Step 3: Add the rule**
+
+In `packages/core/src/rules/correctness/correct001-002.ts`, append:
+
+```ts
+export const correct003EffectAsOnMount = componentRule({
+  id: 'CORRECT003',
+  title: 'Effect used as onMount',
+  category: 'correctness',
+  label: '$effect usage',
+  recommendation:
+    "Move mount-time side effects to onMount (import { onMount } from 'svelte'); reserve $effect for logic that reacts to $state/$derived/$props.",
+  rationale:
+    'An $effect that reads no reactive value runs once after mount and never re-runs — it is an onMount in disguise, which obscures intent and misuses the reactivity system.',
+  applies: (c) => c.effects.length > 0,
+  bad: (c) =>
+    c.effects.filter((e) => e.mountOnly).map((e) => ({ line: e.line, message: '$effect reads no reactive value — use onMount instead' }))
+});
+```
+
+- [ ] **Step 4: Register the rule**
+
+In `packages/core/src/rules/index.ts`:
+
+- Update the import (line 40) to include the new rule:
+  `import { correct001EachKey, correct002EffectDerived, correct003EffectAsOnMount } from './correctness/correct001-002.js';`
+- In `allRules`, replace the `  correct002EffectDerived,` line with:
+  ```ts
+    correct002EffectDerived,
+    correct003EffectAsOnMount,
+  ```
+- In the re-export `export { … }` block, replace the `  correct002EffectDerived,` line with the same two lines.
+
+In `packages/core/src/index.ts`, replace the `  correct002EffectDerived,` line (line 72) with:
+
+```ts
+  correct002EffectDerived,
+  correct003EffectAsOnMount,
+```
+
+- [ ] **Step 5: Run rule tests + typecheck**
+
+Run: `pnpm --filter @svelte-vitals/core test correctness-rules`
+Expected: PASS (CORRECT001/002 + 3 new CORRECT003).
+Run: `pnpm --filter @svelte-vitals/core typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/rules/correctness/correct001-002.ts packages/core/src/rules/index.ts packages/core/src/index.ts packages/core/test/correctness-rules.test.ts
+git commit -m "feat(core): add CORRECT003 effect-used-as-onMount rule"
+```
+
+---
+
+### Task 3: Docs + changeset
+
+**Files:**
+- Create: `docs/src/content/docs/rules/correct003.md`, `docs/src/content/docs/ja/rules/correct003.md`
+- Create: `.changeset/correct003-effect-onmount.md`
+
+- [ ] **Step 1: Write the English doc**
+
+Create `docs/src/content/docs/rules/correct003.md`:
+
+```md
+---
+title: CORRECT003 · Effect used as onMount
+description: Use onMount for an $effect that reads no reactive value.
+---
+
+**Severity:** warning · **Category:** correctness
+
+## What it checks
+
+Flags an `$effect` / `$effect.pre` whose non-empty body reads no reactive value — no `$state`, `$derived`, or `$props`, no store subscription, and no local function call. Such an effect runs once after mount and never re-runs. Checked by static (CLI) analysis of component instance scripts.
+
+## Why it matters
+
+An `$effect` that never reacts to anything is an `onMount` in disguise. Using `$effect` obscures that intent and misuses the reactivity system; `onMount` says "run this once when the component mounts" directly.
+
+## How to fix
+
+```svelte
+<script>
+  import { onMount } from 'svelte';
+  // Instead of: $effect(() => { element.focus(); });
+  onMount(() => {
+    element.focus();
+  });
+</script>
+```
+```
+
+- [ ] **Step 2: Write the Japanese doc**
+
+Create `docs/src/content/docs/ja/rules/correct003.md`:
+
+```md
+---
+title: CORRECT003 · onMount 代わりの $effect
+description: reactive 値を読まない $effect には onMount を使います。
+---
+
+**重大度:** warning · **カテゴリ:** correctness
+
+## チェック内容
+
+空でない本体が reactive 値を一切読まない `$effect` / `$effect.pre` を検出します — `$state`・`$derived`・`$props` の参照、store 購読、ローカル関数呼び出しのいずれも無いものです。そのような effect はマウント後に一度だけ実行され、再実行されません。コンポーネントの instance スクリプトを静的(CLI)解析します。
+
+## なぜ重要か
+
+何にも反応しない `$effect` は実質 `onMount` です。`$effect` を使うとその意図が曖昧になり、リアクティビティの仕組みを誤用します。`onMount` なら「マウント時に一度だけ実行する」ことを直接表現できます。
+
+## 修正方法
+
+```svelte
+<script>
+  import { onMount } from 'svelte';
+  // $effect(() => { element.focus(); }); の代わりに
+  onMount(() => {
+    element.focus();
+  });
+</script>
+```
+```
+
+- [ ] **Step 3: Write the changeset**
+
+Create `.changeset/correct003-effect-onmount.md`:
+
+```md
+---
+'@svelte-vitals/core': minor
+'svelte-vitals': minor
+'@svelte-vitals/mcp': minor
+---
+
+Add **CORRECT003 (effect used as onMount)** — the Correctness/reactivity slice of
+#69. Flags an `$effect`/`$effect.pre` whose non-empty body reads no reactive value
+(no `$state`/`$derived`/`$props`, no store subscription, no bare function call), so
+it never re-runs and should be `onMount`. Reported under `correctness` (warning).
+`EffectFact` gains `mountOnly`.
+```
+
+- [ ] **Step 4: Verify docs build**
+
+Run: `pnpm --filter docs build`
+Expected: build succeeds; page count rises by 2 (both correct003 pages present).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/src/content/docs/rules/correct003.md docs/src/content/docs/ja/rules/correct003.md .changeset/correct003-effect-onmount.md
+git commit -m "docs: CORRECT003 reference pages (en+ja) + changeset"
+```
+
+---
+
+### Task 4: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build core, then run the whole suite / typecheck / lint / docs build**
+
+Run:
+```bash
+pnpm -r build && pnpm -r test && pnpm -r typecheck && pnpm lint && pnpm --filter docs build
+```
+Expected: all green. Core test count rises by 3 (CORRECT003 rule tests); cli by ~5 (mountOnly capture tests).
+
+- [ ] **Step 2: If lint reports formatting, fix and re-run**
+
+Run: `pnpm exec prettier --write . && pnpm lint`
+Expected: "All matched files use Prettier code style!" and eslint clean.
+
+- [ ] **Step 3: Final commit (only if Step 2 changed files)**
+
+```bash
+git add -A
+git commit -m "chore: format CORRECT003 changes"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `EffectFact.mountOnly` field → Task 1 Step 1. ✓
+- Conservative reactive-read scan (reactive names + `$store` + bare call), empty-body exclusion, `$effect.pre`, reactiveNames = $state ∪ $derived ∪ $props → Task 1 Steps 4-5. ✓
+- Existing EffectFact `toEqual`/literal fixups → Task 1 Steps 6-7. ✓
+- CORRECT003 rule (warning/correctness/component, filters `mountOnly`) → Task 2 Step 3. ✓
+- Registration in allRules + both re-exports; MCP via allRules → Task 2 Step 4. ✓
+- Docs 2 pages + changeset (core/svelte-vitals/mcp minor) → Task 3. ✓
+- Testing: capture (member-call / reactive / $store / bare / empty / $effect.pre) + rule (flag / pass / no-signal) → Tasks 1-2. ✓
+- Out of scope (transitive local-fn analysis, other reactive sources, CORRECT002 merge) → not planned. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code. ✓
+
+**Type consistency:** `mountOnly: boolean` identical in `component.ts` and every `EffectFact` literal/assertion. Rule name `correct003EffectAsOnMount` consistent across Task 2 and tests. Helper names (`isDerivedDeclaration`, `isPropsCall`, `addBoundNames`, `bodyReadsReactive`, `bodyIsEmpty`, `RUNE_NAMES`) defined once in Task 1 and used there. ✓

--- a/docs/superpowers/specs/2026-07-02-correct003-effect-as-onmount-design.md
+++ b/docs/superpowers/specs/2026-07-02-correct003-effect-as-onmount-design.md
@@ -1,0 +1,154 @@
+# CORRECT003 — `$effect` used as `onMount`
+
+**Date:** 2026-07-02
+**Status:** Approved design
+**Packages:** `@svelte-vitals/core` (rule + effect analysis), `@svelte-vitals/cli` (capture), `@svelte-vitals/mcp` (surfaces the rule)
+
+## Goal
+
+Add **CORRECT003**, the "More Correctness/reactivity" slice of #69. Flag an
+`$effect` / `$effect.pre` whose body reads **no reactive value** — such an effect
+runs once after mount and never re-runs, so it is really an `onMount` and the
+`$effect` obscures intent. `warning` severity, matching CORRECT002.
+
+Distinct from CORRECT002 (an `$effect` that only *assigns* `$state` → use
+`$derived`): CORRECT003 is an `$effect` that neither reads nor derives reactive
+state → use `onMount`.
+
+## Background / current state
+
+- `ComponentFacts.effects: EffectFact[]` where `EffectFact = { line: number;
+  assignsOnlyState: boolean }` (CORRECT002 uses `assignsOnlyState`).
+- `packages/cli/src/providers/source/parse.ts` collects effects: it tracks
+  `stateNames` (via `isStateDeclaration`, `$state` only), detects effect calls
+  (`isEffectCall` → `$effect`/`$effect.pre`), and computes `assignsOnlyState`
+  via `bodyOnlyAssignsState`. `$derived` / `$props` / store subscriptions are
+  **not** currently tracked.
+- Rules live in `packages/core/src/rules/correctness/correct001-002.ts`, built
+  with the `componentRule` factory (CLI/static only; no-ops in rendered mode).
+
+## Design
+
+### 1. What counts as "reads a reactive value" (conservative — no false positives)
+
+An `$effect` body is treated as reading a reactive value (so it is **not**
+flagged) when it contains **any** of:
+
+1. **A reference to a reactive name** — an identifier bound to `$state` /
+   `$state.raw` / `$derived` / `$derived.by`, or a name introduced by `$props()`
+   (each destructured property name, or the single binding when
+   `let props = $props()`).
+2. **A store auto-subscription** — an identifier whose name starts with `$` and
+   is not a rune (`$state`, `$derived`, `$effect`, `$props`, `$bindable`,
+   `$inspect`, `$host`). (`$count` reads store `count`.)
+3. **A bare-identifier call** — a `CallExpression` whose callee is a plain
+   identifier, e.g. `foo()`. A local or imported function may read reactive
+   state internally, so it is conservatively treated as a reactive read.
+   Member calls (`el.focus()`, `window.scrollTo()`, `console.log('x')`) are
+   **not** suppressive on their own — but a reactive name passed as an argument
+   is caught by rule 1.
+
+An effect is a **mount-only candidate** (flagged) when its body is **non-empty**
+and matches **none** of the three. An empty body (`$effect(() => {})`) is not
+flagged — recommending `onMount` for it is nonsensical; it is a different (rare)
+smell out of scope here.
+
+Examples:
+
+```js
+$effect(() => { el.focus(); });              // flag — member call, no reactive read
+$effect(() => analytics.pageView());         // flag — member call
+$effect(() => { document.title = 'Home'; }); // flag — static assignment
+$effect(() => { count; });                   // ok — reactive name ($state)
+$effect(() => localHelper());                // ok — bare call (may read state)
+$effect(() => console.log($store));          // ok — store subscription
+$effect(() => {});                           // ok — empty body, not flagged
+```
+
+Shadowing (a local `const count` inside the effect that collides with a reactive
+name) is resolved conservatively: the identifier still counts as a reactive read,
+so the effect is not flagged (a false negative, never a false positive).
+
+### 2. Capture model — `EffectFact.mountOnly`
+
+Add a computed intent boolean to `EffectFact` (mirroring `assignsOnlyState`):
+
+```ts
+/** True when this $effect has a NON-EMPTY body that reads no reactive value and makes no bare call — it never re-runs, so it should be onMount (CORRECT003). */
+mountOnly: boolean;
+```
+
+`parse.ts` changes:
+
+- Collect a `reactiveNames: Set<string>` alongside the existing `stateNames`
+  scan: add names from `$derived` / `$derived.by` declarations and from
+  `$props()` (destructured property names, or the plain binding identifier).
+  `stateNames` already covers `$state`; `reactiveNames` is the union.
+- Add a helper `bodyReadsReactive(fn, reactiveNames): boolean` that walks the
+  effect callback body and returns true on the first of: an identifier in
+  `reactiveNames`; a `$`-prefixed non-rune identifier; a bare-identifier
+  `CallExpression`.
+- Add a helper `bodyIsEmpty(fn): boolean` (empty `BlockStatement`, or no body).
+- For each effect: `mountOnly = !bodyIsEmpty(fn) && !bodyReadsReactive(fn, reactiveNames)`.
+
+`assignsOnlyState` is unchanged. Both booleans are independent facts on the same
+`EffectFact`.
+
+### 3. Rule — CORRECT003
+
+Add to `packages/core/src/rules/correctness/correct001-002.ts` (alongside
+CORRECT001/002), built with `componentRule`:
+
+- `id: 'CORRECT003'`, `title: 'Effect used as onMount'`,
+  `category: 'correctness'`, `severity: 'warning'`, `scope: 'component'`.
+- `label` (PASS): `'$effect usage'`.
+- `recommendation`: `"Move mount-time side effects to onMount (import { onMount } from 'svelte'); reserve $effect for logic that reacts to $state/$derived/$props."`
+- `rationale`: `'An $effect that reads no reactive value runs once after mount and never re-runs — it is an onMount in disguise, which obscures intent and misuses the reactivity system.'`
+- `applies`: `(c) => c.effects.length > 0`.
+- `bad`: `(c) => c.effects.filter((e) => e.mountOnly).map((e) => ({ line: e.line, message: '$effect reads no reactive value — use onMount instead' }))`.
+
+Both `$effect` and `$effect.pre` are covered (existing `isEffectCall` already
+matches both).
+
+### 4. Registration & surfaces
+
+- Export `correct003EffectAsOnMount` from `correct001-002.ts`, import + append to
+  `allRules`, and add to the re-export blocks in `packages/core/src/rules/index.ts`
+  and `packages/core/src/index.ts` (after `correct002EffectDerived`).
+- MCP `analyze` / `explain_rule` surface it automatically via `allRules`.
+
+### 5. Docs
+
+Two reference pages following the CORRECT002 format (title; `**Severity:**
+warning · **Category:** correctness`; What it checks / Why it matters / How to
+fix):
+
+- `docs/src/content/docs/rules/correct003.md`
+- `docs/src/content/docs/ja/rules/correct003.md`
+
+### 6. Changeset
+
+`@svelte-vitals/core`, `svelte-vitals`, `@svelte-vitals/mcp` — **minor** (mirrors
+PERF010; the rule is CLI/static-only and no-ops in rendered mode, so not
+`@svelte-vitals/vite`).
+
+## Testing
+
+- **Capture** (`packages/cli` `parse-component-facts` tests): `mountOnly` is
+  `true` for a member-call-only body (`el.focus()`), a static assignment
+  (`document.title = 'x'`); `false` for a body that reads a `$state`/`$derived`/
+  `$props` name, reads a `$store`, makes a bare call (`helper()`), or is empty
+  (`() => {}`); `$effect.pre` is covered. Existing `toEqual` assertions on
+  `EffectFact` gain `mountOnly` with the correct value; existing EffectFact
+  literals in tests gain `mountOnly`.
+- **Rule** (`packages/core` `correctness-rules` tests): a component with a
+  mount-only effect fails; a component whose effect reads reactive passes; a
+  component with no effects is no-signal (`applies` false).
+- Full suite + typecheck + lint + `docs build` green; no assertions loosened.
+
+## Out of scope (YAGNI)
+
+- Transitive reactive analysis of local functions — bare calls are uniformly
+  suppressed instead (conservative).
+- Reactive sources beyond `$state`/`$derived`/`$props`/stores.
+- Merging with CORRECT002's derive-smell detection (distinct signal).

--- a/docs/superpowers/specs/2026-07-02-correct003-effect-as-onmount-design.md
+++ b/docs/superpowers/specs/2026-07-02-correct003-effect-as-onmount-design.md
@@ -11,14 +11,14 @@ Add **CORRECT003**, the "More Correctness/reactivity" slice of #69. Flag an
 runs once after mount and never re-runs, so it is really an `onMount` and the
 `$effect` obscures intent. `warning` severity, matching CORRECT002.
 
-Distinct from CORRECT002 (an `$effect` that only *assigns* `$state` → use
+Distinct from CORRECT002 (an `$effect` that only _assigns_ `$state` → use
 `$derived`): CORRECT003 is an `$effect` that neither reads nor derives reactive
 state → use `onMount`.
 
 ## Background / current state
 
 - `ComponentFacts.effects: EffectFact[]` where `EffectFact = { line: number;
-  assignsOnlyState: boolean }` (CORRECT002 uses `assignsOnlyState`).
+assignsOnlyState: boolean }` (CORRECT002 uses `assignsOnlyState`).
 - `packages/cli/src/providers/source/parse.ts` collects effects: it tracks
   `stateNames` (via `isStateDeclaration`, `$state` only), detects effect calls
   (`isEffectCall` → `$effect`/`$effect.pre`), and computes `assignsOnlyState`
@@ -56,13 +56,19 @@ smell out of scope here.
 Examples:
 
 ```js
-$effect(() => { el.focus(); });              // flag — member call, no reactive read
-$effect(() => analytics.pageView());         // flag — member call
-$effect(() => { document.title = 'Home'; }); // flag — static assignment
-$effect(() => { count; });                   // ok — reactive name ($state)
-$effect(() => localHelper());                // ok — bare call (may read state)
-$effect(() => console.log($store));          // ok — store subscription
-$effect(() => {});                           // ok — empty body, not flagged
+$effect(() => {
+  el.focus();
+}); // flag — member call, no reactive read
+$effect(() => analytics.pageView()); // flag — member call
+$effect(() => {
+  document.title = 'Home';
+}); // flag — static assignment
+$effect(() => {
+  count;
+}); // ok — reactive name ($state)
+$effect(() => localHelper()); // ok — bare call (may read state)
+$effect(() => console.log($store)); // ok — store subscription
+$effect(() => {}); // ok — empty body, not flagged
 ```
 
 Shadowing (a local `const count` inside the effect that collides with a reactive

--- a/packages/cli/src/providers/source/parse.ts
+++ b/packages/cli/src/providers/source/parse.ts
@@ -419,6 +419,56 @@ function bodyOnlyAssignsState(fn: Node, stateNames: Set<string>): boolean {
   return body.body.every((s: Node) => s?.type === 'ExpressionStatement' && isStateAssign(s.expression));
 }
 
+/** `$derived(...)` or `$derived.by(...)` declaration form. */
+function isDerivedDeclaration(node: Node): boolean {
+  const c = node?.callee;
+  if (c?.type === 'Identifier') return c.name === '$derived';
+  if (c?.type === 'MemberExpression' && c.object?.type === 'Identifier' && c.object.name === '$derived') {
+    return c.property?.type === 'Identifier' && c.property.name === 'by';
+  }
+  return false;
+}
+
+/** Add the names a declarator binds (Identifier or destructuring ObjectPattern) to `acc`. */
+function addBoundNames(id: Node, acc: Set<string>): void {
+  if (!id) return;
+  if (id.type === 'Identifier') acc.add(id.name);
+  else if (id.type === 'ObjectPattern') {
+    for (const p of id.properties ?? []) {
+      if (p?.type === 'Property' && p.value?.type === 'Identifier') acc.add(p.value.name);
+      else if (p?.type === 'RestElement' && p.argument?.type === 'Identifier') acc.add(p.argument.name);
+    }
+  }
+}
+
+const RUNE_NAMES = new Set(['$state', '$derived', '$effect', '$props', '$bindable', '$inspect', '$host']);
+
+/**
+ * Whether an $effect callback body reads a reactive value (CORRECT003, conservative):
+ * a reactive name, a `$`-prefixed store subscription, or any bare-identifier call.
+ */
+function bodyReadsReactive(fn: Node, reactiveNames: Set<string>): boolean {
+  let reads = false;
+  walkEstree(fn.body, (n: Node) => {
+    if (reads) return;
+    if (n?.type === 'Identifier') {
+      if (reactiveNames.has(n.name)) reads = true;
+      else if (n.name.startsWith('$') && !RUNE_NAMES.has(n.name)) reads = true;
+    } else if (n?.type === 'CallExpression' && n.callee?.type === 'Identifier') {
+      reads = true;
+    }
+  });
+  return reads;
+}
+
+/** Empty effect callback body (`() => {}` or no body). */
+function bodyIsEmpty(fn: Node): boolean {
+  const body = fn?.body;
+  if (!body) return true;
+  if (body.type === 'BlockStatement') return (body.body ?? []).length === 0;
+  return false;
+}
+
 /** Attributes whose value navigates/executes — a literal `javascript:` here is an XSS vector (SEC002). */
 const URL_ATTRS = ['href', 'src', 'action', 'formaction'];
 
@@ -541,10 +591,11 @@ export function parseComponentFacts(
     collectNamespaceImports(program, source, namespaceImports);
     propCount = countProps(program);
     const stateNames = new Set<string>();
+    const reactiveNames = new Set<string>();
     walkEstree(program, (n) => {
-      if (n.type === 'VariableDeclarator' && n.init && isStateDeclaration(n.init) && n.id?.type === 'Identifier') {
-        stateNames.add(n.id.name);
-      }
+      if (n.type !== 'VariableDeclarator' || !n.init) return;
+      if (isStateDeclaration(n.init) && n.id?.type === 'Identifier') stateNames.add(n.id.name);
+      if (isStateDeclaration(n.init) || isDerivedDeclaration(n.init) || isPropsCall(n.init)) addBoundNames(n.id, reactiveNames);
     });
     walkEstree(program, (n) => {
       if (n.type !== 'CallExpression' || !isEffectCall(n)) return;
@@ -552,7 +603,8 @@ export function parseComponentFacts(
       const isFn = fn?.type === 'ArrowFunctionExpression' || fn?.type === 'FunctionExpression';
       effects.push({
         line: lineOf(source, n.start),
-        assignsOnlyState: isFn ? bodyOnlyAssignsState(fn, stateNames) : false
+        assignsOnlyState: isFn ? bodyOnlyAssignsState(fn, stateNames) : false,
+        mountOnly: isFn ? !bodyIsEmpty(fn) && !bodyReadsReactive(fn, reactiveNames) : false
       });
     });
   }

--- a/packages/cli/src/providers/source/parse.ts
+++ b/packages/cli/src/providers/source/parse.ts
@@ -429,15 +429,33 @@ function isDerivedDeclaration(node: Node): boolean {
   return false;
 }
 
-/** Add the names a declarator binds (Identifier or destructuring ObjectPattern) to `acc`. */
+/**
+ * Add every name a binding target introduces to `acc`, recursing through all
+ * destructuring forms: defaults (`{ a = 1 }`), nested (`{ a: { b } }`), arrays,
+ * and rest. Missing a bound prop would drop it from `reactiveNames` and risk a
+ * false-positive CORRECT003 flag, so this must cover the full pattern grammar.
+ */
 function addBoundNames(id: Node, acc: Set<string>): void {
   if (!id) return;
-  if (id.type === 'Identifier') acc.add(id.name);
-  else if (id.type === 'ObjectPattern') {
-    for (const p of id.properties ?? []) {
-      if (p?.type === 'Property' && p.value?.type === 'Identifier') acc.add(p.value.name);
-      else if (p?.type === 'RestElement' && p.argument?.type === 'Identifier') acc.add(p.argument.name);
-    }
+  switch (id.type) {
+    case 'Identifier':
+      acc.add(id.name);
+      break;
+    case 'ObjectPattern':
+      for (const p of id.properties ?? []) {
+        if (p?.type === 'Property') addBoundNames(p.value, acc);
+        else if (p?.type === 'RestElement') addBoundNames(p.argument, acc);
+      }
+      break;
+    case 'ArrayPattern':
+      for (const el of id.elements ?? []) addBoundNames(el, acc);
+      break;
+    case 'AssignmentPattern':
+      addBoundNames(id.left, acc);
+      break;
+    case 'RestElement':
+      addBoundNames(id.argument, acc);
+      break;
   }
 }
 

--- a/packages/cli/src/providers/source/parse.ts
+++ b/packages/cli/src/providers/source/parse.ts
@@ -449,15 +449,40 @@ const RUNE_NAMES = new Set(['$state', '$derived', '$effect', '$props', '$bindabl
  */
 function bodyReadsReactive(fn: Node, reactiveNames: Set<string>): boolean {
   let reads = false;
-  walkEstree(fn.body, (n: Node) => {
-    if (reads) return;
-    if (n?.type === 'Identifier') {
-      if (reactiveNames.has(n.name)) reads = true;
-      else if (n.name.startsWith('$') && !RUNE_NAMES.has(n.name)) reads = true;
-    } else if (n?.type === 'CallExpression' && n.callee?.type === 'Identifier') {
-      reads = true;
+  const IGNORED_KEYS = new Set(['type', 'start', 'end', 'loc', 'range']);
+  // Dedicated walk (not the generic walkEstree) so a non-computed property NAME
+  // (`obj.count`, `{ count: 5 }`) that happens to match a reactive binding isn't
+  // misread as a reactive read — only value/computed positions count.
+  const visit = (n: Node): void => {
+    if (reads || !n) return;
+    if (Array.isArray(n)) {
+      for (const c of n) visit(c);
+      return;
     }
-  });
+    if (typeof n !== 'object' || typeof n.type !== 'string') return;
+    if (n.type === 'Identifier') {
+      if (reactiveNames.has(n.name) || (n.name.startsWith('$') && !RUNE_NAMES.has(n.name))) reads = true;
+      return;
+    }
+    if (n.type === 'CallExpression' && n.callee?.type === 'Identifier') {
+      reads = true; // bare-identifier call may read reactive state internally
+      return;
+    }
+    if (n.type === 'MemberExpression') {
+      visit(n.object);
+      if (n.computed) visit(n.property); // `obj[count]` reads count; `obj.count` does not
+      return;
+    }
+    if (n.type === 'Property') {
+      if (n.computed) visit(n.key);
+      visit(n.value);
+      return;
+    }
+    for (const key of Object.keys(n)) {
+      if (!IGNORED_KEYS.has(key)) visit(n[key]);
+    }
+  };
+  visit(fn.body);
   return reads;
 }
 

--- a/packages/cli/src/providers/source/parse.ts
+++ b/packages/cli/src/providers/source/parse.ts
@@ -595,7 +595,8 @@ export function parseComponentFacts(
     walkEstree(program, (n) => {
       if (n.type !== 'VariableDeclarator' || !n.init) return;
       if (isStateDeclaration(n.init) && n.id?.type === 'Identifier') stateNames.add(n.id.name);
-      if (isStateDeclaration(n.init) || isDerivedDeclaration(n.init) || isPropsCall(n.init)) addBoundNames(n.id, reactiveNames);
+      if (isStateDeclaration(n.init) || isDerivedDeclaration(n.init) || isPropsCall(n.init))
+        addBoundNames(n.id, reactiveNames);
     });
     walkEstree(program, (n) => {
       if (n.type !== 'CallExpression' || !isEffectCall(n)) return;

--- a/packages/cli/test/parse-component-facts.test.ts
+++ b/packages/cli/test/parse-component-facts.test.ts
@@ -206,6 +206,12 @@ describe('parseComponentFacts — mount-only $effect (CORRECT003)', () => {
   it('is not mountOnly for an empty body', () => {
     expect(facts('$effect(() => {});')[0]!.mountOnly).toBe(false);
   });
+  it('does not treat a non-computed property name matching a reactive binding as a read', () => {
+    // `obj.count` accesses a property named `count`; it does not read the reactive `count`.
+    expect(facts('let count = $state(0); $effect(() => { obj.count = 5; });')[0]!.mountOnly).toBe(true);
+    // but a computed access `obj[count]` DOES read the reactive index.
+    expect(facts('let count = $state(0); $effect(() => { obj[count] = 5; });')[0]!.mountOnly).toBe(false);
+  });
   it('covers $effect.pre', () => {
     expect(facts('$effect.pre(() => { el.focus(); });')[0]!.mountOnly).toBe(true);
   });

--- a/packages/cli/test/parse-component-facts.test.ts
+++ b/packages/cli/test/parse-component-facts.test.ts
@@ -25,11 +25,11 @@ describe('parseComponentFacts — $effect (CORRECT002)', () => {
 
   it('flags an $effect whose body only assigns $state', () => {
     const e = facts('let count = $state(0); let double = $state(0); $effect(() => { double = count * 2; });');
-    expect(e).toEqual([{ line: 1, assignsOnlyState: true }]);
+    expect(e).toEqual([{ line: 1, assignsOnlyState: true, mountOnly: false }]);
   });
   it('does not flag an $effect that does other work', () => {
     const e = facts('let count = $state(0); $effect(() => { console.log(count); });');
-    expect(e).toEqual([{ line: 1, assignsOnlyState: false }]);
+    expect(e).toEqual([{ line: 1, assignsOnlyState: false, mountOnly: false }]);
   });
   it('does not flag assignment to a non-$state variable', () => {
     const e = facts('let count = $state(0); let plain = 0; $effect(() => { plain = count; });');
@@ -54,7 +54,7 @@ describe('parseComponentFacts — $effect (CORRECT002)', () => {
   });
   it('flags an assign-only $effect.pre', () => {
     const e = facts('let count = $state(0); let double = $state(0); $effect.pre(() => { double = count * 2; });');
-    expect(e).toEqual([{ line: 1, assignsOnlyState: true }]);
+    expect(e).toEqual([{ line: 1, assignsOnlyState: true, mountOnly: false }]);
   });
   it('ignores non-effect $effect readers ($effect.tracking / $effect.root)', () => {
     const e = facts('let count = $state(0); const t = $effect.tracking(); $effect.root(() => {});');
@@ -183,5 +183,30 @@ describe('parseComponentFacts — namespace imports (PERF010)', () => {
       'C.svelte'
     ).namespaceImports;
     expect(only!.line).toBeGreaterThan(0);
+  });
+});
+
+describe('parseComponentFacts — mount-only $effect (CORRECT003)', () => {
+  const facts = (script: string) => parseComponentFacts(`<script>${script}</script>`, 'C.svelte').effects;
+
+  it('marks an effect with only member-call side effects as mountOnly', () => {
+    expect(facts('$effect(() => { document.title = "Home"; });')[0]!.mountOnly).toBe(true);
+    expect(facts('$effect(() => { el.focus(); });')[0]!.mountOnly).toBe(true);
+    expect(facts('$effect(() => analytics.pageView());')[0]!.mountOnly).toBe(true);
+  });
+  it('is not mountOnly when the body reads reactive state/derived/props', () => {
+    expect(facts('let count = $state(0); $effect(() => { console.log(count); });')[0]!.mountOnly).toBe(false);
+    expect(facts('let d = $derived(1); $effect(() => { console.log(d); });')[0]!.mountOnly).toBe(false);
+    expect(facts('let { title } = $props(); $effect(() => { document.title = title; });')[0]!.mountOnly).toBe(false);
+  });
+  it('is not mountOnly for a store subscription or a bare call', () => {
+    expect(facts('$effect(() => { console.log($page); });')[0]!.mountOnly).toBe(false);
+    expect(facts('$effect(() => helper());')[0]!.mountOnly).toBe(false);
+  });
+  it('is not mountOnly for an empty body', () => {
+    expect(facts('$effect(() => {});')[0]!.mountOnly).toBe(false);
+  });
+  it('covers $effect.pre', () => {
+    expect(facts('$effect.pre(() => { el.focus(); });')[0]!.mountOnly).toBe(true);
   });
 });

--- a/packages/cli/test/parse-component-facts.test.ts
+++ b/packages/cli/test/parse-component-facts.test.ts
@@ -199,6 +199,14 @@ describe('parseComponentFacts — mount-only $effect (CORRECT003)', () => {
     expect(facts('let d = $derived(1); $effect(() => { console.log(d); });')[0]!.mountOnly).toBe(false);
     expect(facts('let { title } = $props(); $effect(() => { document.title = title; });')[0]!.mountOnly).toBe(false);
   });
+  it('captures reactive names through defaults and nested destructuring (no false positive)', () => {
+    // `title` has a default → its binding is an AssignmentPattern, still a reactive prop.
+    expect(facts("let { title = 'x' } = $props(); $effect(() => { document.title = title; });")[0]!.mountOnly).toBe(
+      false
+    );
+    // nested destructuring binds `b`.
+    expect(facts('let { a: { b } } = $props(); $effect(() => { el.textContent = b; });')[0]!.mountOnly).toBe(false);
+  });
   it('is not mountOnly for a store subscription or a bare call', () => {
     expect(facts('$effect(() => { console.log($page); });')[0]!.mountOnly).toBe(false);
     expect(facts('$effect(() => helper());')[0]!.mountOnly).toBe(false);

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -18,6 +18,8 @@ export interface EffectFact {
   line: number;
   /** True when the effect body only assigns to `$state` variables (the "use $derived" smell). */
   assignsOnlyState: boolean;
+  /** True when this $effect has a NON-EMPTY body that reads no reactive value and makes no bare call — it never re-runs, so it should be onMount (CORRECT003). */
+  mountOnly: boolean;
 }
 
 /** A flagged source position in a component (e.g. an `{@html}` tag or a `javascript:` URL). */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -70,6 +70,7 @@ export {
   seo030HeadingOrder,
   correct001EachKey,
   correct002EffectDerived,
+  correct003EffectAsOnMount,
   sec001Html,
   sec002JavascriptUrl,
   arch001ComponentSize,

--- a/packages/core/src/rules/correctness/correct001-002.ts
+++ b/packages/core/src/rules/correctness/correct001-002.ts
@@ -26,3 +26,17 @@ export const correct002EffectDerived = componentRule({
       .filter((e) => e.assignsOnlyState)
       .map((e) => ({ line: e.line, message: '$effect only assigns state — use $derived instead' }))
 });
+
+export const correct003EffectAsOnMount = componentRule({
+  id: 'CORRECT003',
+  title: 'Effect used as onMount',
+  category: 'correctness',
+  label: '$effect usage',
+  recommendation:
+    "Move mount-time side effects to onMount (import { onMount } from 'svelte'); reserve $effect for logic that reacts to $state/$derived/$props.",
+  rationale:
+    'An $effect that reads no reactive value runs once after mount and never re-runs — it is an onMount in disguise, which obscures intent and misuses the reactivity system.',
+  applies: (c) => c.effects.length > 0,
+  bad: (c) =>
+    c.effects.filter((e) => e.mountOnly).map((e) => ({ line: e.line, message: '$effect reads no reactive value — use onMount instead' }))
+});

--- a/packages/core/src/rules/correctness/correct001-002.ts
+++ b/packages/core/src/rules/correctness/correct001-002.ts
@@ -38,5 +38,7 @@ export const correct003EffectAsOnMount = componentRule({
     'An $effect that reads no reactive value runs once after mount and never re-runs — it is an onMount in disguise, which obscures intent and misuses the reactivity system.',
   applies: (c) => c.effects.length > 0,
   bad: (c) =>
-    c.effects.filter((e) => e.mountOnly).map((e) => ({ line: e.line, message: '$effect reads no reactive value — use onMount instead' }))
+    c.effects
+      .filter((e) => e.mountOnly)
+      .map((e) => ({ line: e.line, message: '$effect reads no reactive value — use onMount instead' }))
 });

--- a/packages/core/src/rules/index.ts
+++ b/packages/core/src/rules/index.ts
@@ -37,7 +37,7 @@ import { seo026Hreflang } from './seo/seo026-hreflang.js';
 import { seo027Heading } from './seo/seo027-heading.js';
 import { seo028TitleUnique, seo029DescriptionUnique } from './seo/seo028-029-uniqueness.js';
 import { seo030HeadingOrder } from './seo/seo030-heading-order.js';
-import { correct001EachKey, correct002EffectDerived } from './correctness/correct001-002.js';
+import { correct001EachKey, correct002EffectDerived, correct003EffectAsOnMount } from './correctness/correct001-002.js';
 import { sec001Html, sec002JavascriptUrl } from './security/sec001-002.js';
 import { arch001ComponentSize, arch002PropCount } from './architecture/arch001-002.js';
 import { perf009HeavyImport } from './performance/perf009-heavy-import.js';
@@ -84,6 +84,7 @@ export const allRules: Rule[] = [
   seo030HeadingOrder,
   correct001EachKey,
   correct002EffectDerived,
+  correct003EffectAsOnMount,
   sec001Html,
   sec002JavascriptUrl,
   arch001ComponentSize,
@@ -133,6 +134,7 @@ export {
   seo030HeadingOrder,
   correct001EachKey,
   correct002EffectDerived,
+  correct003EffectAsOnMount,
   sec001Html,
   sec002JavascriptUrl,
   arch001ComponentSize,

--- a/packages/core/test/correctness-rules.test.ts
+++ b/packages/core/test/correctness-rules.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { correct001EachKey, correct002EffectDerived } from '../src/index.js';
+import { correct001EachKey, correct002EffectDerived, correct003EffectAsOnMount } from '../src/index.js';
 import { defineConfig, defaultProject } from '../src/types.js';
 import type { ComponentFacts } from '../src/component.js';
 import type { RuleContext } from '../src/rule.js';
@@ -60,5 +60,27 @@ describe('CORRECT002 effect used to derive state', () => {
   });
   it('emits nothing for a component with no $effect', async () => {
     expect(await correct002EffectDerived.check(ctx([comp({})]))).toHaveLength(0);
+  });
+});
+
+describe('CORRECT003 effect used as onMount', () => {
+  it('flags a mount-only $effect', async () => {
+    const rs = await correct003EffectAsOnMount.check(
+      ctx([comp({ effects: [{ line: 4, assignsOnlyState: false, mountOnly: true }] })])
+    );
+    expect(fails(rs)).toHaveLength(1);
+    expect(rs[0]!.category).toBe('correctness');
+    expect(rs[0]!.message).toContain('onMount');
+  });
+  it('passes an $effect that reads reactive state', async () => {
+    const rs = await correct003EffectAsOnMount.check(
+      ctx([comp({ effects: [{ line: 4, assignsOnlyState: false, mountOnly: false }] })])
+    );
+    expect(fails(rs)).toHaveLength(0);
+    expect(rs).toHaveLength(1); // a passing seed (applies=true, no findings)
+  });
+  it('is no-signal when there are no effects', async () => {
+    const rs = await correct003EffectAsOnMount.check(ctx([comp({ effects: [] })]));
+    expect(rs).toHaveLength(0);
   });
 });

--- a/packages/core/test/correctness-rules.test.ts
+++ b/packages/core/test/correctness-rules.test.ts
@@ -45,12 +45,16 @@ describe('CORRECT001 keyed each block', () => {
 
 describe('CORRECT002 effect used to derive state', () => {
   it('flags an $effect that only assigns state', async () => {
-    const rs = await correct002EffectDerived.check(ctx([comp({ effects: [{ line: 5, assignsOnlyState: true }] })]));
+    const rs = await correct002EffectDerived.check(
+      ctx([comp({ effects: [{ line: 5, assignsOnlyState: true, mountOnly: false }] })])
+    );
     expect(fails(rs)).toHaveLength(1);
     expect(rs[0]!.message).toContain('$derived');
   });
   it('passes an $effect that does real work', async () => {
-    const rs = await correct002EffectDerived.check(ctx([comp({ effects: [{ line: 5, assignsOnlyState: false }] })]));
+    const rs = await correct002EffectDerived.check(
+      ctx([comp({ effects: [{ line: 5, assignsOnlyState: false, mountOnly: false }] })])
+    );
     expect(fails(rs)).toHaveLength(0);
     expect(rs).toHaveLength(1);
   });


### PR DESCRIPTION
The Correctness/reactivity slice of #69. Adds **CORRECT003**, flagging an `$effect`/`$effect.pre` whose non-empty body reads **no reactive value** — such an effect runs once after mount and never re-runs, so it is an `onMount` in disguise. `warning` severity, matching CORRECT002.

Distinct from CORRECT002 (an `$effect` that only *assigns* `$state` → use `$derived`): CORRECT003 is an `$effect` that neither reads nor derives reactive state → use `onMount`.

## What's flagged

```js
$effect(() => { el.focus(); });        // ✗ flag — member call, no reactive read
$effect(() => analytics.pageView());   // ✗ flag
$effect(() => { count; });             // ok — reads $state
$effect(() => localHelper());          // ok — bare call (may read state)
$effect(() => console.log($store));    // ok — store subscription
$effect(() => {});                     // ok — empty body
```

## How it works (precision-first)

A new computed `EffectFact.mountOnly` boolean, set by the CLI parser. An effect is **not** flagged (conservative) when its body:
1. references a reactive name (`reactiveNames` = `$state` ∪ `$derived` ∪ `$props` bindings, incl. destructured + rest),
2. reads a `$`-prefixed non-rune identifier (store subscription), or
3. contains a bare-identifier call `foo()` (a local/imported fn may read state internally).

Member calls (`el.focus()`, `console.log('x')`) are not suppressive on their own, but a reactive name in a call **argument** is caught by rule 1. Empty bodies are never flagged. The **cardinal sin** — flagging an effect that legitimately reacts — was scrutinized hardest in review; no false-positive path found.

The `componentRule`-built rule filters `mountOnly` and no-ops in rendered mode. `assignsOnlyState`/`stateNames` (CORRECT002) are untouched.

## Docs & release

- 2 rule reference pages (CORRECT003, en + ja).
- `@svelte-vitals/core` + `svelte-vitals` + `@svelte-vitals/mcp` **minor** (CLI/static rule; not `@svelte-vitals/vite`).

## Validation

`pnpm -r test` (554: core 250 / vite 76 / cli 219 / mcp 9), `pnpm -r typecheck`, `pnpm lint`, `pnpm --filter docs build` (111 pages incl. the 2 new) — all green.

## Process

spec → plan → subagent-driven (3 impl tasks, each spec + quality reviewed) + a whole-branch review on Opus (verdict: ready to merge). Zero review-loop fixes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new warning (CORRECT003) that flags `$effect` / `$effect.pre` used as one-time, mount-like side effects, encouraging use of `onMount`.
* **Documentation**
  * Added English and Japanese rule reference pages for CORRECT003, including examples and guidance on how to rewrite flagged code.
* **Tests**
  * Expanded parsing and correctness-rule test coverage to detect and verify the new “mount-only” behavior, including cases that should not be flagged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->