### PR TITLE
docs: document the svelte-vitals install command

### DIFF
--- a/docs/src/content/docs/guides/cli.md
+++ b/docs/src/content/docs/guides/cli.md
@@ -11,6 +11,8 @@ svelte-vitals [path] [options]
 
 `path` is optional and defaults to the current directory.
 
+> There is also an [`install` subcommand](#svelte-vitals-install) for setting up the MCP server in your AI-agent clients.
+
 ## Flags
 
 ### `--reporter <fmt>`
@@ -136,6 +138,52 @@ Print the help text and exit.
 ### `-v, --version`
 
 Print the version and exit.
+
+## `svelte-vitals install`
+
+Interactively set up the svelte-vitals [MCP server](/svelte-vitals/guides/mcp/) for your AI-agent clients — **Claude Code**, **Cursor**, and **Codex** — by merging the server entry into each client's config (your other servers are left untouched).
+
+```bash
+npx svelte-vitals install
+```
+
+With no flags it launches an interactive wizard: pick your clients, choose a scope per client, review the plan, and confirm. For non-interactive/CI use, drive it entirely with flags.
+
+### `--client <ids>`
+
+Comma-separated clients to configure: `claude-code`, `cursor`, `codex`. When given, the interactive picker is skipped.
+
+### `--scope <project|global>`
+
+Where to write the config. Applies to all selected clients; **Codex is always global** (it has no project-scoped config).
+
+| Client      | project            | global                 |
+| ----------- | ------------------ | ---------------------- |
+| Claude Code | `.mcp.json`        | `~/.claude.json`       |
+| Cursor      | `.cursor/mcp.json` | `~/.cursor/mcp.json`   |
+| Codex       | —                  | `~/.codex/config.toml` |
+
+### `--yes`, `-y`
+
+Skip the confirmation prompt.
+
+### `--dry-run`
+
+Print the planned changes and exit without writing anything.
+
+### `--force`
+
+Overwrite an existing `svelte-vitals` entry. By default an entry that already exists is left untouched.
+
+```bash
+# Non-interactive: configure Claude Code + Cursor for this project
+npx svelte-vitals install --client claude-code,cursor --scope project --yes
+
+# Preview what would change, without writing
+npx svelte-vitals install --client codex --dry-run
+```
+
+If an existing config can't be parsed, the command fails without writing (exit `2`) rather than overwriting it.
 
 ## Exit codes
 

--- a/docs/src/content/docs/guides/getting-started.md
+++ b/docs/src/content/docs/guides/getting-started.md
@@ -73,4 +73,4 @@ These codes are stable and suitable for CI gates.
 
 - See [CLI reference](/svelte-vitals/guides/cli/) for all flags.
 - Use [Plugin mode](/svelte-vitals/guides/plugin-mode/) to integrate with `vite build`.
-- Use [MCP](/svelte-vitals/guides/mcp/) to let AI agents run the analysis automatically.
+- Use [MCP](/svelte-vitals/guides/mcp/) to let AI agents run the analysis automatically — `npx svelte-vitals install` wires it into Claude Code / Cursor / Codex in one step.

--- a/docs/src/content/docs/guides/mcp.md
+++ b/docs/src/content/docs/guides/mcp.md
@@ -49,7 +49,7 @@ Run the interactive installer from your project root — it configures the MCP s
 npx svelte-vitals install
 ```
 
-It supports **Claude Code**, **Cursor**, and **Codex**, merging the server entry into each client's config without touching your other servers. See the [`install` command](/svelte-vitals/guides/cli/#svelte-vitals-install) for the available flags (`--client`, `--scope`, `--dry-run`, `--force`).
+It supports **Claude Code**, **Cursor**, and **Codex**, merging the server entry into each client's config without touching your other servers. See the [`install` command](/svelte-vitals/guides/cli/#svelte-vitals-install) for the available flags (`--client`, `--scope`, `--yes`, `--dry-run`, `--force`).
 
 ### Manual setup
 

--- a/docs/src/content/docs/guides/mcp.md
+++ b/docs/src/content/docs/guides/mcp.md
@@ -41,9 +41,19 @@ Return documentation for a single rule.
 
 ## Setup
 
-### Claude Desktop / Claude Code
+### Quick setup (recommended)
 
-Add to your MCP client configuration (e.g. `~/.claude/claude_desktop_config.json`):
+Run the interactive installer from your project root — it configures the MCP server for you:
+
+```bash
+npx svelte-vitals install
+```
+
+It supports **Claude Code**, **Cursor**, and **Codex**, merging the server entry into each client's config without touching your other servers. See the [`install` command](/svelte-vitals/guides/cli/#svelte-vitals-install) for the available flags (`--client`, `--scope`, `--dry-run`, `--force`).
+
+### Manual setup
+
+Any MCP client that supports stdio-transport servers can be configured by hand. Add the following to the client's config (e.g. Claude Code's `.mcp.json`, or `~/.claude.json`):
 
 ```json
 {
@@ -56,9 +66,13 @@ Add to your MCP client configuration (e.g. `~/.claude/claude_desktop_config.json
 }
 ```
 
-### Other MCP clients
+For Codex, the equivalent TOML in `~/.codex/config.toml`:
 
-Any client that supports stdio-transport MCP servers can use the same pattern — set the command to `npx` and args to `["-y", "@svelte-vitals/mcp"]`.
+```toml
+[mcp_servers.svelte-vitals]
+command = "npx"
+args = ["-y", "@svelte-vitals/mcp"]
+```
 
 ## Transport
 

--- a/docs/src/content/docs/ja/guides/cli.md
+++ b/docs/src/content/docs/ja/guides/cli.md
@@ -11,6 +11,8 @@ svelte-vitals [path] [options]
 
 `path` は省略可能で、デフォルトはカレントディレクトリです。
 
+> AI エージェントのクライアントに MCP サーバーをセットアップするための [`install` サブコマンド](#svelte-vitals-install) もあります。
+
 ## フラグ
 
 ### `--reporter <fmt>`
@@ -117,6 +119,52 @@ svelte-vitals --meta-components "SeoHead,PageMeta"
 ### `-v, --version`
 
 バージョンを表示して終了します。
+
+## `svelte-vitals install`
+
+svelte-vitals の [MCP サーバー](/svelte-vitals/ja/guides/mcp/) を、AI エージェントのクライアント（**Claude Code**、**Cursor**、**Codex**）に対話的にセットアップします。各クライアントの設定にサーバーエントリをマージします（既存の他のサーバーはそのまま維持されます）。
+
+```bash
+npx svelte-vitals install
+```
+
+フラグなしで実行すると対話式ウィザードが起動します — クライアントを選択し、クライアントごとにスコープを選び、変更計画を確認して適用します。非対話環境／CI ではフラグだけで実行できます。
+
+### `--client <ids>`
+
+設定するクライアントをカンマ区切りで指定します：`claude-code`、`cursor`、`codex`。指定した場合は対話式の選択がスキップされます。
+
+### `--scope <project|global>`
+
+設定の書き込み先。選択したすべてのクライアントに適用されます。**Codex は常に global** です（プロジェクトスコープの設定を持たないため）。
+
+| クライアント | project            | global                 |
+| ------------ | ------------------ | ---------------------- |
+| Claude Code  | `.mcp.json`        | `~/.claude.json`       |
+| Cursor       | `.cursor/mcp.json` | `~/.cursor/mcp.json`   |
+| Codex        | —                  | `~/.codex/config.toml` |
+
+### `--yes`, `-y`
+
+確認プロンプトをスキップします。
+
+### `--dry-run`
+
+変更計画を表示し、何も書き込まずに終了します。
+
+### `--force`
+
+既存の `svelte-vitals` エントリを上書きします。デフォルトでは、既に存在するエントリはそのまま維持されます。
+
+```bash
+# 非対話：このプロジェクトに Claude Code + Cursor を設定
+npx svelte-vitals install --client claude-code,cursor --scope project --yes
+
+# 何が変更されるかを書き込まずにプレビュー
+npx svelte-vitals install --client codex --dry-run
+```
+
+既存の設定ファイルが解析できない場合、上書きせずに失敗します（終了コード `2`）。
 
 ## 終了コード
 

--- a/docs/src/content/docs/ja/guides/getting-started.md
+++ b/docs/src/content/docs/ja/guides/getting-started.md
@@ -73,4 +73,4 @@ Passed (3)
 
 - すべてのフラグについては [CLI リファレンス](/svelte-vitals/ja/guides/cli/) を参照してください。
 - `vite build` と連携するには [プラグインモード](/svelte-vitals/ja/guides/plugin-mode/) を使用してください。
-- AI エージェントが自動的に分析を実行できるようにするには [MCP](/svelte-vitals/ja/guides/mcp/) を使用してください。
+- AI エージェントが自動的に分析を実行できるようにするには [MCP](/svelte-vitals/ja/guides/mcp/) を使用してください — `npx svelte-vitals install` で Claude Code / Cursor / Codex に一発で組み込めます。

--- a/docs/src/content/docs/ja/guides/mcp.md
+++ b/docs/src/content/docs/ja/guides/mcp.md
@@ -49,7 +49,7 @@ SvelteKit プロジェクトの静的モード分析を実行します。
 npx svelte-vitals install
 ```
 
-**Claude Code**、**Cursor**、**Codex** に対応しており、各クライアントの設定にサーバーエントリをマージします（既存の他のサーバーはそのまま維持されます）。利用可能なフラグ（`--client`、`--scope`、`--dry-run`、`--force`）については [`install` コマンド](/svelte-vitals/ja/guides/cli/#svelte-vitals-install) を参照してください。
+**Claude Code**、**Cursor**、**Codex** に対応しており、各クライアントの設定にサーバーエントリをマージします（既存の他のサーバーはそのまま維持されます）。利用可能なフラグ（`--client`、`--scope`、`--yes`、`--dry-run`、`--force`）については [`install` コマンド](/svelte-vitals/ja/guides/cli/#svelte-vitals-install) を参照してください。
 
 ### 手動セットアップ
 

--- a/docs/src/content/docs/ja/guides/mcp.md
+++ b/docs/src/content/docs/ja/guides/mcp.md
@@ -41,9 +41,19 @@ SvelteKit プロジェクトの静的モード分析を実行します。
 
 ## セットアップ
 
-### Claude Desktop / Claude Code
+### クイックセットアップ（推奨）
 
-MCP クライアント設定（例：`~/.claude/claude_desktop_config.json`）に追加します：
+プロジェクトルートで対話式インストーラーを実行すると、MCP サーバーを自動で設定します：
+
+```bash
+npx svelte-vitals install
+```
+
+**Claude Code**、**Cursor**、**Codex** に対応しており、各クライアントの設定にサーバーエントリをマージします（既存の他のサーバーはそのまま維持されます）。利用可能なフラグ（`--client`、`--scope`、`--dry-run`、`--force`）については [`install` コマンド](/svelte-vitals/ja/guides/cli/#svelte-vitals-install) を参照してください。
+
+### 手動セットアップ
+
+stdio トランスポートをサポートする任意の MCP クライアントは手動で設定できます。クライアントの設定（例：Claude Code の `.mcp.json` や `~/.claude.json`）に以下を追加します：
 
 ```json
 {
@@ -56,9 +66,13 @@ MCP クライアント設定（例：`~/.claude/claude_desktop_config.json`）�
 }
 ```
 
-### その他の MCP クライアント
+Codex の場合、`~/.codex/config.toml` に相当する TOML を追加します：
 
-stdio トランスポート MCP サーバーをサポートする任意のクライアントで同じパターンを使用できます — コマンドを `npx` に、引数を `["-y", "@svelte-vitals/mcp"]` に設定してください。
+```toml
+[mcp_servers.svelte-vitals]
+command = "npx"
+args = ["-y", "@svelte-vitals/mcp"]
+```
 
 ## トランスポート
 


### PR DESCRIPTION
## Summary

Documents the `svelte-vitals install` command, which shipped in `svelte-vitals@0.17.0` (#85) but was not yet covered in the docs.

## Changes

- **CLI reference** (`guides/cli.md`, en + ja): new `svelte-vitals install` section documenting the subcommand and its flags (`--client`, `--scope`, `--yes`, `--dry-run`, `--force`), with the per-client config-path table (Claude Code / Cursor / Codex) and a note that an unparseable existing config fails without overwriting. A pointer to it is added to the Usage section.
- **MCP guide** (`guides/mcp.md`, en + ja): the Setup section now leads with the interactive installer (`npx svelte-vitals install`) as the recommended path and keeps hand-editing as "Manual setup", including the Codex TOML form.
- **Getting started** (`guides/getting-started.md`, en + ja): the MCP next-step line now mentions the one-step installer.

## Testing

- `prettier --check` clean on all six edited files.
- `astro build` succeeds (113 pages); verified the generated `#svelte-vitals-install` anchor exists in both the en and ja CLI pages and that the MCP guide links to it.

Docs-only change — no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for a new `svelte-vitals install` command to simplify MCP setup.
  * Included quick-start guidance for configuring Claude Code, Cursor, and Codex in one step.

* **Documentation**
  * Expanded CLI reference with command usage, flags, examples, and failure behavior.
  * Updated getting-started and MCP guides with clearer setup paths, including Codex configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->