### PR TITLE
docs: order the sidebar naturally instead of alphabetically

### DIFF
--- a/docs/src/content/docs/guides/choosing-a-package.md
+++ b/docs/src/content/docs/guides/choosing-a-package.md
@@ -1,6 +1,8 @@
 ---
 title: Choosing a package
 description: Which of svelte-vitals' three packages to use, and when to combine them.
+sidebar:
+  order: 2
 ---
 
 svelte-vitals ships as three packages — `svelte-vitals` (CLI), `@svelte-vitals/vite` (plugin + dev overlay), and `@svelte-vitals/mcp` (MCP server). They share the same rule engine and scoring, but read different input and cover different ground. Most projects end up using more than one.

--- a/docs/src/content/docs/guides/cli.md
+++ b/docs/src/content/docs/guides/cli.md
@@ -1,6 +1,8 @@
 ---
 title: CLI reference
 description: Complete reference for all svelte-vitals command-line flags.
+sidebar:
+  order: 3
 ---
 
 ## Usage

--- a/docs/src/content/docs/guides/dev-overlay.md
+++ b/docs/src/content/docs/guides/dev-overlay.md
@@ -1,6 +1,8 @@
 ---
 title: Dev overlay
 description: Get live SEO warnings in the dev server without waiting for a build.
+sidebar:
+  order: 5
 ---
 
 `@svelte-vitals/vite` includes a SvelteKit `handle` hook — `svelteVitalsHandle` — that runs SEO analysis on every page served in the **development server**. Warnings are printed to the terminal as you navigate your app. No build step needed.

--- a/docs/src/content/docs/guides/getting-started.md
+++ b/docs/src/content/docs/guides/getting-started.md
@@ -1,6 +1,8 @@
 ---
 title: Getting started
 description: Install svelte-vitals and run your first SEO audit in seconds.
+sidebar:
+  order: 1
 ---
 
 ## What is svelte-vitals?

--- a/docs/src/content/docs/guides/health-report.md
+++ b/docs/src/content/docs/guides/health-report.md
@@ -1,6 +1,8 @@
 ---
 title: Health report
 description: Understand the weighted Health score and use --min-health as a CI gate.
+sidebar:
+  order: 8
 ---
 
 The **Health score** is a single 0–100 number that summarizes your project's overall quality across the categories present in the analysis results. It is used by the `--min-health` flag to gate CI pipelines.

--- a/docs/src/content/docs/guides/mcp.md
+++ b/docs/src/content/docs/guides/mcp.md
@@ -1,6 +1,8 @@
 ---
 title: MCP server
 description: Let AI agents run svelte-vitals analysis via the Model Context Protocol.
