### PR TITLE
docs: rewrite homepage copy (en/ja) to reflect all 5 categories

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,14 +1,14 @@
 ---
 title: svelte-vitals
-description: A SvelteKit SEO & Performance checker — static analysis of your routes, before they ship.
+description: A static code-health checker for SvelteKit — SEO, Performance, Correctness, Security, and Architecture, from source.
 template: splash
 hero:
   title: '<img src="/svelte-vitals/wordmark.svg" alt="svelte-vitals" style="height: 3.5rem; max-width: 100%;" />'
-  tagline: Audit your SvelteKit app's SEO and Performance from source — no running site needed.
+  tagline: No build, no browser — just read the source to see your SvelteKit app's health.
   actions:
     - text: Get started
       link: /svelte-vitals/guides/getting-started/
       icon: right-arrow
 ---
 
-svelte-vitals statically resolves each route's effective `<head>` and `<img>` usage, scores SEO and Performance per route and site-wide, and gates CI — all before you deploy.
+svelte-vitals statically resolves each route's effective `<head>` and `<img>` usage from source, then scores your app across five categories — SEO, Performance, Correctness, Security, and Architecture — per route and site-wide. Fall below a threshold and it gates CI. All of it, before you ever deploy.

--- a/docs/src/content/docs/ja/index.mdx
+++ b/docs/src/content/docs/ja/index.mdx
@@ -1,14 +1,14 @@
 ---
 title: svelte-vitals
-description: SvelteKit 向けの SEO・パフォーマンス チェッカー — 出荷前にルートを静的解析します。
+description: SvelteKit 向けの静的コードヘルスチェッカー — SEO・Performance・Correctness・Security・Architecture を、ソースコードから診断します。
 template: splash
 hero:
   title: '<img src="/svelte-vitals/wordmark.svg" alt="svelte-vitals" style="height: 3.5rem; max-width: 100%;" />'
-  tagline: 稼働中のサイト不要。ソースから SvelteKit アプリの SEO とパフォーマンスを審査します。
+  tagline: ビルドもブラウザも不要。ソースコードを読むだけで、SvelteKitアプリの健康状態がわかります。
   actions:
     - text: はじめに
       link: /svelte-vitals/ja/guides/getting-started/
       icon: right-arrow
 ---
 
-svelte-vitals は各ルートの実効 `<head>` と `<img>` を静的に解決し、SEO とパフォーマンスをルート単位・サイト全体で採点し、CI をゲートします。出荷前にすべて完結します。
+svelte-vitals は、各ルートの実効的な `<head>` や `<img>` の使われ方をソースコードから静的に解決し、SEO・Performance・Correctness・Security・Architecture の5カテゴリでスコアリングします。ルート単位でもサイト全体でも一目で把握でき、基準を下回ればCIで止められます。すべて、実際にデプロイする前に。


### PR DESCRIPTION
## Summary
- The docs homepage's Japanese copy read as a stiff, verb-chained literal translation ("〜を解決し、〜を採点し、〜をゲートします" style). Rewrote it to read naturally.
- Both locales still described svelte-vitals as an "SEO & Performance" checker only — stale since the Correctness/Security/Architecture categories shipped. Updated description/tagline/body in both `en` and `ja` to reflect all 5 categories, keeping content in sync across locales.

## Test plan
- [x] `pnpm --filter docs build` — 115 pages built, no errors