### PR TITLE
docs: replace hero title text with the logo (en/ja)

### DIFF
--- a/docs/public/wordmark.svg
+++ b/docs/public/wordmark.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 380 56" role="img" aria-labelledby="sv-hero-wordmark-title">
+  <title id="sv-hero-wordmark-title">svelte-vitals</title>
+  <defs>
+    <clipPath id="sv-hero-wordmark-clip">
+      <rect x="2" y="2" width="52" height="52" rx="14" />
+    </clipPath>
+  </defs>
+  <rect x="2" y="2" width="52" height="52" rx="14" fill="#FF3E00" />
+  <polyline
+    clip-path="url(#sv-hero-wordmark-clip)"
+    points="4,28 15,28 17.5,23.5 20,28 23,28 26,7 29,49 32,28 35,28 37,24.5 39.5,28 52,28"
+    fill="none"
+    stroke="#fff"
+    stroke-width="3"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <text
+    x="70"
+    y="38"
+    font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif"
+    font-size="30"
+    font-weight="700"
+    fill="#FF3E00"
+  >svelte-vitals</text>
+</svg>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -3,6 +3,7 @@ title: svelte-vitals
 description: A SvelteKit SEO & Performance checker — static analysis of your routes, before they ship.
 template: splash
 hero:
+  title: '<img src="/svelte-vitals/wordmark.svg" alt="svelte-vitals" style="height: 3.5rem; max-width: 100%;" />'
   tagline: Audit your SvelteKit app's SEO and Performance from source — no running site needed.
   actions:
     - text: Get started

--- a/docs/src/content/docs/ja/index.mdx
+++ b/docs/src/content/docs/ja/index.mdx
@@ -3,6 +3,7 @@ title: svelte-vitals
 description: SvelteKit 向けの SEO・パフォーマンス チェッカー — 出荷前にルートを静的解析します。
 template: splash
 hero:
+  title: '<img src="/svelte-vitals/wordmark.svg" alt="svelte-vitals" style="height: 3.5rem; max-width: 100%;" />'
   tagline: 稼働中のサイト不要。ソースから SvelteKit アプリの SEO とパフォーマンスを審査します。
   actions:
     - text: はじめに


### PR DESCRIPTION
## Summary
- The docs homepage (`en`/`ja`) hero still showed plain "svelte-vitals" text; the README already replaced this with the logo earlier. This does the same for the docs site's top page.
- Uses a single wordmark colored to work on both Starlight themes (not the README's light/dark `<picture>` pair), since Starlight's theme toggle can be set independently of the OS `prefers-color-scheme`, so a media-query-based swap could pick the wrong variant for a manually-toggled theme.

## Test plan
- [x] `pnpm --filter docs build` — 115 pages built, no errors
- [x] Verified the built `dist/index.html` and `dist/ja/index.html` both render `<h1>` containing the wordmark `<img>` instead of plain text
- [x] Rendered the SVG on both a white and near-black background to confirm legibility in both themes