### PR TITLE
Add inline svelte-vitals-disable-next-line suppression directive

### DIFF
--- a/.changeset/inline-suppression-directive.md
+++ b/.changeset/inline-suppression-directive.md
@@ -1,0 +1,7 @@
+---
+'@svelte-vitals/core': minor
+'svelte-vitals': minor
+'@svelte-vitals/mcp': minor
+---
+
+Add an inline `svelte-vitals-disable-next-line` comment to suppress a specific component-scoped rule's finding on the following line (`// ...` in `<script>`, `<!-- ... -->` in markup) — a targeted escape hatch for intentional patterns a rule can't infer statically, such as a mount-only `$effect` used to avoid a hydration mismatch. Covers CORRECT001–004, SEC001–002, ARCH001–002, and PERF009–010. Fixes #92.

--- a/docs/src/content/docs/guides/cli.md
+++ b/docs/src/content/docs/guides/cli.md
@@ -115,6 +115,38 @@ Disable the specified rules. Accepts a comma-separated list of rule IDs.
 svelte-vitals --ignore PERF001
 ```
 
+### Suppressing a single finding inline
+
+For one intentional occurrence that `--ignore` would silence project-wide, add a
+`svelte-vitals-disable-next-line` comment on the line directly above it. Works for
+any component-scoped rule (Correctness, Security, Architecture): CORRECT001–004,
+SEC001–002, ARCH001–002, PERF009–010.
+
+```svelte
+<script>
+  // The prerendered HTML always renders this hidden; canVibrate() must run only
+  // after mount, or hydration mismatches. $derived would re-run during hydration.
+  // svelte-vitals-disable-next-line CORRECT002
+  $effect(() => {
+    mounted = true;
+  });
+</script>
+```
+
+In markup, use an HTML comment instead:
+
+```svelte
+<!-- svelte-vitals-disable-next-line SEC001 -->
+<div>{@html trustedMarkup}</div>
+```
+
+Omit the rule id to suppress every rule on the next line, or list several
+comma-separated (`CORRECT002, SEC001`).
+
+Two constraints: the comment must be the only thing on its line (a trailing
+same-line comment is not recognized), and it must be the line **immediately**
+above the target — a blank line in between breaks the match.
+
 ### `--meta-components <names>`
 
 Comma-separated list of custom component names that emit `<head>` metadata. Tells the analyzer to treat those components as head-metadata emitters.

--- a/docs/src/content/docs/guides/cli.md
+++ b/docs/src/content/docs/guides/cli.md
@@ -135,8 +135,9 @@ SEC001–002, ARCH001–002, PERF009–010.
 
 In markup, use an HTML comment instead:
 
-```svelte
-<!-- svelte-vitals-disable-next-line SEC001 --><div>{@html trustedMarkup}</div>
+```html
+<!-- svelte-vitals-disable-next-line SEC001 -->
+<div>{@html trustedMarkup}</div>
 ```
 
 Omit the rule id to suppress every rule on the next line, or list several

--- a/docs/src/content/docs/guides/cli.md
+++ b/docs/src/content/docs/guides/cli.md
@@ -119,7 +119,7 @@ svelte-vitals --ignore PERF001
 
 For one intentional occurrence that `--ignore` would silence project-wide, add a
 `svelte-vitals-disable-next-line` comment on the line directly above it. Works for
-any component-scoped rule (Correctness, Security, Architecture): CORRECT001–004,
+any component-scoped rule (Correctness, Security, Architecture, Performance): CORRECT001–004,
 SEC001–002, ARCH001–002, PERF009–010.
 
 ```svelte

--- a/docs/src/content/docs/guides/cli.md
+++ b/docs/src/content/docs/guides/cli.md
@@ -136,8 +136,7 @@ SEC001–002, ARCH001–002, PERF009–010.
 In markup, use an HTML comment instead:
 
 ```svelte
-<!-- svelte-vitals-disable-next-line SEC001 -->
-<div>{@html trustedMarkup}</div>
+<!-- svelte-vitals-disable-next-line SEC001 --><div>{@html trustedMarkup}</div>
 ```
 
 Omit the rule id to suppress every rule on the next line, or list several

--- a/docs/src/content/docs/ja/guides/cli.md
+++ b/docs/src/content/docs/ja/guides/cli.md
@@ -98,7 +98,7 @@ svelte-vitals --ignore PERF001
 
 ### 特定の指摘だけをインラインで抑制する
 
-`--ignore` はプロジェクト全体でルールを無効にしますが、意図的な1箇所だけを黙らせたい場合は、対象行の直前に `svelte-vitals-disable-next-line` コメントを書きます。コンポーネントスコープの全ルール（Correctness、Security、Architecture）に対応: CORRECT001–004、SEC001–002、ARCH001–002、PERF009–010。
+`--ignore` はプロジェクト全体でルールを無効にしますが、意図的な1箇所だけを黙らせたい場合は、対象行の直前に `svelte-vitals-disable-next-line` コメントを書きます。コンポーネントスコープの全ルール（Correctness、Security、Architecture、Performance）に対応: CORRECT001–004、SEC001–002、ARCH001–002、PERF009–010。
 
 ```svelte
 <script>

--- a/docs/src/content/docs/ja/guides/cli.md
+++ b/docs/src/content/docs/ja/guides/cli.md
@@ -114,8 +114,7 @@ svelte-vitals --ignore PERF001
 マークアップ内では HTML コメントを使います。
 
 ```svelte
-<!-- svelte-vitals-disable-next-line SEC001 -->
-<div>{@html trustedMarkup}</div>
+<!-- svelte-vitals-disable-next-line SEC001 --><div>{@html trustedMarkup}</div>
 ```
 
 ルール ID を省略すると次の行のすべてのルールを抑制します。複数指定する場合はカンマ区切りで書けます（`CORRECT002, SEC001`）。

--- a/docs/src/content/docs/ja/guides/cli.md
+++ b/docs/src/content/docs/ja/guides/cli.md
@@ -98,7 +98,7 @@ svelte-vitals --ignore PERF001
 
 ### 特定の指摘だけをインラインで抑制する
 
-`--ignore` はプロジェクト全体でルールを無効にしますが、意図的な1箇所だけを黙らせたい場合は、対象行の直前に `svelte-vitals-disable-next-line` コメントを書きます。component スコープの全ルール（Correctness、Security、Architecture）に対応: CORRECT001–004、SEC001–002、ARCH001–002、PERF009–010。
+`--ignore` はプロジェクト全体でルールを無効にしますが、意図的な1箇所だけを黙らせたい場合は、対象行の直前に `svelte-vitals-disable-next-line` コメントを書きます。コンポーネントスコープの全ルール（Correctness、Security、Architecture）に対応: CORRECT001–004、SEC001–002、ARCH001–002、PERF009–010。
 
 ```svelte
 <script>

--- a/docs/src/content/docs/ja/guides/cli.md
+++ b/docs/src/content/docs/ja/guides/cli.md
@@ -96,6 +96,32 @@ svelte-vitals --rules SEO001,SEO002
 svelte-vitals --ignore PERF001
 ```
 
+### 特定の指摘だけをインラインで抑制する
+
+`--ignore` はプロジェクト全体でルールを無効にしますが、意図的な1箇所だけを黙らせたい場合は、対象行の直前に `svelte-vitals-disable-next-line` コメントを書きます。component スコープの全ルール（Correctness、Security、Architecture）に対応: CORRECT001–004、SEC001–002、ARCH001–002、PERF009–010。
+
+```svelte
+<script>
+  // プリレンダリングされたHTMLは常に非表示。canVibrate() はマウント後にのみ評価する必要があり、
+  // そうしないとハイドレーション不一致が発生する。$derived だとハイドレーション中にも評価される。
+  // svelte-vitals-disable-next-line CORRECT002
+  $effect(() => {
+    mounted = true;
+  });
+</script>
+```
+
+マークアップ内では HTML コメントを使います。
+
+```svelte
+<!-- svelte-vitals-disable-next-line SEC001 -->
+<div>{@html trustedMarkup}</div>
+```
+
+ルール ID を省略すると次の行のすべてのルールを抑制します。複数指定する場合はカンマ区切りで書けます（`CORRECT002, SEC001`）。
+
+2つの制約があります。コメントはその行に単独で書かれている必要があり（同一行の末尾コメントは認識されません）、対象行の**直前**の行になければなりません（間に空行があると一致しません）。
+
 ### `--meta-components <names>`
 
 `<head>` メタデータを出力するカスタムコンポーネント名のカンマ区切りリストです。アナライザーにそれらのコンポーネントをヘッドメタデータエミッターとして扱うよう指示します。

--- a/docs/src/content/docs/ja/guides/cli.md
+++ b/docs/src/content/docs/ja/guides/cli.md
@@ -113,8 +113,9 @@ svelte-vitals --ignore PERF001
 
 マークアップ内では HTML コメントを使います。
 
