### PR TITLE
chore(renovate): stop auto-bumping published packages' engines.node

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,12 @@
   "rangeStrategy": "bump",
   "packageRules": [
     {
+      "description": "Published packages' engines.node is a public compatibility floor for consumers, not a dev-toolchain pin — never auto-bump it.",
+      "matchDepTypes": ["engines"],
+      "matchFileNames": ["packages/*/package.json"],
+      "enabled": false
+    },
+    {
       "groupName": "dependencies",
       "matchDepTypes": ["dependencies"]
     },


### PR DESCRIPTION
## Summary
- #98 bumped `engines.node` to `>=24.18.0` across all four published packages (`svelte-vitals`, `@svelte-vitals/core`, `@svelte-vitals/vite`, `@svelte-vitals/mcp`). That field is a public compatibility promise to consumers, not the dev-toolchain pin (the root `devEngines.runtime.version`, which #98 did not touch) — jumping to a Node release that was 11 days old at the time would drop support for anyone still on Node 18/20/22 LTS.
- Adds a Renovate `packageRules` entry disabling `engines` updates specifically for `packages/*/package.json`, so this can't recur. Root-level dev tooling versions are unaffected and still tracked normally.
- #98 should be closed without merging (will do once this lands).

## Test plan
- [x] `renovate.json` validated as well-formed JSON
- N/A — config-only change, no code/build/test surface