### PR TITLE
feat(cli): rich console output — colors, hierarchy, and spinner

### DIFF
--- a/.changeset/cli-rich-console.md
+++ b/.changeset/cli-rich-console.md
@@ -1,0 +1,11 @@
+---
+'@svelte-vitals/core': minor
+'svelte-vitals': minor
+---
+
+Rich console output: the default `console` reporter now colorizes the Health/category
+scores, severity sections, and pass/fail markers, and shows an "Analyzing…" spinner
+during the scan. All of it auto-disables under `NO_COLOR`, a non-TTY stdout, a
+non-`console` reporter, or `--no-color` (and honors `FORCE_COLOR`). Color is an
+injected `Palette` (identity by default), so `@svelte-vitals/core` stays
+dependency-free and other reporters are unchanged.

--- a/docs/superpowers/plans/2026-07-03-cli-rich-console-output.md
+++ b/docs/superpowers/plans/2026-07-03-cli-rich-console-output.md
@@ -1,0 +1,629 @@
+# CLI rich console output Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `--reporter console` output rich — severity/score/category colors, visual hierarchy, and an "Analyzing…" spinner — while keeping `@svelte-vitals/core` pure & dependency-free and auto-disabling under non-TTY / `NO_COLOR` / non-console reporters.
+
+**Architecture:** Core's `formatConsoleReport` takes an injected `Palette` (string→string fns) defaulting to identity, so existing plain output/tests are unchanged. The CLI supplies a hand-rolled ANSI palette gated on TTY/`NO_COLOR`/`FORCE_COLOR`/reporter, plus a stderr spinner. No new dependency.
+
+**Tech Stack:** TypeScript, Vitest, pnpm workspaces (`@svelte-vitals/core`, `@svelte-vitals/cli`), Changesets.
+
+## Global Constraints
+
+- `@svelte-vitals/core` stays dependency-free and pure: color is an **injected `Palette`** with an **identity default** (`noColorPalette`). No ANSI codes or TTY/env reads in core.
+- CLI hand-rolls ANSI + spinner (no new dependency; repo uses only `mri` in the CLI).
+- Color/spinner auto-disable when: reporter ≠ `console`, stdout/stderr not a TTY, `NO_COLOR` set, or `--no-color`. `FORCE_COLOR` (non-empty, ≠ `0`) forces on. Spinner also disabled under an auto-detected agent env.
+- Spinner writes to **stderr** (stdout / piped report stays clean). No `Date.now()`/`new Date()` (use `setInterval`).
+- Score color thresholds: green ≥ 90, yellow ≥ 70, red otherwise.
+- No existing test assertion is loosened (identity default keeps current output byte-identical).
+- Spec: `docs/superpowers/specs/2026-07-03-cli-rich-console-output-design.md`.
+- Branch: `feat/cli-rich-console` (created; spec committed).
+- Run commands from the repo root.
+
+---
+
+## File Structure
+
+- Create: `packages/core/src/reporter/palette.ts` — `Palette`, `noColorPalette`, `scoreColor`.
+- Modify: `packages/core/src/reporter/console.ts` — accept `options.palette`, apply it.
+- Modify: `packages/core/src/index.ts` — export the palette API.
+- Modify: `packages/core/test/console-report.test.ts` (or the existing console reporter test) — add palette tests.
+- Create: `packages/cli/src/color.ts` — `ansiPalette`, `colorEnabled`, `paletteFor`.
+- Create: `packages/cli/src/spinner.ts` — `startSpinner`.
+- Modify: `packages/cli/src/index.ts` — hoist reporter/env resolution; wire palette + spinner; add `noColor`/`stdoutIsTTY`/`stderrIsTTY` to `RunOptions`.
+- Modify: `packages/cli/src/bin.ts` — `--no-color` flag; help tagline fix.
+- Create: `packages/cli/test/color.test.ts`, `packages/cli/test/spinner.test.ts`.
+- Create: `.changeset/cli-rich-console.md`.
+
+---
+
+### Task 1: Core palette injection
+
+**Files:**
+- Create: `packages/core/src/reporter/palette.ts`
+- Modify: `packages/core/src/reporter/console.ts`
+- Modify: `packages/core/src/index.ts`
+- Test: `packages/core/test/console-palette.test.ts` (create)
+
+**Interfaces:**
+- Produces: `interface Palette`, `const noColorPalette: Palette`, `function scoreColor(p, score)`; `ConsoleReportOptions.palette?`.
+- Consumes: nothing new.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/core/test/console-palette.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { formatConsoleReport, noColorPalette, scoreColor, type Palette } from '../src/index.js';
+import { defineConfig } from '../src/types.js';
+import type { Result } from '../src/types.js';
+
+const config = defineConfig({});
+// Marker palette: wraps text so we can assert where color is applied.
+const mark: Palette = {
+  bold: (s) => `[b]${s}[/b]`,
+  dim: (s) => `[d]${s}[/d]`,
+  red: (s) => `[r]${s}[/r]`,
+  yellow: (s) => `[y]${s}[/y]`,
+  green: (s) => `[g]${s}[/g]`,
+  cyan: (s) => `[c]${s}[/c]`
+};
+const fail: Result = {
+  id: 'SEO001',
+  category: 'seo',
+  severity: 'critical',
+  detection: { presence: 'none', value: 'absent' },
+  route: '/',
+  message: 'Missing <title>'
+};
+
+describe('console palette', () => {
+  it('is identity by default (output unchanged)', () => {
+    const out = formatConsoleReport([fail], config);
+    expect(out).not.toContain('[');
+    expect(out).toContain('✗ SEO001');
+  });
+  it('applies the palette to markers and severity titles when provided', () => {
+    const out = formatConsoleReport([fail], config, { palette: mark });
+    expect(out).toContain('[r]✗[/r]'); // failure marker red
+    expect(out).toContain('[r]'); // critical title colored
+    expect(out).toContain('[b]'); // header/title bold
+  });
+  it('scoreColor picks green/yellow/red by threshold', () => {
+    expect(scoreColor(mark, 90)('9')).toBe('[g]9[/g]');
+    expect(scoreColor(mark, 70)('7')).toBe('[y]7[/y]');
+    expect(scoreColor(mark, 69)('6')).toBe('[r]6[/r]');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @svelte-vitals/core test console-palette`
+Expected: FAIL — `noColorPalette`/`scoreColor` not exported.
+
+- [ ] **Step 3: Create the palette module**
+
+Create `packages/core/src/reporter/palette.ts`:
+
+```ts
+/** String decorators for the console reporter. Injected so core stays pure/dep-free. */
+export interface Palette {
+  bold: (s: string) => string;
+  dim: (s: string) => string;
+  red: (s: string) => string;
+  yellow: (s: string) => string;
+  green: (s: string) => string;
+  cyan: (s: string) => string;
+}
+
+/** Default: no decoration (identity) — output is byte-identical to plain text. */
+export const noColorPalette: Palette = {
+  bold: (s) => s,
+  dim: (s) => s,
+  red: (s) => s,
+  yellow: (s) => s,
+  green: (s) => s,
+  cyan: (s) => s
+};
+
+/** Green ≥ 90, yellow ≥ 70, red otherwise — for a 0–100 score. */
+export function scoreColor(p: Palette, score: number): (s: string) => string {
+  if (score >= 90) return p.green;
+  if (score >= 70) return p.yellow;
+  return p.red;
+}
+```
+
+- [ ] **Step 4: Apply the palette in `console.ts`**
+
+In `packages/core/src/reporter/console.ts`:
+
+Add the import at the top:
+
+```ts
+import { noColorPalette, scoreColor, type Palette } from './palette.js';
+```
+
+Add `palette` to the options interface:
+
+```ts
+export interface ConsoleReportOptions {
+  byRoute?: boolean;
+  /** Mode label shown in the header (default 'static mode'). */
+  mode?: string;
+  /** Color decorators; defaults to no color. */
+  palette?: Palette;
+}
+```
+
+Change `scoreLine` to take and apply the palette:
+
+```ts
+function scoreLine(p: Palette, label: string, { score, scoreModel }: ScoreResult): string {
+  const parts = [`route avg ${scoreModel.routeAverage}`];
+  if (scoreModel.sitePenalty > 0) parts.push(`site −${scoreModel.sitePenalty}`);
+  if (scoreModel.criticalCap !== null) parts.push(`capped at ${scoreModel.criticalCap}: critical present`);
+  return `${label} Score: ${scoreColor(p, score)(`${score}/100`)}   ${p.dim(`(${parts.join(' · ')})`)}`;
+}
+```
+
+Change `byRouteTree` to take the palette and color the score + failure marker:
+
+```ts
+function byRouteTree(p: Palette, results: Result[], config: Config): string[] {
+  const routes = new Map<string, Result[]>();
+  for (const r of results) {
+    if (r.route === undefined) continue;
+    if (!routes.has(r.route)) routes.set(r.route, []);
+    routes.get(r.route)!.push(r);
+  }
+  const lines: string[] = [p.bold('By route'), p.dim(RULE)];
+  for (const [route, rs] of [...routes.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+    const { score } = computeScore(rs, config, { applyCriticalCap: false });
+    lines.push(`${route.padEnd(28)} ${scoreColor(p, score)(`${score}`)}`);
+    for (const r of rs.filter((x) => classify(x, config) === 'fail')) {
+      lines.push(`    ${p.red('✗')} ${r.id}  ${r.message}`);
+    }
+  }
+  lines.push('');
+  return lines;
+}
+```
+
+In `formatConsoleReport`, add `const p = options.palette ?? noColorPalette;` at the top, then color the header/sections. Replace the header + section-title + marker construction so it reads:
+
+```ts
+  const p = options.palette ?? noColorPalette;
+  const summary = summarize(results, config);
+  const { health, categories: byCat } = computeHealth(results, config);
+  const present = CATEGORY_ORDER.filter((c) => byCat[c] !== undefined);
+  const header: string[] = [
+    p.bold(`Svelte Vitals  ·  ${options.mode ?? 'static mode'}`),
+    '',
+    `${p.bold('Health:')} ${scoreColor(p, health)(`${health}/100`)}`
+  ];
+  for (const c of present) {
+    header.push(scoreLine(p, CATEGORY_LABEL[c] ?? c, byCat[c]!));
+  }
+  const lines: string[] = [...header, ''];
+
+  const SEVERITY_COLOR: Record<Severity, (s: string) => string> = {
+    critical: (s) => p.red(p.bold(s)),
+    warning: (s) => p.yellow(p.bold(s)),
+    info: (s) => p.dim(s)
+  };
+
+  const failures = results.filter((r) => classify(r, config) === 'fail');
+  for (const severity of ['critical', 'warning', 'info'] as const) {
+    const bucket = failures.filter((r) => effectiveSeverity(r, config) === severity);
+    if (bucket.length === 0) continue;
+    lines.push(SEVERITY_COLOR[severity](`${SEVERITY_TITLE[severity]} (${bucket.length})`), p.dim(RULE));
+    for (const r of bucket) {
+      lines.push(`${p.red('✗')} ${r.id}  ${r.message}`);
+      if (r.route) lines.push(p.dim(`            ${r.route}`));
+      if (r.location) lines.push(p.dim(`            ${r.location}${r.line ? `:${r.line}` : ''}`));
+    }
+    lines.push('');
+  }
+
+  const passed = results.filter((r) => classify(r, config) !== 'fail');
+  if (passed.length > 0) {
+    lines.push(p.bold(`Passed (${passed.length})`), p.dim(RULE));
+    for (const r of passed) {
+      const marker = classify(r, config) === 'dynamic' ? p.cyan('  ↯ dynamic') : '';
+      const route = r.route ? `  ${r.route}` : '';
+      lines.push(`${p.green('✓')} ${r.id}  ${r.message}${marker}${route}`);
+    }
+    lines.push('');
+  }
+
+  if (options.byRoute) lines.push(...byRouteTree(p, results, config));
+  if (summary.dynamic > 0) lines.push(p.dim('↯ = set dynamically (verified at runtime).'));
+
+  return lines.join('\n').replace(/\n+$/, '\n');
+```
+
+(The `SEVERITY_TITLE`, `CATEGORY_LABEL`, `CATEGORY_ORDER`, `RULE` constants and the early `import` lines are unchanged.)
+
+- [ ] **Step 5: Export the palette API from core**
+
+In `packages/core/src/index.ts`, next to the console reporter export (line ~90-91), add:
+
+```ts
+export { noColorPalette, scoreColor } from './reporter/palette.js';
+export type { Palette } from './reporter/palette.js';
+```
+
+- [ ] **Step 6: Run the palette tests + the existing console tests + typecheck**
+
+Run: `pnpm --filter @svelte-vitals/core test console`
+Expected: PASS — new `console-palette` tests pass AND the pre-existing console reporter tests are unchanged (identity default).
+Run: `pnpm --filter @svelte-vitals/core typecheck`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/reporter/palette.ts packages/core/src/reporter/console.ts packages/core/src/index.ts packages/core/test/console-palette.test.ts
+git commit -m "feat(core): inject a Palette into the console reporter (identity default)"
+```
+
+---
+
+### Task 2: CLI color palette + `--no-color` + tagline
+
+**Files:**
+- Create: `packages/cli/src/color.ts`
+- Modify: `packages/cli/src/index.ts` (`RunOptions`; hoist reporter/env; console branch)
+- Modify: `packages/cli/src/bin.ts` (`--no-color` flag; help)
+- Test: `packages/cli/test/color.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `Palette`, `noColorPalette` from `@svelte-vitals/core` (Task 1); `resolveReporter` (existing).
+- Produces: `ansiPalette`, `colorEnabled(opts)`, `paletteFor(enabled)`; `RunOptions.noColor?`, `RunOptions.stdoutIsTTY?`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/cli/test/color.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { colorEnabled, paletteFor, ansiPalette } from '../src/color.js';
+
+const base = { reporter: 'console', isTTY: true, env: {} as NodeJS.ProcessEnv };
+
+describe('colorEnabled', () => {
+  it('is on for a console reporter on a TTY', () => {
+    expect(colorEnabled(base)).toBe(true);
+  });
+  it('is off when not a TTY', () => {
+    expect(colorEnabled({ ...base, isTTY: false })).toBe(false);
+  });
+  it('is off for a non-console reporter', () => {
+    expect(colorEnabled({ ...base, reporter: 'json' })).toBe(false);
+  });
+  it('is off when NO_COLOR is set', () => {
+    expect(colorEnabled({ ...base, env: { NO_COLOR: '1' } })).toBe(false);
+  });
+  it('is off with --no-color', () => {
+    expect(colorEnabled({ ...base, noColorFlag: true })).toBe(false);
+  });
+  it('FORCE_COLOR forces on even off-TTY', () => {
+    expect(colorEnabled({ ...base, isTTY: false, env: { FORCE_COLOR: '1' } })).toBe(true);
+  });
+});
+
+describe('paletteFor', () => {
+  it('applies ANSI when enabled, identity when not', () => {
+    expect(paletteFor(true).red('x')).toBe(ansiPalette.red('x'));
+    expect(paletteFor(true).red('x')).toContain('\x1b[31m');
+    expect(paletteFor(false).red('x')).toBe('x');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter svelte-vitals test color`
+Expected: FAIL — `../src/color.js` does not exist.
+
+- [ ] **Step 3: Create `color.ts`**
+
+Create `packages/cli/src/color.ts`:
+
+```ts
+import { noColorPalette, type Palette } from '@svelte-vitals/core';
+
+const wrap =
+  (open: number, close = 0) =>
+  (s: string): string =>
+    `\x1b[${open}m${s}\x1b[${close}m`;
+
+/** Hand-rolled ANSI palette (no dependency). */
+export const ansiPalette: Palette = {
+  bold: wrap(1, 22),
+  dim: wrap(2, 22),
+  red: wrap(31, 39),
+  yellow: wrap(33, 39),
+  green: wrap(32, 39),
+  cyan: wrap(36, 39)
+};
+
+/** Whether ANSI color is enabled, following the de-facto env conventions. */
+export function colorEnabled(opts: {
+  reporter: string;
+  isTTY: boolean;
+  env: NodeJS.ProcessEnv;
+  noColorFlag?: boolean;
+}): boolean {
+  if (opts.noColorFlag) return false;
+  if (opts.env.NO_COLOR !== undefined && opts.env.NO_COLOR !== '') return false;
+  const fc = opts.env.FORCE_COLOR;
+  if (fc !== undefined && fc !== '' && fc !== '0') return true;
+  return opts.reporter === 'console' && opts.isTTY;
+}
+
+export const paletteFor = (enabled: boolean): Palette => (enabled ? ansiPalette : noColorPalette);
+```
+
+- [ ] **Step 4: Wire the palette into `run()`**
+
+In `packages/cli/src/index.ts`:
+
+Add to `RunOptions` (after `staged?: boolean;`):
+
+```ts
+  /** Disable ANSI color in console output. */
+  noColor?: boolean;
+  /** Override stdout TTY detection (tests). */
+  stdoutIsTTY?: boolean;
+  /** Override stderr TTY detection (tests). */
+  stderrIsTTY?: boolean;
+```
+
+Add the import at the top of the file:
+
+```ts
+import { colorEnabled, paletteFor } from './color.js';
+```
+
+In `run()`, the console branch currently reads:
+
+```ts
+    } else {
+      log(formatConsoleReport(results, config, { byRoute: opts.byRoute ?? false }));
+    }
+```
+
+Replace with (uses the already-resolved `reporter` and `env` in that scope):
+
+```ts
+    } else {
+      const colorOn = colorEnabled({
+        reporter,
+        isTTY: opts.stdoutIsTTY ?? !!process.stdout.isTTY,
+        env,
+        noColorFlag: opts.noColor
+      });
+      log(formatConsoleReport(results, config, { byRoute: opts.byRoute ?? false, palette: paletteFor(colorOn) }));
+    }
+```
+
+- [ ] **Step 5: Add the `--no-color` flag and fix the tagline in `bin.ts`**
+
+In `packages/cli/src/bin.ts`:
+
+- Add `'no-color'` to the `boolean` array in the `mri` call.
+- After computing `minHealth`, pass it through: change `const code = await run({ ...options, minHealth });` to `const code = await run({ ...options, minHealth, noColor: argv['no-color'] });`.
+- In `HELP`, add a line under Options: `  --no-color                  Disable ANSI color in console output`.
+- Change the first HELP line from `svelte-vitals — a SvelteKit SEO checker (static mode)` to:
+  `svelte-vitals — a deterministic SvelteKit code-health scanner (SEO · performance · correctness · security · architecture)`
+
+  (If `resolveArgs`/`resolve-args.ts` validates/whitelists known flags, add `no-color` there too so it isn't reported as unknown. Check `resolve-args.ts`; if it passes `argv` through untouched, no change is needed.)
+
+- [ ] **Step 6: Run tests + typecheck**
+
+Run: `pnpm --filter svelte-vitals test color`
+Expected: PASS.
+Run: `pnpm --filter @svelte-vitals/core build && pnpm --filter svelte-vitals typecheck`
+Expected: no errors (core rebuilt first — cli imports the new `Palette`/`noColorPalette` from core's dist).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/cli/src/color.ts packages/cli/src/index.ts packages/cli/src/bin.ts packages/cli/test/color.test.ts
+git commit -m "feat(cli): colorize console output (gated on TTY/NO_COLOR); --no-color; fix tagline"
+```
+
+---
+
+### Task 3: Analysis spinner
+
+**Files:**
+- Create: `packages/cli/src/spinner.ts`
+- Modify: `packages/cli/src/index.ts` (wrap the analysis phase)
+- Test: `packages/cli/test/spinner.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `colorEnabled` (Task 2) for gating.
+- Produces: `startSpinner(text, opts): Spinner`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/cli/test/spinner.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { startSpinner } from '../src/spinner.js';
+
+function fakeStream() {
+  const writes: string[] = [];
+  return { writes, stream: { write: (s: string) => writes.push(s) } as unknown as NodeJS.WriteStream };
+}
+
+describe('startSpinner', () => {
+  it('writes nothing when disabled and returns a working stop()', () => {
+    const { writes, stream } = fakeStream();
+    const spin = startSpinner('Analyzing…', { enabled: false, stream });
+    spin.stop();
+    expect(writes).toEqual([]);
+  });
+  it('writes a frame immediately when enabled and clears on stop', () => {
+    const { writes, stream } = fakeStream();
+    const spin = startSpinner('Analyzing…', { enabled: true, stream });
+    expect(writes.length).toBeGreaterThan(0);
+    expect(writes[0]).toContain('Analyzing…');
+    spin.stop();
+    expect(writes[writes.length - 1]).toContain('\x1b[K'); // clears the line
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter svelte-vitals test spinner`
+Expected: FAIL — `../src/spinner.js` does not exist.
+
+- [ ] **Step 3: Create `spinner.ts`**
+
+Create `packages/cli/src/spinner.ts`:
+
+```ts
+const FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+export interface Spinner {
+  stop(): void;
+}
+
+/** A minimal stderr spinner. When `enabled` is false it is a no-op. */
+export function startSpinner(text: string, opts: { enabled: boolean; stream?: NodeJS.WriteStream }): Spinner {
+  const stream = opts.stream ?? process.stderr;
+  if (!opts.enabled) return { stop() {} };
+  let i = 0;
+  const tick = (): void => {
+    stream.write(`\r${FRAMES[i % FRAMES.length]} ${text}`);
+    i++;
+  };
+  tick();
+  const timer = setInterval(tick, 80);
+  if (typeof timer.unref === 'function') timer.unref();
+  return {
+    stop() {
+      clearInterval(timer);
+      stream.write('\r\x1b[K');
+    }
+  };
+}
+```
+
+- [ ] **Step 4: Wrap the analysis phase in `run()`**
+
+In `packages/cli/src/index.ts`, `run()` currently resolves the reporter *after* `analyzeProject`. To gate the spinner (which runs *during* analysis) we resolve `env`/`reporter` up front.
+
+Immediately after the `minHealth` validation block and before `let analysis: AnalyzeResult;`, add:
+
+```ts
+  const env = opts.env ?? process.env;
+  const reporter = resolveReporter(opts.reporter, env);
+  const spinnerEnabled =
+    reporter === 'console' &&
+    !isAutoDetectedAgent(opts.reporter, env) &&
+    colorEnabled({
+      reporter,
+      isTTY: opts.stderrIsTTY ?? !!process.stderr.isTTY,
+      env,
+      noColorFlag: opts.noColor
+    });
+  const spinner = startSpinner('Analyzing…', { enabled: spinnerEnabled });
+```
+
+Add the import at the top: `import { startSpinner } from './spinner.js';`
+
+In the analyze `try { … } catch (err) { … }` block, stop the spinner on both paths: add `spinner.stop();` as the **first line** of the `catch (err) {` block, and add `spinner.stop();` on the line **immediately after** the analyze `try/catch` (before `try { const { config, version } = analysis; …`).
+
+Then, in the output section, the existing `const env = opts.env ?? process.env;` and `const reporter = resolveReporter(opts.reporter, env);` lines are now **duplicates** — delete those two lines (the hoisted `env`/`reporter` are in scope). The `isAutoDetectedAgent`/`isAutoDetectedGithub` warning emissions and everything else stay unchanged.
+
+- [ ] **Step 5: Run tests + typecheck**
+
+Run: `pnpm --filter svelte-vitals test spinner`
+Expected: PASS.
+Run: `pnpm --filter svelte-vitals typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/cli/src/spinner.ts packages/cli/src/index.ts packages/cli/test/spinner.test.ts
+git commit -m "feat(cli): stderr 'Analyzing…' spinner during static analysis (TTY-gated)"
+```
+
+---
+
+### Task 4: Changeset + full verification
+
+**Files:**
+- Create: `.changeset/cli-rich-console.md`
+
+- [ ] **Step 1: Write the changeset**
+
+Create `.changeset/cli-rich-console.md`:
+
+```md
+---
+'@svelte-vitals/core': minor
+'svelte-vitals': minor
+---
+
+Rich console output: the default `console` reporter now colorizes the Health/category
+scores, severity sections, and pass/fail markers, and shows an "Analyzing…" spinner
+during the scan. All of it auto-disables under `NO_COLOR`, a non-TTY stdout, a
+non-`console` reporter, or `--no-color` (and honors `FORCE_COLOR`). Color is an
+injected `Palette` (identity by default), so `@svelte-vitals/core` stays
+dependency-free and other reporters are unchanged.
+```
+
+- [ ] **Step 2: Full verification**
+
+Run:
+```bash
+pnpm -r build && pnpm -r test && pnpm -r typecheck && pnpm lint && pnpm --filter docs build
+```
+Expected: all green. Core test count rises by 3 (`console-palette`); cli by ~8 (`color` + `spinner`).
+
+- [ ] **Step 3: If lint reports formatting, fix and re-run**
+
+Run: `pnpm exec prettier --write . && pnpm lint`
+Expected: clean.
+
+- [ ] **Step 4: Manual smoke check (optional, informative)**
+
+Run: `node packages/cli/dist/bin.js --help` (confirm the new tagline + `--no-color`).
+Run the CLI against a fixture with a TTY to eyeball colors; `NO_COLOR=1 …` and `… | cat` to confirm color/spinner disappear. (Informational; not a gating test.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "docs: changeset for rich console output"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Palette injection, identity default, `scoreColor` thresholds → Task 1. ✓
+- Color applied to health/category/severity/markers/dividers → Task 1 Step 4. ✓
+- CLI ANSI palette + `colorEnabled` gating (TTY/NO_COLOR/FORCE_COLOR/reporter/--no-color) → Task 2. ✓
+- `--no-color` flag + tagline fix → Task 2 Step 5. ✓
+- stderr spinner, gated, `setInterval` (no Date.now), stop on all paths → Task 3. ✓
+- core stays dep-free (color injected; ANSI only in CLI) → Tasks 1-2. ✓
+- No existing assertion loosened (identity default) → Task 1 Step 6. ✓
+- Changeset (core + cli minor) → Task 4. ✓
+- Out of scope (install wizard = sub-project B; themes; truecolor) → not planned. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code. ✓
+
+**Type consistency:** `Palette` defined in Task 1, imported by Task 2's `color.ts`. `colorEnabled` signature identical in Task 2 def, its test, and Task 3's spinner gating. `paletteFor`/`ansiPalette`/`noColorPalette` consistent. `RunOptions.noColor`/`stdoutIsTTY`/`stderrIsTTY` added in Task 2/3 and consumed in the console branch/spinner gating. ✓

--- a/docs/superpowers/plans/2026-07-03-cli-rich-console-output.md
+++ b/docs/superpowers/plans/2026-07-03-cli-rich-console-output.md
@@ -40,12 +40,14 @@
 ### Task 1: Core palette injection
 
 **Files:**
+
 - Create: `packages/core/src/reporter/palette.ts`
 - Modify: `packages/core/src/reporter/console.ts`
 - Modify: `packages/core/src/index.ts`
 - Test: `packages/core/test/console-palette.test.ts` (create)
 
 **Interfaces:**
+
 - Produces: `interface Palette`, `const noColorPalette: Palette`, `function scoreColor(p, score)`; `ConsoleReportOptions.palette?`.
 - Consumes: nothing new.
 
@@ -195,54 +197,54 @@ function byRouteTree(p: Palette, results: Result[], config: Config): string[] {
 In `formatConsoleReport`, add `const p = options.palette ?? noColorPalette;` at the top, then color the header/sections. Replace the header + section-title + marker construction so it reads:
 
 ```ts
-  const p = options.palette ?? noColorPalette;
-  const summary = summarize(results, config);
-  const { health, categories: byCat } = computeHealth(results, config);
-  const present = CATEGORY_ORDER.filter((c) => byCat[c] !== undefined);
-  const header: string[] = [
-    p.bold(`Svelte Vitals  ·  ${options.mode ?? 'static mode'}`),
-    '',
-    `${p.bold('Health:')} ${scoreColor(p, health)(`${health}/100`)}`
-  ];
-  for (const c of present) {
-    header.push(scoreLine(p, CATEGORY_LABEL[c] ?? c, byCat[c]!));
+const p = options.palette ?? noColorPalette;
+const summary = summarize(results, config);
+const { health, categories: byCat } = computeHealth(results, config);
+const present = CATEGORY_ORDER.filter((c) => byCat[c] !== undefined);
+const header: string[] = [
+  p.bold(`Svelte Vitals  ·  ${options.mode ?? 'static mode'}`),
+  '',
+  `${p.bold('Health:')} ${scoreColor(p, health)(`${health}/100`)}`
+];
+for (const c of present) {
+  header.push(scoreLine(p, CATEGORY_LABEL[c] ?? c, byCat[c]!));
+}
+const lines: string[] = [...header, ''];
+
+const SEVERITY_COLOR: Record<Severity, (s: string) => string> = {
+  critical: (s) => p.red(p.bold(s)),
+  warning: (s) => p.yellow(p.bold(s)),
+  info: (s) => p.dim(s)
+};
+
+const failures = results.filter((r) => classify(r, config) === 'fail');
+for (const severity of ['critical', 'warning', 'info'] as const) {
+  const bucket = failures.filter((r) => effectiveSeverity(r, config) === severity);
+  if (bucket.length === 0) continue;
+  lines.push(SEVERITY_COLOR[severity](`${SEVERITY_TITLE[severity]} (${bucket.length})`), p.dim(RULE));
+  for (const r of bucket) {
+    lines.push(`${p.red('✗')} ${r.id}  ${r.message}`);
+    if (r.route) lines.push(p.dim(`            ${r.route}`));
+    if (r.location) lines.push(p.dim(`            ${r.location}${r.line ? `:${r.line}` : ''}`));
   }
-  const lines: string[] = [...header, ''];
+  lines.push('');
+}
 
-  const SEVERITY_COLOR: Record<Severity, (s: string) => string> = {
-    critical: (s) => p.red(p.bold(s)),
-    warning: (s) => p.yellow(p.bold(s)),
-    info: (s) => p.dim(s)
-  };
-
-  const failures = results.filter((r) => classify(r, config) === 'fail');
-  for (const severity of ['critical', 'warning', 'info'] as const) {
-    const bucket = failures.filter((r) => effectiveSeverity(r, config) === severity);
-    if (bucket.length === 0) continue;
-    lines.push(SEVERITY_COLOR[severity](`${SEVERITY_TITLE[severity]} (${bucket.length})`), p.dim(RULE));
-    for (const r of bucket) {
-      lines.push(`${p.red('✗')} ${r.id}  ${r.message}`);
-      if (r.route) lines.push(p.dim(`            ${r.route}`));
-      if (r.location) lines.push(p.dim(`            ${r.location}${r.line ? `:${r.line}` : ''}`));
-    }
-    lines.push('');
+const passed = results.filter((r) => classify(r, config) !== 'fail');
+if (passed.length > 0) {
+  lines.push(p.bold(`Passed (${passed.length})`), p.dim(RULE));
+  for (const r of passed) {
+    const marker = classify(r, config) === 'dynamic' ? p.cyan('  ↯ dynamic') : '';
+    const route = r.route ? `  ${r.route}` : '';
+    lines.push(`${p.green('✓')} ${r.id}  ${r.message}${marker}${route}`);
   }
+  lines.push('');
+}
 
-  const passed = results.filter((r) => classify(r, config) !== 'fail');
-  if (passed.length > 0) {
-    lines.push(p.bold(`Passed (${passed.length})`), p.dim(RULE));
-    for (const r of passed) {
-      const marker = classify(r, config) === 'dynamic' ? p.cyan('  ↯ dynamic') : '';
-      const route = r.route ? `  ${r.route}` : '';
-      lines.push(`${p.green('✓')} ${r.id}  ${r.message}${marker}${route}`);
-    }
-    lines.push('');
-  }
+if (options.byRoute) lines.push(...byRouteTree(p, results, config));
+if (summary.dynamic > 0) lines.push(p.dim('↯ = set dynamically (verified at runtime).'));
 
-  if (options.byRoute) lines.push(...byRouteTree(p, results, config));
-  if (summary.dynamic > 0) lines.push(p.dim('↯ = set dynamically (verified at runtime).'));
-
-  return lines.join('\n').replace(/\n+$/, '\n');
+return lines.join('\n').replace(/\n+$/, '\n');
 ```
 
 (The `SEVERITY_TITLE`, `CATEGORY_LABEL`, `CATEGORY_ORDER`, `RULE` constants and the early `import` lines are unchanged.)
@@ -275,12 +277,14 @@ git commit -m "feat(core): inject a Palette into the console reporter (identity 
 ### Task 2: CLI color palette + `--no-color` + tagline
 
 **Files:**
+
 - Create: `packages/cli/src/color.ts`
 - Modify: `packages/cli/src/index.ts` (`RunOptions`; hoist reporter/env; console branch)
 - Modify: `packages/cli/src/bin.ts` (`--no-color` flag; help)
 - Test: `packages/cli/test/color.test.ts` (create)
 
 **Interfaces:**
+
 - Consumes: `Palette`, `noColorPalette` from `@svelte-vitals/core` (Task 1); `resolveReporter` (existing).
 - Produces: `ansiPalette`, `colorEnabled(opts)`, `paletteFor(enabled)`; `RunOptions.noColor?`, `RunOptions.stdoutIsTTY?`.
 
@@ -442,11 +446,13 @@ git commit -m "feat(cli): colorize console output (gated on TTY/NO_COLOR); --no-
 ### Task 3: Analysis spinner
 
 **Files:**
+
 - Create: `packages/cli/src/spinner.ts`
 - Modify: `packages/cli/src/index.ts` (wrap the analysis phase)
 - Test: `packages/cli/test/spinner.test.ts` (create)
 
 **Interfaces:**
+
 - Consumes: `colorEnabled` (Task 2) for gating.
 - Produces: `startSpinner(text, opts): Spinner`.
 
@@ -520,23 +526,23 @@ export function startSpinner(text: string, opts: { enabled: boolean; stream?: No
 
 - [ ] **Step 4: Wrap the analysis phase in `run()`**
 
-In `packages/cli/src/index.ts`, `run()` currently resolves the reporter *after* `analyzeProject`. To gate the spinner (which runs *during* analysis) we resolve `env`/`reporter` up front.
+In `packages/cli/src/index.ts`, `run()` currently resolves the reporter _after_ `analyzeProject`. To gate the spinner (which runs _during_ analysis) we resolve `env`/`reporter` up front.
 
 Immediately after the `minHealth` validation block and before `let analysis: AnalyzeResult;`, add:
 
 ```ts
-  const env = opts.env ?? process.env;
-  const reporter = resolveReporter(opts.reporter, env);
-  const spinnerEnabled =
-    reporter === 'console' &&
-    !isAutoDetectedAgent(opts.reporter, env) &&
-    colorEnabled({
-      reporter,
-      isTTY: opts.stderrIsTTY ?? !!process.stderr.isTTY,
-      env,
-      noColorFlag: opts.noColor
-    });
-  const spinner = startSpinner('Analyzing…', { enabled: spinnerEnabled });
+const env = opts.env ?? process.env;
+const reporter = resolveReporter(opts.reporter, env);
+const spinnerEnabled =
+  reporter === 'console' &&
+  !isAutoDetectedAgent(opts.reporter, env) &&
+  colorEnabled({
+    reporter,
+    isTTY: opts.stderrIsTTY ?? !!process.stderr.isTTY,
+    env,
+    noColorFlag: opts.noColor
+  });
+const spinner = startSpinner('Analyzing…', { enabled: spinnerEnabled });
 ```
 
 Add the import at the top: `import { startSpinner } from './spinner.js';`
@@ -564,6 +570,7 @@ git commit -m "feat(cli): stderr 'Analyzing…' spinner during static analysis (
 ### Task 4: Changeset + full verification
 
 **Files:**
+
 - Create: `.changeset/cli-rich-console.md`
 
 - [ ] **Step 1: Write the changeset**
@@ -587,9 +594,11 @@ dependency-free and other reporters are unchanged.
 - [ ] **Step 2: Full verification**
 
 Run:
+
 ```bash
 pnpm -r build && pnpm -r test && pnpm -r typecheck && pnpm lint && pnpm --filter docs build
 ```
+
 Expected: all green. Core test count rises by 3 (`console-palette`); cli by ~8 (`color` + `spinner`).
 
 - [ ] **Step 3: If lint reports formatting, fix and re-run**
@@ -614,6 +623,7 @@ git commit -m "docs: changeset for rich console output"
 ## Self-Review
 
 **Spec coverage:**
+
 - Palette injection, identity default, `scoreColor` thresholds → Task 1. ✓
 - Color applied to health/category/severity/markers/dividers → Task 1 Step 4. ✓
 - CLI ANSI palette + `colorEnabled` gating (TTY/NO_COLOR/FORCE_COLOR/reporter/--no-color) → Task 2. ✓

--- a/docs/superpowers/specs/2026-07-03-cli-rich-console-output-design.md
+++ b/docs/superpowers/specs/2026-07-03-cli-rich-console-output-design.md
@@ -88,7 +88,10 @@ New `packages/cli/src/color.ts` (hand-rolled ANSI, no dep):
 ```ts
 import { noColorPalette, type Palette } from '@svelte-vitals/core';
 
-const wrap = (open: number, close = 0) => (s: string) => `\x1b[${open}m${s}\x1b[${close}m`;
+const wrap =
+  (open: number, close = 0) =>
+  (s: string) =>
+    `\x1b[${open}m${s}\x1b[${close}m`;
 const ansiPalette: Palette = {
   bold: wrap(1, 22),
   dim: wrap(2, 22),
@@ -164,7 +167,7 @@ Enable only when: `reporter === 'console'` AND `process.stderr.isTTY` AND color 
 
 ## Testing
 
-- **core** (`console` reporter): existing tests unchanged (identity default). New: with a **marker palette** (e.g. `bold: s => `[b]${s}[/b]``, `red: s => `[r]${s}[/r]``), assert the Health number, `Critical` title, and `✗` carry the expected markers; `scoreColor` returns green/yellow/red fn at 90/70 boundaries.
+- **core** (`console` reporter): existing tests unchanged (identity default). New: with a **marker palette** (e.g. `bold: s => `[b]${s}[/b]``, `red: s => `[r]${s}[/r]``), assert the Health number, `Critical`title, and`✗`carry the expected markers;`scoreColor` returns green/yellow/red fn at 90/70 boundaries.
 - **cli**: `colorEnabled` truth table — `--no-color` off; `NO_COLOR` off; `FORCE_COLOR` on; console+TTY on; non-TTY off; non-console reporter off. `startSpinner({enabled:false})` writes nothing and returns a working `stop()`; enabled writes frames to the injected stream and `stop()` clears.
 - Full suite + typecheck + lint + `docs build` green; no assertions loosened.
 

--- a/docs/superpowers/specs/2026-07-03-cli-rich-console-output-design.md
+++ b/docs/superpowers/specs/2026-07-03-cli-rich-console-output-design.md
@@ -1,0 +1,175 @@
+# CLI rich console output (colors + hierarchy + spinner)
+
+**Date:** 2026-07-03
+**Status:** Draft — awaiting review (author away mid-brainstorm; sensible defaults chosen, flagged below)
+**Packages:** `@svelte-vitals/core` (console reporter — palette injection), `@svelte-vitals/cli` (real palette, gating, spinner, flags)
+
+## Context
+
+Sub-project **A** of "catch up to [react.doctor](https://www.react.doctor/)'s interactive & rich CLI." svelte-vitals already matches react.doctor on features (0–100 Health score; SEO/Performance/Correctness/Security/Architecture categories; `--diff`/`--staged`/`--min-health`/`--rules`/`--ignore`; json/github/sarif/agent reporters; MCP; rule docs). The real gaps are UX:
+
+- **A (this spec): rich console output** — the console reporter is currently plain text (no ANSI color, no visual hierarchy, no progress indicator).
+- **B (next sub-project): interactive `init`/`install` wizard** — agent (Claude Code/Cursor/Codex) + MCP setup. Separate spec.
+
+The user chose "both, A → B order"; this spec covers A only.
+
+## Goal
+
+Make the default `--reporter console` output visually rich — severity/score/category **colors**, a clearer **visual hierarchy**, and an **"Analyzing…" spinner** during the scan — while (1) keeping `@svelte-vitals/core` **pure and dependency-free**, (2) auto-disabling all of it under non-TTY / `NO_COLOR` / non-console reporters / CI-agent, and (3) not loosening any existing test.
+
+## Open decisions (chosen by best-judgment; adjust at review)
+
+1. **Scope = color + hierarchy + spinner** (the fullest "rich"). The spinner is the most separable piece — if undesired, drop §4 and its tests; the rest stands alone.
+2. **No new dependency** — hand-roll a tiny ANSI helper and spinner in the CLI (the repo is dep-minimal: core is dep-free, CLI uses only `mri`). Alternative: `picocolors` (0-dep, battle-tested TTY/NO_COLOR handling) — swap in if preferred.
+
+## Design
+
+### 1. Palette injection (keeps core pure & dep-free)
+
+Color must not make the core reporter impure or dependency-bearing. Inject a **palette** of string→string functions; default to identity.
+
+New `packages/core/src/reporter/palette.ts`:
+
+```ts
+/** String decorators for the console reporter. Injected so core stays pure/dep-free. */
+export interface Palette {
+  bold: (s: string) => string;
+  dim: (s: string) => string;
+  red: (s: string) => string;
+  yellow: (s: string) => string;
+  green: (s: string) => string;
+  cyan: (s: string) => string;
+}
+
+/** Default: no decoration (identity) — output is byte-identical to today. */
+export const noColorPalette: Palette = {
+  bold: (s) => s,
+  dim: (s) => s,
+  red: (s) => s,
+  yellow: (s) => s,
+  green: (s) => s,
+  cyan: (s) => s
+};
+
+/** Green ≥ 90, yellow ≥ 70, red otherwise — for a 0–100 score. */
+export function scoreColor(p: Palette, score: number): (s: string) => string {
+  if (score >= 90) return p.green;
+  if (score >= 70) return p.yellow;
+  return p.red;
+}
+```
+
+`formatConsoleReport` (in `console.ts`) gains one option:
+
+```ts
+export interface ConsoleReportOptions {
+  byRoute?: boolean;
+  mode?: string;
+  palette?: Palette; // default noColorPalette
+}
+```
+
+Apply the palette at these spots (all via `const p = options.palette ?? noColorPalette`):
+
+- Header `Svelte Vitals · <mode>` → `p.bold`.
+- `Health: N/100` → the number via `scoreColor(p, health)`, label `p.bold`.
+- Each category `… Score: N/100` → the number via `scoreColor(p, score)`.
+- Severity section titles: `Critical (n)` → `p.red`+`p.bold`; `Warnings (n)` → `p.yellow`+`p.bold`; `Info (n)` → `p.dim`.
+- Finding marker `✗` → `p.red`; passed `✓` → `p.green`; `↯ dynamic` → `p.cyan`.
+- `RULE` dividers and the `location`/`route` sub-lines → `p.dim`.
+- `by-route` tree: score via `scoreColor`, `✗` red.
+
+Because the default is identity, **every existing console test stays green unchanged** (they call `formatConsoleReport` without a palette).
+
+### 2. CLI real palette + gating
+
+New `packages/cli/src/color.ts` (hand-rolled ANSI, no dep):
+
+```ts
+import { noColorPalette, type Palette } from '@svelte-vitals/core';
+
+const wrap = (open: number, close = 0) => (s: string) => `\x1b[${open}m${s}\x1b[${close}m`;
+const ansiPalette: Palette = {
+  bold: wrap(1, 22),
+  dim: wrap(2, 22),
+  red: wrap(31, 39),
+  yellow: wrap(33, 39),
+  green: wrap(32, 39),
+  cyan: wrap(36, 39)
+};
+
+/** Decide whether ANSI color is enabled, following the de-facto env conventions. */
+export function colorEnabled(opts: {
+  reporter: string;
+  isTTY: boolean;
+  env: NodeJS.ProcessEnv;
+  noColorFlag?: boolean;
+}): boolean {
+  if (opts.noColorFlag) return false;
+  if (opts.env.NO_COLOR !== undefined && opts.env.NO_COLOR !== '') return false;
+  if (opts.env.FORCE_COLOR !== undefined && opts.env.FORCE_COLOR !== '' && opts.env.FORCE_COLOR !== '0') return true;
+  return opts.reporter === 'console' && opts.isTTY;
+}
+
+export const paletteFor = (enabled: boolean): Palette => (enabled ? ansiPalette : noColorPalette);
+```
+
+`Palette`, `noColorPalette`, `scoreColor` are re-exported from `@svelte-vitals/core`'s index.
+
+`run()` (in `packages/cli/src/index.ts`), console branch: compute `enabled = colorEnabled({ reporter, isTTY: !!process.stdout.isTTY, env, noColorFlag: opts.noColor })` and pass `{ byRoute, palette: paletteFor(enabled) }` to `formatConsoleReport`. Add `noColor?: boolean` to `RunOptions` (and a `stdoutIsTTY?: boolean` override for tests, mirroring the existing `env` override).
+
+### 3. `--no-color` flag + help tagline
+
+In `bin.ts`:
+
+- Add `no-color` to the boolean flags; pass `noColor: argv['no-color']` into `run`.
+- Document `--no-color` in help.
+- Fix the stale tagline: `svelte-vitals — a SvelteKit SEO checker (static mode)` → `svelte-vitals — a deterministic SvelteKit code-health scanner (SEO · performance · correctness · security · architecture)`.
+
+### 4. Spinner (separable)
+
+New `packages/cli/src/spinner.ts` (hand-rolled, writes to **stderr** so stdout/piped output stays clean):
+
+```ts
+const FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+export interface Spinner {
+  stop(): void;
+}
+
+/** A minimal stderr spinner. No-op (returns a stop()) when not enabled. */
+export function startSpinner(text: string, opts: { enabled: boolean; stream?: NodeJS.WriteStream }): Spinner {
+  const stream = opts.stream ?? process.stderr;
+  if (!opts.enabled) return { stop() {} };
+  let i = 0;
+  const tick = () => stream.write(`\r${FRAMES[i++ % FRAMES.length]} ${text}`);
+  tick();
+  const timer = setInterval(tick, 80);
+  return {
+    stop() {
+      clearInterval(timer);
+      stream.write('\r\x1b[K'); // clear the line
+    }
+  };
+}
+```
+
+Enable only when: `reporter === 'console'` AND `process.stderr.isTTY` AND color is enabled (same env gating) AND not an auto-detected agent env. In `run()`, wrap the analysis phase: `const spin = startSpinner('Analyzing…', { enabled }); try { …collect+check… } finally { spin.stop(); }`, stopping before any output is printed. Note: `Date.now()`-free (uses `setInterval`); no timestamps.
+
+### 5. Non-goals for this spec
+
+- No change to json/agent/sarif/github/html reporters (they never get a palette or spinner).
+- No box-drawing/table layout rework beyond the existing line structure (YAGNI).
+- The `init`/`install` wizard is sub-project **B** (separate spec).
+
+## Testing
+
+- **core** (`console` reporter): existing tests unchanged (identity default). New: with a **marker palette** (e.g. `bold: s => `[b]${s}[/b]``, `red: s => `[r]${s}[/r]``), assert the Health number, `Critical` title, and `✗` carry the expected markers; `scoreColor` returns green/yellow/red fn at 90/70 boundaries.
+- **cli**: `colorEnabled` truth table — `--no-color` off; `NO_COLOR` off; `FORCE_COLOR` on; console+TTY on; non-TTY off; non-console reporter off. `startSpinner({enabled:false})` writes nothing and returns a working `stop()`; enabled writes frames to the injected stream and `stop()` clears.
+- Full suite + typecheck + lint + `docs build` green; no assertions loosened.
+
+## Out of scope (YAGNI / deferred)
+
+- Sub-project **B**: interactive `init`/`install` wizard (agent + MCP setup).
+- Configurable color themes; 256-color/truecolor; hyperlink escapes (OSC 8).
+- A watch/TUI mode (the vite live UI already covers browser-based live viewing).

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -4,7 +4,7 @@ import { run } from './index.js';
 import { readPackageVersion } from './version.js';
 import { resolveArgs } from './resolve-args.js';
 
-const HELP = `svelte-vitals — a SvelteKit SEO checker (static mode)
+const HELP = `svelte-vitals — a deterministic SvelteKit code-health scanner (SEO · performance · correctness · security · architecture)
 
 Usage:
   svelte-vitals [path] [options]
@@ -24,6 +24,7 @@ Options:
   --min-health <0-100>        Fail (exit 1) when the combined Health score is below this value
   --rules <ids>               Comma-separated rule ids to enable (all others disabled)
   --ignore <ids>              Comma-separated rule ids to disable
+  --no-color                  Disable ANSI color in console output
   -h, --help                  Show this help
   -v, --version               Show version
 
@@ -37,7 +38,7 @@ const VERSION = readPackageVersion();
 async function main(): Promise<void> {
   const argv = mri(process.argv.slice(2), {
     alias: { h: 'help', v: 'version' },
-    boolean: ['by-route', 'json', 'fail-on-warning', 'staged'],
+    boolean: ['by-route', 'json', 'fail-on-warning', 'staged', 'no-color'],
     string: [
       'meta-components',
       'treat-dynamic-as',
@@ -77,7 +78,7 @@ async function main(): Promise<void> {
     minHealth = n;
   }
 
-  const code = await run({ ...options, minHealth });
+  const code = await run({ ...options, minHealth, noColor: argv['no-color'] });
   process.exit(code);
 }
 

--- a/packages/cli/src/color.ts
+++ b/packages/cli/src/color.ts
@@ -1,0 +1,32 @@
+import { noColorPalette, type Palette } from '@svelte-vitals/core';
+
+const wrap =
+  (open: number, close = 0) =>
+  (s: string): string =>
+    `\x1b[${open}m${s}\x1b[${close}m`;
+
+/** Hand-rolled ANSI palette (no dependency). */
+export const ansiPalette: Palette = {
+  bold: wrap(1, 22),
+  dim: wrap(2, 22),
+  red: wrap(31, 39),
+  yellow: wrap(33, 39),
+  green: wrap(32, 39),
+  cyan: wrap(36, 39)
+};
+
+/** Whether ANSI color is enabled, following the de-facto env conventions. */
+export function colorEnabled(opts: {
+  reporter: string;
+  isTTY: boolean;
+  env: NodeJS.ProcessEnv;
+  noColorFlag?: boolean;
+}): boolean {
+  if (opts.noColorFlag) return false;
+  if (opts.env.NO_COLOR !== undefined && opts.env.NO_COLOR !== '') return false;
+  const fc = opts.env.FORCE_COLOR;
+  if (fc !== undefined && fc !== '' && fc !== '0') return true;
+  return opts.reporter === 'console' && opts.isTTY;
+}
+
+export const paletteFor = (enabled: boolean): Palette => (enabled ? ansiPalette : noColorPalette);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -27,6 +27,7 @@ import { detectProject, ProjectError, collectProjectFacts } from './providers/so
 import { readPackageVersion } from './version.js';
 import { resolveReporter, isAutoDetectedAgent, isAutoDetectedGithub, type ReporterName } from './reporter-resolve.js';
 import { getChangedFiles, filterToChangedFiles } from './changed-files.js';
+import { colorEnabled, paletteFor } from './color.js';
 
 export interface RunOptions {
   cwd?: string;
@@ -52,6 +53,12 @@ export interface RunOptions {
   diffBase?: string;
   /** Report only findings in files staged for commit. Takes precedence over `diffBase`. */
   staged?: boolean;
+  /** Disable ANSI color in console output. */
+  noColor?: boolean;
+  /** Override stdout TTY detection (tests). */
+  stdoutIsTTY?: boolean;
+  /** Override stderr TTY detection (tests). */
+  stderrIsTTY?: boolean;
 }
 
 export function routeMatcher(glob: string | undefined): (route: string) => boolean {
@@ -211,7 +218,13 @@ export async function run(opts: RunOptions = {}): Promise<number> {
         errorLog(`svelte-vitals: wrote report to ${path}`);
       }
     } else {
-      log(formatConsoleReport(results, config, { byRoute: opts.byRoute ?? false }));
+      const colorOn = colorEnabled({
+        reporter,
+        isTTY: opts.stdoutIsTTY ?? !!process.stdout.isTTY,
+        env,
+        noColorFlag: opts.noColor
+      });
+      log(formatConsoleReport(results, config, { byRoute: opts.byRoute ?? false, palette: paletteFor(colorOn) }));
     }
     const summary = summarize(results, config);
     const failBySeverity = hasFailureAtOrAbove(summary, config.failOn);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -62,6 +62,28 @@ export interface RunOptions {
   stderrIsTTY?: boolean;
 }
 
+/**
+ * Whether the "Analyzing…" spinner should run. Unlike color, the spinner animates
+ * with carriage returns and escape codes, so it needs a real interactive stderr —
+ * `FORCE_COLOR` must NOT force it on in a non-TTY stderr (e.g. CI), where `\r` would
+ * clutter the log. So gate on `stderrIsTTY` unconditionally, then reuse the color
+ * gating (NO_COLOR / --no-color / agent env) with that same TTY value.
+ */
+export function spinnerEnabled(opts: {
+  reporter: ReporterName;
+  rawReporter: ReporterName | undefined;
+  stderrIsTTY: boolean;
+  env: NodeJS.ProcessEnv;
+  noColorFlag?: boolean;
+}): boolean {
+  return (
+    opts.reporter === 'console' &&
+    opts.stderrIsTTY &&
+    !isAutoDetectedAgent(opts.rawReporter, opts.env) &&
+    colorEnabled({ reporter: opts.reporter, isTTY: opts.stderrIsTTY, env: opts.env, noColorFlag: opts.noColorFlag })
+  );
+}
+
 export function routeMatcher(glob: string | undefined): (route: string) => boolean {
   if (!glob) return () => true;
   const body = glob
@@ -142,16 +164,15 @@ export async function run(opts: RunOptions = {}): Promise<number> {
 
   const env = opts.env ?? process.env;
   const reporter = resolveReporter(opts.reporter, env);
-  const spinnerEnabled =
-    reporter === 'console' &&
-    !isAutoDetectedAgent(opts.reporter, env) &&
-    colorEnabled({
+  const spinner = startSpinner('Analyzing…', {
+    enabled: spinnerEnabled({
       reporter,
-      isTTY: opts.stderrIsTTY ?? !!process.stderr.isTTY,
+      rawReporter: opts.reporter,
+      stderrIsTTY: opts.stderrIsTTY ?? !!process.stderr.isTTY,
       env,
       noColorFlag: opts.noColor
-    });
-  const spinner = startSpinner('Analyzing…', { enabled: spinnerEnabled });
+    })
+  });
 
   let analysis: AnalyzeResult;
   try {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,6 +28,7 @@ import { readPackageVersion } from './version.js';
 import { resolveReporter, isAutoDetectedAgent, isAutoDetectedGithub, type ReporterName } from './reporter-resolve.js';
 import { getChangedFiles, filterToChangedFiles } from './changed-files.js';
 import { colorEnabled, paletteFor } from './color.js';
+import { startSpinner } from './spinner.js';
 
 export interface RunOptions {
   cwd?: string;
@@ -139,6 +140,19 @@ export async function run(opts: RunOptions = {}): Promise<number> {
     return 2;
   }
 
+  const env = opts.env ?? process.env;
+  const reporter = resolveReporter(opts.reporter, env);
+  const spinnerEnabled =
+    reporter === 'console' &&
+    !isAutoDetectedAgent(opts.reporter, env) &&
+    colorEnabled({
+      reporter,
+      isTTY: opts.stderrIsTTY ?? !!process.stderr.isTTY,
+      env,
+      noColorFlag: opts.noColor
+    });
+  const spinner = startSpinner('Analyzing…', { enabled: spinnerEnabled });
+
   let analysis: AnalyzeResult;
   try {
     analysis = await analyzeProject({
@@ -150,6 +164,7 @@ export async function run(opts: RunOptions = {}): Promise<number> {
       rules: opts.rules
     });
   } catch (err) {
+    spinner.stop();
     if (err instanceof ProjectError) {
       errorLog(err.message);
       return 2;
@@ -157,6 +172,7 @@ export async function run(opts: RunOptions = {}): Promise<number> {
     errorLog(`svelte-vitals: ${err instanceof Error ? err.message : String(err)}`);
     return 2;
   }
+  spinner.stop();
 
   try {
     const { config, version } = analysis;
@@ -177,8 +193,6 @@ export async function run(opts: RunOptions = {}): Promise<number> {
       }
     }
 
-    const env = opts.env ?? process.env;
-    const reporter = resolveReporter(opts.reporter, env);
     if (reporter === 'agent' && isAutoDetectedAgent(opts.reporter, env)) {
       errorLog(
         'svelte-vitals: agent reporter auto-selected (AI-agent env detected); override with --reporter console|json.'

--- a/packages/cli/src/spinner.ts
+++ b/packages/cli/src/spinner.ts
@@ -1,0 +1,25 @@
+const FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
+export interface Spinner {
+  stop(): void;
+}
+
+/** A minimal stderr spinner. When `enabled` is false it is a no-op. */
+export function startSpinner(text: string, opts: { enabled: boolean; stream?: NodeJS.WriteStream }): Spinner {
+  const stream = opts.stream ?? process.stderr;
+  if (!opts.enabled) return { stop() {} };
+  let i = 0;
+  const tick = (): void => {
+    stream.write(`\r${FRAMES[i % FRAMES.length]} ${text}`);
+    i++;
+  };
+  tick();
+  const timer = setInterval(tick, 80);
+  if (typeof timer.unref === 'function') timer.unref();
+  return {
+    stop() {
+      clearInterval(timer);
+      stream.write('\r\x1b[K');
+    }
+  };
+}

--- a/packages/cli/test/color.test.ts
+++ b/packages/cli/test/color.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { colorEnabled, paletteFor, ansiPalette } from '../src/color.js';
+import { spinnerEnabled } from '../src/index.js';
 
 const base = { reporter: 'console', isTTY: true, env: {} as NodeJS.ProcessEnv };
 
@@ -35,5 +36,32 @@ describe('paletteFor', () => {
     expect(paletteFor(true).red('x')).toBe(ansiPalette.red('x'));
     expect(paletteFor(true).red('x')).toContain('\x1b[31m');
     expect(paletteFor(false).red('x')).toBe('x');
+  });
+});
+
+describe('spinnerEnabled', () => {
+  const sbase = {
+    reporter: 'console' as const,
+    rawReporter: undefined,
+    stderrIsTTY: true,
+    env: {} as NodeJS.ProcessEnv
+  };
+  it('is on for a console reporter on an interactive stderr', () => {
+    expect(spinnerEnabled(sbase)).toBe(true);
+  });
+  it('is off when stderr is not a TTY', () => {
+    expect(spinnerEnabled({ ...sbase, stderrIsTTY: false })).toBe(false);
+  });
+  it('is off for a non-console reporter', () => {
+    expect(spinnerEnabled({ ...sbase, reporter: 'json' })).toBe(false);
+  });
+  it('is off with --no-color / NO_COLOR', () => {
+    expect(spinnerEnabled({ ...sbase, noColorFlag: true })).toBe(false);
+    expect(spinnerEnabled({ ...sbase, env: { NO_COLOR: '1' } })).toBe(false);
+  });
+  it('FORCE_COLOR does NOT force the spinner on when stderr is not a TTY', () => {
+    // Regression: color may be forced on for a piped log, but the spinner animates
+    // with \r/escape codes and must stay off in a non-interactive stderr (e.g. CI).
+    expect(spinnerEnabled({ ...sbase, stderrIsTTY: false, env: { FORCE_COLOR: '1' } })).toBe(false);
   });
 });

--- a/packages/cli/test/color.test.ts
+++ b/packages/cli/test/color.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { colorEnabled, paletteFor, ansiPalette } from '../src/color.js';
+
+const base = { reporter: 'console', isTTY: true, env: {} as NodeJS.ProcessEnv };
+
+describe('colorEnabled', () => {
+  it('is on for a console reporter on a TTY', () => {
+    expect(colorEnabled(base)).toBe(true);
+  });
+  it('is off when not a TTY', () => {
+    expect(colorEnabled({ ...base, isTTY: false })).toBe(false);
+  });
+  it('is off for a non-console reporter', () => {
+    expect(colorEnabled({ ...base, reporter: 'json' })).toBe(false);
+  });
+  it('is off when NO_COLOR is set', () => {
+    expect(colorEnabled({ ...base, env: { NO_COLOR: '1' } })).toBe(false);
+  });
+  it('is off with --no-color', () => {
+    expect(colorEnabled({ ...base, noColorFlag: true })).toBe(false);
+  });
+  it('FORCE_COLOR forces on even off-TTY', () => {
+    expect(colorEnabled({ ...base, isTTY: false, env: { FORCE_COLOR: '1' } })).toBe(true);
+  });
+});
+
+describe('paletteFor', () => {
+  it('applies ANSI when enabled, identity when not', () => {
+    expect(paletteFor(true).red('x')).toBe(ansiPalette.red('x'));
+    expect(paletteFor(true).red('x')).toContain('\x1b[31m');
+    expect(paletteFor(false).red('x')).toBe('x');
+  });
+});

--- a/packages/cli/test/color.test.ts
+++ b/packages/cli/test/color.test.ts
@@ -22,6 +22,12 @@ describe('colorEnabled', () => {
   it('FORCE_COLOR forces on even off-TTY', () => {
     expect(colorEnabled({ ...base, isTTY: false, env: { FORCE_COLOR: '1' } })).toBe(true);
   });
+  it('an empty NO_COLOR does not disable', () => {
+    expect(colorEnabled({ ...base, env: { NO_COLOR: '' } })).toBe(true);
+  });
+  it("FORCE_COLOR='0' does not force on", () => {
+    expect(colorEnabled({ ...base, isTTY: false, env: { FORCE_COLOR: '0' } })).toBe(false);
+  });
 });
 
 describe('paletteFor', () => {

--- a/packages/cli/test/spinner.test.ts
+++ b/packages/cli/test/spinner.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { startSpinner } from '../src/spinner.js';
+
+function fakeStream() {
+  const writes: string[] = [];
+  return { writes, stream: { write: (s: string) => writes.push(s) } as unknown as NodeJS.WriteStream };
+}
+
+describe('startSpinner', () => {
+  it('writes nothing when disabled and returns a working stop()', () => {
+    const { writes, stream } = fakeStream();
+    const spin = startSpinner('Analyzing…', { enabled: false, stream });
+    spin.stop();
+    expect(writes).toEqual([]);
+  });
+  it('writes a frame immediately when enabled and clears on stop', () => {
+    const { writes, stream } = fakeStream();
+    const spin = startSpinner('Analyzing…', { enabled: true, stream });
+    expect(writes.length).toBeGreaterThan(0);
+    expect(writes[0]).toContain('Analyzing…');
+    spin.stop();
+    expect(writes[writes.length - 1]).toContain('\x1b[K'); // clears the line
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -89,6 +89,8 @@ export { summarize, classify, hasFailureAtOrAbove, effectiveSeverity } from './s
 
 export type { ConsoleReportOptions } from './reporter/console.js';
 export { formatConsoleReport } from './reporter/console.js';
+export { noColorPalette, scoreColor } from './reporter/palette.js';
+export type { Palette } from './reporter/palette.js';
 export { buildJsonReport, formatJsonReport } from './reporter/json.js';
 export type { JsonReport } from './reporter/json.js';
 export { formatAgentReport } from './reporter/agent.js';

--- a/packages/core/src/reporter/console.ts
+++ b/packages/core/src/reporter/console.ts
@@ -1,6 +1,7 @@
 import type { Category, Config, Result, Severity } from '../types.js';
 import { classify, summarize, effectiveSeverity } from '../summary.js';
 import { computeScore, computeHealth, type ScoreResult } from '../scoring/score.js';
+import { noColorPalette, scoreColor, type Palette } from './palette.js';
 
 const RULE = '────────────────────────';
 const SEVERITY_TITLE: Record<Severity, string> = {
@@ -22,28 +23,30 @@ export interface ConsoleReportOptions {
   byRoute?: boolean;
   /** Mode label shown in the header (default 'static mode'). */
   mode?: string;
+  /** Color decorators; defaults to no color. */
+  palette?: Palette;
 }
 
-function scoreLine(label: string, { score, scoreModel }: ScoreResult): string {
+function scoreLine(p: Palette, label: string, { score, scoreModel }: ScoreResult): string {
   const parts = [`route avg ${scoreModel.routeAverage}`];
   if (scoreModel.sitePenalty > 0) parts.push(`site −${scoreModel.sitePenalty}`);
   if (scoreModel.criticalCap !== null) parts.push(`capped at ${scoreModel.criticalCap}: critical present`);
-  return `${label} Score: ${score}/100   (${parts.join(' · ')})`;
+  return `${label} Score: ${scoreColor(p, score)(`${score}/100`)}   ${p.dim(`(${parts.join(' · ')})`)}`;
 }
 
-function byRouteTree(results: Result[], config: Config): string[] {
+function byRouteTree(p: Palette, results: Result[], config: Config): string[] {
   const routes = new Map<string, Result[]>();
   for (const r of results) {
     if (r.route === undefined) continue;
     if (!routes.has(r.route)) routes.set(r.route, []);
     routes.get(r.route)!.push(r);
   }
-  const lines: string[] = ['By route', RULE];
+  const lines: string[] = [p.bold('By route'), p.dim(RULE)];
   for (const [route, rs] of [...routes.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
     const { score } = computeScore(rs, config, { applyCriticalCap: false });
-    lines.push(`${route.padEnd(28)} ${score}`);
+    lines.push(`${route.padEnd(28)} ${scoreColor(p, score)(`${score}`)}`);
     for (const r of rs.filter((x) => classify(x, config) === 'fail')) {
-      lines.push(`    ✗ ${r.id}  ${r.message}`);
+      lines.push(`    ${p.red('✗')} ${r.id}  ${r.message}`);
     }
   }
   lines.push('');
@@ -56,41 +59,52 @@ function byRouteTree(results: Result[], config: Config): string[] {
  * set, adds a per-route score tree.
  */
 export function formatConsoleReport(results: Result[], config: Config, options: ConsoleReportOptions = {}): string {
+  const p = options.palette ?? noColorPalette;
   const summary = summarize(results, config);
   const { health, categories: byCat } = computeHealth(results, config);
   const present = CATEGORY_ORDER.filter((c) => byCat[c] !== undefined);
-  const header: string[] = [`Svelte Vitals  ·  ${options.mode ?? 'static mode'}`, '', `Health: ${health}/100`];
+  const header: string[] = [
+    p.bold(`Svelte Vitals  ·  ${options.mode ?? 'static mode'}`),
+    '',
+    `${p.bold('Health:')} ${scoreColor(p, health)(`${health}/100`)}`
+  ];
   for (const c of present) {
-    header.push(scoreLine(CATEGORY_LABEL[c] ?? c, byCat[c]!));
+    header.push(scoreLine(p, CATEGORY_LABEL[c] ?? c, byCat[c]!));
   }
   const lines: string[] = [...header, ''];
+
+  const SEVERITY_COLOR: Record<Severity, (s: string) => string> = {
+    critical: (s) => p.red(p.bold(s)),
+    warning: (s) => p.yellow(p.bold(s)),
+    info: (s) => p.dim(s)
+  };
 
   const failures = results.filter((r) => classify(r, config) === 'fail');
   for (const severity of ['critical', 'warning', 'info'] as const) {
     const bucket = failures.filter((r) => effectiveSeverity(r, config) === severity);
     if (bucket.length === 0) continue;
-    lines.push(`${SEVERITY_TITLE[severity]} (${bucket.length})`, RULE);
+    lines.push(SEVERITY_COLOR[severity](`${SEVERITY_TITLE[severity]} (${bucket.length})`), p.dim(RULE));
     for (const r of bucket) {
-      lines.push(`✗ ${r.id}  ${r.message}`);
-      if (r.route) lines.push(`            ${r.route}`);
-      if (r.location) lines.push(`            ${r.location}${r.line ? `:${r.line}` : ''}`);
+      lines.push(`${p.red('✗')} ${r.id}  ${r.message}`);
+      if (r.route) lines.push(p.dim(`            ${r.route}`));
+      if (r.location) lines.push(p.dim(`            ${r.location}${r.line ? `:${r.line}` : ''}`));
     }
     lines.push('');
   }
 
   const passed = results.filter((r) => classify(r, config) !== 'fail');
   if (passed.length > 0) {
-    lines.push(`Passed (${passed.length})`, RULE);
+    lines.push(p.bold(`Passed (${passed.length})`), p.dim(RULE));
     for (const r of passed) {
-      const marker = classify(r, config) === 'dynamic' ? '  ↯ dynamic' : '';
+      const marker = classify(r, config) === 'dynamic' ? p.cyan('  ↯ dynamic') : '';
       const route = r.route ? `  ${r.route}` : '';
-      lines.push(`✓ ${r.id}  ${r.message}${marker}${route}`);
+      lines.push(`${p.green('✓')} ${r.id}  ${r.message}${marker}${route}`);
     }
     lines.push('');
   }
 
-  if (options.byRoute) lines.push(...byRouteTree(results, config));
-  if (summary.dynamic > 0) lines.push('↯ = set dynamically (verified at runtime).');
+  if (options.byRoute) lines.push(...byRouteTree(p, results, config));
+  if (summary.dynamic > 0) lines.push(p.dim('↯ = set dynamically (verified at runtime).'));
 
   return lines.join('\n').replace(/\n+$/, '\n');
 }

--- a/packages/core/src/reporter/palette.ts
+++ b/packages/core/src/reporter/palette.ts
@@ -1,0 +1,26 @@
+/** String decorators for the console reporter. Injected so core stays pure/dep-free. */
+export interface Palette {
+  bold: (s: string) => string;
+  dim: (s: string) => string;
+  red: (s: string) => string;
+  yellow: (s: string) => string;
+  green: (s: string) => string;
+  cyan: (s: string) => string;
+}
+
+/** Default: no decoration (identity) — output is byte-identical to plain text. */
+export const noColorPalette: Palette = {
+  bold: (s) => s,
+  dim: (s) => s,
+  red: (s) => s,
+  yellow: (s) => s,
+  green: (s) => s,
+  cyan: (s) => s
+};
+
+/** Green ≥ 90, yellow ≥ 70, red otherwise — for a 0–100 score. */
+export function scoreColor(p: Palette, score: number): (s: string) => string {
+  if (score >= 90) return p.green;
+  if (score >= 70) return p.yellow;
+  return p.red;
+}

--- a/packages/core/test/console-palette.test.ts
+++ b/packages/core/test/console-palette.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { formatConsoleReport, noColorPalette, scoreColor, type Palette } from '../src/index.js';
+import { defineConfig } from '../src/types.js';
+import type { Result } from '../src/types.js';
+
+const config = defineConfig({});
+// Marker palette: wraps text so we can assert where color is applied.
+const mark: Palette = {
+  bold: (s) => `[b]${s}[/b]`,
+  dim: (s) => `[d]${s}[/d]`,
+  red: (s) => `[r]${s}[/r]`,
+  yellow: (s) => `[y]${s}[/y]`,
+  green: (s) => `[g]${s}[/g]`,
+  cyan: (s) => `[c]${s}[/c]`
+};
+const fail: Result = {
+  id: 'SEO001',
+  category: 'seo',
+  severity: 'critical',
+  detection: { presence: 'none', value: 'absent' },
+  route: '/',
+  message: 'Missing <title>'
+};
+
+describe('console palette', () => {
+  it('is identity by default (output unchanged)', () => {
+    const out = formatConsoleReport([fail], config);
+    expect(out).not.toContain('[');
+    expect(out).toContain('✗ SEO001');
+  });
+  it('applies the palette to markers and severity titles when provided', () => {
+    const out = formatConsoleReport([fail], config, { palette: mark });
+    expect(out).toContain('[r]✗[/r]'); // failure marker red
+    expect(out).toContain('[r]'); // critical title colored
+    expect(out).toContain('[b]'); // header/title bold
+  });
+  it('scoreColor picks green/yellow/red by threshold', () => {
+    expect(scoreColor(mark, 90)('9')).toBe('[g]9[/g]');
+    expect(scoreColor(mark, 70)('7')).toBe('[y]7[/y]');
+    expect(scoreColor(mark, 69)('6')).toBe('[r]6[/r]');
+  });
+});

--- a/packages/core/test/console-palette.test.ts
+++ b/packages/core/test/console-palette.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatConsoleReport, noColorPalette, scoreColor, type Palette } from '../src/index.js';
+import { formatConsoleReport, scoreColor, type Palette } from '../src/index.js';
 import { defineConfig } from '../src/types.js';
 import type { Result } from '../src/types.js';
 


### PR DESCRIPTION
## Summary

This is sub-project **A: rich console output**, part of an ongoing effort to make the CLI more interactive and visually rich. It adds **colors, visual hierarchy, and a spinner** to the default `--reporter console` output.

The feature set (0–100 Health score, per-category scoring, `--diff`/`--staged`/etc., the json/github/sarif/agent reporters, MCP) was already solid — the real gap was UX. This PR covers the console output; the interactive `install`/`init` wizard is a separate follow-up (sub-project B).

## Changes

- **core: Palette injection** (`packages/core/src/reporter/palette.ts`)
  - Adds a `Palette` interface (bold/dim/red/yellow/green/cyan), an identity default `noColorPalette`, and `scoreColor` (green ≥90 / yellow ≥70 / red).
  - `formatConsoleReport` gains a `palette` option, applied to the header, scores, severity titles, ✗/✓ markers, dividers, and the by-route tree.
  - **The default is identity, so every existing console test stays byte-identical** — `@svelte-vitals/core` remains dependency-free.
- **cli: real ANSI palette + gating** (`packages/cli/src/color.ts`)
  - Hand-rolled ANSI palette (no new dependency; the CLI still uses only `mri`).
  - `colorEnabled` precedence: `--no-color` > `NO_COLOR` (non-empty) > `FORCE_COLOR` (non-empty, ≠ '0') > console reporter + stdout TTY.
- **cli: spinner** (`packages/cli/src/spinner.ts`)
  - Renders an "Analyzing…" spinner **to stderr only** during the scan phase, so stdout/piped output stays clean.
  - Uses `setInterval` + `timer.unref()` (no `Date.now()`); no-op when disabled.
- **cli: `--no-color` flag + help tagline fix**
  - Old "a SvelteKit SEO checker (static mode)" → "a deterministic SvelteKit code-health scanner (SEO · performance · correctness · security · architecture)".

## Safety

ANSI and the spinner never corrupt piped/JSON stdout:
- the spinner writes to stderr only,
- color is gated on stdout being a TTY,
- non-console reporters never receive a palette.

## Testing

- Full suite green: core 256 / vite 76 / cli 245 / mcp 9 = **586 tests**.
- New: marker-palette assertions on where color is applied, `scoreColor` boundaries (90/70), the `colorEnabled` truth table (including the `NO_COLOR=''` and `FORCE_COLOR='0'` boundaries), and the spinner's no-op/render/clear behavior.
- lint / typecheck / docs build all green; no existing assertions loosened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