-```svelte
-<!-- svelte-vitals-disable-next-line SEC001 --><div>{@html trustedMarkup}</div>
+```html
+<!-- svelte-vitals-disable-next-line SEC001 -->
+<div>{@html trustedMarkup}</div>
 ```
 
 ルール ID を省略すると次の行のすべてのルールを抑制します。複数指定する場合はカンマ区切りで書けます（`CORRECT002, SEC001`）。

--- a/docs/superpowers/plans/2026-07-04-inline-suppression-directive.md
+++ b/docs/superpowers/plans/2026-07-04-inline-suppression-directive.md
@@ -537,8 +537,9 @@ SEC001–002, ARCH001–002, PERF009–010.
 
 In markup, use an HTML comment instead:
 
-```svelte
-<!-- svelte-vitals-disable-next-line SEC001 --><div>{@html trustedMarkup}</div>
+```html
+<!-- svelte-vitals-disable-next-line SEC001 -->
+<div>{@html trustedMarkup}</div>
 ```
 
 Omit the rule id to suppress every rule on the next line, or list several
@@ -572,8 +573,9 @@ In `docs/src/content/docs/ja/guides/cli.md`, insert the equivalent section right
 
 マークアップ内では HTML コメントを使います。
 
-```svelte
-<!-- svelte-vitals-disable-next-line SEC001 --><div>{@html trustedMarkup}</div>
+```html
+<!-- svelte-vitals-disable-next-line SEC001 -->
+<div>{@html trustedMarkup}</div>
 ```
 
 ルール ID を省略すると次の行のすべてのルールを抑制します。複数指定する場合はカンマ区切りで書けます（`CORRECT002, SEC001`）。

--- a/docs/superpowers/plans/2026-07-04-inline-suppression-directive.md
+++ b/docs/superpowers/plans/2026-07-04-inline-suppression-directive.md
@@ -1,0 +1,632 @@
+# Inline Suppression Directive Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a `// svelte-vitals-disable-next-line CORRECT002` (or `<!-- svelte-vitals-disable-next-line -->` in markup) comment suppress a specific component-scoped rule's finding on the following line, fixing the CORRECT002 false positive in [issue #92](https://github.com/oekazuma/svelte-vitals/issues/92).
+
+**Architecture:** A pure text scan (`collectSuppressions`) finds directive comments in a `.svelte` file's source and records `{ line, ruleIds? }` entries on `ComponentFacts.suppressions`. A single filter added to the shared `componentRule()` factory drops any `bad()` occurrence whose line matches a directive for that rule id (or a blanket directive) — this one change covers every rule built on `componentRule()` (CORRECT001–004, SEC001–002, ARCH001–002, PERF009–010) with no per-rule code.
+
+**Tech Stack:** TypeScript, vitest, pnpm workspaces (`@svelte-vitals/core`, `svelte-vitals` CLI package).
+
+**Branch:** `correct002-suppression-directive` (already checked out; work happens here).
+
+## Global Constraints
+
+- Directive must be the **entire content of its line** (leading whitespace only before it) — no same-line trailing-comment form in this iteration.
+- The suppressed line is the directive's line **+ 1**; an intervening blank line means no match.
+- Rule ids match `/^[A-Za-z]+\d+$/`, case-insensitive, stored uppercased; a blank id list means "suppress every rule on that line."
+- An unmatched/misspelled rule id is not an error — it simply suppresses nothing.
+- No `--show-suppressions` reporting, no "unused directive" warning, no route/project-scope (SEO) suppression — all out of scope per the approved design (`docs/superpowers/specs/2026-07-04-inline-suppression-directive-design.md`).
+
+---
+
+## Task 1: Add `SuppressionDirective` to `ComponentFacts` (plumbing only, no new behavior)
+
+**Files:**
+
+- Modify: `packages/core/src/component.ts`
+- Modify: `packages/core/src/index.ts:23`
+- Modify: `packages/cli/src/providers/source/components.ts`
+- Modify: `packages/core/test/correctness-rules.test.ts:17-29` (`comp()` fixture)
+- Modify: `packages/core/test/security-rules.test.ts:12-24` (`comp()` fixture)
+- Modify: `packages/core/test/architecture-rules.test.ts:12-24` (`comp()` fixture)
+- Modify: `packages/core/test/bundle-rules.test.ts:12-23` (`comp()` fixture)
+
+**Interfaces:**
+
+- Produces: `SuppressionDirective { line: number; ruleIds?: string[] }`, exported from `@svelte-vitals/core`. `ComponentFacts.suppressions: SuppressionDirective[]` (new required field — every literal that builds a full `ComponentFacts` must supply it).
+
+This task only adds the field and keeps every existing fixture/literal compiling. No new tests are needed (no new behavior yet) — the check is that the existing suite still passes.
+
+- [ ] **Step 1: Add the type and field in `packages/core/src/component.ts`**
+
+Add this interface right before `ComponentFacts` (after the `SourceSpan` interface, i.e. after line 29):
+
+```ts
+/** An inline `svelte-vitals-disable-next-line` directive found in the component's source (issue #92). */
+export interface SuppressionDirective {
+  /** 1-based line the directive suppresses (the line immediately after the comment). */
+  line: number;
+  /** Rule ids suppressed on that line; undefined = suppress every rule on that line. */
+  ruleIds?: string[];
+}
+```
+
+Then add this field to `ComponentFacts` (after `constableStates`, i.e. after the current last field at line 50):
+
+```ts
+  /** Inline `svelte-vitals-disable-next-line` directives found in this file's source — component-rule escape hatch (issue #92). */
+  suppressions: SuppressionDirective[];
+```
+
+- [ ] **Step 2: Export the new type from `packages/core/src/index.ts`**
+
+Change line 23 from:
+
+```ts
+export type { EachBlockFact, EffectFact, SourceSpan, ComponentFacts } from './component.js';
+```
+
+to:
+
+```ts
+export type { EachBlockFact, EffectFact, SourceSpan, ComponentFacts, SuppressionDirective } from './component.js';
+```
+
+- [ ] **Step 3: Add the fallback field in `packages/cli/src/providers/source/components.ts`**
+
+In the `catch` branch's fallback object (currently ends with `constableStates: []`), add `suppressions: []`:
+
+```ts
+      } catch {
+        return {
+          file: rel,
+          eachBlocks: [],
+          effects: [],
+          htmlTags: [],
+          javascriptUrls: [],
+          loc: 0,
+          propCount: 0,
+          imports: [],
+          namespaceImports: [],
+          constableStates: [],
+          suppressions: []
+        };
+      }
+```
+
+- [ ] **Step 4: Add `suppressions: []` to the four test fixtures**
+
+In each of these files, the `comp()` helper builds a full `ComponentFacts` literal ending with `constableStates: [],` (and in `bundle-rules.test.ts`, `constableStates: []` with no trailing comma before `...over`/close). Add `suppressions: [],` right after `constableStates: [],` in:
+
+- `packages/core/test/correctness-rules.test.ts`
+- `packages/core/test/security-rules.test.ts`
+- `packages/core/test/architecture-rules.test.ts`
+
+For `packages/core/test/bundle-rules.test.ts`, the literal has no `...over` spread (it takes `imports: string[]` directly) and currently ends:
+
+```ts
+  namespaceImports: [],
+  constableStates: []
+});
+```
+
+Change to:
+
+```ts
+  namespaceImports: [],
+  constableStates: [],
+  suppressions: []
+});
+```
+
+- [ ] **Step 5: Run the full test suite and typecheck to confirm nothing broke**
+
+Run: `pnpm --filter @svelte-vitals/core test && pnpm --filter @svelte-vitals/core typecheck && pnpm --filter svelte-vitals test && pnpm --filter svelte-vitals typecheck`
+Expected: all PASS, zero TypeScript errors (this step only adds a field with fixtures updated everywhere it's constructed — no behavior changed, so no test assertions should change).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/component.ts packages/core/src/index.ts packages/cli/src/providers/source/components.ts packages/core/test/correctness-rules.test.ts packages/core/test/security-rules.test.ts packages/core/test/architecture-rules.test.ts packages/core/test/bundle-rules.test.ts
+git commit -m "feat(core): add SuppressionDirective type to ComponentFacts (issue #92)"
+```
+
+---
+
+## Task 2: Implement `collectSuppressions` and wire it into `parseComponentFacts`
+
+**Files:**
+
+- Modify: `packages/cli/src/providers/source/parse.ts`
+- Test: `packages/cli/test/parse-component-facts.test.ts`
+
+**Interfaces:**
+
+- Consumes: `SuppressionDirective` from `@svelte-vitals/core` (Task 1).
+- Produces: `parseComponentFacts(source, filename).suppressions: SuppressionDirective[]` — the CLI-side capture, used by `collectComponentFacts()` (already wired since `parseComponentFacts`'s return is spread directly into the `ComponentFacts` object in `components.ts`; no further change needed there beyond Task 1's fallback).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this new `describe` block to `packages/cli/test/parse-component-facts.test.ts` (e.g. after the `constable $state (CORRECT004)` block, at the end of the file):
+
+```ts
+describe('parseComponentFacts — suppression directives (issue #92)', () => {
+  it('captures a script-side disable-next-line with a rule id', () => {
+    const src = '<script>\n// svelte-vitals-disable-next-line CORRECT002\n$effect(() => { x = 1; });\n</script>';
+    expect(parseComponentFacts(src, 'C.svelte').suppressions).toEqual([{ line: 3, ruleIds: ['CORRECT002'] }]);
+  });
+  it('captures multiple comma-separated rule ids', () => {
+    const src = '<script>\n// svelte-vitals-disable-next-line CORRECT002, SEC001\nx = 1;\n</script>';
+    expect(parseComponentFacts(src, 'C.svelte').suppressions).toEqual([{ line: 3, ruleIds: ['CORRECT002', 'SEC001'] }]);
+  });
+  it('captures a blanket disable-next-line with no rule id', () => {
+    const src = '<script>\n// svelte-vitals-disable-next-line\nx = 1;\n</script>';
+    expect(parseComponentFacts(src, 'C.svelte').suppressions).toEqual([{ line: 3, ruleIds: undefined }]);
+  });
+  it('captures a template-side HTML comment directive', () => {
+    const src = '<!-- svelte-vitals-disable-next-line SEC001 -->\n<div>{@html body}</div>';
+    expect(parseComponentFacts(src, 'C.svelte').suppressions).toEqual([{ line: 2, ruleIds: ['SEC001'] }]);
+  });
+  it('does not match a same-line trailing comment', () => {
+    const src = '<script>\nx = 1; // svelte-vitals-disable-next-line CORRECT002\n</script>';
+    expect(parseComponentFacts(src, 'C.svelte').suppressions).toEqual([]);
+  });
+  it('reports no suppressions for a component without any directive', () => {
+    expect(parseComponentFacts('<p>hi</p>', 'C.svelte').suppressions).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `pnpm --filter svelte-vitals test -- parse-component-facts`
+Expected: FAIL — `suppressions` does not exist on the object returned by `parseComponentFacts` (TypeScript error / undefined property), since `collectSuppressions` doesn't exist yet.
+
+- [ ] **Step 3: Implement `collectSuppressions` in `packages/cli/src/providers/source/parse.ts`**
+
+Update the type-only import on line 3 from:
+
+```ts
+import type { Value, EachBlockFact, EffectFact, SourceSpan } from '@svelte-vitals/core';
+```
+
+to:
+
+```ts
+import type { Value, EachBlockFact, EffectFact, SourceSpan, SuppressionDirective } from '@svelte-vitals/core';
+```
+
+Add this just before the `/** Parse a component's reactivity/correctness + security + architecture facts (CLI/static only). */` comment (i.e. right before `export function parseComponentFacts` at line 683):
+
+```ts
+const JS_DIRECTIVE = /^\s*\/\/\s*svelte-vitals-disable-next-line(?:\s+([A-Za-z]+\d+(?:\s*,\s*[A-Za-z]+\d+)*))?\s*$/;
+const HTML_DIRECTIVE =
+  /^\s*<!--\s*svelte-vitals-disable-next-line(?:\s+([A-Za-z]+\d+(?:\s*,\s*[A-Za-z]+\d+)*))?\s*-->\s*$/;
+
+/**
+ * Inline `svelte-vitals-disable-next-line` directives (issue #92). A plain text scan, not an
+ * AST walk, so `<script>` (`//`) and template (`<!-- -->`) comments are covered uniformly. The
+ * directive must be the entire content of its line; the suppressed line is directive-line + 1.
+ */
+function collectSuppressions(source: string): SuppressionDirective[] {
+  const out: SuppressionDirective[] = [];
+  const lines = source.split('\n');
+  lines.forEach((line, i) => {
+    const m = JS_DIRECTIVE.exec(line) ?? HTML_DIRECTIVE.exec(line);
+    if (!m) return;
+    const ruleIds = m[1]?.split(',').map((s) => s.trim().toUpperCase());
+    out.push({ line: i + 2, ruleIds });
+  });
+  return out;
+}
+```
+
+Now wire it into `parseComponentFacts`. Update the return-type declaration (currently lines 686–696) to add the field:
+
+```ts
+export function parseComponentFacts(
+  source: string,
+  filename: string
+): {
+  eachBlocks: EachBlockFact[];
+  effects: EffectFact[];
+  htmlTags: SourceSpan[];
+  javascriptUrls: SourceSpan[];
+  loc: number;
+  propCount: number;
+  imports: string[];
+  namespaceImports: { source: string; line: number }[];
+  constableStates: { name: string; line: number }[];
+  suppressions: SuppressionDirective[];
+} {
+```
+
+Inside the function body, add the call right after `const loc = countLines(source);` (currently line 703):
+
+```ts
+const loc = countLines(source);
+const suppressions = collectSuppressions(source);
+```
+
+And add `suppressions` to the final return statement (currently line 753):
+
+```ts
+return {
+  eachBlocks,
+  effects,
+  htmlTags,
+  javascriptUrls,
+  loc,
+  propCount,
+  imports,
+  namespaceImports,
+  constableStates,
+  suppressions
+};
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter svelte-vitals test -- parse-component-facts`
+Expected: PASS — all 6 new cases green, and every pre-existing test in the file still green (unaffected).
+
+- [ ] **Step 5: Run the full CLI package test suite and typecheck**
+
+Run: `pnpm --filter svelte-vitals test && pnpm --filter svelte-vitals typecheck`
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/cli/src/providers/source/parse.ts packages/cli/test/parse-component-facts.test.ts
+git commit -m "feat(cli): capture svelte-vitals-disable-next-line directives (issue #92)"
+```
+
+---
+
+## Task 3: Enforce suppression in `componentRule()`
+
+**Files:**
+
+- Modify: `packages/core/src/rules/component-rule.ts`
+- Test: `packages/core/test/component-rule.test.ts` (new)
+
+**Interfaces:**
+
+- Consumes: `ComponentFacts.suppressions` (Task 1), `ComponentIssue { line: number; message: string }` (existing, `component-rule.ts:9-12`).
+- Produces: `componentRule()`'s `check()` now drops any `bad()` item matching a suppression before deciding pass/fail — no signature change, so every existing caller (`correct001EachKey`, `correct002EffectDerived`, etc.) is unaffected except in behavior when a matching directive is present.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/core/test/component-rule.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { componentRule } from '../src/rules/component-rule.js';
+import { defineConfig, defaultProject } from '../src/types.js';
+import type { ComponentFacts } from '../src/component.js';
+import type { RuleContext } from '../src/rule.js';
+
+const config = defineConfig({});
+const base = { heads: [], project: defaultProject, config };
+const fails = (rs: { detection: { presence: string; value: string } }[]) =>
+  rs.filter((r) => r.detection.presence === 'none' || r.detection.value === 'absent');
+const ctx = (components: ComponentFacts[]): RuleContext => ({ components, ...base });
+const comp = (over: Partial<ComponentFacts>): ComponentFacts => ({
+  file: 'src/lib/C.svelte',
+  eachBlocks: [],
+  effects: [],
+  htmlTags: [],
+  javascriptUrls: [],
+  loc: 10,
+  propCount: 0,
+  imports: [],
+  namespaceImports: [],
+  constableStates: [],
+  suppressions: [],
+  ...over
+});
+
+// A minimal fake rule with one hard-coded bad occurrence at line 5, so each test
+// controls suppression purely through comp({ suppressions: [...] }).
+const fakeRule = componentRule({
+  id: 'FAKE001',
+  title: 'Fake rule',
+  category: 'correctness',
+  label: 'Fake check',
+  recommendation: 'n/a',
+  rationale: 'n/a',
+  applies: () => true,
+  bad: () => [{ line: 5, message: 'fake violation' }]
+});
+
+describe('componentRule — inline suppression directives (issue #92)', () => {
+  it('flags the violation when there is no suppression', async () => {
+    const rs = await fakeRule.check(ctx([comp({})]));
+    expect(fails(rs)).toHaveLength(1);
+  });
+  it('suppresses the violation when a directive matches its line and rule id', async () => {
+    const rs = await fakeRule.check(ctx([comp({ suppressions: [{ line: 5, ruleIds: ['FAKE001'] }] })]));
+    expect(fails(rs)).toHaveLength(0);
+    expect(rs).toHaveLength(1); // falls back to the normal PASS result
+  });
+  it('does not suppress when the directive targets a different rule id', async () => {
+    const rs = await fakeRule.check(ctx([comp({ suppressions: [{ line: 5, ruleIds: ['OTHER999'] }] })]));
+    expect(fails(rs)).toHaveLength(1);
+  });
+  it('suppresses regardless of rule id when the directive is blanket (no ruleIds)', async () => {
+    const rs = await fakeRule.check(ctx([comp({ suppressions: [{ line: 5 }] })]));
+    expect(fails(rs)).toHaveLength(0);
+  });
+  it('does not suppress when the directive is on a different line', async () => {
+    const rs = await fakeRule.check(ctx([comp({ suppressions: [{ line: 6, ruleIds: ['FAKE001'] }] })]));
+    expect(fails(rs)).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @svelte-vitals/core test -- component-rule`
+Expected: FAIL on the suppression-related cases (2nd, 4th) — `componentRule()` doesn't filter on `suppressions` yet, so the violation is still reported.
+
+- [ ] **Step 3: Implement the filter in `packages/core/src/rules/component-rule.ts`**
+
+Add this function after the `ComponentRuleOptions` interface (i.e. after line 32, before the `componentRule` doc comment):
+
+```ts
+/** Whether `ruleId`'s finding on `line` is silenced by an inline directive on this component. */
+function isSuppressed(c: ComponentFacts, ruleId: string, line: number): boolean {
+  return (c.suppressions ?? []).some((s) => s.line === line && (!s.ruleIds || s.ruleIds.includes(ruleId)));
+}
+```
+
+Then, inside `check()`, replace:
+
+```ts
+const bad = opts.bad(c);
+```
+
+with:
+
+```ts
+const bad = opts.bad(c).filter((b) => !(b.line > 0 && isSuppressed(c, opts.id, b.line)));
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @svelte-vitals/core test -- component-rule`
+Expected: PASS — all 5 cases green.
+
+- [ ] **Step 5: Run the full core package test suite and typecheck**
+
+Run: `pnpm --filter @svelte-vitals/core test && pnpm --filter @svelte-vitals/core typecheck`
+Expected: all PASS (including `correctness-rules.test.ts`, `security-rules.test.ts`, `architecture-rules.test.ts`, `bundle-rules.test.ts` from Task 1 — none of their fixtures set a non-empty `suppressions`, so none of their existing assertions change).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/rules/component-rule.ts packages/core/test/component-rule.test.ts
+git commit -m "feat(core): suppress component-rule findings via inline directive (issue #92)"
+```
+
+---
+
+## Task 4: Regression tests for the issue's exact scenarios
+
+**Files:**
+
+- Modify: `packages/core/test/correctness-rules.test.ts`
+- Modify: `packages/core/test/security-rules.test.ts`
+
+**Interfaces:**
+
+- Consumes: `correct002EffectDerived`, `sec001Html` (existing exports), the `comp()`/`ctx()`/`fails()` helpers already present in each file (updated in Task 1).
+
+These document, at the specific-rule level, that the issue's reported false positive (and the analogous template-side SEC001 case) are now suppressible — on top of the generic mechanism test in Task 3.
+
+- [ ] **Step 1: Write the failing test in `correctness-rules.test.ts`**
+
+Add to the `'CORRECT002 effect used to derive state'` describe block (after the existing `'emits nothing for a component with no $effect'` case):
+
+```ts
+it('passes the mount-signal pattern when suppressed via inline directive (issue #92)', async () => {
+  const rs = await correct002EffectDerived.check(
+    ctx([
+      comp({
+        effects: [{ line: 5, assignsOnlyState: true, mountOnly: false }],
+        suppressions: [{ line: 5, ruleIds: ['CORRECT002'] }]
+      })
+    ])
+  );
+  expect(fails(rs)).toHaveLength(0);
+});
+```
+
+- [ ] **Step 2: Write the failing test in `security-rules.test.ts`**
+
+Add to the `'SEC001 raw HTML render'` describe block (after the existing `'emits nothing for a component without {@html}'` case):
+
+```ts
+it('passes when the {@html} finding is suppressed via a template-side directive (issue #92)', async () => {
+  const rs = await sec001Html.check(
+    ctx([comp({ htmlTags: [{ line: 4 }], suppressions: [{ line: 4, ruleIds: ['SEC001'] }] })])
+  );
+  expect(fails(rs)).toHaveLength(0);
+});
+```
+
+- [ ] **Step 3: Verify the tests would fail without Task 3's filter**
+
+Task 3 already implemented the filter, so these new tests will pass immediately —
+that's expected, but it means running them now doesn't prove they'd catch a
+regression. Confirm that directly: in `packages/core/src/rules/component-rule.ts`,
+temporarily change
+
+```ts
+const bad = opts.bad(c).filter((b) => !(b.line > 0 && isSuppressed(c, opts.id, b.line)));
+```
+
+back to
+
+```ts
+const bad = opts.bad(c);
+```
+
+Run: `pnpm --filter @svelte-vitals/core test -- correctness-rules security-rules`
+Expected: FAIL — both new cases from Steps 1–2 fail (the suppression is no longer applied).
+
+- [ ] **Step 4: Restore the filter and verify the tests pass**
+
+Revert the temporary change from Step 3 back to:
+
+```ts
+const bad = opts.bad(c).filter((b) => !(b.line > 0 && isSuppressed(c, opts.id, b.line)));
+```
+
+Run: `pnpm --filter @svelte-vitals/core test -- correctness-rules security-rules`
+Expected: PASS — both new cases green, all pre-existing cases in both files still green.
+
+- [ ] **Step 5: Run the full core suite**
+
+Run: `pnpm --filter @svelte-vitals/core test`
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/test/correctness-rules.test.ts packages/core/test/security-rules.test.ts
+git commit -m "test(core): add issue #92 regression tests for CORRECT002/SEC001 suppression"
+```
+
+---
+
+## Task 5: Document the directive in the CLI guide (en + ja)
+
+**Files:**
+
+- Modify: `docs/src/content/docs/guides/cli.md`
+- Modify: `docs/src/content/docs/ja/guides/cli.md`
+
+**Interfaces:** None (docs only).
+
+- [ ] **Step 1: Add the English section**
+
+In `docs/src/content/docs/guides/cli.md`, insert a new section right after the `### --ignore <ids>` section (after its closing code fence, before `### --meta-components <names>` — currently between lines 116 and 118):
+
+````md
+### Suppressing a single finding inline
+
+For one intentional occurrence that `--ignore` would silence project-wide, add a
+`svelte-vitals-disable-next-line` comment on the line directly above it. Works for
+any component-scoped rule (Correctness, Security, Architecture): CORRECT001–004,
+SEC001–002, ARCH001–002, PERF009–010.
+
+```svelte
+<script>
+  // The prerendered HTML always renders this hidden; canVibrate() must run only
+  // after mount, or hydration mismatches. $derived would re-run during hydration.
+  // svelte-vitals-disable-next-line CORRECT002
+  $effect(() => {
+    mounted = true;
+  });
+</script>
+```
+````
+
+In markup, use an HTML comment instead:
+
+```svelte
+<!-- svelte-vitals-disable-next-line SEC001 --><div>{@html trustedMarkup}</div>
+```
+
+Omit the rule id to suppress every rule on the next line, or list several
+comma-separated (`CORRECT002, SEC001`).
+
+Two constraints: the comment must be the only thing on its line (a trailing
+same-line comment is not recognized), and it must be the line **immediately**
+above the target — a blank line in between breaks the match.
+
+````
+
+- [ ] **Step 2: Add the Japanese section**
+
+In `docs/src/content/docs/ja/guides/cli.md`, insert the equivalent section right after `### --ignore <ids>` (after its closing code fence, before `### --meta-components <names>` — currently between lines 97 and 99):
+
+```md
+### 特定の指摘だけをインラインで抑制する
+
+`--ignore` はプロジェクト全体でルールを無効にしますが、意図的な1箇所だけを黙らせたい場合は、対象行の直前に `svelte-vitals-disable-next-line` コメントを書きます。component スコープの全ルール（Correctness、Security、Architecture）に対応: CORRECT001–004、SEC001–002、ARCH001–002、PERF009–010。
+
+```svelte
+<script>
+  // プリレンダリングされたHTMLは常に非表示。canVibrate() はマウント後にのみ評価する必要があり、
+  // そうしないとハイドレーション不一致が発生する。$derived だとハイドレーション中にも評価される。
+  // svelte-vitals-disable-next-line CORRECT002
+  $effect(() => {
+    mounted = true;
+  });
+</script>
+````
+
+マークアップ内では HTML コメントを使います。
+
+```svelte
+<!-- svelte-vitals-disable-next-line SEC001 --><div>{@html trustedMarkup}</div>
+```
+
+ルール ID を省略すると次の行のすべてのルールを抑制します。複数指定する場合はカンマ区切りで書けます（`CORRECT002, SEC001`）。
+
+2つの制約があります。コメントはその行に単独で書かれている必要があり（同一行の末尾コメントは認識されません）、対象行の**直前**の行になければなりません（間に空行があると一致しません）。
+
+````
+
+- [ ] **Step 3: Build the docs site to verify no errors**
+
+Run: `pnpm --filter docs build`
+Expected: build succeeds with no MDX/markdown errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/src/content/docs/guides/cli.md docs/src/content/docs/ja/guides/cli.md
+git commit -m "docs: document svelte-vitals-disable-next-line in the CLI guide"
+````
+
+---
+
+## Task 6: Changeset
+
+**Files:**
+
+- Create: `.changeset/inline-suppression-directive.md`
+
+- [ ] **Step 1: Write the changeset**
+
+```md
+---
+'@svelte-vitals/core': minor
+'svelte-vitals': minor
+'@svelte-vitals/mcp': minor
+---
+
+Add an inline `svelte-vitals-disable-next-line` comment to suppress a specific component-scoped rule's finding on the following line (`// ...` in `<script>`, `<!-- ... -->` in markup) — a targeted escape hatch for intentional patterns a rule can't infer statically, such as a mount-only `$effect` used to avoid a hydration mismatch. Covers CORRECT001–004, SEC001–002, ARCH001–002, and PERF009–010. Fixes #92.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .changeset/inline-suppression-directive.md
+git commit -m "chore: add changeset for inline suppression directive"
+```
+
+---
+
+## Final verification (run once, after all tasks)
+
+- [ ] Run: `pnpm typecheck && pnpm test && pnpm lint`
+      Expected: all green across every package.
+- [ ] Run: `pnpm --filter docs build`
+      Expected: docs build succeeds.
+- [ ] Manually re-read the issue's original code sample and confirm the plan's Task 4 regression test in `correctness-rules.test.ts` mirrors it (mount-signal `$effect` + `$derived`, suppressed via `CORRECT002` directive).

--- a/docs/superpowers/specs/2026-07-04-inline-suppression-directive-design.md
+++ b/docs/superpowers/specs/2026-07-04-inline-suppression-directive-design.md
@@ -1,0 +1,195 @@
+# Inline suppression directive — `svelte-vitals-disable-next-line`
+
+**Date:** 2026-07-04
+**Status:** Approved design
+**Packages:** `@svelte-vitals/core` (type + filter), `svelte-vitals` (CLI capture), `@svelte-vitals/mcp` (surfaces automatically via `allRules`)
+**Issue:** [#92](https://github.com/oekazuma/svelte-vitals/issues/92)
+
+## Goal
+
+CORRECT002 ("`$effect` only assigns state — use `$derived` instead") false-positives
+on the intentional "mount signal" pattern:
+
+```svelte
+<script>
+  // eslint-disable-next-line svelte/prefer-writable-derived
+  let mounted = $state(false);
+  $effect(() => {
+    mounted = true;
+  });
+  const showVibrationToggle = $derived(mounted && canVibrate());
+</script>
+```
+
+Here `$derived(canVibrate())` would run during hydration and reintroduce the
+mismatch the `$effect` exists to avoid — the analyzer cannot infer that distinction
+statically. Rather than add narrow heuristics for this one shape (issue #92's
+options 1/2), add a general-purpose escape hatch (option 3): an inline comment,
+`// svelte-vitals-disable-next-line CORRECT002`, that suppresses a specific
+rule's finding on the following line. This also covers analogous false positives
+in other component-scoped rules (CORRECT001/003/004, SEC001/002, ARCH001/002,
+PERF009/010) without any per-rule work.
+
+Out of scope: fixing the `svelte-meta-tags` detection gaps in #91 — unrelated
+detection logic, not a suppression need.
+
+## Background / current state
+
+- Component-scoped rules (Correctness/Security/Architecture/some Bundle rules)
+  are built via `componentRule()` (`packages/core/src/rules/component-rule.ts`),
+  which iterates `ctx.components: ComponentFacts[]` — one entry per `.svelte` file,
+  produced by `parseComponentFacts()` (`packages/cli/src/providers/source/parse.ts`)
+  and collected by `collectComponentFacts()` (`packages/cli/src/providers/source/components.ts`).
+- `componentRule()` calls `opts.applies(c)` then `opts.bad(c)` (a `{ line, message }[]`);
+  if empty it emits one PASS `Result`, otherwise one PENALIZED `Result` per bad item.
+- There is no existing inline-suppression mechanism anywhere in the codebase.
+  The only existing silencing mechanism is whole-rule, whole-run: `--ignore
+  <ids>` / `--rules <ids>` (`packages/cli/src/rules-config.ts`), which is too
+  coarse for a single intentional occurrence.
+- Every component-rule fact already carries a 1-based source `line` (each block's
+  opening tag, the `$effect(` call, the `{@html}` tag, the flagged attribute, …),
+  which is exactly what a "disable next line" directive needs to match against.
+
+## Design
+
+### 1. Directive syntax
+
+Two forms, symmetric across script and template:
+
+```js
+// svelte-vitals-disable-next-line CORRECT002
+// svelte-vitals-disable-next-line CORRECT002, SEC001   // multiple ids, comma-separated
+// svelte-vitals-disable-next-line                      // no id = suppress every rule on the next line
+```
+
+```html
+<!-- svelte-vitals-disable-next-line CORRECT001 -->
+<!-- svelte-vitals-disable-next-line -->
+```
+
+**Matching rules (strict — avoid false suppressions):**
+
+- The directive must be the **entire content of its line** (leading whitespace
+  allowed). A trailing same-line comment (`let x = 1; // svelte-vitals-disable-next-line CORRECT002`)
+  is **not** recognized in v1 — no `disable-line` variant for now (YAGNI; can be
+  added later if requested).
+- Rule ids match `/^[A-Za-z]+\d+$/` (e.g. `CORRECT002`); compared case-insensitively
+  and uppercased for storage.
+- The suppressed line is the directive's line **+ 1** (an intervening blank line
+  breaks the match — same as ESLint's `disable-next-line`).
+- An unknown/misspelled rule id is not an error — it simply matches nothing.
+  No "unused directive" warning in v1 (YAGNI).
+
+### 2. Capture — `ComponentFacts.suppressions`
+
+`packages/core/src/component.ts`:
+
+```ts
+/** An inline `svelte-vitals-disable-next-line` directive found in the component's source. */
+export interface SuppressionDirective {
+  /** 1-based line the directive suppresses (the line immediately after the comment). */
+  line: number;
+  /** Rule ids suppressed on that line; undefined = suppress every rule on that line. */
+  ruleIds?: string[];
+}
+```
+
+Add `suppressions: SuppressionDirective[];` to `ComponentFacts`.
+
+`packages/cli/src/providers/source/parse.ts` — new function, pure text scan
+(no AST — works uniformly for `<script>` and template):
+
+```ts
+const JS_DIRECTIVE = /^\s*\/\/\s*svelte-vitals-disable-next-line(?:\s+([A-Za-z]+\d+(?:\s*,\s*[A-Za-z]+\d+)*))?\s*$/;
+const HTML_DIRECTIVE = /^\s*<!--\s*svelte-vitals-disable-next-line(?:\s+([A-Za-z]+\d+(?:\s*,\s*[A-Za-z]+\d+)*))?\s*-->\s*$/;
+
+function collectSuppressions(source: string): SuppressionDirective[] {
+  const lines = source.split('\n');
+  const out: SuppressionDirective[] = [];
+  lines.forEach((line, i) => {
+    const m = JS_DIRECTIVE.exec(line) ?? HTML_DIRECTIVE.exec(line);
+    if (!m) return;
+    const ruleIds = m[1]?.split(',').map((s) => s.trim().toUpperCase());
+    out.push({ line: i + 2, ruleIds });
+  });
+  return out;
+}
+```
+
+Call it once in `parseComponentFacts()` and include `suppressions` in its return
+value / return-type declaration.
+
+`packages/cli/src/providers/source/components.ts` — add `suppressions: []` to the
+catch-branch fallback `ComponentFacts` (parse failure → no facts, consistent with
+the other empty-array fields).
+
+### 3. Enforcement — `component-rule.ts`
+
+```ts
+function isSuppressed(c: ComponentFacts, ruleId: string, line: number): boolean {
+  return (c.suppressions ?? []).some((s) => s.line === line && (!s.ruleIds || s.ruleIds.includes(ruleId)));
+}
+```
+
+In `check()`, filter `opts.bad(c)` before the pass/fail branch:
+
+```ts
+const bad = opts.bad(c).filter((b) => !(b.line > 0 && isSuppressed(c, opts.id, b.line)));
+```
+
+(`b.line > 0` mirrors the existing "0 = unknown line" convention — a finding with
+no line can't be matched to a directive, so it's never suppressible.)
+
+No other change to `component-rule.ts`: if `bad` becomes empty (either originally,
+or because every item was suppressed), the existing PASS branch fires unchanged.
+This one filter point automatically covers every rule built with `componentRule()`
+— CORRECT001–004, SEC001–002, ARCH001–002, PERF009–010 — with no per-rule code.
+
+### 4. Docs
+
+Add one section to the CLI guide, next to `--ignore` (not per-rule pages — 10
+rule pages × 2 languages is out of proportion to this feature; can be linked from
+individual rule pages later if it comes up):
+
+- `docs/src/content/docs/guides/cli.md` — new `### Suppressing a single finding
+  inline` section after `### --ignore <ids>`: syntax, the Vibration-pattern
+  example from the issue, and the two matching caveats (no same-line trailing
+  form; a blank line between comment and code breaks the match).
+- `docs/src/content/docs/ja/guides/cli.md` — same content in Japanese.
+
+### 5. Changeset
+
+`@svelte-vitals/core`, `svelte-vitals`, `@svelte-vitals/mcp` — **minor** (new
+capability, backward compatible; no `@svelte-vitals/vite` change since it's static
+source analysis only).
+
+## Testing
+
+- `packages/cli/test/parse-component-facts.test.ts`: `collectSuppressions` via
+  `parseComponentFacts` — single id, blanket (no id), comma-separated multiple
+  ids, `<script>` `//` form, template `<!-- -->` form, a blank line between the
+  directive and the target line does **not** suppress, a same-line trailing
+  comment does **not** suppress.
+- `packages/core/test/component-rule.test.ts` (new): unit-tests the filter in
+  `componentRule()` directly against a fake `ComponentFacts` — a suppression
+  matching the bad item's line + rule id removes it (and yields PASS when it was
+  the only bad item); a suppression for a different rule id does not remove it;
+  a blanket suppression (`ruleIds: undefined`) removes it regardless of rule id.
+- `packages/core/test/correctness-rules.test.ts`: regression test using the
+  issue's exact Vibration-toggle shape — CORRECT002 passes when preceded by
+  `// svelte-vitals-disable-next-line CORRECT002`.
+- `packages/core/test/security-rules.test.ts`: a template-side regression —
+  `<!-- svelte-vitals-disable-next-line SEC001 -->` above an `{@html}` tag passes.
+- Full suite + typecheck + lint + `docs build` green; no assertions loosened.
+
+## Out of scope (YAGNI)
+
+- `disable-line` (same-line trailing comment) variant.
+- "Unused suppression directive" detection/warning.
+- Any suppression mechanism for route/project-scoped rules (SEO, perf resource
+  hints, etc.) — those aren't part of this issue and would need a different
+  integration point (they don't all go through `componentRule()`).
+- Per-rule-page documentation of the directive (10 pages × 2 languages); the CLI
+  guide is the single source of truth for now.
+- Fixing #91 (svelte-meta-tags detection gaps) — different problem, not a
+  suppression need.

--- a/docs/superpowers/specs/2026-07-04-inline-suppression-directive-design.md
+++ b/docs/superpowers/specs/2026-07-04-inline-suppression-directive-design.md
@@ -44,7 +44,7 @@ detection logic, not a suppression need.
   if empty it emits one PASS `Result`, otherwise one PENALIZED `Result` per bad item.
 - There is no existing inline-suppression mechanism anywhere in the codebase.
   The only existing silencing mechanism is whole-rule, whole-run: `--ignore
-  <ids>` / `--rules <ids>` (`packages/cli/src/rules-config.ts`), which is too
+<ids>` / `--rules <ids>` (`packages/cli/src/rules-config.ts`), which is too
   coarse for a single intentional occurrence.
 - Every component-rule fact already carries a 1-based source `line` (each block's
   opening tag, the `$effect(` call, the `{@html}` tag, the flagged attribute, …),
@@ -101,7 +101,8 @@ Add `suppressions: SuppressionDirective[];` to `ComponentFacts`.
 
 ```ts
 const JS_DIRECTIVE = /^\s*\/\/\s*svelte-vitals-disable-next-line(?:\s+([A-Za-z]+\d+(?:\s*,\s*[A-Za-z]+\d+)*))?\s*$/;
-const HTML_DIRECTIVE = /^\s*<!--\s*svelte-vitals-disable-next-line(?:\s+([A-Za-z]+\d+(?:\s*,\s*[A-Za-z]+\d+)*))?\s*-->\s*$/;
+const HTML_DIRECTIVE =
+  /^\s*<!--\s*svelte-vitals-disable-next-line(?:\s+([A-Za-z]+\d+(?:\s*,\s*[A-Za-z]+\d+)*))?\s*-->\s*$/;
 
 function collectSuppressions(source: string): SuppressionDirective[] {
   const lines = source.split('\n');
@@ -152,7 +153,7 @@ rule pages × 2 languages is out of proportion to this feature; can be linked fr
 individual rule pages later if it comes up):
 
 - `docs/src/content/docs/guides/cli.md` — new `### Suppressing a single finding
-  inline` section after `### --ignore <ids>`: syntax, the Vibration-pattern
+inline` section after `### --ignore <ids>`: syntax, the Vibration-pattern
   example from the issue, and the two matching caveats (no same-line trailing
   form; a blank line between comment and code breaks the match).
 - `docs/src/content/docs/ja/guides/cli.md` — same content in Japanese.

--- a/packages/cli/src/providers/source/components.ts
+++ b/packages/cli/src/providers/source/components.ts
@@ -24,7 +24,8 @@ export async function collectComponentFacts(rt: Runtime, cwd: string): Promise<C
           propCount: 0,
           imports: [],
           namespaceImports: [],
-          constableStates: []
+          constableStates: [],
+          suppressions: []
         };
       }
     })

--- a/packages/cli/src/providers/source/parse.ts
+++ b/packages/cli/src/providers/source/parse.ts
@@ -1,6 +1,6 @@
 import { parse } from 'svelte/compiler';
 import type { HeadTag } from '@svelte-vitals/core';
-import type { Value, EachBlockFact, EffectFact, SourceSpan } from '@svelte-vitals/core';
+import type { Value, EachBlockFact, EffectFact, SourceSpan, SuppressionDirective } from '@svelte-vitals/core';
 import { collectImports, type ImportMap } from './imports.js';
 
 /** A head tag parsed from one file, before layout-chain presence is assigned. */
@@ -693,6 +693,7 @@ export function parseComponentFacts(
   imports: string[];
   namespaceImports: { source: string; line: number }[];
   constableStates: { name: string; line: number }[];
+  suppressions: SuppressionDirective[];
 } {
   const ast = parse(source, { modern: true, filename }) as Node;
   const eachBlocks: EachBlockFact[] = [];
@@ -750,5 +751,5 @@ export function parseComponentFacts(
       if (!writtenOrEscaped.has(d.name)) constableStates.push(d);
     }
   }
-  return { eachBlocks, effects, htmlTags, javascriptUrls, loc, propCount, imports, namespaceImports, constableStates };
+  return { eachBlocks, effects, htmlTags, javascriptUrls, loc, propCount, imports, namespaceImports, constableStates, suppressions: [] };
 }

--- a/packages/cli/src/providers/source/parse.ts
+++ b/packages/cli/src/providers/source/parse.ts
@@ -679,6 +679,27 @@ function collectNamespaceImports(program: Node, source: string, acc: { source: s
   });
 }
 
+const JS_DIRECTIVE = /^\s*\/\/\s*svelte-vitals-disable-next-line(?:\s+([A-Za-z]+\d+(?:\s*,\s*[A-Za-z]+\d+)*))?\s*$/;
+const HTML_DIRECTIVE =
+  /^\s*<!--\s*svelte-vitals-disable-next-line(?:\s+([A-Za-z]+\d+(?:\s*,\s*[A-Za-z]+\d+)*))?\s*-->\s*$/;
+
+/**
+ * Inline `svelte-vitals-disable-next-line` directives (issue #92). A plain text scan, not an
+ * AST walk, so `<script>` (`//`) and template (`<!-- -->`) comments are covered uniformly. The
+ * directive must be the entire content of its line; the suppressed line is directive-line + 1.
+ */
+function collectSuppressions(source: string): SuppressionDirective[] {
+  const out: SuppressionDirective[] = [];
+  const lines = source.split('\n');
+  lines.forEach((line, i) => {
+    const m = JS_DIRECTIVE.exec(line) ?? HTML_DIRECTIVE.exec(line);
+    if (!m) return;
+    const ruleIds = m[1]?.split(',').map((s) => s.trim().toUpperCase());
+    out.push({ line: i + 2, ruleIds });
+  });
+  return out;
+}
+
 /** Parse a component's reactivity/correctness + security + architecture facts (CLI/static only). */
 export function parseComponentFacts(
   source: string,
@@ -702,6 +723,7 @@ export function parseComponentFacts(
   const javascriptUrls: SourceSpan[] = [];
   collectSecurityFacts(ast.fragment ?? ast, source, htmlTags, javascriptUrls);
   const loc = countLines(source);
+  const suppressions = collectSuppressions(source);
 
   // Imports live in either the instance (<script>) or module (<script module>) program.
   const imports: string[] = [];
@@ -751,5 +773,5 @@ export function parseComponentFacts(
       if (!writtenOrEscaped.has(d.name)) constableStates.push(d);
     }
   }
-  return { eachBlocks, effects, htmlTags, javascriptUrls, loc, propCount, imports, namespaceImports, constableStates, suppressions: [] };
+  return { eachBlocks, effects, htmlTags, javascriptUrls, loc, propCount, imports, namespaceImports, constableStates, suppressions };
 }

--- a/packages/cli/src/providers/source/parse.ts
+++ b/packages/cli/src/providers/source/parse.ts
@@ -773,5 +773,16 @@ export function parseComponentFacts(
       if (!writtenOrEscaped.has(d.name)) constableStates.push(d);
     }
   }
-  return { eachBlocks, effects, htmlTags, javascriptUrls, loc, propCount, imports, namespaceImports, constableStates, suppressions };
+  return {
+    eachBlocks,
+    effects,
+    htmlTags,
+    javascriptUrls,
+    loc,
+    propCount,
+    imports,
+    namespaceImports,
+    constableStates,
+    suppressions
+  };
 }

--- a/packages/cli/test/parse-component-facts.test.ts
+++ b/packages/cli/test/parse-component-facts.test.ts
@@ -282,9 +282,7 @@ describe('parseComponentFacts — suppression directives (issue #92)', () => {
   });
   it('captures multiple comma-separated rule ids', () => {
     const src = '<script>\n// svelte-vitals-disable-next-line CORRECT002, SEC001\nx = 1;\n</script>';
-    expect(parseComponentFacts(src, 'C.svelte').suppressions).toEqual([
-      { line: 3, ruleIds: ['CORRECT002', 'SEC001'] }
-    ]);
+    expect(parseComponentFacts(src, 'C.svelte').suppressions).toEqual([{ line: 3, ruleIds: ['CORRECT002', 'SEC001'] }]);
   });
   it('captures a blanket disable-next-line with no rule id', () => {
     const src = '<script>\n// svelte-vitals-disable-next-line\nx = 1;\n</script>';

--- a/packages/cli/test/parse-component-facts.test.ts
+++ b/packages/cli/test/parse-component-facts.test.ts
@@ -274,3 +274,31 @@ describe('parseComponentFacts — constable $state (CORRECT004)', () => {
     expect(names('<script>let t = $state("x");</script><p>{t}</p>')).toEqual(['t']);
   });
 });
+
+describe('parseComponentFacts — suppression directives (issue #92)', () => {
+  it('captures a script-side disable-next-line with a rule id', () => {
+    const src = '<script>\n// svelte-vitals-disable-next-line CORRECT002\n$effect(() => { x = 1; });\n</script>';
+    expect(parseComponentFacts(src, 'C.svelte').suppressions).toEqual([{ line: 3, ruleIds: ['CORRECT002'] }]);
+  });
+  it('captures multiple comma-separated rule ids', () => {
+    const src = '<script>\n// svelte-vitals-disable-next-line CORRECT002, SEC001\nx = 1;\n</script>';
+    expect(parseComponentFacts(src, 'C.svelte').suppressions).toEqual([
+      { line: 3, ruleIds: ['CORRECT002', 'SEC001'] }
+    ]);
+  });
+  it('captures a blanket disable-next-line with no rule id', () => {
+    const src = '<script>\n// svelte-vitals-disable-next-line\nx = 1;\n</script>';
+    expect(parseComponentFacts(src, 'C.svelte').suppressions).toEqual([{ line: 3, ruleIds: undefined }]);
+  });
+  it('captures a template-side HTML comment directive', () => {
+    const src = '<!-- svelte-vitals-disable-next-line SEC001 -->\n<div>{@html body}</div>';
+    expect(parseComponentFacts(src, 'C.svelte').suppressions).toEqual([{ line: 2, ruleIds: ['SEC001'] }]);
+  });
+  it('does not match a same-line trailing comment', () => {
+    const src = '<script>\nx = 1; // svelte-vitals-disable-next-line CORRECT002\n</script>';
+    expect(parseComponentFacts(src, 'C.svelte').suppressions).toEqual([]);
+  });
+  it('reports no suppressions for a component without any directive', () => {
+    expect(parseComponentFacts('<p>hi</p>', 'C.svelte').suppressions).toEqual([]);
+  });
+});

--- a/packages/cli/test/suppression-e2e.test.ts
+++ b/packages/cli/test/suppression-e2e.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { parseComponentFacts } from '../src/providers/source/parse.js';
+import { correct002EffectDerived, sec001Html, defineConfig, defaultProject } from '@svelte-vitals/core';
+import type { RuleContext, ComponentFacts } from '@svelte-vitals/core';
+
+const config = defineConfig({});
+const base = { heads: [], project: defaultProject, config };
+const fails = (rs: { detection: { presence: string; value: string } }[]) =>
+  rs.filter((r) => r.detection.presence === 'none' || r.detection.value === 'absent');
+
+const comp = (over: Partial<ComponentFacts>): ComponentFacts => ({
+  file: 'src/lib/C.svelte',
+  eachBlocks: [],
+  effects: [],
+  htmlTags: [],
+  javascriptUrls: [],
+  loc: 10,
+  propCount: 0,
+  imports: [],
+  namespaceImports: [],
+  constableStates: [],
+  suppressions: [],
+  ...over
+});
+
+describe('inline suppression directive — end-to-end (issue #92)', () => {
+  it('CORRECT002 passes for the real mount-signal $effect source, suppressed via inline directive', async () => {
+    const src = [
+      '<script>',
+      '  let mounted = $state(false);',
+      '  // svelte-vitals-disable-next-line CORRECT002',
+      '  $effect(() => {',
+      '    mounted = true;',
+      '  });',
+      '  const showVibrationToggle = $derived(mounted && canVibrate());',
+      '</script>'
+    ].join('\n');
+    const facts = parseComponentFacts(src, 'src/lib/C.svelte');
+    const ctx: RuleContext = { components: [comp({ effects: facts.effects, suppressions: facts.suppressions })], ...base };
+    const rs = await correct002EffectDerived.check(ctx);
+    expect(fails(rs)).toHaveLength(0);
+  });
+
+  it('SEC001 passes for a real template-side {@html} suppressed via an HTML-comment directive', async () => {
+    const src = ['<!-- svelte-vitals-disable-next-line SEC001 -->', '<div>{@html trustedMarkup}</div>'].join('\n');
+    const facts = parseComponentFacts(src, 'src/lib/C.svelte');
+    const ctx: RuleContext = { components: [comp({ htmlTags: facts.htmlTags, suppressions: facts.suppressions })], ...base };
+    const rs = await sec001Html.check(ctx);
+    expect(fails(rs)).toHaveLength(0);
+  });
+
+  it('does not suppress when a blank line separates the directive from the $effect (documented constraint)', async () => {
+    const src = [
+      '<script>',
+      '  let mounted = $state(false);',
+      '  // svelte-vitals-disable-next-line CORRECT002',
+      '',
+      '  $effect(() => {',
+      '    mounted = true;',
+      '  });',
+      '</script>'
+    ].join('\n');
+    const facts = parseComponentFacts(src, 'src/lib/C.svelte');
+    const ctx: RuleContext = { components: [{ file: 'src/lib/C.svelte', ...facts }], ...base };
+    const rs = await correct002EffectDerived.check(ctx);
+    expect(fails(rs)).toHaveLength(1);
+  });
+});

--- a/packages/cli/test/suppression-e2e.test.ts
+++ b/packages/cli/test/suppression-e2e.test.ts
@@ -36,7 +36,10 @@ describe('inline suppression directive — end-to-end (issue #92)', () => {
       '</script>'
     ].join('\n');
     const facts = parseComponentFacts(src, 'src/lib/C.svelte');
-    const ctx: RuleContext = { components: [comp({ effects: facts.effects, suppressions: facts.suppressions })], ...base };
+    const ctx: RuleContext = {
+      components: [comp({ effects: facts.effects, suppressions: facts.suppressions })],
+      ...base
+    };
     const rs = await correct002EffectDerived.check(ctx);
     expect(fails(rs)).toHaveLength(0);
   });
@@ -44,7 +47,10 @@ describe('inline suppression directive — end-to-end (issue #92)', () => {
   it('SEC001 passes for a real template-side {@html} suppressed via an HTML-comment directive', async () => {
     const src = ['<!-- svelte-vitals-disable-next-line SEC001 -->', '<div>{@html trustedMarkup}</div>'].join('\n');
     const facts = parseComponentFacts(src, 'src/lib/C.svelte');
-    const ctx: RuleContext = { components: [comp({ htmlTags: facts.htmlTags, suppressions: facts.suppressions })], ...base };
+    const ctx: RuleContext = {
+      components: [comp({ htmlTags: facts.htmlTags, suppressions: facts.suppressions })],
+      ...base
+    };
     const rs = await sec001Html.check(ctx);
     expect(fails(rs)).toHaveLength(0);
   });

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -28,6 +28,14 @@ export interface SourceSpan {
   line: number;
 }
 
+/** An inline `svelte-vitals-disable-next-line` directive found in the component's source (issue #92). */
+export interface SuppressionDirective {
+  /** 1-based line the directive suppresses (the line immediately after the comment). */
+  line: number;
+  /** Rule ids suppressed on that line; undefined = suppress every rule on that line. */
+  ruleIds?: string[];
+}
+
 /** Reactivity/correctness + security + architecture facts parsed from one `.svelte` component. */
 export interface ComponentFacts {
   /** Source file the component came from. */
@@ -48,4 +56,6 @@ export interface ComponentFacts {
   namespaceImports: { source: string; line: number }[];
   /** `$state` declarations never written or escaped anywhere in the component — candidates for const (CORRECT004). */
   constableStates: { name: string; line: number }[];
+  /** Inline `svelte-vitals-disable-next-line` directives found in this file's source — component-rule escape hatch (issue #92). */
+  suppressions: SuppressionDirective[];
 }

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -56,6 +56,6 @@ export interface ComponentFacts {
   namespaceImports: { source: string; line: number }[];
   /** `$state` declarations never written or escaped anywhere in the component — candidates for const (CORRECT004). */
   constableStates: { name: string; line: number }[];
-  /** Inline `svelte-vitals-disable-next-line` directives found in this file's source — component-rule escape hatch (issue #92). */
-  suppressions: SuppressionDirective[];
+  /** Inline `svelte-vitals-disable-next-line` directives found in this file's source — component-rule escape hatch (issue #92). Optional: absent is equivalent to no directives, so existing external constructors of `ComponentFacts` are unaffected. */
+  suppressions?: SuppressionDirective[];
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,7 +20,7 @@ export { defaultConfig, defineConfig, defaultProject } from './types.js';
 export type { HeadTag, ResolvedHead, HeadProvider } from './head.js';
 export type { ImageInfo, ResolvedImages } from './images.js';
 export type { HeadingInfo, ResolvedHeadings } from './headings.js';
-export type { EachBlockFact, EffectFact, SourceSpan, ComponentFacts } from './component.js';
+export type { EachBlockFact, EffectFact, SourceSpan, ComponentFacts, SuppressionDirective } from './component.js';
 export { ROBOTS_SOURCE_PATHS, SITEMAP_SOURCE_PATHS } from './project-paths.js';
 export type { Runtime } from './runtime.js';
 export type { Rule, RuleContext } from './rule.js';

--- a/packages/core/src/rules/component-rule.ts
+++ b/packages/core/src/rules/component-rule.ts
@@ -31,6 +31,11 @@ export interface ComponentRuleOptions {
   bad: (c: ComponentFacts) => ComponentIssue[];
 }
 
+/** Whether `ruleId`'s finding on `line` is silenced by an inline directive on this component. */
+function isSuppressed(c: ComponentFacts, ruleId: string, line: number): boolean {
+  return (c.suppressions ?? []).some((s) => s.line === line && (!s.ruleIds || s.ruleIds.includes(ruleId)));
+}
+
 /**
  * Build a component-scoped rule (Correctness/Security) over `ctx.components`. CLI/static
  * only — `ctx.components` is unset in rendered mode, so it emits nothing there. Findings
@@ -50,7 +55,7 @@ export function componentRule(opts: ComponentRuleOptions): Rule {
       const out: Result[] = [];
       for (const c of ctx.components ?? []) {
         if (!opts.applies(c)) continue; // no signal in this file → neither penalize nor seed
-        const bad = opts.bad(c);
+        const bad = opts.bad(c).filter((b) => !(b.line > 0 && isSuppressed(c, opts.id, b.line)));
         if (bad.length === 0) {
           out.push({
             id: opts.id,

--- a/packages/core/test/architecture-rules.test.ts
+++ b/packages/core/test/architecture-rules.test.ts
@@ -20,6 +20,7 @@ const comp = (over: Partial<ComponentFacts>): ComponentFacts => ({
   imports: [],
   namespaceImports: [],
   constableStates: [],
+  suppressions: [],
   ...over
 });
 

--- a/packages/core/test/bundle-rules.test.ts
+++ b/packages/core/test/bundle-rules.test.ts
@@ -19,7 +19,8 @@ const comp = (imports: string[]): ComponentFacts => ({
   propCount: 0,
   imports,
   namespaceImports: [],
-  constableStates: []
+  constableStates: [],
+  suppressions: []
 });
 
 describe('PERF009 heavy dependency import', () => {

--- a/packages/core/test/component-rule.test.ts
+++ b/packages/core/test/component-rule.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { componentRule } from '../src/rules/component-rule.js';
+import { defineConfig, defaultProject } from '../src/types.js';
+import type { ComponentFacts } from '../src/component.js';
+import type { RuleContext } from '../src/rule.js';
+
+const config = defineConfig({});
+const base = { heads: [], project: defaultProject, config };
+const fails = (rs: { detection: { presence: string; value: string } }[]) =>
+  rs.filter((r) => r.detection.presence === 'none' || r.detection.value === 'absent');
+const ctx = (components: ComponentFacts[]): RuleContext => ({ components, ...base });
+const comp = (over: Partial<ComponentFacts>): ComponentFacts => ({
+  file: 'src/lib/C.svelte',
+  eachBlocks: [],
+  effects: [],
+  htmlTags: [],
+  javascriptUrls: [],
+  loc: 10,
+  propCount: 0,
+  imports: [],
+  namespaceImports: [],
+  constableStates: [],
+  suppressions: [],
+  ...over
+});
+
+// A minimal fake rule with one hard-coded bad occurrence at line 5, so each test
+// controls suppression purely through comp({ suppressions: [...] }).
+const fakeRule = componentRule({
+  id: 'FAKE001',
+  title: 'Fake rule',
+  category: 'correctness',
+  label: 'Fake check',
+  recommendation: 'n/a',
+  rationale: 'n/a',
+  applies: () => true,
+  bad: () => [{ line: 5, message: 'fake violation' }]
+});
+
+describe('componentRule — inline suppression directives (issue #92)', () => {
+  it('flags the violation when there is no suppression', async () => {
+    const rs = await fakeRule.check(ctx([comp({})]));
+    expect(fails(rs)).toHaveLength(1);
+  });
+  it('suppresses the violation when a directive matches its line and rule id', async () => {
+    const rs = await fakeRule.check(ctx([comp({ suppressions: [{ line: 5, ruleIds: ['FAKE001'] }] })]));
+    expect(fails(rs)).toHaveLength(0);
+    expect(rs).toHaveLength(1); // falls back to the normal PASS result
+  });
+  it('does not suppress when the directive targets a different rule id', async () => {
+    const rs = await fakeRule.check(ctx([comp({ suppressions: [{ line: 5, ruleIds: ['OTHER999'] }] })]));
+    expect(fails(rs)).toHaveLength(1);
+  });
+  it('suppresses regardless of rule id when the directive is blanket (no ruleIds)', async () => {
+    const rs = await fakeRule.check(ctx([comp({ suppressions: [{ line: 5 }] })]));
+    expect(fails(rs)).toHaveLength(0);
+  });
+  it('does not suppress when the directive is on a different line', async () => {
+    const rs = await fakeRule.check(ctx([comp({ suppressions: [{ line: 6, ruleIds: ['FAKE001'] }] })]));
+    expect(fails(rs)).toHaveLength(1);
+  });
+});

--- a/packages/core/test/correctness-rules.test.ts
+++ b/packages/core/test/correctness-rules.test.ts
@@ -25,6 +25,7 @@ const comp = (over: Partial<ComponentFacts>): ComponentFacts => ({
   imports: [],
   namespaceImports: [],
   constableStates: [],
+  suppressions: [],
   ...over
 });
 

--- a/packages/core/test/correctness-rules.test.ts
+++ b/packages/core/test/correctness-rules.test.ts
@@ -68,6 +68,17 @@ describe('CORRECT002 effect used to derive state', () => {
   it('emits nothing for a component with no $effect', async () => {
     expect(await correct002EffectDerived.check(ctx([comp({})]))).toHaveLength(0);
   });
+  it('passes the mount-signal pattern when suppressed via inline directive (issue #92)', async () => {
+    const rs = await correct002EffectDerived.check(
+      ctx([
+        comp({
+          effects: [{ line: 5, assignsOnlyState: true, mountOnly: false }],
+          suppressions: [{ line: 5, ruleIds: ['CORRECT002'] }]
+        })
+      ])
+    );
+    expect(fails(rs)).toHaveLength(0);
+  });
 });
 
 describe('CORRECT003 effect used as onMount', () => {

--- a/packages/core/test/security-rules.test.ts
+++ b/packages/core/test/security-rules.test.ts
@@ -20,6 +20,7 @@ const comp = (over: Partial<ComponentFacts>): ComponentFacts => ({
   imports: [],
   namespaceImports: [],
   constableStates: [],
+  suppressions: [],
   ...over
 });
 

--- a/packages/core/test/security-rules.test.ts
+++ b/packages/core/test/security-rules.test.ts
@@ -34,6 +34,12 @@ describe('SEC001 raw HTML render', () => {
   it('emits nothing for a component without {@html}', async () => {
     expect(await sec001Html.check(ctx([comp({})]))).toHaveLength(0);
   });
+  it('passes when the {@html} finding is suppressed via a template-side directive (issue #92)', async () => {
+    const rs = await sec001Html.check(
+      ctx([comp({ htmlTags: [{ line: 4 }], suppressions: [{ line: 4, ruleIds: ['SEC001'] }] })])
+    );
+    expect(fails(rs)).toHaveLength(0);
+  });
   it('emits nothing when the component channel is unset (rendered mode)', async () => {
     expect(await sec001Html.check(base as RuleContext)).toHaveLength(0);
   });


### PR DESCRIPTION
## Summary
- Add a `// svelte-vitals-disable-next-line CORRECT002` (or `<!-- svelte-vitals-disable-next-line -->` in markup) comment that suppresses a specific component-scoped rule's finding on the following line
- One filter point in the shared `componentRule()` factory covers every rule built on it (CORRECT001–004, SEC001–002, ARCH001–002, PERF009–010) — no per-rule code
- Fixes the CORRECT002 false positive on an intentional mount-signal `$effect` used to avoid a hydration mismatch (issue's exact reported scenario)

Fixes #92

## Design
See `docs/superpowers/specs/2026-07-04-inline-suppression-directive-design.md` (approved design) and `docs/superpowers/plans/2026-07-04-inline-suppression-directive.md` (implementation plan).

## Test plan
- [x] `pnpm test` — all packages green (core 263, cli 341, vite 76, mcp 9)
- [x] `pnpm typecheck` — zero errors
- [x] `pnpm lint` — clean
- [x] `pnpm --filter docs build` — succeeds
- [x] New end-to-end test (`packages/cli/test/suppression-e2e.test.ts`) parses real `.svelte` source through `parseComponentFacts` and a real rule (`correct002EffectDerived`, `sec001Html`), including a negative case proving a blank line between the directive and its target breaks the match
- [x] Docs added (English + Japanese) to the CLI guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for inline `svelte-vitals-disable-next-line` comments to suppress a single finding on the next line, with optional rule-specific targeting.

* **Documentation**
  * Updated CLI guides in English and Japanese with usage examples and matching rules.
  * Added design and implementation planning notes.

* **Tests**
  * Expanded parser, rule, and end-to-end coverage for suppression behavior, including script and markup examples and invalid placements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->