### PR TITLE
feat(cli): interactive install command for MCP setup (Claude Code / Cursor / Codex)

### DIFF
--- a/.changeset/cli-install-wizard.md
+++ b/.changeset/cli-install-wizard.md
@@ -1,0 +1,9 @@
+---
+'svelte-vitals': minor
+---
+
+Add an interactive `svelte-vitals install` command that sets up the svelte-vitals
+MCP server for Claude Code, Cursor, and Codex. It merges into your existing client
+config without touching other servers, prompts for the clients and scope
+(project/global) interactively, and supports `--client`, `--scope`, `--yes`,
+`--dry-run`, and `--force` for non-interactive use.

--- a/docs/superpowers/plans/2026-07-03-cli-install-wizard.md
+++ b/docs/superpowers/plans/2026-07-03-cli-install-wizard.md
@@ -13,7 +13,7 @@
 - **ESM-only** — tsup emits `format: ['esm']` only; never add `'cjs'` (issue #20).
 - **Node 18+** (`engines.node >= 18`).
 - **New deps go through the pnpm workspace catalog** — add the version range to `catalog:` in `pnpm-workspace.yaml`, then reference `"catalog:"` in `packages/cli/package.json`. (`minimumReleaseAge` is enforced; both libs are long-published.)
-- **No competitor product names** in any artifact (code, comments, docs, changeset, commit messages).
+- **No competitor product names** in any artifact — do not reference competing scanner/analysis tools by name. (The supported MCP clients — Claude Code, Cursor, Codex — are integration targets, not competitors, and are named freely.)
 - **Release via changeset** — this feature ships a `svelte-vitals` **minor** bump. Never publish manually.
 - **Do not loosen any existing test.** Follow TDD; commit after each green step.
 - The MCP entry written for every client is exactly `{ command: 'npx', args: ['-y', '@svelte-vitals/mcp'] }`.

--- a/docs/superpowers/plans/2026-07-03-cli-install-wizard.md
+++ b/docs/superpowers/plans/2026-07-03-cli-install-wizard.md
@@ -888,7 +888,7 @@ Expected: prints `Plan:`, a line containing `Claude Code (project)` and a path e
 Run (real write into a throwaway dir):
 
 ```bash
-D=$(mktemp -d) && node "$PWD/packages/cli/dist/bin.js" install --client cursor --scope project --yes >/tmp/out.txt 2>&1; cd "$D"; cat .cursor/mcp.json; cd - >/dev/null
+D=$(mktemp -d) && cd "$D" && node "$OLDPWD/packages/cli/dist/bin.js" install --client cursor --scope project --yes && cat .cursor/mcp.json
 ```
 
 Expected: `.cursor/mcp.json` contains `mcpServers.svelte-vitals` with `command: "npx"`, `args: ["-y", "@svelte-vitals/mcp"]`.

--- a/docs/superpowers/plans/2026-07-03-cli-install-wizard.md
+++ b/docs/superpowers/plans/2026-07-03-cli-install-wizard.md
@@ -23,10 +23,12 @@
 ### Task 1: Client writer modules
 
 **Files:**
+
 - Create: `packages/cli/src/install/clients.ts`
 - Test: `packages/cli/test/install/clients.test.ts`
 
 **Interfaces:**
+
 - Consumes: nothing (leaf module).
 - Produces: `McpEntry`, `MCP_ENTRY`, `ClientId` (`'claude-code' | 'cursor' | 'codex'`), `Scope` (`'project' | 'global'`), `ClientWriter`, `CLIENTS: ClientWriter[]`, `clientById(id: ClientId): ClientWriter | undefined`.
 
@@ -147,12 +149,14 @@ git commit -m "feat(cli): install — client writer definitions (paths + format)
 ### Task 2: JSON/TOML merge helpers
 
 **Files:**
+
 - Modify: `pnpm-workspace.yaml` (add `smol-toml` to catalog)
 - Modify: `packages/cli/package.json` (add `"smol-toml": "catalog:"` to dependencies)
 - Create: `packages/cli/src/install/merge.ts`
 - Test: `packages/cli/test/install/merge.test.ts`
 
 **Interfaces:**
+
 - Consumes: `McpEntry`, `MCP_ENTRY` from `./clients.js`.
 - Produces: `MergeStatus` (`'created' | 'added' | 'exists' | 'updated'`), `MergeResult` (`{ content: string; status: MergeStatus }`), `mergeJson(existing: string | undefined, entry: McpEntry, force: boolean): MergeResult`, `mergeToml(existing, entry, force): MergeResult`.
 
@@ -161,7 +165,7 @@ git commit -m "feat(cli): install — client writer definitions (paths + format)
 In `pnpm-workspace.yaml`, under `catalog:`, add (keep alphabetical-ish with neighbors):
 
 ```yaml
-  smol-toml: ^1.4.1
+smol-toml: ^1.4.1
 ```
 
 In `packages/cli/package.json` `dependencies`, add:
@@ -283,12 +287,7 @@ function sameEntry(prior: unknown, entry: McpEntry): boolean {
 }
 
 /** Decide the merge status for a table that may already hold a svelte-vitals key. */
-function statusFor(
-  prior: unknown,
-  entry: McpEntry,
-  force: boolean,
-  created: boolean
-): MergeStatus | 'skip' {
+function statusFor(prior: unknown, entry: McpEntry, force: boolean, created: boolean): MergeStatus | 'skip' {
   if (prior !== undefined) {
     if (sameEntry(prior, entry)) return 'exists';
     return force ? 'updated' : 'skip';
@@ -301,9 +300,7 @@ export function mergeJson(existing: string | undefined, entry: McpEntry, force: 
   const created = existing === undefined;
   const root: Record<string, unknown> = created ? {} : (JSON.parse(existing) as Record<string, unknown>);
   const servers =
-    typeof root.mcpServers === 'object' && root.mcpServers !== null
-      ? (root.mcpServers as Record<string, unknown>)
-      : {};
+    typeof root.mcpServers === 'object' && root.mcpServers !== null ? (root.mcpServers as Record<string, unknown>) : {};
   const status = statusFor(servers[SERVER_KEY], entry, force, created);
   if (status === 'exists' || status === 'skip') return { content: existing as string, status: 'exists' };
   servers[SERVER_KEY] = { command: entry.command, args: entry.args };
@@ -346,10 +343,12 @@ git commit -m "feat(cli): install — pure JSON/TOML config merge (adds smol-tom
 ### Task 3: runInstall orchestration
 
 **Files:**
+
 - Create: `packages/cli/src/install/index.ts`
 - Test: `packages/cli/test/install/run.test.ts`
 
 **Interfaces:**
+
 - Consumes: `CLIENTS`, `clientById`, `MCP_ENTRY`, `ClientId`, `ClientWriter`, `Scope` from `./clients.js`; `mergeJson`, `mergeToml`, `MergeStatus` from `./merge.js`.
 - Produces: `InstallIO`, `InstallPrompts`, `InstallFlags`, `runInstall(flags: InstallFlags, io: InstallIO, prompts: InstallPrompts): Promise<number>`.
 
@@ -515,9 +514,7 @@ export async function runInstall(flags: InstallFlags, io: InstallIO, prompts: In
     }
     ids = picked;
   } else {
-    io.errorLog(
-      'svelte-vitals: no TTY; pass --client <claude-code,cursor,codex> to install non-interactively.'
-    );
+    io.errorLog('svelte-vitals: no TTY; pass --client <claude-code,cursor,codex> to install non-interactively.');
     return 2;
   }
 
@@ -604,10 +601,12 @@ git commit -m "feat(cli): install — runInstall orchestration (injected IO + pr
 ### Task 4: Install flag parsing
 
 **Files:**
+
 - Create: `packages/cli/src/install/args.ts`
 - Test: `packages/cli/test/install/args.test.ts`
 
 **Interfaces:**
+
 - Consumes: `ClientId`, `Scope` from `./clients.js`; `InstallFlags` from `./index.js`.
 - Produces: `ResolvedInstallArgs` (`{ flags: InstallFlags | null; warnings: string[]; errors: string[] }`), `resolveInstallArgs(argv: mri.Argv): ResolvedInstallArgs`.
 
@@ -733,6 +732,7 @@ git commit -m "feat(cli): install — pure flag parsing (resolveInstallArgs)"
 ### Task 5: Wire the `install` subcommand into bin.ts
 
 **Files:**
+
 - Modify: `pnpm-workspace.yaml` (add `@clack/prompts` to catalog)
 - Modify: `packages/cli/package.json` (add `"@clack/prompts": "catalog:"`)
 - Create: `packages/cli/src/install/cli.ts` (real IO + clack adapter + `runInstallCli`)
@@ -740,6 +740,7 @@ git commit -m "feat(cli): install — pure flag parsing (resolveInstallArgs)"
 - Create: `.changeset/cli-install-wizard.md`
 
 **Interfaces:**
+
 - Consumes: `runInstall`, `InstallIO`, `InstallPrompts` from `./index.js`; `resolveInstallArgs` from `./args.js`; `ClientId`, `ClientWriter`, `Scope` from `./clients.js`.
 - Produces: `runInstallCli(args: string[]): Promise<number>`.
 
@@ -748,7 +749,7 @@ git commit -m "feat(cli): install — pure flag parsing (resolveInstallArgs)"
 In `pnpm-workspace.yaml` under `catalog:`, add:
 
 ```yaml
-  '@clack/prompts': ^0.11.0
+'@clack/prompts': ^0.11.0
 ```
 
 In `packages/cli/package.json` `dependencies`, add:
@@ -863,11 +864,11 @@ import { runInstallCli } from './install/cli.js';
 Then inside `main()`, as the first statements:
 
 ```ts
-  const rawArgs = process.argv.slice(2);
-  if (rawArgs[0] === 'install') {
-    const code = await runInstallCli(rawArgs.slice(1));
-    process.exit(code);
-  }
+const rawArgs = process.argv.slice(2);
+if (rawArgs[0] === 'install') {
+  const code = await runInstallCli(rawArgs.slice(1));
+  process.exit(code);
+}
 ```
 
 Add a one-line pointer to the top-level `HELP` string. Insert this line into the `Usage:` block (after the `svelte-vitals [path] [options]` line):
@@ -885,9 +886,11 @@ Run: `node packages/cli/dist/bin.js install --client claude-code --scope project
 Expected: prints `Plan:`, a line containing `Claude Code (project)` and a path ending `.mcp.json  [created]`, then `Dry run — no files written.` Exit code 0.
 
 Run (real write into a throwaway dir):
+
 ```bash
 D=$(mktemp -d) && node "$PWD/packages/cli/dist/bin.js" install --client cursor --scope project --yes >/tmp/out.txt 2>&1; cd "$D"; cat .cursor/mcp.json; cd - >/dev/null
 ```
+
 Expected: `.cursor/mcp.json` contains `mcpServers.svelte-vitals` with `command: "npx"`, `args: ["-y", "@svelte-vitals/mcp"]`.
 
 Run (non-TTY guard — should fail cleanly): `node packages/cli/dist/bin.js install </dev/null`
@@ -938,6 +941,7 @@ git commit -m "feat(cli): install subcommand — clack wizard + bin routing + he
 ## Self-Review
 
 **Spec coverage:**
+
 - Command surface & flags (spec §1) → Task 4 (parsing) + Task 5 (routing, help, subcommand).
 - Client writer modules (spec §2) → Task 1.
 - Merge/write safety (spec §3) → Task 2 (pure merge, parse-failure throws) + Task 3 (write via IO).

--- a/docs/superpowers/plans/2026-07-03-cli-install-wizard.md
+++ b/docs/superpowers/plans/2026-07-03-cli-install-wizard.md
@@ -1,0 +1,953 @@
+# CLI Interactive Install Wizard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an interactive `svelte-vitals install` subcommand that wires the svelte-vitals MCP server into Claude Code / Cursor / Codex configs without clobbering existing servers, with flag-driven fallback for non-interactive environments.
+
+**Architecture:** A new `src/install/` module in `packages/cli`. Per-client "writer" definitions (path + format) and pure JSON/TOML merge helpers do the real work and are unit-tested. `runInstall(flags, io, prompts)` orchestrates via injected IO + prompt interfaces so it is testable without real fs or clack. `bin.ts` routes the `install` subcommand to a thin adapter that supplies the real node:fs IO and a `@clack/prompts`-backed prompt implementation.
+
+**Tech Stack:** TypeScript (ESM-only), `mri` (arg parsing), `@clack/prompts` (interactive prompts), `smol-toml` (TOML parse/stringify), `vitest`.
+
+## Global Constraints
+
+- **ESM-only** — tsup emits `format: ['esm']` only; never add `'cjs'` (issue #20).
+- **Node 18+** (`engines.node >= 18`).
+- **New deps go through the pnpm workspace catalog** — add the version range to `catalog:` in `pnpm-workspace.yaml`, then reference `"catalog:"` in `packages/cli/package.json`. (`minimumReleaseAge` is enforced; both libs are long-published.)
+- **No competitor product names** in any artifact (code, comments, docs, changeset, commit messages).
+- **Release via changeset** — this feature ships a `svelte-vitals` **minor** bump. Never publish manually.
+- **Do not loosen any existing test.** Follow TDD; commit after each green step.
+- The MCP entry written for every client is exactly `{ command: 'npx', args: ['-y', '@svelte-vitals/mcp'] }`.
+
+---
+
+### Task 1: Client writer modules
+
+**Files:**
+- Create: `packages/cli/src/install/clients.ts`
+- Test: `packages/cli/test/install/clients.test.ts`
+
+**Interfaces:**
+- Consumes: nothing (leaf module).
+- Produces: `McpEntry`, `MCP_ENTRY`, `ClientId` (`'claude-code' | 'cursor' | 'codex'`), `Scope` (`'project' | 'global'`), `ClientWriter`, `CLIENTS: ClientWriter[]`, `clientById(id: ClientId): ClientWriter | undefined`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/cli/test/install/clients.test.ts
+import { describe, it, expect } from 'vitest';
+import { join } from 'node:path';
+import { CLIENTS, clientById, MCP_ENTRY } from '../../src/install/clients.js';
+
+const cwd = '/proj';
+const home = '/home/u';
+
+describe('client writers', () => {
+  it('exposes the fixed MCP entry', () => {
+    expect(MCP_ENTRY).toEqual({ command: 'npx', args: ['-y', '@svelte-vitals/mcp'] });
+  });
+  it('claude-code: project → .mcp.json, global → ~/.claude.json', () => {
+    const c = clientById('claude-code')!;
+    expect(c.format).toBe('json');
+    expect(c.resolvePath('project', cwd, home)).toBe(join('/proj', '.mcp.json'));
+    expect(c.resolvePath('global', cwd, home)).toBe(join('/home/u', '.claude.json'));
+  });
+  it('cursor: project → .cursor/mcp.json, global → ~/.cursor/mcp.json', () => {
+    const c = clientById('cursor')!;
+    expect(c.format).toBe('json');
+    expect(c.resolvePath('project', cwd, home)).toBe(join('/proj', '.cursor', 'mcp.json'));
+    expect(c.resolvePath('global', cwd, home)).toBe(join('/home/u', '.cursor', 'mcp.json'));
+  });
+  it('codex: global-only → ~/.codex/config.toml, toml format', () => {
+    const c = clientById('codex')!;
+    expect(c.scopes).toEqual(['global']);
+    expect(c.format).toBe('toml');
+    expect(c.resolvePath('global', cwd, home)).toBe(join('/home/u', '.codex', 'config.toml'));
+  });
+  it('CLIENTS has all three ids', () => {
+    expect(CLIENTS.map((c) => c.id).sort()).toEqual(['claude-code', 'codex', 'cursor']);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/install/clients.test.ts`
+Expected: FAIL — cannot resolve `../../src/install/clients.js`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// packages/cli/src/install/clients.ts
+import { join } from 'node:path';
+
+export interface McpEntry {
+  command: string;
+  args: string[];
+}
+
+/** The MCP server entry written for every client. */
+export const MCP_ENTRY: McpEntry = { command: 'npx', args: ['-y', '@svelte-vitals/mcp'] };
+
+export type ClientId = 'claude-code' | 'cursor' | 'codex';
+export type Scope = 'project' | 'global';
+
+export interface ClientWriter {
+  id: ClientId;
+  label: string;
+  scopes: Scope[];
+  format: 'json' | 'toml';
+  /** Config file path for a scope. `cwd` = project root, `home` = user home dir. */
+  resolvePath(scope: Scope, cwd: string, home: string): string;
+}
+
+export const CLIENTS: ClientWriter[] = [
+  {
+    id: 'claude-code',
+    label: 'Claude Code',
+    scopes: ['project', 'global'],
+    format: 'json',
+    resolvePath: (scope, cwd, home) => (scope === 'project' ? join(cwd, '.mcp.json') : join(home, '.claude.json'))
+  },
+  {
+    id: 'cursor',
+    label: 'Cursor',
+    scopes: ['project', 'global'],
+    format: 'json',
+    resolvePath: (scope, cwd, home) =>
+      scope === 'project' ? join(cwd, '.cursor', 'mcp.json') : join(home, '.cursor', 'mcp.json')
+  },
+  {
+    id: 'codex',
+    label: 'Codex',
+    scopes: ['global'],
+    format: 'toml',
+    resolvePath: (_scope, _cwd, home) => join(home, '.codex', 'config.toml')
+  }
+];
+
+export function clientById(id: ClientId): ClientWriter | undefined {
+  return CLIENTS.find((c) => c.id === id);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/install/clients.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/install/clients.ts packages/cli/test/install/clients.test.ts
+git commit -m "feat(cli): install — client writer definitions (paths + format)"
+```
+
+---
+
+### Task 2: JSON/TOML merge helpers
+
+**Files:**
+- Modify: `pnpm-workspace.yaml` (add `smol-toml` to catalog)
+- Modify: `packages/cli/package.json` (add `"smol-toml": "catalog:"` to dependencies)
+- Create: `packages/cli/src/install/merge.ts`
+- Test: `packages/cli/test/install/merge.test.ts`
+
+**Interfaces:**
+- Consumes: `McpEntry`, `MCP_ENTRY` from `./clients.js`.
+- Produces: `MergeStatus` (`'created' | 'added' | 'exists' | 'updated'`), `MergeResult` (`{ content: string; status: MergeStatus }`), `mergeJson(existing: string | undefined, entry: McpEntry, force: boolean): MergeResult`, `mergeToml(existing, entry, force): MergeResult`.
+
+- [ ] **Step 1: Add the smol-toml dependency**
+
+In `pnpm-workspace.yaml`, under `catalog:`, add (keep alphabetical-ish with neighbors):
+
+```yaml
+  smol-toml: ^1.4.1
+```
+
+In `packages/cli/package.json` `dependencies`, add:
+
+```json
+    "smol-toml": "catalog:",
+```
+
+Then install:
+
+Run: `pnpm install`
+Expected: lockfile updates; `smol-toml` resolves. If pnpm reports the range is unsatisfiable, bump to the latest published caret it names and re-run.
+
+- [ ] **Step 2: Write the failing test**
+
+```ts
+// packages/cli/test/install/merge.test.ts
+import { describe, it, expect } from 'vitest';
+import { parse as parseToml } from 'smol-toml';
+import { mergeJson, mergeToml } from '../../src/install/merge.js';
+import { MCP_ENTRY } from '../../src/install/clients.js';
+
+describe('mergeJson', () => {
+  it('creates a new config when none exists', () => {
+    const r = mergeJson(undefined, MCP_ENTRY, false);
+    expect(r.status).toBe('created');
+    expect(JSON.parse(r.content)).toEqual({
+      mcpServers: { 'svelte-vitals': { command: 'npx', args: ['-y', '@svelte-vitals/mcp'] } }
+    });
+    expect(r.content.endsWith('\n')).toBe(true);
+  });
+  it('adds to an existing config without clobbering other servers', () => {
+    const existing = JSON.stringify({ mcpServers: { other: { command: 'x', args: [] } } });
+    const r = mergeJson(existing, MCP_ENTRY, false);
+    expect(r.status).toBe('added');
+    const parsed = JSON.parse(r.content);
+    expect(parsed.mcpServers.other).toEqual({ command: 'x', args: [] });
+    expect(parsed.mcpServers['svelte-vitals'].command).toBe('npx');
+  });
+  it('preserves unrelated top-level keys', () => {
+    const existing = JSON.stringify({ theme: 'dark', mcpServers: {} });
+    const r = mergeJson(existing, MCP_ENTRY, false);
+    expect(JSON.parse(r.content).theme).toBe('dark');
+  });
+  it('is exists (no change) when already identical', () => {
+    const first = mergeJson(undefined, MCP_ENTRY, false).content;
+    expect(mergeJson(first, MCP_ENTRY, false).status).toBe('exists');
+  });
+  it('skips a differing entry without force; updates with force', () => {
+    const existing = JSON.stringify({ mcpServers: { 'svelte-vitals': { command: 'old', args: [] } } });
+    expect(mergeJson(existing, MCP_ENTRY, false).status).toBe('exists');
+    const forced = mergeJson(existing, MCP_ENTRY, true);
+    expect(forced.status).toBe('updated');
+    expect(JSON.parse(forced.content).mcpServers['svelte-vitals'].command).toBe('npx');
+  });
+  it('throws on unparseable existing content', () => {
+    expect(() => mergeJson('{not json', MCP_ENTRY, false)).toThrow();
+  });
+});
+
+describe('mergeToml', () => {
+  it('creates a new toml config', () => {
+    const r = mergeToml(undefined, MCP_ENTRY, false);
+    expect(r.status).toBe('created');
+    const parsed = parseToml(r.content) as Record<string, any>;
+    expect(parsed.mcp_servers['svelte-vitals']).toEqual({ command: 'npx', args: ['-y', '@svelte-vitals/mcp'] });
+  });
+  it('adds without clobbering existing tables or scalars', () => {
+    const existing = 'model = "gpt"\n\n[mcp_servers.other]\ncommand = "x"\nargs = []\n';
+    const r = mergeToml(existing, MCP_ENTRY, false);
+    expect(r.status).toBe('added');
+    const parsed = parseToml(r.content) as Record<string, any>;
+    expect(parsed.model).toBe('gpt');
+    expect(parsed.mcp_servers.other.command).toBe('x');
+    expect(parsed.mcp_servers['svelte-vitals'].command).toBe('npx');
+  });
+  it('exists when identical; updates with force', () => {
+    const first = mergeToml(undefined, MCP_ENTRY, false).content;
+    expect(mergeToml(first, MCP_ENTRY, false).status).toBe('exists');
+    const existing = '[mcp_servers.svelte-vitals]\ncommand = "old"\nargs = []\n';
+    expect(mergeToml(existing, MCP_ENTRY, false).status).toBe('exists');
+    expect(mergeToml(existing, MCP_ENTRY, true).status).toBe('updated');
+  });
+  it('throws on unparseable toml', () => {
+    expect(() => mergeToml('= = =', MCP_ENTRY, false)).toThrow();
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/install/merge.test.ts`
+Expected: FAIL — cannot resolve `../../src/install/merge.js`.
+
+- [ ] **Step 4: Write minimal implementation**
+
+```ts
+// packages/cli/src/install/merge.ts
+import { parse as parseToml, stringify as stringifyToml } from 'smol-toml';
+import { type McpEntry } from './clients.js';
+
+export type MergeStatus = 'created' | 'added' | 'exists' | 'updated';
+export interface MergeResult {
+  content: string;
+  status: MergeStatus;
+}
+
+const SERVER_KEY = 'svelte-vitals';
+
+function sameEntry(prior: unknown, entry: McpEntry): boolean {
+  if (typeof prior !== 'object' || prior === null) return false;
+  const o = prior as { command?: unknown; args?: unknown };
+  return (
+    o.command === entry.command &&
+    Array.isArray(o.args) &&
+    o.args.length === entry.args.length &&
+    o.args.every((v, i) => v === entry.args[i])
+  );
+}
+
+/** Decide the merge status for a table that may already hold a svelte-vitals key. */
+function statusFor(
+  prior: unknown,
+  entry: McpEntry,
+  force: boolean,
+  created: boolean
+): MergeStatus | 'skip' {
+  if (prior !== undefined) {
+    if (sameEntry(prior, entry)) return 'exists';
+    return force ? 'updated' : 'skip';
+  }
+  return created ? 'created' : 'added';
+}
+
+/** Merge the svelte-vitals server into a JSON `{ mcpServers: {...} }` config. */
+export function mergeJson(existing: string | undefined, entry: McpEntry, force: boolean): MergeResult {
+  const created = existing === undefined;
+  const root: Record<string, unknown> = created ? {} : (JSON.parse(existing) as Record<string, unknown>);
+  const servers =
+    typeof root.mcpServers === 'object' && root.mcpServers !== null
+      ? (root.mcpServers as Record<string, unknown>)
+      : {};
+  const status = statusFor(servers[SERVER_KEY], entry, force, created);
+  if (status === 'exists' || status === 'skip') return { content: existing as string, status: 'exists' };
+  servers[SERVER_KEY] = { command: entry.command, args: entry.args };
+  root.mcpServers = servers;
+  return { content: JSON.stringify(root, null, 2) + '\n', status };
+}
+
+/** Merge the svelte-vitals server into a TOML config under [mcp_servers.svelte-vitals]. */
+export function mergeToml(existing: string | undefined, entry: McpEntry, force: boolean): MergeResult {
+  const created = existing === undefined;
+  const root = (created ? {} : parseToml(existing)) as Record<string, unknown>;
+  const servers =
+    typeof root.mcp_servers === 'object' && root.mcp_servers !== null
+      ? (root.mcp_servers as Record<string, unknown>)
+      : {};
+  const status = statusFor(servers[SERVER_KEY], entry, force, created);
+  if (status === 'exists' || status === 'skip') return { content: existing as string, status: 'exists' };
+  servers[SERVER_KEY] = { command: entry.command, args: entry.args };
+  root.mcp_servers = servers;
+  return { content: stringifyToml(root), status };
+}
+```
+
+Note: when a differing entry exists and `force` is false, `statusFor` returns `'skip'`, which both merge functions collapse to a no-write `'exists'` result (the caller surfaces "already configured — use --force"). This keeps the four spec statuses.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/install/merge.test.ts`
+Expected: PASS (10 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pnpm-workspace.yaml pnpm-lock.yaml packages/cli/package.json packages/cli/src/install/merge.ts packages/cli/test/install/merge.test.ts
+git commit -m "feat(cli): install — pure JSON/TOML config merge (adds smol-toml)"
+```
+
+---
+
+### Task 3: runInstall orchestration
+
+**Files:**
+- Create: `packages/cli/src/install/index.ts`
+- Test: `packages/cli/test/install/run.test.ts`
+
+**Interfaces:**
+- Consumes: `CLIENTS`, `clientById`, `MCP_ENTRY`, `ClientId`, `ClientWriter`, `Scope` from `./clients.js`; `mergeJson`, `mergeToml`, `MergeStatus` from `./merge.js`.
+- Produces: `InstallIO`, `InstallPrompts`, `InstallFlags`, `runInstall(flags: InstallFlags, io: InstallIO, prompts: InstallPrompts): Promise<number>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/cli/test/install/run.test.ts
+import { describe, it, expect } from 'vitest';
+import { runInstall, type InstallIO, type InstallPrompts } from '../../src/install/index.js';
+
+function fakeIO(over: { files?: Record<string, string>; isTTY?: boolean } = {}) {
+  const files = over.files ?? {};
+  const writes: Record<string, string> = {};
+  const out: string[] = [];
+  const err: string[] = [];
+  const io: InstallIO = {
+    readFile: (p) => files[p],
+    writeFile: (p, c) => {
+      writes[p] = c;
+    },
+    cwd: '/proj',
+    home: '/home/u',
+    isTTY: over.isTTY ?? false,
+    log: (l) => out.push(l),
+    errorLog: (l) => err.push(l)
+  };
+  return { io, writes, out, err };
+}
+
+const noPrompts: InstallPrompts = {
+  selectClients: async () => null,
+  selectScope: async () => null,
+  confirm: async () => true
+};
+
+describe('runInstall', () => {
+  it('non-TTY without --client exits 2 with guidance', async () => {
+    const { io, err } = fakeIO();
+    expect(await runInstall({}, io, noPrompts)).toBe(2);
+    expect(err.join('\n')).toContain('--client');
+  });
+  it('flag-only writes the selected client config', async () => {
+    const { io, writes } = fakeIO();
+    expect(await runInstall({ client: ['claude-code'], scope: 'project', yes: true }, io, noPrompts)).toBe(0);
+    expect(Object.keys(writes)).toEqual(['/proj/.mcp.json']);
+    expect(JSON.parse(writes['/proj/.mcp.json']).mcpServers['svelte-vitals'].command).toBe('npx');
+  });
+  it('dry-run writes nothing', async () => {
+    const { io, writes, out } = fakeIO();
+    expect(await runInstall({ client: ['cursor'], scope: 'global', dryRun: true }, io, noPrompts)).toBe(0);
+    expect(writes).toEqual({});
+    expect(out.join('\n')).toContain('Dry run');
+  });
+  it('codex ignores scope and uses the global config.toml', async () => {
+    const { io, writes } = fakeIO();
+    await runInstall({ client: ['codex'], yes: true }, io, noPrompts);
+    expect(Object.keys(writes)).toEqual(['/home/u/.codex/config.toml']);
+  });
+  it('an existing identical entry is skipped (no write)', async () => {
+    const first = fakeIO();
+    await runInstall({ client: ['claude-code'], scope: 'project', yes: true }, first.io, noPrompts);
+    const content = first.writes['/proj/.mcp.json'];
+    const { io, writes, out } = fakeIO({ files: { '/proj/.mcp.json': content } });
+    await runInstall({ client: ['claude-code'], scope: 'project', yes: true }, io, noPrompts);
+    expect(writes).toEqual({});
+    expect(out.join('\n')).toContain('already configured');
+  });
+  it('force overwrites a differing entry', async () => {
+    const existing = JSON.stringify({ mcpServers: { 'svelte-vitals': { command: 'old', args: [] } } });
+    const { io, writes } = fakeIO({ files: { '/proj/.mcp.json': existing } });
+    await runInstall({ client: ['claude-code'], scope: 'project', yes: true, force: true }, io, noPrompts);
+    expect(JSON.parse(writes['/proj/.mcp.json']).mcpServers['svelte-vitals'].command).toBe('npx');
+  });
+  it('a multi-client plan writes each config', async () => {
+    const { io, writes } = fakeIO();
+    await runInstall({ client: ['claude-code', 'cursor'], scope: 'project', yes: true }, io, noPrompts);
+    expect(Object.keys(writes).sort()).toEqual(['/proj/.cursor/mcp.json', '/proj/.mcp.json']);
+  });
+  it('TTY confirm=false writes nothing', async () => {
+    const { io, writes } = fakeIO({ isTTY: true });
+    const prompts: InstallPrompts = { ...noPrompts, confirm: async () => false };
+    expect(await runInstall({ client: ['claude-code'], scope: 'project' }, io, prompts)).toBe(0);
+    expect(writes).toEqual({});
+  });
+  it('TTY client-picker cancel exits 0 without writing', async () => {
+    const { io, writes } = fakeIO({ isTTY: true });
+    const prompts: InstallPrompts = { ...noPrompts, selectClients: async () => null };
+    expect(await runInstall({}, io, prompts)).toBe(0);
+    expect(writes).toEqual({});
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/install/run.test.ts`
+Expected: FAIL — cannot resolve `../../src/install/index.js`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// packages/cli/src/install/index.ts
+import { CLIENTS, clientById, MCP_ENTRY, type ClientId, type ClientWriter, type Scope } from './clients.js';
+import { mergeJson, mergeToml, type MergeStatus } from './merge.js';
+
+export interface InstallIO {
+  /** File contents, or undefined if the file does not exist. */
+  readFile(path: string): string | undefined;
+  /** Write the file, creating parent directories as needed. */
+  writeFile(path: string, content: string): void;
+  cwd: string;
+  home: string;
+  isTTY: boolean;
+  log(line: string): void;
+  errorLog(line: string): void;
+}
+
+export interface InstallPrompts {
+  /** Returns chosen client ids, or null when cancelled. */
+  selectClients(all: ClientWriter[], defaults: ClientId[]): Promise<ClientId[] | null>;
+  /** Returns chosen scope, or null when cancelled. */
+  selectScope(client: ClientWriter): Promise<Scope | null>;
+  confirm(planText: string): Promise<boolean>;
+}
+
+export interface InstallFlags {
+  client?: ClientId[];
+  scope?: Scope;
+  yes?: boolean;
+  dryRun?: boolean;
+  force?: boolean;
+}
+
+interface PlanRow {
+  client: ClientWriter;
+  scope: Scope;
+  path: string;
+  status: MergeStatus;
+  content: string;
+}
+
+function planFor(client: ClientWriter, scope: Scope, io: InstallIO, force: boolean): PlanRow {
+  const path = client.resolvePath(scope, io.cwd, io.home);
+  const existing = io.readFile(path);
+  const merged =
+    client.format === 'toml' ? mergeToml(existing, MCP_ENTRY, force) : mergeJson(existing, MCP_ENTRY, force);
+  return { client, scope, path, status: merged.status, content: merged.content };
+}
+
+export async function runInstall(flags: InstallFlags, io: InstallIO, prompts: InstallPrompts): Promise<number> {
+  // 1. Select clients.
+  let ids: ClientId[];
+  if (flags.client && flags.client.length > 0) {
+    ids = flags.client;
+  } else if (io.isTTY) {
+    const detected = CLIENTS.filter((c) =>
+      c.scopes.some((s) => io.readFile(c.resolvePath(s, io.cwd, io.home)) !== undefined)
+    ).map((c) => c.id);
+    const picked = await prompts.selectClients(CLIENTS, detected);
+    if (picked === null) {
+      io.log('Cancelled.');
+      return 0;
+    }
+    ids = picked;
+  } else {
+    io.errorLog(
+      'svelte-vitals: no TTY; pass --client <claude-code,cursor,codex> to install non-interactively.'
+    );
+    return 2;
+  }
+
+  const clients = ids.map(clientById).filter((c): c is ClientWriter => c !== undefined);
+  if (clients.length === 0) {
+    io.errorLog('svelte-vitals: no valid clients selected.');
+    return 2;
+  }
+
+  // 2. Resolve a scope per client and build the plan.
+  const rows: PlanRow[] = [];
+  for (const client of clients) {
+    let scope: Scope;
+    if (client.scopes.length === 1) {
+      scope = client.scopes[0];
+    } else if (flags.scope) {
+      scope = flags.scope;
+    } else if (io.isTTY) {
+      const picked = await prompts.selectScope(client);
+      if (picked === null) {
+        io.log('Cancelled.');
+        return 0;
+      }
+      scope = picked;
+    } else {
+      scope = 'project';
+    }
+    rows.push(planFor(client, scope, io, flags.force ?? false));
+  }
+
+  // 3. Preview.
+  const planText = rows.map((r) => `  ${r.client.label} (${r.scope}) → ${r.path}  [${r.status}]`).join('\n');
+  io.log('Plan:');
+  io.log(planText);
+
+  // 4. Dry-run / confirm.
+  if (flags.dryRun) {
+    io.log('Dry run — no files written.');
+    return 0;
+  }
+  if (!flags.yes && io.isTTY) {
+    const ok = await prompts.confirm(planText);
+    if (!ok) {
+      io.log('Cancelled.');
+      return 0;
+    }
+  }
+
+  // 5. Write.
+  try {
+    for (const r of rows) {
+      if (r.status === 'exists') {
+        io.log(`= ${r.client.label}: already configured (${r.path}) — use --force to overwrite.`);
+        continue;
+      }
+      io.writeFile(r.path, r.content);
+      io.log(`✓ ${r.client.label}: ${r.status} ${r.path}`);
+    }
+  } catch (err) {
+    io.errorLog(`svelte-vitals: failed to write config: ${err instanceof Error ? err.message : String(err)}`);
+    return 2;
+  }
+
+  io.log('');
+  io.log('Done. Restart your client to load the svelte-vitals MCP server.');
+  return 0;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/install/run.test.ts`
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/install/index.ts packages/cli/test/install/run.test.ts
+git commit -m "feat(cli): install — runInstall orchestration (injected IO + prompts)"
+```
+
+---
+
+### Task 4: Install flag parsing
+
+**Files:**
+- Create: `packages/cli/src/install/args.ts`
+- Test: `packages/cli/test/install/args.test.ts`
+
+**Interfaces:**
+- Consumes: `ClientId`, `Scope` from `./clients.js`; `InstallFlags` from `./index.js`.
+- Produces: `ResolvedInstallArgs` (`{ flags: InstallFlags | null; warnings: string[]; errors: string[] }`), `resolveInstallArgs(argv: mri.Argv): ResolvedInstallArgs`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/cli/test/install/args.test.ts
+import { describe, it, expect } from 'vitest';
+import mri from 'mri';
+import { resolveInstallArgs } from '../../src/install/args.js';
+
+const parse = (args: string[]) =>
+  mri(args, { boolean: ['yes', 'dry-run', 'force'], string: ['client', 'scope'], alias: { y: 'yes' } });
+
+describe('resolveInstallArgs', () => {
+  it('parses clients and scope', () => {
+    const r = resolveInstallArgs(parse(['--client', 'claude-code,cursor', '--scope', 'project']));
+    expect(r.flags).toEqual({
+      client: ['claude-code', 'cursor'],
+      scope: 'project',
+      yes: false,
+      dryRun: false,
+      force: false
+    });
+  });
+  it('warns and drops unknown client ids', () => {
+    const r = resolveInstallArgs(parse(['--client', 'claude-code,bogus']));
+    expect(r.flags!.client).toEqual(['claude-code']);
+    expect(r.warnings.join('\n')).toContain('bogus');
+  });
+  it('errors on an invalid scope (fatal)', () => {
+    const r = resolveInstallArgs(parse(['--scope', 'weird']));
+    expect(r.flags).toBeNull();
+    expect(r.errors.join('\n')).toContain('weird');
+  });
+  it('maps -y, --dry-run, --force', () => {
+    const r = resolveInstallArgs(parse(['-y', '--dry-run', '--force']));
+    expect(r.flags).toMatchObject({ yes: true, dryRun: true, force: true });
+  });
+  it('omits client/scope keys when not provided', () => {
+    const r = resolveInstallArgs(parse([]));
+    expect(r.flags).toEqual({ yes: false, dryRun: false, force: false });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/install/args.test.ts`
+Expected: FAIL — cannot resolve `../../src/install/args.js`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// packages/cli/src/install/args.ts
+import type mri from 'mri';
+import type { ClientId, Scope } from './clients.js';
+import type { InstallFlags } from './index.js';
+
+const VALID_CLIENTS: readonly ClientId[] = ['claude-code', 'cursor', 'codex'];
+
+export interface ResolvedInstallArgs {
+  /** Flags to pass to runInstall, or null when a fatal (exit-2) error was found. */
+  flags: InstallFlags | null;
+  warnings: string[];
+  errors: string[];
+}
+
+export function resolveInstallArgs(argv: mri.Argv): ResolvedInstallArgs {
+  const warnings: string[] = [];
+  const errors: string[] = [];
+
+  const rawClients =
+    typeof argv.client === 'string'
+      ? argv.client
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : [];
+  const client: ClientId[] = [];
+  for (const c of rawClients) {
+    if ((VALID_CLIENTS as readonly string[]).includes(c)) client.push(c as ClientId);
+    else warnings.push(`svelte-vitals: unknown --client '${c}'; expected claude-code|cursor|codex. Skipping.`);
+  }
+
+  let scope: Scope | undefined;
+  const rawScope = argv.scope;
+  if (typeof rawScope === 'string') {
+    if (rawScope === 'project' || rawScope === 'global') scope = rawScope;
+    else errors.push(`svelte-vitals: unknown --scope '${rawScope}'; expected project|global.`);
+  }
+
+  if (errors.length > 0) return { flags: null, warnings, errors };
+
+  return {
+    flags: {
+      ...(client.length > 0 ? { client } : {}),
+      ...(scope ? { scope } : {}),
+      yes: Boolean(argv.yes),
+      dryRun: Boolean(argv['dry-run']),
+      force: Boolean(argv.force)
+    },
+    warnings,
+    errors
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/install/args.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/install/args.ts packages/cli/test/install/args.test.ts
+git commit -m "feat(cli): install — pure flag parsing (resolveInstallArgs)"
+```
+
+---
+
+### Task 5: Wire the `install` subcommand into bin.ts
+
+**Files:**
+- Modify: `pnpm-workspace.yaml` (add `@clack/prompts` to catalog)
+- Modify: `packages/cli/package.json` (add `"@clack/prompts": "catalog:"`)
+- Create: `packages/cli/src/install/cli.ts` (real IO + clack adapter + `runInstallCli`)
+- Modify: `packages/cli/src/bin.ts` (subcommand routing + help)
+- Create: `.changeset/cli-install-wizard.md`
+
+**Interfaces:**
+- Consumes: `runInstall`, `InstallIO`, `InstallPrompts` from `./index.js`; `resolveInstallArgs` from `./args.js`; `ClientId`, `ClientWriter`, `Scope` from `./clients.js`.
+- Produces: `runInstallCli(args: string[]): Promise<number>`.
+
+- [ ] **Step 1: Add the @clack/prompts dependency**
+
+In `pnpm-workspace.yaml` under `catalog:`, add:
+
+```yaml
+  '@clack/prompts': ^0.11.0
+```
+
+In `packages/cli/package.json` `dependencies`, add:
+
+```json
+    "@clack/prompts": "catalog:",
+```
+
+Run: `pnpm install`
+Expected: lockfile updates; `@clack/prompts` resolves. If the range is unsatisfiable, bump to the latest published caret pnpm names and re-run.
+
+- [ ] **Step 2: Create the clack adapter + CLI entry**
+
+```ts
+// packages/cli/src/install/cli.ts
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { homedir } from 'node:os';
+import mri from 'mri';
+import * as p from '@clack/prompts';
+import { runInstall, type InstallIO, type InstallPrompts } from './index.js';
+import { resolveInstallArgs } from './args.js';
+import type { ClientId, ClientWriter, Scope } from './clients.js';
+
+const INSTALL_HELP = `svelte-vitals install — set up the svelte-vitals MCP server for your AI-agent clients
+
+Usage:
+  svelte-vitals install [options]
+
+Options:
+  --client <ids>    Comma-separated: claude-code,cursor,codex (skips the interactive picker)
+  --scope <scope>   project | global (applies to all selected clients; codex is always global)
+  --yes, -y         Skip the confirmation prompt
+  --dry-run         Print the planned changes and exit without writing
+  --force           Overwrite an existing svelte-vitals entry
+  -h, --help        Show this help`;
+
+function realIO(): InstallIO {
+  return {
+    readFile: (path) => {
+      try {
+        return readFileSync(path, 'utf8');
+      } catch {
+        return undefined;
+      }
+    },
+    writeFile: (path, content) => {
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, content);
+    },
+    cwd: process.cwd(),
+    home: homedir(),
+    isTTY: Boolean(process.stdout.isTTY),
+    log: (line) => console.log(line),
+    errorLog: (line) => console.error(line)
+  };
+}
+
+function clackPrompts(): InstallPrompts {
+  return {
+    selectClients: async (all: ClientWriter[], defaults: ClientId[]) => {
+      const res = await p.multiselect({
+        message: 'Which clients should svelte-vitals be installed for?',
+        options: all.map((c) => ({ value: c.id, label: c.label })),
+        initialValues: defaults,
+        required: true
+      });
+      return p.isCancel(res) ? null : (res as ClientId[]);
+    },
+    selectScope: async (client: ClientWriter) => {
+      const res = await p.select({
+        message: `Scope for ${client.label}?`,
+        options: client.scopes.map((s) => ({ value: s, label: s })),
+        initialValue: client.scopes[0]
+      });
+      return p.isCancel(res) ? null : (res as Scope);
+    },
+    confirm: async (planText: string) => {
+      const res = await p.confirm({ message: `Apply this plan?\n${planText}` });
+      return p.isCancel(res) ? false : Boolean(res);
+    }
+  };
+}
+
+/** Parse install args, print diagnostics, and run the wizard. Returns the exit code. */
+export async function runInstallCli(args: string[]): Promise<number> {
+  const argv = mri(args, {
+    boolean: ['yes', 'dry-run', 'force', 'help'],
+    string: ['client', 'scope'],
+    alias: { y: 'yes', h: 'help' }
+  });
+  if (argv.help) {
+    console.log(INSTALL_HELP);
+    return 0;
+  }
+  const { flags, warnings, errors } = resolveInstallArgs(argv);
+  for (const w of warnings) console.error(w);
+  for (const e of errors) console.error(e);
+  if (!flags) return 2;
+  return runInstall(flags, realIO(), clackPrompts());
+}
+```
+
+- [ ] **Step 3: Route the subcommand in bin.ts**
+
+At the top of `main()` in `packages/cli/src/bin.ts`, before the existing scanner parse, add the subcommand branch. Add the import near the other imports:
+
+```ts
+import { runInstallCli } from './install/cli.js';
+```
+
+Then inside `main()`, as the first statements:
+
+```ts
+  const rawArgs = process.argv.slice(2);
+  if (rawArgs[0] === 'install') {
+    const code = await runInstallCli(rawArgs.slice(1));
+    process.exit(code);
+  }
+```
+
+Add a one-line pointer to the top-level `HELP` string. Insert this line into the `Usage:` block (after the `svelte-vitals [path] [options]` line):
+
+```
+  svelte-vitals install          Set up the MCP server for Claude Code / Cursor / Codex
+```
+
+- [ ] **Step 4: Build and verify the subcommand end-to-end**
+
+Run: `pnpm --filter svelte-vitals build`
+Expected: build succeeds; `dist/bin.js` produced.
+
+Run: `node packages/cli/dist/bin.js install --client claude-code --scope project --dry-run`
+Expected: prints `Plan:`, a line containing `Claude Code (project)` and a path ending `.mcp.json  [created]`, then `Dry run — no files written.` Exit code 0.
+
+Run (real write into a throwaway dir):
+```bash
+D=$(mktemp -d) && node "$PWD/packages/cli/dist/bin.js" install --client cursor --scope project --yes >/tmp/out.txt 2>&1; cd "$D"; cat .cursor/mcp.json; cd - >/dev/null
+```
+Expected: `.cursor/mcp.json` contains `mcpServers.svelte-vitals` with `command: "npx"`, `args: ["-y", "@svelte-vitals/mcp"]`.
+
+Run (non-TTY guard — should fail cleanly): `node packages/cli/dist/bin.js install </dev/null`
+Expected: stderr contains `--client`; exit code 2.
+
+Run: `node packages/cli/dist/bin.js install --help`
+Expected: prints the install help block; exit 0.
+
+Run (existing scanner still works — backward compat): `node packages/cli/dist/bin.js --help`
+Expected: prints the top-level scanner help including the new `svelte-vitals install` line.
+
+- [ ] **Step 5: Add the changeset**
+
+```markdown
+---
+'svelte-vitals': minor
+---
+
+Add an interactive `svelte-vitals install` command that sets up the svelte-vitals
+MCP server for Claude Code, Cursor, and Codex. It merges into your existing client
+config without touching other servers, prompts for the clients and scope
+(project/global) interactively, and supports `--client`, `--scope`, `--yes`,
+`--dry-run`, and `--force` for non-interactive use.
+```
+
+Save as `.changeset/cli-install-wizard.md`.
+
+- [ ] **Step 6: Run the full CLI suite + lint + typecheck**
+
+Run: `pnpm --filter svelte-vitals test`
+Expected: all CLI tests pass (existing + new install tests).
+
+Run: `pnpm -r typecheck`
+Expected: all packages typecheck clean.
+
+Run: `pnpm lint`
+Expected: prettier + eslint clean. If prettier flags files, run `pnpm exec prettier --write .` and re-run.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pnpm-workspace.yaml pnpm-lock.yaml packages/cli/package.json packages/cli/src/install/cli.ts packages/cli/src/bin.ts .changeset/cli-install-wizard.md
+git commit -m "feat(cli): install subcommand — clack wizard + bin routing + help (adds @clack/prompts)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Command surface & flags (spec §1) → Task 4 (parsing) + Task 5 (routing, help, subcommand).
+- Client writer modules (spec §2) → Task 1.
+- Merge/write safety (spec §3) → Task 2 (pure merge, parse-failure throws) + Task 3 (write via IO).
+- Wizard flow (spec §4) → Task 3 (runInstall) + Task 5 (real IO + clack).
+- Deps & file layout (spec §5) → Task 2 (smol-toml), Task 5 (@clack/prompts); files created across Tasks 1–5.
+- Testing (spec §6) → pure tests in Tasks 1,2,4; orchestration tests in Task 3; end-to-end verification in Task 5.
+- Non-goals (spec §7) → nothing built for them. ✓
+
+**Deviation noted:** `InstallIO` carries `log`/`errorLog` (not spelled out in the spec's IO snippet) so orchestration output is injectable and testable. This is an additive superset of the spec and does not change behavior.
+
+**Placeholder scan:** none — every code step contains full code; every run step has an expected result.
+
+**Type consistency:** `InstallIO`/`InstallPrompts`/`InstallFlags` defined in Task 3 are consumed unchanged in Tasks 4–5. `MergeResult`/`MergeStatus` from Task 2 used in Task 3. `ClientId`/`Scope`/`ClientWriter`/`MCP_ENTRY` from Task 1 used throughout. `resolveInstallArgs` (Task 4) → `runInstallCli` (Task 5). Consistent.

--- a/docs/superpowers/specs/2026-07-03-cli-install-wizard-design.md
+++ b/docs/superpowers/specs/2026-07-03-cli-install-wizard-design.md
@@ -1,0 +1,161 @@
+# CLI interactive install wizard (MCP setup)
+
+**Date:** 2026-07-03
+**Status:** Approved
+**Package:** `@svelte-vitals/cli` (aka `svelte-vitals`)
+
+## Context
+
+Sub-project **B** of making the CLI more interactive and rich. Sub-project A (rich console output) shipped in #82. Today, wiring svelte-vitals into an AI-agent's MCP client is manual: the user hand-edits their client config to add a `svelte-vitals` server pointing at `npx -y @svelte-vitals/mcp` (see `docs/.../guides/mcp.md`). This sub-project automates that with an interactive `svelte-vitals install` wizard.
+
+AI-agent integration is a core product pillar, so a one-command MCP setup directly serves it. This is product-specific convenience (configuring *our* server across clients), not a duplication of any client's general tooling.
+
+## Goal
+
+`npx svelte-vitals install` interactively configures the svelte-vitals MCP server for the user's chosen clients (Claude Code, Cursor, Codex), merging into their existing config **without clobbering** other servers, with flag-driven fallback for non-interactive environments.
+
+## Decisions (settled during brainstorming)
+
+1. **Scope = MCP config only.** No agent-instruction files, no pre-commit hook (both deferred/declined).
+2. **Clients = Claude Code, Cursor, Codex** (all three in v1).
+3. **Write scope chosen at runtime**, per client (project vs global where both apply).
+4. **Interactive prompts via a lightweight library** — `@clack/prompts` (hand-rolling a multi-select TUI was judged too costly vs. a spinner). The CLI already carries a few small deps; adding a prompt + TOML lib is accepted.
+5. **Approach = per-client writer modules + clack orchestration.** TOML merge uses `smol-toml` (not hand-rolled) to avoid corrupting Codex's global config.
+
+## Design
+
+### 1. Command surface & flags
+
+New subcommand `svelte-vitals install`. In `bin.ts`, branch on `argv._[0] === 'install'` → route to `runInstall()`. No subcommand → the existing scanner, unchanged (**backward compatible**).
+
+Flags (all enable non-interactive use):
+
+| Flag | Meaning |
+| ---- | ------- |
+| `--client <ids>` | Comma-separated `claude-code,cursor,codex`. When given, skips the client picker. |
+| `--scope <project\|global>` | Applies to all selected clients. Codex is always forced to `global`. |
+| `--yes` / `-y` | Skip the confirmation prompt. |
+| `--dry-run` | Print the planned changes and exit without writing. |
+| `--force` | Overwrite an existing `svelte-vitals` entry without asking. |
+
+The `install` subcommand is parsed with its own `mri` options (separate from the scanner's), so scanner flags and install flags don't collide. Help gains an `install` usage section.
+
+### 2. Client writer modules (`src/install/clients.ts`)
+
+```ts
+export interface McpEntry {
+  command: string;
+  args: string[];
+}
+export const MCP_ENTRY: McpEntry = { command: 'npx', args: ['-y', '@svelte-vitals/mcp'] };
+
+export type ClientId = 'claude-code' | 'cursor' | 'codex';
+export type Scope = 'project' | 'global';
+
+export interface ClientWriter {
+  id: ClientId;
+  label: string;
+  scopes: Scope[]; // codex: ['global'] only
+  format: 'json' | 'toml';
+  /** Resolve the config file path for a scope. `cwd` = project root, `home` = user home. */
+  resolvePath(scope: Scope, cwd: string, home: string): string;
+}
+```
+
+| Client | project path | global path | format | key |
+| ------ | ------------ | ----------- | ------ | --- |
+| Claude Code | `.mcp.json` | `~/.claude.json` | json | `mcpServers.svelte-vitals` |
+| Cursor | `.cursor/mcp.json` | `~/.cursor/mcp.json` | json | `mcpServers.svelte-vitals` |
+| Codex | — | `~/.codex/config.toml` | toml | `mcp_servers.svelte-vitals` |
+
+### 3. Merge / write (`src/install/merge.ts`, pure)
+
+```ts
+export type MergeStatus = 'created' | 'added' | 'exists' | 'updated';
+export interface MergeResult {
+  content: string;
+  status: MergeStatus;
+}
+export function mergeJson(existing: string | undefined, entry: McpEntry, force: boolean): MergeResult;
+export function mergeToml(existing: string | undefined, entry: McpEntry, force: boolean): MergeResult;
+```
+
+- Read the existing file if present. JSON → `JSON.parse`; TOML → `smol-toml.parse`. **On parse failure, throw** (never clobber a config we can't understand).
+- Preserve the whole existing object; ensure the `mcpServers` / `mcp_servers` table exists; set only the `svelte-vitals` key.
+- If the `svelte-vitals` key already exists:
+  - equal to what we'd write → `exists` (no change),
+  - different and `force` → `updated`,
+  - different and not `force` → `exists` (skip; caller reports "already configured, use --force").
+- Missing file → `created`; existing file, new key → `added`.
+- Serialize: JSON with 2-space indent + trailing newline; TOML via `smol-toml.stringify`.
+
+### 4. Wizard flow (`src/install/index.ts`)
+
+`runInstall` takes injected IO + prompt so it is testable without real fs/clack:
+
+```ts
+export interface InstallIO {
+  readFile(path: string): string | undefined; // undefined if missing
+  writeFile(path: string, content: string): void; // mkdir -p dirname internally
+  cwd: string;
+  home: string;
+  isTTY: boolean;
+}
+export interface InstallPrompts {
+  selectClients(all: ClientWriter[], defaults: ClientId[]): Promise<ClientId[] | null>; // null = cancelled
+  selectScope(client: ClientWriter): Promise<Scope | null>;
+  confirm(planText: string): Promise<boolean>;
+}
+export interface InstallFlags {
+  client?: ClientId[];
+  scope?: Scope;
+  yes?: boolean;
+  dryRun?: boolean;
+  force?: boolean;
+}
+export function runInstall(flags: InstallFlags, io: InstallIO, prompts: InstallPrompts): Promise<number>;
+```
+
+Flow:
+
+1. **Select clients** — `flags.client` if given; else if `io.isTTY` → `prompts.selectClients` (default-checked = clients whose config file already exists via `io.readFile`); else (non-TTY, no flag) → error asking for `--client`, exit 2.
+2. **Per-client scope** — for each client with `scopes.length > 1`: `flags.scope` if given; else if TTY → `prompts.selectScope`; else default `project`. Codex → always `global`.
+3. **Build plan** — for each (client, scope): resolve path, read existing, compute `MergeResult`. Plan rows: client label, path, action (create/add/update/exists).
+4. **Preview & confirm** — render the plan. `--dry-run` → print, exit 0, no writes. Else if not `--yes` and TTY → `prompts.confirm`; cancel → exit 0 (nothing written).
+5. **Write** — write each file whose status ≠ `exists`. Report per-client result + next step ("restart <client> to load the MCP server").
+6. **Exit codes** — 0 success (incl. dry-run and cancel), 2 on write error / bad flag / non-TTY without `--client`.
+
+`bin.ts` builds the real `InstallIO` (node:fs, `os.homedir()`, `process.stdout.isTTY`) and the real clack-backed `InstallPrompts`, then calls `runInstall`. Cancellation (Ctrl+C / clack cancel symbol) maps to a clean exit 0 with "cancelled".
+
+### 5. Dependencies & file layout
+
+Add to `packages/cli` deps: `@clack/prompts`, `smol-toml`. The repo pins shared versions via the pnpm workspace `catalog:` (see other packages), so add both to the catalog and reference them as `catalog:` in `packages/cli/package.json`.
+
+```
+packages/cli/src/install/
+  index.ts     // runInstall orchestration + InstallIO/Prompts/Flags
+  clients.ts   // ClientWriter defs + MCP_ENTRY
+  merge.ts     // mergeJson / mergeToml (pure)
+packages/cli/test/install/
+  clients.test.ts // resolvePath per scope×client
+  merge.test.ts   // json+toml: created/added/exists/updated, preserves existing servers
+  index.test.ts   // runInstall with injected IO+prompts: plan, dry-run, non-TTY, force, cancel
+```
+
+Plus: `bin.ts` subcommand routing + install flag parsing + help; a changeset (`svelte-vitals` minor).
+
+The clack-backed `InstallPrompts` implementation is a thin adapter; it is exercised by hand, not unit-tested. All decision logic lives in the pure functions and in `runInstall` (tested via injection).
+
+### 6. Testing
+
+- **Pure:** `mergeJson`/`mergeToml` (all four statuses; existing servers preserved; parse-failure throws), `resolvePath` for every scope×client.
+- **Orchestration:** `runInstall` with fake IO + fake prompts — flag-only run, dry-run writes nothing, non-TTY without `--client` exits 2, `exists` skipped without `--force` and rewritten with it, cancel writes nothing, multi-client plan.
+- Full suite + typecheck + lint + docs build green; no existing assertions loosened.
+
+### 7. Non-goals (YAGNI / deferred)
+
+- Other clients (Windsurf, Zed, etc.) — the writer-module shape makes them easy to add later.
+- An `uninstall` command.
+- Editing agent-instruction files (scope option B, declined).
+- Deep client auto-detection — presence detection only sets the default-checked state in the picker.
+- Docs update to `guides/mcp.md` advertising the wizard can follow in the same PR but is not a design concern here.

--- a/docs/superpowers/specs/2026-07-03-cli-install-wizard-design.md
+++ b/docs/superpowers/specs/2026-07-03-cli-install-wizard-design.md
@@ -8,7 +8,7 @@
 
 Sub-project **B** of making the CLI more interactive and rich. Sub-project A (rich console output) shipped in #82. Today, wiring svelte-vitals into an AI-agent's MCP client is manual: the user hand-edits their client config to add a `svelte-vitals` server pointing at `npx -y @svelte-vitals/mcp` (see `docs/.../guides/mcp.md`). This sub-project automates that with an interactive `svelte-vitals install` wizard.
 
-AI-agent integration is a core product pillar, so a one-command MCP setup directly serves it. This is product-specific convenience (configuring *our* server across clients), not a duplication of any client's general tooling.
+AI-agent integration is a core product pillar, so a one-command MCP setup directly serves it. This is product-specific convenience (configuring _our_ server across clients), not a duplication of any client's general tooling.
 
 ## Goal
 
@@ -30,13 +30,13 @@ New subcommand `svelte-vitals install`. In `bin.ts`, branch on `argv._[0] === 'i
 
 Flags (all enable non-interactive use):
 
-| Flag | Meaning |
-| ---- | ------- |
-| `--client <ids>` | Comma-separated `claude-code,cursor,codex`. When given, skips the client picker. |
-| `--scope <project\|global>` | Applies to all selected clients. Codex is always forced to `global`. |
-| `--yes` / `-y` | Skip the confirmation prompt. |
-| `--dry-run` | Print the planned changes and exit without writing. |
-| `--force` | Overwrite an existing `svelte-vitals` entry without asking. |
+| Flag                        | Meaning                                                                          |
+| --------------------------- | -------------------------------------------------------------------------------- |
+| `--client <ids>`            | Comma-separated `claude-code,cursor,codex`. When given, skips the client picker. |
+| `--scope <project\|global>` | Applies to all selected clients. Codex is always forced to `global`.             |
+| `--yes` / `-y`              | Skip the confirmation prompt.                                                    |
+| `--dry-run`                 | Print the planned changes and exit without writing.                              |
+| `--force`                   | Overwrite an existing `svelte-vitals` entry without asking.                      |
 
 The `install` subcommand is parsed with its own `mri` options (separate from the scanner's), so scanner flags and install flags don't collide. Help gains an `install` usage section.
 
@@ -62,11 +62,11 @@ export interface ClientWriter {
 }
 ```
 
-| Client | project path | global path | format | key |
-| ------ | ------------ | ----------- | ------ | --- |
-| Claude Code | `.mcp.json` | `~/.claude.json` | json | `mcpServers.svelte-vitals` |
-| Cursor | `.cursor/mcp.json` | `~/.cursor/mcp.json` | json | `mcpServers.svelte-vitals` |
-| Codex | — | `~/.codex/config.toml` | toml | `mcp_servers.svelte-vitals` |
+| Client      | project path       | global path            | format | key                         |
+| ----------- | ------------------ | ---------------------- | ------ | --------------------------- |
+| Claude Code | `.mcp.json`        | `~/.claude.json`       | json   | `mcpServers.svelte-vitals`  |
+| Cursor      | `.cursor/mcp.json` | `~/.cursor/mcp.json`   | json   | `mcpServers.svelte-vitals`  |
+| Codex       | —                  | `~/.codex/config.toml` | toml   | `mcp_servers.svelte-vitals` |
 
 ### 3. Merge / write (`src/install/merge.ts`, pure)
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@svelte-vitals/core": "workspace:*",
     "mri": "catalog:",
+    "smol-toml": "catalog:",
     "svelte": "catalog:",
     "tinyglobby": "catalog:"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@svelte-vitals/core": "workspace:*",
+    "@clack/prompts": "catalog:",
     "mri": "catalog:",
     "smol-toml": "catalog:",
     "svelte": "catalog:",

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -3,11 +3,13 @@ import mri from 'mri';
 import { run } from './index.js';
 import { readPackageVersion } from './version.js';
 import { resolveArgs } from './resolve-args.js';
+import { runInstallCli } from './install/cli.js';
 
 const HELP = `svelte-vitals — a deterministic SvelteKit code-health scanner (SEO · performance · correctness · security · architecture)
 
 Usage:
   svelte-vitals [path] [options]
+  svelte-vitals install          Set up the MCP server for Claude Code / Cursor / Codex
 
 Options:
   --meta-components <names>   Comma-separated component names that emit head metadata
@@ -36,6 +38,12 @@ Exit codes:
 const VERSION = readPackageVersion();
 
 async function main(): Promise<void> {
+  const rawArgs = process.argv.slice(2);
+  if (rawArgs[0] === 'install') {
+    const code = await runInstallCli(rawArgs.slice(1));
+    process.exit(code);
+  }
+
   const argv = mri(process.argv.slice(2), {
     alias: { h: 'help', v: 'version' },
     boolean: ['by-route', 'json', 'fail-on-warning', 'staged', 'no-color'],

--- a/packages/cli/src/install/args.ts
+++ b/packages/cli/src/install/args.ts
@@ -24,8 +24,11 @@ export function resolveInstallArgs(argv: mri.Argv): ResolvedInstallArgs {
       : [];
   const client: ClientId[] = [];
   for (const c of rawClients) {
-    if ((VALID_CLIENTS as readonly string[]).includes(c)) client.push(c as ClientId);
-    else warnings.push(`svelte-vitals: unknown --client '${c}'; expected claude-code|cursor|codex. Skipping.`);
+    if ((VALID_CLIENTS as readonly string[]).includes(c)) {
+      if (!client.includes(c as ClientId)) client.push(c as ClientId);
+    } else {
+      warnings.push(`svelte-vitals: unknown --client '${c}'; expected claude-code|cursor|codex. Skipping.`);
+    }
   }
   if (rawClients.length > 0 && client.length === 0) {
     errors.push('svelte-vitals: no valid --client values; expected claude-code|cursor|codex.');

--- a/packages/cli/src/install/args.ts
+++ b/packages/cli/src/install/args.ts
@@ -1,8 +1,8 @@
 import type mri from 'mri';
-import type { ClientId, Scope } from './clients.js';
+import { CLIENTS, type ClientId, type Scope } from './clients.js';
 import type { InstallFlags } from './index.js';
 
-const VALID_CLIENTS: readonly ClientId[] = ['claude-code', 'cursor', 'codex'];
+const VALID_CLIENTS: readonly ClientId[] = CLIENTS.map((c) => c.id);
 
 export interface ResolvedInstallArgs {
   /** Flags to pass to runInstall, or null when a fatal (exit-2) error was found. */
@@ -26,6 +26,9 @@ export function resolveInstallArgs(argv: mri.Argv): ResolvedInstallArgs {
   for (const c of rawClients) {
     if ((VALID_CLIENTS as readonly string[]).includes(c)) client.push(c as ClientId);
     else warnings.push(`svelte-vitals: unknown --client '${c}'; expected claude-code|cursor|codex. Skipping.`);
+  }
+  if (rawClients.length > 0 && client.length === 0) {
+    errors.push('svelte-vitals: no valid --client values; expected claude-code|cursor|codex.');
   }
 
   let scope: Scope | undefined;

--- a/packages/cli/src/install/args.ts
+++ b/packages/cli/src/install/args.ts
@@ -1,0 +1,51 @@
+import type mri from 'mri';
+import type { ClientId, Scope } from './clients.js';
+import type { InstallFlags } from './index.js';
+
+const VALID_CLIENTS: readonly ClientId[] = ['claude-code', 'cursor', 'codex'];
+
+export interface ResolvedInstallArgs {
+  /** Flags to pass to runInstall, or null when a fatal (exit-2) error was found. */
+  flags: InstallFlags | null;
+  warnings: string[];
+  errors: string[];
+}
+
+export function resolveInstallArgs(argv: mri.Argv): ResolvedInstallArgs {
+  const warnings: string[] = [];
+  const errors: string[] = [];
+
+  const rawClients =
+    typeof argv.client === 'string'
+      ? argv.client
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : [];
+  const client: ClientId[] = [];
+  for (const c of rawClients) {
+    if ((VALID_CLIENTS as readonly string[]).includes(c)) client.push(c as ClientId);
+    else warnings.push(`svelte-vitals: unknown --client '${c}'; expected claude-code|cursor|codex. Skipping.`);
+  }
+
+  let scope: Scope | undefined;
+  const rawScope = argv.scope;
+  if (typeof rawScope === 'string') {
+    if (rawScope === 'project' || rawScope === 'global') scope = rawScope;
+    else errors.push(`svelte-vitals: unknown --scope '${rawScope}'; expected project|global.`);
+  }
+
+  if (errors.length > 0) return { flags: null, warnings, errors };
+
+  return {
+    flags: {
+      ...(client.length > 0 ? { client } : {}),
+      ...(scope ? { scope } : {}),
+      yes: Boolean(argv.yes),
+      dryRun: Boolean(argv['dry-run']),
+      force: Boolean(argv.force)
+    },
+    warnings,
+    errors
+  };
+}

--- a/packages/cli/src/install/cli.ts
+++ b/packages/cli/src/install/cli.ts
@@ -20,13 +20,14 @@ Options:
   --force           Overwrite an existing svelte-vitals entry
   -h, --help        Show this help`;
 
-function realIO(): InstallIO {
+export function realIO(): InstallIO {
   return {
     readFile: (path) => {
       try {
         return readFileSync(path, 'utf8');
-      } catch {
-        return undefined;
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+        throw err;
       }
     },
     writeFile: (path, content) => {

--- a/packages/cli/src/install/cli.ts
+++ b/packages/cli/src/install/cli.ts
@@ -1,0 +1,86 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { homedir } from 'node:os';
+import mri from 'mri';
+import * as p from '@clack/prompts';
+import { runInstall, type InstallIO, type InstallPrompts } from './index.js';
+import { resolveInstallArgs } from './args.js';
+import type { ClientId, ClientWriter, Scope } from './clients.js';
+
+const INSTALL_HELP = `svelte-vitals install — set up the svelte-vitals MCP server for your AI-agent clients
+
+Usage:
+  svelte-vitals install [options]
+
+Options:
+  --client <ids>    Comma-separated: claude-code,cursor,codex (skips the interactive picker)
+  --scope <scope>   project | global (applies to all selected clients; codex is always global)
+  --yes, -y         Skip the confirmation prompt
+  --dry-run         Print the planned changes and exit without writing
+  --force           Overwrite an existing svelte-vitals entry
+  -h, --help        Show this help`;
+
+function realIO(): InstallIO {
+  return {
+    readFile: (path) => {
+      try {
+        return readFileSync(path, 'utf8');
+      } catch {
+        return undefined;
+      }
+    },
+    writeFile: (path, content) => {
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, content);
+    },
+    cwd: process.cwd(),
+    home: homedir(),
+    isTTY: Boolean(process.stdout.isTTY),
+    log: (line) => console.log(line),
+    errorLog: (line) => console.error(line)
+  };
+}
+
+function clackPrompts(): InstallPrompts {
+  return {
+    selectClients: async (all: ClientWriter[], defaults: ClientId[]) => {
+      const res = await p.multiselect({
+        message: 'Which clients should svelte-vitals be installed for?',
+        options: all.map((c) => ({ value: c.id, label: c.label })),
+        initialValues: defaults,
+        required: true
+      });
+      return p.isCancel(res) ? null : (res as ClientId[]);
+    },
+    selectScope: async (client: ClientWriter) => {
+      const res = await p.select({
+        message: `Scope for ${client.label}?`,
+        options: client.scopes.map((s) => ({ value: s, label: s })),
+        initialValue: client.scopes[0]
+      });
+      return p.isCancel(res) ? null : (res as Scope);
+    },
+    confirm: async (planText: string) => {
+      const res = await p.confirm({ message: `Apply this plan?\n${planText}` });
+      return p.isCancel(res) ? false : Boolean(res);
+    }
+  };
+}
+
+/** Parse install args, print diagnostics, and run the wizard. Returns the exit code. */
+export async function runInstallCli(args: string[]): Promise<number> {
+  const argv = mri(args, {
+    boolean: ['yes', 'dry-run', 'force', 'help'],
+    string: ['client', 'scope'],
+    alias: { y: 'yes', h: 'help' }
+  });
+  if (argv.help) {
+    console.log(INSTALL_HELP);
+    return 0;
+  }
+  const { flags, warnings, errors } = resolveInstallArgs(argv);
+  for (const w of warnings) console.error(w);
+  for (const e of errors) console.error(e);
+  if (!flags) return 2;
+  return runInstall(flags, realIO(), clackPrompts());
+}

--- a/packages/cli/src/install/clients.ts
+++ b/packages/cli/src/install/clients.ts
@@ -1,0 +1,50 @@
+import { join } from 'node:path';
+
+export interface McpEntry {
+  command: string;
+  args: string[];
+}
+
+/** The MCP server entry written for every client. */
+export const MCP_ENTRY: McpEntry = { command: 'npx', args: ['-y', '@svelte-vitals/mcp'] };
+
+export type ClientId = 'claude-code' | 'cursor' | 'codex';
+export type Scope = 'project' | 'global';
+
+export interface ClientWriter {
+  id: ClientId;
+  label: string;
+  scopes: Scope[];
+  format: 'json' | 'toml';
+  /** Config file path for a scope. `cwd` = project root, `home` = user home dir. */
+  resolvePath(scope: Scope, cwd: string, home: string): string;
+}
+
+export const CLIENTS: ClientWriter[] = [
+  {
+    id: 'claude-code',
+    label: 'Claude Code',
+    scopes: ['project', 'global'],
+    format: 'json',
+    resolvePath: (scope, cwd, home) => (scope === 'project' ? join(cwd, '.mcp.json') : join(home, '.claude.json'))
+  },
+  {
+    id: 'cursor',
+    label: 'Cursor',
+    scopes: ['project', 'global'],
+    format: 'json',
+    resolvePath: (scope, cwd, home) =>
+      scope === 'project' ? join(cwd, '.cursor', 'mcp.json') : join(home, '.cursor', 'mcp.json')
+  },
+  {
+    id: 'codex',
+    label: 'Codex',
+    scopes: ['global'],
+    format: 'toml',
+    resolvePath: (_scope, _cwd, home) => join(home, '.codex', 'config.toml')
+  }
+];
+
+export function clientById(id: ClientId): ClientWriter | undefined {
+  return CLIENTS.find((c) => c.id === id);
+}

--- a/packages/cli/src/install/index.ts
+++ b/packages/cli/src/install/index.ts
@@ -1,0 +1,131 @@
+import { CLIENTS, clientById, MCP_ENTRY, type ClientId, type ClientWriter, type Scope } from './clients.js';
+import { mergeJson, mergeToml, type MergeStatus } from './merge.js';
+
+export interface InstallIO {
+  /** File contents, or undefined if the file does not exist. */
+  readFile(path: string): string | undefined;
+  /** Write the file, creating parent directories as needed. */
+  writeFile(path: string, content: string): void;
+  cwd: string;
+  home: string;
+  isTTY: boolean;
+  log(line: string): void;
+  errorLog(line: string): void;
+}
+
+export interface InstallPrompts {
+  /** Returns chosen client ids, or null when cancelled. */
+  selectClients(all: ClientWriter[], defaults: ClientId[]): Promise<ClientId[] | null>;
+  /** Returns chosen scope, or null when cancelled. */
+  selectScope(client: ClientWriter): Promise<Scope | null>;
+  confirm(planText: string): Promise<boolean>;
+}
+
+export interface InstallFlags {
+  client?: ClientId[];
+  scope?: Scope;
+  yes?: boolean;
+  dryRun?: boolean;
+  force?: boolean;
+}
+
+interface PlanRow {
+  client: ClientWriter;
+  scope: Scope;
+  path: string;
+  status: MergeStatus;
+  content: string;
+}
+
+function planFor(client: ClientWriter, scope: Scope, io: InstallIO, force: boolean): PlanRow {
+  const path = client.resolvePath(scope, io.cwd, io.home);
+  const existing = io.readFile(path);
+  const merged =
+    client.format === 'toml' ? mergeToml(existing, MCP_ENTRY, force) : mergeJson(existing, MCP_ENTRY, force);
+  return { client, scope, path, status: merged.status, content: merged.content };
+}
+
+export async function runInstall(flags: InstallFlags, io: InstallIO, prompts: InstallPrompts): Promise<number> {
+  // 1. Select clients.
+  let ids: ClientId[];
+  if (flags.client && flags.client.length > 0) {
+    ids = flags.client;
+  } else if (io.isTTY) {
+    const detected = CLIENTS.filter((c) =>
+      c.scopes.some((s) => io.readFile(c.resolvePath(s, io.cwd, io.home)) !== undefined)
+    ).map((c) => c.id);
+    const picked = await prompts.selectClients(CLIENTS, detected);
+    if (picked === null) {
+      io.log('Cancelled.');
+      return 0;
+    }
+    ids = picked;
+  } else {
+    io.errorLog('svelte-vitals: no TTY; pass --client <claude-code,cursor,codex> to install non-interactively.');
+    return 2;
+  }
+
+  const clients = ids.map(clientById).filter((c): c is ClientWriter => c !== undefined);
+  if (clients.length === 0) {
+    io.errorLog('svelte-vitals: no valid clients selected.');
+    return 2;
+  }
+
+  // 2. Resolve a scope per client and build the plan.
+  const rows: PlanRow[] = [];
+  for (const client of clients) {
+    let scope: Scope;
+    if (client.scopes.length === 1) {
+      scope = client.scopes[0]!;
+    } else if (flags.scope) {
+      scope = flags.scope;
+    } else if (io.isTTY) {
+      const picked = await prompts.selectScope(client);
+      if (picked === null) {
+        io.log('Cancelled.');
+        return 0;
+      }
+      scope = picked;
+    } else {
+      scope = 'project';
+    }
+    rows.push(planFor(client, scope, io, flags.force ?? false));
+  }
+
+  // 3. Preview.
+  const planText = rows.map((r) => `  ${r.client.label} (${r.scope}) → ${r.path}  [${r.status}]`).join('\n');
+  io.log('Plan:');
+  io.log(planText);
+
+  // 4. Dry-run / confirm.
+  if (flags.dryRun) {
+    io.log('Dry run — no files written.');
+    return 0;
+  }
+  if (!flags.yes && io.isTTY) {
+    const ok = await prompts.confirm(planText);
+    if (!ok) {
+      io.log('Cancelled.');
+      return 0;
+    }
+  }
+
+  // 5. Write.
+  try {
+    for (const r of rows) {
+      if (r.status === 'exists') {
+        io.log(`= ${r.client.label}: already configured (${r.path}) — use --force to overwrite.`);
+        continue;
+      }
+      io.writeFile(r.path, r.content);
+      io.log(`✓ ${r.client.label}: ${r.status} ${r.path}`);
+    }
+  } catch (err) {
+    io.errorLog(`svelte-vitals: failed to write config: ${err instanceof Error ? err.message : String(err)}`);
+    return 2;
+  }
+
+  io.log('');
+  io.log('Done. Restart your client to load the svelte-vitals MCP server.');
+  return 0;
+}

--- a/packages/cli/src/install/index.ts
+++ b/packages/cli/src/install/index.ts
@@ -89,7 +89,15 @@ export async function runInstall(flags: InstallFlags, io: InstallIO, prompts: In
     } else {
       scope = 'project';
     }
-    rows.push(planFor(client, scope, io, flags.force ?? false));
+    try {
+      rows.push(planFor(client, scope, io, flags.force ?? false));
+    } catch (err) {
+      const path = client.resolvePath(scope, io.cwd, io.home);
+      io.errorLog(
+        `svelte-vitals: could not parse existing config at ${path}: ${err instanceof Error ? err.message : String(err)}`
+      );
+      return 2;
+    }
   }
 
   // 3. Preview.

--- a/packages/cli/src/install/index.ts
+++ b/packages/cli/src/install/index.ts
@@ -119,19 +119,21 @@ export async function runInstall(flags: InstallFlags, io: InstallIO, prompts: In
   }
 
   // 5. Write.
-  try {
-    for (const r of rows) {
-      if (r.status === 'exists') {
-        io.log(`= ${r.client.label}: already configured (${r.path}) — use --force to overwrite.`);
-        continue;
-      }
+  let hadFailure = false;
+  for (const r of rows) {
+    if (r.status === 'exists') {
+      io.log(`= ${r.client.label}: already configured (${r.path}) — use --force to overwrite.`);
+      continue;
+    }
+    try {
       io.writeFile(r.path, r.content);
       io.log(`✓ ${r.client.label}: ${r.status} ${r.path}`);
+    } catch (err) {
+      hadFailure = true;
+      io.errorLog(`svelte-vitals: failed to write ${r.path}: ${err instanceof Error ? err.message : String(err)}`);
     }
-  } catch (err) {
-    io.errorLog(`svelte-vitals: failed to write config: ${err instanceof Error ? err.message : String(err)}`);
-    return 2;
   }
+  if (hadFailure) return 2;
 
   io.log('');
   io.log('Done. Restart your client to load the svelte-vitals MCP server.');

--- a/packages/cli/src/install/index.ts
+++ b/packages/cli/src/install/index.ts
@@ -51,9 +51,16 @@ export async function runInstall(flags: InstallFlags, io: InstallIO, prompts: In
   if (flags.client && flags.client.length > 0) {
     ids = flags.client;
   } else if (io.isTTY) {
-    const detected = CLIENTS.filter((c) =>
-      c.scopes.some((s) => io.readFile(c.resolvePath(s, io.cwd, io.home)) !== undefined)
-    ).map((c) => c.id);
+    const configExists = (path: string): boolean => {
+      try {
+        return io.readFile(path) !== undefined;
+      } catch {
+        return false;
+      }
+    };
+    const detected = CLIENTS.filter((c) => c.scopes.some((s) => configExists(c.resolvePath(s, io.cwd, io.home)))).map(
+      (c) => c.id
+    );
     const picked = await prompts.selectClients(CLIENTS, detected);
     if (picked === null) {
       io.log('Cancelled.');

--- a/packages/cli/src/install/merge.ts
+++ b/packages/cli/src/install/merge.ts
@@ -9,6 +9,10 @@ export interface MergeResult {
 
 const SERVER_KEY = 'svelte-vitals';
 
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
 function sameEntry(prior: unknown, entry: McpEntry): boolean {
   if (typeof prior !== 'object' || prior === null) return false;
   const o = prior as { command?: unknown; args?: unknown };
@@ -32,9 +36,15 @@ function statusFor(prior: unknown, entry: McpEntry, force: boolean, created: boo
 /** Merge the svelte-vitals server into a JSON `{ mcpServers: {...} }` config. */
 export function mergeJson(existing: string | undefined, entry: McpEntry, force: boolean): MergeResult {
   const created = existing === undefined;
-  const root: Record<string, unknown> = created ? {} : (JSON.parse(existing) as Record<string, unknown>);
-  const servers =
-    typeof root.mcpServers === 'object' && root.mcpServers !== null ? (root.mcpServers as Record<string, unknown>) : {};
+  const parsed: unknown = created ? {} : JSON.parse(existing);
+  if (!isPlainObject(parsed)) {
+    throw new Error('existing config is not a JSON object');
+  }
+  const root = parsed;
+  if (root.mcpServers !== undefined && !isPlainObject(root.mcpServers)) {
+    throw new Error('existing config has a non-object "mcpServers" table');
+  }
+  const servers = isPlainObject(root.mcpServers) ? root.mcpServers : {};
   const status = statusFor(servers[SERVER_KEY], entry, force, created);
   if (status === 'exists' || status === 'skip') return { content: existing as string, status: 'exists' };
   servers[SERVER_KEY] = { command: entry.command, args: entry.args };
@@ -45,11 +55,15 @@ export function mergeJson(existing: string | undefined, entry: McpEntry, force: 
 /** Merge the svelte-vitals server into a TOML config under [mcp_servers.svelte-vitals]. */
 export function mergeToml(existing: string | undefined, entry: McpEntry, force: boolean): MergeResult {
   const created = existing === undefined;
-  const root = (created ? {} : parseToml(existing)) as Record<string, unknown>;
-  const servers =
-    typeof root.mcp_servers === 'object' && root.mcp_servers !== null
-      ? (root.mcp_servers as Record<string, unknown>)
-      : {};
+  const parsed: unknown = created ? {} : parseToml(existing);
+  if (!isPlainObject(parsed)) {
+    throw new Error('existing config is not a TOML table');
+  }
+  const root = parsed;
+  if (root.mcp_servers !== undefined && !isPlainObject(root.mcp_servers)) {
+    throw new Error('existing config has a non-table "mcp_servers" section');
+  }
+  const servers = isPlainObject(root.mcp_servers) ? root.mcp_servers : {};
   const status = statusFor(servers[SERVER_KEY], entry, force, created);
   if (status === 'exists' || status === 'skip') return { content: existing as string, status: 'exists' };
   servers[SERVER_KEY] = { command: entry.command, args: entry.args };

--- a/packages/cli/src/install/merge.ts
+++ b/packages/cli/src/install/merge.ts
@@ -21,12 +21,7 @@ function sameEntry(prior: unknown, entry: McpEntry): boolean {
 }
 
 /** Decide the merge status for a table that may already hold a svelte-vitals key. */
-function statusFor(
-  prior: unknown,
-  entry: McpEntry,
-  force: boolean,
-  created: boolean
-): MergeStatus | 'skip' {
+function statusFor(prior: unknown, entry: McpEntry, force: boolean, created: boolean): MergeStatus | 'skip' {
   if (prior !== undefined) {
     if (sameEntry(prior, entry)) return 'exists';
     return force ? 'updated' : 'skip';
@@ -39,9 +34,7 @@ export function mergeJson(existing: string | undefined, entry: McpEntry, force: 
   const created = existing === undefined;
   const root: Record<string, unknown> = created ? {} : (JSON.parse(existing) as Record<string, unknown>);
   const servers =
-    typeof root.mcpServers === 'object' && root.mcpServers !== null
-      ? (root.mcpServers as Record<string, unknown>)
-      : {};
+    typeof root.mcpServers === 'object' && root.mcpServers !== null ? (root.mcpServers as Record<string, unknown>) : {};
   const status = statusFor(servers[SERVER_KEY], entry, force, created);
   if (status === 'exists' || status === 'skip') return { content: existing as string, status: 'exists' };
   servers[SERVER_KEY] = { command: entry.command, args: entry.args };

--- a/packages/cli/src/install/merge.ts
+++ b/packages/cli/src/install/merge.ts
@@ -1,0 +1,65 @@
+import { parse as parseToml, stringify as stringifyToml } from 'smol-toml';
+import { type McpEntry } from './clients.js';
+
+export type MergeStatus = 'created' | 'added' | 'exists' | 'updated';
+export interface MergeResult {
+  content: string;
+  status: MergeStatus;
+}
+
+const SERVER_KEY = 'svelte-vitals';
+
+function sameEntry(prior: unknown, entry: McpEntry): boolean {
+  if (typeof prior !== 'object' || prior === null) return false;
+  const o = prior as { command?: unknown; args?: unknown };
+  return (
+    o.command === entry.command &&
+    Array.isArray(o.args) &&
+    o.args.length === entry.args.length &&
+    o.args.every((v, i) => v === entry.args[i])
+  );
+}
+
+/** Decide the merge status for a table that may already hold a svelte-vitals key. */
+function statusFor(
+  prior: unknown,
+  entry: McpEntry,
+  force: boolean,
+  created: boolean
+): MergeStatus | 'skip' {
+  if (prior !== undefined) {
+    if (sameEntry(prior, entry)) return 'exists';
+    return force ? 'updated' : 'skip';
+  }
+  return created ? 'created' : 'added';
+}
+
+/** Merge the svelte-vitals server into a JSON `{ mcpServers: {...} }` config. */
+export function mergeJson(existing: string | undefined, entry: McpEntry, force: boolean): MergeResult {
+  const created = existing === undefined;
+  const root: Record<string, unknown> = created ? {} : (JSON.parse(existing) as Record<string, unknown>);
+  const servers =
+    typeof root.mcpServers === 'object' && root.mcpServers !== null
+      ? (root.mcpServers as Record<string, unknown>)
+      : {};
+  const status = statusFor(servers[SERVER_KEY], entry, force, created);
+  if (status === 'exists' || status === 'skip') return { content: existing as string, status: 'exists' };
+  servers[SERVER_KEY] = { command: entry.command, args: entry.args };
+  root.mcpServers = servers;
+  return { content: JSON.stringify(root, null, 2) + '\n', status };
+}
+
+/** Merge the svelte-vitals server into a TOML config under [mcp_servers.svelte-vitals]. */
+export function mergeToml(existing: string | undefined, entry: McpEntry, force: boolean): MergeResult {
+  const created = existing === undefined;
+  const root = (created ? {} : parseToml(existing)) as Record<string, unknown>;
+  const servers =
+    typeof root.mcp_servers === 'object' && root.mcp_servers !== null
+      ? (root.mcp_servers as Record<string, unknown>)
+      : {};
+  const status = statusFor(servers[SERVER_KEY], entry, force, created);
+  if (status === 'exists' || status === 'skip') return { content: existing as string, status: 'exists' };
+  servers[SERVER_KEY] = { command: entry.command, args: entry.args };
+  root.mcp_servers = servers;
+  return { content: stringifyToml(root), status };
+}

--- a/packages/cli/test/install/args.test.ts
+++ b/packages/cli/test/install/args.test.ts
@@ -21,6 +21,11 @@ describe('resolveInstallArgs', () => {
     expect(r.flags!.client).toEqual(['claude-code']);
     expect(r.warnings.join('\n')).toContain('bogus');
   });
+  it('errors on an all-invalid --client (fatal)', () => {
+    const r = resolveInstallArgs(parse(['--client', 'bogus']));
+    expect(r.flags).toBeNull();
+    expect(r.errors.join('\n')).toContain('claude-code');
+  });
   it('errors on an invalid scope (fatal)', () => {
     const r = resolveInstallArgs(parse(['--scope', 'weird']));
     expect(r.flags).toBeNull();

--- a/packages/cli/test/install/args.test.ts
+++ b/packages/cli/test/install/args.test.ts
@@ -21,6 +21,10 @@ describe('resolveInstallArgs', () => {
     expect(r.flags!.client).toEqual(['claude-code']);
     expect(r.warnings.join('\n')).toContain('bogus');
   });
+  it('de-duplicates repeated --client ids, preserving first-seen order', () => {
+    const r = resolveInstallArgs(parse(['--client', 'claude-code,claude-code,cursor']));
+    expect(r.flags!.client).toEqual(['claude-code', 'cursor']);
+  });
   it('errors on an all-invalid --client (fatal)', () => {
     const r = resolveInstallArgs(parse(['--client', 'bogus']));
     expect(r.flags).toBeNull();

--- a/packages/cli/test/install/args.test.ts
+++ b/packages/cli/test/install/args.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import mri from 'mri';
+import { resolveInstallArgs } from '../../src/install/args.js';
+
+const parse = (args: string[]) =>
+  mri(args, { boolean: ['yes', 'dry-run', 'force'], string: ['client', 'scope'], alias: { y: 'yes' } });
+
+describe('resolveInstallArgs', () => {
+  it('parses clients and scope', () => {
+    const r = resolveInstallArgs(parse(['--client', 'claude-code,cursor', '--scope', 'project']));
+    expect(r.flags).toEqual({
+      client: ['claude-code', 'cursor'],
+      scope: 'project',
+      yes: false,
+      dryRun: false,
+      force: false
+    });
+  });
+  it('warns and drops unknown client ids', () => {
+    const r = resolveInstallArgs(parse(['--client', 'claude-code,bogus']));
+    expect(r.flags!.client).toEqual(['claude-code']);
+    expect(r.warnings.join('\n')).toContain('bogus');
+  });
+  it('errors on an invalid scope (fatal)', () => {
+    const r = resolveInstallArgs(parse(['--scope', 'weird']));
+    expect(r.flags).toBeNull();
+    expect(r.errors.join('\n')).toContain('weird');
+  });
+  it('maps -y, --dry-run, --force', () => {
+    const r = resolveInstallArgs(parse(['-y', '--dry-run', '--force']));
+    expect(r.flags).toMatchObject({ yes: true, dryRun: true, force: true });
+  });
+  it('omits client/scope keys when not provided', () => {
+    const r = resolveInstallArgs(parse([]));
+    expect(r.flags).toEqual({ yes: false, dryRun: false, force: false });
+  });
+});

--- a/packages/cli/test/install/cli.test.ts
+++ b/packages/cli/test/install/cli.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { realIO } from '../../src/install/cli.js';
+
+describe('realIO().readFile', () => {
+  it('returns undefined for a nonexistent path (ENOENT)', () => {
+    const path = join(tmpdir(), `svelte-vitals-install-cli-test-${Date.now()}-nonexistent.json`);
+    expect(realIO().readFile(path)).toBeUndefined();
+  });
+
+  it('rethrows non-ENOENT errors instead of swallowing them (e.g. a directory path)', () => {
+    expect(() => realIO().readFile(tmpdir())).toThrow();
+  });
+});

--- a/packages/cli/test/install/clients.test.ts
+++ b/packages/cli/test/install/clients.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { join } from 'node:path';
+import { CLIENTS, clientById, MCP_ENTRY } from '../../src/install/clients.js';
+
+const cwd = '/proj';
+const home = '/home/u';
+
+describe('client writers', () => {
+  it('exposes the fixed MCP entry', () => {
+    expect(MCP_ENTRY).toEqual({ command: 'npx', args: ['-y', '@svelte-vitals/mcp'] });
+  });
+  it('claude-code: project → .mcp.json, global → ~/.claude.json', () => {
+    const c = clientById('claude-code')!;
+    expect(c.format).toBe('json');
+    expect(c.resolvePath('project', cwd, home)).toBe(join('/proj', '.mcp.json'));
+    expect(c.resolvePath('global', cwd, home)).toBe(join('/home/u', '.claude.json'));
+  });
+  it('cursor: project → .cursor/mcp.json, global → ~/.cursor/mcp.json', () => {
+    const c = clientById('cursor')!;
+    expect(c.format).toBe('json');
+    expect(c.resolvePath('project', cwd, home)).toBe(join('/proj', '.cursor', 'mcp.json'));
+    expect(c.resolvePath('global', cwd, home)).toBe(join('/home/u', '.cursor', 'mcp.json'));
+  });
+  it('codex: global-only → ~/.codex/config.toml, toml format', () => {
+    const c = clientById('codex')!;
+    expect(c.scopes).toEqual(['global']);
+    expect(c.format).toBe('toml');
+    expect(c.resolvePath('global', cwd, home)).toBe(join('/home/u', '.codex', 'config.toml'));
+  });
+  it('CLIENTS has all three ids', () => {
+    expect(CLIENTS.map((c) => c.id).sort()).toEqual(['claude-code', 'codex', 'cursor']);
+  });
+});

--- a/packages/cli/test/install/merge.test.ts
+++ b/packages/cli/test/install/merge.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { parse as parseToml } from 'smol-toml';
+import { mergeJson, mergeToml } from '../../src/install/merge.js';
+import { MCP_ENTRY } from '../../src/install/clients.js';
+
+describe('mergeJson', () => {
+  it('creates a new config when none exists', () => {
+    const r = mergeJson(undefined, MCP_ENTRY, false);
+    expect(r.status).toBe('created');
+    expect(JSON.parse(r.content)).toEqual({
+      mcpServers: { 'svelte-vitals': { command: 'npx', args: ['-y', '@svelte-vitals/mcp'] } }
+    });
+    expect(r.content.endsWith('\n')).toBe(true);
+  });
+  it('adds to an existing config without clobbering other servers', () => {
+    const existing = JSON.stringify({ mcpServers: { other: { command: 'x', args: [] } } });
+    const r = mergeJson(existing, MCP_ENTRY, false);
+    expect(r.status).toBe('added');
+    const parsed = JSON.parse(r.content);
+    expect(parsed.mcpServers.other).toEqual({ command: 'x', args: [] });
+    expect(parsed.mcpServers['svelte-vitals'].command).toBe('npx');
+  });
+  it('preserves unrelated top-level keys', () => {
+    const existing = JSON.stringify({ theme: 'dark', mcpServers: {} });
+    const r = mergeJson(existing, MCP_ENTRY, false);
+    expect(JSON.parse(r.content).theme).toBe('dark');
+  });
+  it('is exists (no change) when already identical', () => {
+    const first = mergeJson(undefined, MCP_ENTRY, false).content;
+    expect(mergeJson(first, MCP_ENTRY, false).status).toBe('exists');
+  });
+  it('skips a differing entry without force; updates with force', () => {
+    const existing = JSON.stringify({ mcpServers: { 'svelte-vitals': { command: 'old', args: [] } } });
+    expect(mergeJson(existing, MCP_ENTRY, false).status).toBe('exists');
+    const forced = mergeJson(existing, MCP_ENTRY, true);
+    expect(forced.status).toBe('updated');
+    expect(JSON.parse(forced.content).mcpServers['svelte-vitals'].command).toBe('npx');
+  });
+  it('throws on unparseable existing content', () => {
+    expect(() => mergeJson('{not json', MCP_ENTRY, false)).toThrow();
+  });
+});
+
+describe('mergeToml', () => {
+  it('creates a new toml config', () => {
+    const r = mergeToml(undefined, MCP_ENTRY, false);
+    expect(r.status).toBe('created');
+    const parsed = parseToml(r.content) as Record<string, any>;
+    expect(parsed.mcp_servers['svelte-vitals']).toEqual({ command: 'npx', args: ['-y', '@svelte-vitals/mcp'] });
+  });
+  it('adds without clobbering existing tables or scalars', () => {
+    const existing = 'model = "gpt"\n\n[mcp_servers.other]\ncommand = "x"\nargs = []\n';
+    const r = mergeToml(existing, MCP_ENTRY, false);
+    expect(r.status).toBe('added');
+    const parsed = parseToml(r.content) as Record<string, any>;
+    expect(parsed.model).toBe('gpt');
+    expect(parsed.mcp_servers.other.command).toBe('x');
+    expect(parsed.mcp_servers['svelte-vitals'].command).toBe('npx');
+  });
+  it('exists when identical; updates with force', () => {
+    const first = mergeToml(undefined, MCP_ENTRY, false).content;
+    expect(mergeToml(first, MCP_ENTRY, false).status).toBe('exists');
+    const existing = '[mcp_servers.svelte-vitals]\ncommand = "old"\nargs = []\n';
+    expect(mergeToml(existing, MCP_ENTRY, false).status).toBe('exists');
+    expect(mergeToml(existing, MCP_ENTRY, true).status).toBe('updated');
+  });
+  it('throws on unparseable toml', () => {
+    expect(() => mergeToml('= = =', MCP_ENTRY, false)).toThrow();
+  });
+});

--- a/packages/cli/test/install/merge.test.ts
+++ b/packages/cli/test/install/merge.test.ts
@@ -45,17 +45,20 @@ describe('mergeToml', () => {
   it('creates a new toml config', () => {
     const r = mergeToml(undefined, MCP_ENTRY, false);
     expect(r.status).toBe('created');
-    const parsed = parseToml(r.content) as Record<string, any>;
+    const parsed = parseToml(r.content) as { mcp_servers: Record<string, { command: string; args: unknown[] }> };
     expect(parsed.mcp_servers['svelte-vitals']).toEqual({ command: 'npx', args: ['-y', '@svelte-vitals/mcp'] });
   });
   it('adds without clobbering existing tables or scalars', () => {
     const existing = 'model = "gpt"\n\n[mcp_servers.other]\ncommand = "x"\nargs = []\n';
     const r = mergeToml(existing, MCP_ENTRY, false);
     expect(r.status).toBe('added');
-    const parsed = parseToml(r.content) as Record<string, any>;
+    const parsed = parseToml(r.content) as {
+      model?: string;
+      mcp_servers: Record<string, { command: string; args: unknown[] }>;
+    };
     expect(parsed.model).toBe('gpt');
-    expect(parsed.mcp_servers.other.command).toBe('x');
-    expect(parsed.mcp_servers['svelte-vitals'].command).toBe('npx');
+    expect(parsed.mcp_servers.other!.command).toBe('x');
+    expect(parsed.mcp_servers['svelte-vitals']!.command).toBe('npx');
   });
   it('exists when identical; updates with force', () => {
     const first = mergeToml(undefined, MCP_ENTRY, false).content;

--- a/packages/cli/test/install/merge.test.ts
+++ b/packages/cli/test/install/merge.test.ts
@@ -39,6 +39,13 @@ describe('mergeJson', () => {
   it('throws on unparseable existing content', () => {
     expect(() => mergeJson('{not json', MCP_ENTRY, false)).toThrow();
   });
+  it('throws when existing content parses to a non-object root', () => {
+    expect(() => mergeJson('["x"]', MCP_ENTRY, false)).toThrow();
+  });
+  it('throws when mcpServers is not a plain object', () => {
+    const existing = JSON.stringify({ mcpServers: ['x'] });
+    expect(() => mergeJson(existing, MCP_ENTRY, false)).toThrow();
+  });
 });
 
 describe('mergeToml', () => {
@@ -69,5 +76,9 @@ describe('mergeToml', () => {
   });
   it('throws on unparseable toml', () => {
     expect(() => mergeToml('= = =', MCP_ENTRY, false)).toThrow();
+  });
+  it('throws when mcp_servers is not a table', () => {
+    const existing = 'mcp_servers = ["x"]\n';
+    expect(() => mergeToml(existing, MCP_ENTRY, false)).toThrow();
   });
 });

--- a/packages/cli/test/install/run.test.ts
+++ b/packages/cli/test/install/run.test.ts
@@ -81,4 +81,10 @@ describe('runInstall', () => {
     expect(await runInstall({}, io, prompts)).toBe(0);
     expect(writes).toEqual({});
   });
+  it('unparseable existing config exits 2 without writing', async () => {
+    const { io, writes, err } = fakeIO({ files: { '/proj/.mcp.json': '{not json' } });
+    expect(await runInstall({ client: ['claude-code'], scope: 'project', yes: true }, io, noPrompts)).toBe(2);
+    expect(writes).toEqual({});
+    expect(err.join('\n')).toContain('/proj/.mcp.json');
+  });
 });

--- a/packages/cli/test/install/run.test.ts
+++ b/packages/cli/test/install/run.test.ts
@@ -1,13 +1,20 @@
 import { describe, it, expect } from 'vitest';
 import { runInstall, type InstallIO, type InstallPrompts } from '../../src/install/index.js';
 
-function fakeIO(over: { files?: Record<string, string>; isTTY?: boolean; failWritePath?: string } = {}) {
+function fakeIO(
+  over: { files?: Record<string, string>; isTTY?: boolean; failWritePath?: string; throwOnRead?: string } = {}
+) {
   const files = over.files ?? {};
   const writes: Record<string, string> = {};
   const out: string[] = [];
   const err: string[] = [];
   const io: InstallIO = {
-    readFile: (p) => files[p],
+    readFile: (p) => {
+      if (over.throwOnRead && p === over.throwOnRead) {
+        throw new Error(`EACCES: permission denied, open '${p}'`);
+      }
+      return files[p];
+    },
     writeFile: (p, c) => {
       if (over.failWritePath && p === over.failWritePath) {
         throw new Error(`EACCES: permission denied, open '${p}'`);
@@ -94,6 +101,17 @@ describe('runInstall', () => {
     const { io, writes } = fakeIO();
     await runInstall({ client: ['claude-code'], yes: true }, io, noPrompts);
     expect(Object.keys(writes)).toEqual(['/proj/.mcp.json']);
+  });
+  it('TTY detection tolerates a throwing readFile (e.g. EACCES) without crashing', async () => {
+    const { io, writes } = fakeIO({ isTTY: true, throwOnRead: '/proj/.cursor/mcp.json' });
+    const prompts: InstallPrompts = {
+      ...noPrompts,
+      selectClients: async () => ['claude-code'],
+      selectScope: async () => 'project',
+      confirm: async () => true
+    };
+    expect(await runInstall({}, io, prompts)).toBe(0);
+    expect(writes['/proj/.mcp.json']).toBeDefined();
   });
   it('a per-file write failure names the failing path, keeps earlier writes, and does not abort the run', async () => {
     const { io, writes, err } = fakeIO({ failWritePath: '/proj/.cursor/mcp.json' });

--- a/packages/cli/test/install/run.test.ts
+++ b/packages/cli/test/install/run.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { runInstall, type InstallIO, type InstallPrompts } from '../../src/install/index.js';
 
-function fakeIO(over: { files?: Record<string, string>; isTTY?: boolean } = {}) {
+function fakeIO(over: { files?: Record<string, string>; isTTY?: boolean; failWritePath?: string } = {}) {
   const files = over.files ?? {};
   const writes: Record<string, string> = {};
   const out: string[] = [];
@@ -9,6 +9,9 @@ function fakeIO(over: { files?: Record<string, string>; isTTY?: boolean } = {}) 
   const io: InstallIO = {
     readFile: (p) => files[p],
     writeFile: (p, c) => {
+      if (over.failWritePath && p === over.failWritePath) {
+        throw new Error(`EACCES: permission denied, open '${p}'`);
+      }
       writes[p] = c;
     },
     cwd: '/proj',
@@ -86,5 +89,18 @@ describe('runInstall', () => {
     expect(await runInstall({ client: ['claude-code'], scope: 'project', yes: true }, io, noPrompts)).toBe(2);
     expect(writes).toEqual({});
     expect(err.join('\n')).toContain('/proj/.mcp.json');
+  });
+  it('non-TTY without --scope defaults to project for multi-scope clients', async () => {
+    const { io, writes } = fakeIO();
+    await runInstall({ client: ['claude-code'], yes: true }, io, noPrompts);
+    expect(Object.keys(writes)).toEqual(['/proj/.mcp.json']);
+  });
+  it('a per-file write failure names the failing path, keeps earlier writes, and does not abort the run', async () => {
+    const { io, writes, err } = fakeIO({ failWritePath: '/proj/.cursor/mcp.json' });
+    const code = await runInstall({ client: ['claude-code', 'cursor'], scope: 'project', yes: true }, io, noPrompts);
+    expect(code).toBe(2);
+    expect(writes['/proj/.mcp.json']).toBeDefined();
+    expect(writes['/proj/.cursor/mcp.json']).toBeUndefined();
+    expect(err.join('\n')).toContain('/proj/.cursor/mcp.json');
   });
 });

--- a/packages/cli/test/install/run.test.ts
+++ b/packages/cli/test/install/run.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { runInstall, type InstallIO, type InstallPrompts } from '../../src/install/index.js';
+
+function fakeIO(over: { files?: Record<string, string>; isTTY?: boolean } = {}) {
+  const files = over.files ?? {};
+  const writes: Record<string, string> = {};
+  const out: string[] = [];
+  const err: string[] = [];
+  const io: InstallIO = {
+    readFile: (p) => files[p],
+    writeFile: (p, c) => {
+      writes[p] = c;
+    },
+    cwd: '/proj',
+    home: '/home/u',
+    isTTY: over.isTTY ?? false,
+    log: (l) => out.push(l),
+    errorLog: (l) => err.push(l)
+  };
+  return { io, writes, out, err };
+}
+
+const noPrompts: InstallPrompts = {
+  selectClients: async () => null,
+  selectScope: async () => null,
+  confirm: async () => true
+};
+
+describe('runInstall', () => {
+  it('non-TTY without --client exits 2 with guidance', async () => {
+    const { io, err } = fakeIO();
+    expect(await runInstall({}, io, noPrompts)).toBe(2);
+    expect(err.join('\n')).toContain('--client');
+  });
+  it('flag-only writes the selected client config', async () => {
+    const { io, writes } = fakeIO();
+    expect(await runInstall({ client: ['claude-code'], scope: 'project', yes: true }, io, noPrompts)).toBe(0);
+    expect(Object.keys(writes)).toEqual(['/proj/.mcp.json']);
+    expect(JSON.parse(writes['/proj/.mcp.json']!).mcpServers['svelte-vitals'].command).toBe('npx');
+  });
+  it('dry-run writes nothing', async () => {
+    const { io, writes, out } = fakeIO();
+    expect(await runInstall({ client: ['cursor'], scope: 'global', dryRun: true }, io, noPrompts)).toBe(0);
+    expect(writes).toEqual({});
+    expect(out.join('\n')).toContain('Dry run');
+  });
+  it('codex ignores scope and uses the global config.toml', async () => {
+    const { io, writes } = fakeIO();
+    await runInstall({ client: ['codex'], yes: true }, io, noPrompts);
+    expect(Object.keys(writes)).toEqual(['/home/u/.codex/config.toml']);
+  });
+  it('an existing identical entry is skipped (no write)', async () => {
+    const first = fakeIO();
+    await runInstall({ client: ['claude-code'], scope: 'project', yes: true }, first.io, noPrompts);
+    const content = first.writes['/proj/.mcp.json']!;
+    const { io, writes, out } = fakeIO({ files: { '/proj/.mcp.json': content } });
+    await runInstall({ client: ['claude-code'], scope: 'project', yes: true }, io, noPrompts);
+    expect(writes).toEqual({});
+    expect(out.join('\n')).toContain('already configured');
+  });
+  it('force overwrites a differing entry', async () => {
+    const existing = JSON.stringify({ mcpServers: { 'svelte-vitals': { command: 'old', args: [] } } });
+    const { io, writes } = fakeIO({ files: { '/proj/.mcp.json': existing } });
+    await runInstall({ client: ['claude-code'], scope: 'project', yes: true, force: true }, io, noPrompts);
+    expect(JSON.parse(writes['/proj/.mcp.json']!).mcpServers['svelte-vitals'].command).toBe('npx');
+  });
+  it('a multi-client plan writes each config', async () => {
+    const { io, writes } = fakeIO();
+    await runInstall({ client: ['claude-code', 'cursor'], scope: 'project', yes: true }, io, noPrompts);
+    expect(Object.keys(writes).sort()).toEqual(['/proj/.cursor/mcp.json', '/proj/.mcp.json']);
+  });
+  it('TTY confirm=false writes nothing', async () => {
+    const { io, writes } = fakeIO({ isTTY: true });
+    const prompts: InstallPrompts = { ...noPrompts, confirm: async () => false };
+    expect(await runInstall({ client: ['claude-code'], scope: 'project' }, io, prompts)).toBe(0);
+    expect(writes).toEqual({});
+  });
+  it('TTY client-picker cancel exits 0 without writing', async () => {
+    const { io, writes } = fakeIO({ isTTY: true });
+    const prompts: InstallPrompts = { ...noPrompts, selectClients: async () => null };
+    expect(await runInstall({}, io, prompts)).toBe(0);
+    expect(writes).toEqual({});
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ catalogs:
     sharp:
       specifier: ^0.35.2
       version: 0.35.2
+    smol-toml:
+      specifier: ^1.4.1
+      version: 1.6.1
     svelte:
       specifier: ^5.56.3
       version: 5.56.3
@@ -185,6 +188,9 @@ importers:
       mri:
         specifier: 'catalog:'
         version: 1.2.0
+      smol-toml:
+        specifier: 'catalog:'
+        version: 1.6.1
       svelte:
         specifier: 'catalog:'
         version: 5.56.3(@typescript-eslint/types@8.61.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     '@changesets/cli':
       specifier: ^2.31.0
       version: 2.31.0
+    '@clack/prompts':
+      specifier: ^0.11.0
+      version: 0.11.0
     '@eslint/compat':
       specifier: ^2.1.0
       version: 2.1.0
@@ -182,6 +185,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@clack/prompts':
+        specifier: 'catalog:'
+        version: 0.11.0
       '@svelte-vitals/core':
         specifier: workspace:*
         version: link:../core
@@ -411,9 +417,15 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
+  '@clack/core@0.5.0':
+    resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
+
   '@clack/core@1.4.2':
     resolution: {integrity: sha512-0Ty/1Gfm+Kb07sXcuESjyKfwEhSy4Ns1AgeEisHb/bDY5fWme0tTeTkU14T1Gmcs17YIjB/teiDe4uaCghbYqQ==}
     engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@0.11.0':
+    resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
 
   '@clack/prompts@1.6.0':
     resolution: {integrity: sha512-EYlRokl8szrP9Z25qT5aepMdBjzBvHF9ZEhzIiUBc9guz/T31EqRgvD0QSgZcpE93xiwrr+OkB4nz0BZyF6fSA==}
@@ -4705,9 +4717,20 @@ snapshots:
       human-id: 4.2.0
       prettier: 2.8.8
 
+  '@clack/core@0.5.0':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
   '@clack/core@1.4.2':
     dependencies:
       fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  '@clack/prompts@0.11.0':
+    dependencies:
+      '@clack/core': 0.5.0
+      picocolors: 1.1.1
       sisteransi: 1.0.5
 
   '@clack/prompts@1.6.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ allowBuilds:
 
 catalog:
   '@arethetypeswrong/cli': ^0.18.0
+  '@clack/prompts': ^0.11.0
   '@astrojs/check': ^0.9.9
   '@astrojs/starlight': ^0.40.0
   '@changesets/cli': ^2.31.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,7 @@ catalog:
   sharp: ^0.35.2
   prettier-plugin-svelte: ^4.1.0
   publint: ^0.3.21
+  smol-toml: ^1.4.1
   svelte: ^5.56.3
   tinyglobby: ^0.2.17
   tsup: ^8.5.1


### PR DESCRIPTION
## Summary

Adds an interactive `svelte-vitals install` command that sets up the svelte-vitals MCP server for the user's AI-agent clients — **Claude Code, Cursor, and Codex** — so wiring up the server no longer means hand-editing each client's config. It merges into the existing config **without touching other servers**, prompts for the clients and scope interactively, and supports flags for non-interactive/CI use.

This is the second half of making the CLI more interactive and rich (the first half — colorized console output — shipped in #82). AI-agent integration is a core product pillar, so a one-command MCP setup directly serves it.

## What it does

```
npx svelte-vitals install
```

- **Interactive**: pick clients (multiselect, pre-checked for clients whose config already exists), pick a scope per client, preview the plan, confirm.
- **Non-interactive / CI**: `--client claude-code,cursor,codex --scope project --yes` (also `--dry-run`, `--force`).
- **Per-client config**:
  | Client | project | global | format |
  | ------ | ------- | ------ | ------ |
  | Claude Code | `.mcp.json` | `~/.claude.json` | JSON |
  | Cursor | `.cursor/mcp.json` | `~/.cursor/mcp.json` | JSON |
  | Codex | — | `~/.codex/config.toml` | TOML |
- Writes exactly `{ "command": "npx", "args": ["-y", "@svelte-vitals/mcp"] }` under each client's server table.

## Design

- **Per-client writer modules** (`clients.ts`) localize each client's path/format quirks (Codex is global-only TOML).
- **Pure JSON/TOML merge** (`merge.ts`) preserves all other servers and unrelated keys, and **throws rather than clobbering** a config it can't parse (or one whose root/servers table isn't an object). TOML round-trips via `smol-toml`.
- **`runInstall(flags, io, prompts)`** (`index.ts`) orchestrates via injected IO + prompt interfaces, so the whole flow is unit-tested without real fs or a real TTY. `bin.ts` supplies the node:fs IO and a `@clack/prompts`-backed adapter.
- The existing scanner CLI (no subcommand) is unchanged — the `install` branch triggers only on the literal first arg.

## Safety

The cardinal risk for a config-mutating command is corrupting a user's existing config. Guarded by:
- merges mutate only the `svelte-vitals` key; other servers and top-level keys are preserved (asserted by tests),
- parse failures and non-object roots/tables **throw** — the plan-building phase is wrapped so this surfaces as a clean `svelte-vitals: could not parse existing config at <path>` and exit 2, never a partial write,
- an existing identical entry is a no-op; a differing entry is left alone unless `--force`.

## Dependencies

Adds `@clack/prompts` (interactive prompts) and `smol-toml` (TOML parse/stringify) to the CLI, both via the pnpm workspace catalog. `@svelte-vitals/core` is untouched.

## Testing

- Full suite green: core 256 / vite 76 / cli 283 / mcp 9 = **624 tests**.
- New install tests: client path resolution, JSON/TOML merge (all four statuses + preserve-existing + throw-on-bad-input), `runInstall` orchestration (flag-only, dry-run, non-TTY guard, force, cancel, multi-client, codex-forced-global, unparseable-config → exit 2), and flag parsing.
- End-to-end verified: dry-run, real write to a temp dir, non-TTY guard, `install --help`, and the unchanged scanner `--help`.
- typecheck + lint + prettier clean; no existing assertions loosened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `install` command to set up the MCP server for Claude Code, Cursor, and Codex.
  * Supports guided prompts for client and scope selection, plus non-interactive flags like `--client`, `--scope`, `--yes`, `--dry-run`, and `--force`.
  * Automatically merges the setup into existing config files without removing other entries.

* **Bug Fixes**
  * Preserves existing configuration while updating only the relevant MCP server entry.
  * Handles duplicate installs by skipping unchanged setups unless forced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->