### PR TITLE
chore: add missing changeset for install-wizard Vite plugin targets

### DIFF
--- a/.changeset/install-vite-targets.md
+++ b/.changeset/install-vite-targets.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': minor
+---
+
+`npx svelte-vitals install` can now also set up `@svelte-vitals/vite`: `--client vite-plugin` registers the build-mode plugin in `vite.config.{ts,js,mjs}`, and `--client vite-dev-overlay` wires the dev-overlay hook into `src/hooks.server.{ts,js}`. Both use a `magicast` codemod that only edits a file whose shape it confidently recognizes — anything else is left untouched and a snippet is printed instead. When either target is written and `@svelte-vitals/vite` isn't already a dependency, it's installed automatically via the detected package manager. `--force` does not apply to these two targets — an existing registration is always left as-is.


### PR DESCRIPTION
## Summary
- #99 (Vite plugin targets in the install wizard) merged without a changeset. This adds it — `svelte-vitals` minor bump, matching the description used for the original MCP install-wizard changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `npx svelte-vitals install` to configure additional Vite-related targets.
  * Introduced two new client options: one to register the Vite build-mode plugin and another to wire up the dev-overlay hook.
  * If the required Vite package is missing, it will now be installed automatically when either target is added.
  * Existing registrations are preserved, even when using `--force`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->