+sidebar:
+  order: 6
 ---
 
 `@svelte-vitals/mcp` is a [Model Context Protocol](https://modelcontextprotocol.io) server that exposes svelte-vitals as tools an AI agent can call inside its tool loop. The agent receives structured, actionable findings — each with a `fix`, `recommendation`, and `docsUrl` — without needing to spawn a CLI subprocess manually.

--- a/docs/src/content/docs/guides/plugin-mode.md
+++ b/docs/src/content/docs/guides/plugin-mode.md
@@ -1,6 +1,8 @@
 ---
 title: Plugin mode
 description: Integrate svelte-vitals into vite build to analyze prerendered HTML at build time.
+sidebar:
+  order: 4
 ---
 
 `@svelte-vitals/vite` is a Vite / SvelteKit plugin that piggybacks on `vite build`, parses the **prerendered HTML's `<head>`**, and runs the same SEO and Performance rules as the CLI. Because it inspects the real HTML output, it is library-agnostic. The build fails when findings reach the `failOn` threshold.

--- a/docs/src/content/docs/guides/reporters.md
+++ b/docs/src/content/docs/guides/reporters.md
@@ -1,6 +1,8 @@
 ---
 title: Reporters
 description: Choose how svelte-vitals formats and outputs its findings.
+sidebar:
+  order: 7
 ---
 
 svelte-vitals supports six output reporters. Select one with `--reporter <fmt>`, or let auto-selection pick the right one for your environment.

--- a/docs/src/content/docs/ja/guides/choosing-a-package.md
+++ b/docs/src/content/docs/ja/guides/choosing-a-package.md
@@ -1,6 +1,8 @@
 ---
 title: パッケージの選び方
 description: svelte-vitals の3つのパッケージをどう使い分け、どう組み合わせるか。
+sidebar:
+  order: 2
 ---
 
 svelte-vitals は `svelte-vitals`(CLI)、`@svelte-vitals/vite`(プラグイン + 開発オーバーレイ)、`@svelte-vitals/mcp`(MCPサーバー)という3つのパッケージで構成されています。いずれも同じルールエンジンとスコアリングを共有していますが、読み取る対象とカバー範囲が異なります。ほとんどのプロジェクトでは複数を組み合わせて使うことになります。

--- a/docs/src/content/docs/ja/guides/cli.md
+++ b/docs/src/content/docs/ja/guides/cli.md
@@ -1,6 +1,8 @@
 ---
 title: CLI リファレンス
 description: svelte-vitals のすべてのコマンドラインフラグの完全なリファレンス。
+sidebar:
+  order: 3
 ---
 
 ## 使用方法

--- a/docs/src/content/docs/ja/guides/dev-overlay.md
+++ b/docs/src/content/docs/ja/guides/dev-overlay.md
@@ -1,6 +1,8 @@
 ---
 title: 開発オーバーレイ
 description: ビルドを待たずに開発サーバーでライブの SEO 警告を取得します。
+sidebar:
+  order: 5
 ---
 
 `@svelte-vitals/vite` には SvelteKit の `handle` フック — `svelteVitalsHandle` — が含まれており、**開発サーバー**で配信される各ページの SEO 分析を実行します。アプリをナビゲートするとターミナルに警告が出力されます。ビルドステップは不要です。

--- a/docs/src/content/docs/ja/guides/getting-started.md
+++ b/docs/src/content/docs/ja/guides/getting-started.md
@@ -1,6 +1,8 @@
 ---
 title: はじめに
 description: svelte-vitals をインストールして、数秒で最初の SEO 監査を実行しましょう。
+sidebar:
+  order: 1
 ---
 
 ## svelte-vitals とは？

--- a/docs/src/content/docs/ja/guides/health-report.md
+++ b/docs/src/content/docs/ja/guides/health-report.md
@@ -1,6 +1,8 @@
 ---
 title: Health レポート
 description: 重み付き Health スコアを理解し、--min-health を CI ゲートとして使用します。
+sidebar:
+  order: 8
 ---
 
 **Health スコア**は、分析結果に存在するカテゴリ全体のプロジェクトの総合的な品質を要約した 0〜100 の単一の数値です。CI パイプラインをゲートするために `--min-health` フラグで使用されます。

--- a/docs/src/content/docs/ja/guides/mcp.md
+++ b/docs/src/content/docs/ja/guides/mcp.md
@@ -1,6 +1,8 @@
 ---
 title: MCP サーバー
 description: Model Context Protocol を通じて AI エージェントが svelte-vitals 分析を実行できるようにします。
+sidebar:
+  order: 6
 ---
 
 `@svelte-vitals/mcp` は、svelte-vitals をツールとして公開する [Model Context Protocol](https://modelcontextprotocol.io) サーバーです。AI エージェントはそのツールループ内でこれらのツールを呼び出すことができます。エージェントは構造化された実行可能な検出結果を受け取ります — それぞれに `fix`、`recommendation`、`docsUrl` が含まれており、CLI サブプロセスを手動で起動する必要はありません。

--- a/docs/src/content/docs/ja/guides/plugin-mode.md
+++ b/docs/src/content/docs/ja/guides/plugin-mode.md
@@ -1,6 +1,8 @@
 ---
 title: プラグインモード
 description: ビルド時にプリレンダリングされた HTML を分析するために svelte-vitals を vite build に統合します。
+sidebar:
+  order: 4
 ---
 
 `@svelte-vitals/vite` は Vite / SvelteKit プラグインで、`vite build` に便乗して**プリレンダリングされた HTML の `<head>`** を解析し、CLI と同じ SEO およびパフォーマンスルールを実行します。実際の HTML 出力を検査するため、ライブラリに依存しません。検出結果が `failOn` の閾値に達するとビルドが失敗します。

--- a/docs/src/content/docs/ja/guides/reporters.md
+++ b/docs/src/content/docs/ja/guides/reporters.md
@@ -1,6 +1,8 @@
 ---
 title: レポーター
 description: svelte-vitals が検出結果をフォーマットして出力する方法を選択します。
+sidebar:
+  order: 7
 ---
 
 svelte-vitals は 6 つの出力レポーターをサポートしています。`--reporter <fmt>` で選択するか、環境に適したものを自動選択に任せてください。


### PR DESCRIPTION
## Summary
- Starlight's autogenerated sidebar sorts alphabetically by default (via slug), which put "Choosing a package" and "CLI reference" ahead of "Getting started".
- Adds explicit `sidebar.order` to all 8 guide pages (en + ja) for a natural reading order: Getting started → Choosing a package → CLI reference → Plugin mode → Dev overlay → MCP server → Reporters → Health report.

## Test plan
- [x] `pnpm --filter docs build` — 115 pages built, no errors
- [x] Verified the rendered sidebar link order in `dist/guides/getting-started/index.html` matches the intended order