### PR TITLE
fix(cli): make --diff/--staged work when the project is not at the git repo root

### DIFF
--- a/.changeset/fix-diff-staged-repo-subdirectory.md
+++ b/.changeset/fix-diff-staged-repo-subdirectory.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': patch
+---
+
+Fix `--diff`/`--staged` silently reporting zero findings when the analyzed project is not at the git repository root (monorepos): git paths are now resolved relative to the analyzed directory.

--- a/packages/cli/src/changed-files.ts
+++ b/packages/cli/src/changed-files.ts
@@ -13,9 +13,15 @@ function git(args: string[], cwd: string): string[] {
 }
 
 /**
- * Repo-relative POSIX paths changed per the options, or `undefined` when git can't
+ * `cwd`-relative POSIX paths changed per the options, or `undefined` when git can't
  * answer (not a repo, git missing, bad ref). Deleted files are excluded — there is
  * nothing left to analyze. Used to scope `--diff` / `--staged` runs.
+ *
+ * Paths are resolved relative to `cwd` (via `--relative`), matching the basis of
+ * `Result.location` — this matters when the analyzed project lives in a subdirectory
+ * of the git repo (e.g. a monorepo's `apps/web/`), since `git diff --name-only` on
+ * its own reports repo-root-relative paths. `git ls-files --others` is already
+ * `cwd`-relative and scoped to `cwd`, so it needs no such flag.
  *
  * For `--diff`, the working tree is compared against the **merge-base** with `base`
  * (so `--diff main` is "what this branch changed", not files that only moved on
@@ -25,9 +31,9 @@ function git(args: string[], cwd: string): string[] {
 export function getChangedFiles(cwd: string, opts: ChangedFilesOptions): Set<string> | undefined {
   try {
     const files = opts.staged
-      ? git(['diff', '--name-only', '--cached', '--diff-filter=d'], cwd)
+      ? git(['diff', '--name-only', '--relative', '--cached', '--diff-filter=d'], cwd)
       : [
-          ...git(['diff', '--name-only', '--diff-filter=d', '--merge-base', opts.base ?? 'HEAD'], cwd),
+          ...git(['diff', '--name-only', '--relative', '--diff-filter=d', '--merge-base', opts.base ?? 'HEAD'], cwd),
           ...git(['ls-files', '--others', '--exclude-standard'], cwd) // untracked / new files
         ];
     return new Set(files.map((s) => s.trim()).filter(Boolean));

--- a/packages/cli/test/changed-files.test.ts
+++ b/packages/cli/test/changed-files.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'vitest';
-import { filterToChangedFiles } from '../src/changed-files.js';
+import { describe, it, expect, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { filterToChangedFiles, getChangedFiles } from '../src/changed-files.js';
 import type { Result } from '@svelte-vitals/core';
 
 const r = (over: Partial<Result>): Result => ({
@@ -29,5 +33,91 @@ describe('filterToChangedFiles', () => {
 
   it('returns nothing when no result is in the changed set', () => {
     expect(filterToChangedFiles(results, new Set(['src/other.svelte']))).toEqual([]);
+  });
+});
+
+describe('getChangedFiles', () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    while (dirs.length > 0) {
+      const dir = dirs.pop();
+      if (dir) rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function git(args: string[], cwd: string): void {
+    execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+  }
+
+  function makeRepo(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'svelte-vitals-changed-files-'));
+    dirs.push(dir);
+    git(['init'], dir);
+    git(['config', 'user.email', 'test@example.com'], dir);
+    git(['config', 'user.name', 'Test'], dir);
+    return dir;
+  }
+
+  it('reports cwd-relative paths for tracked changes when the project is a subdirectory of the repo', () => {
+    const repo = makeRepo();
+    const projectDir = join(repo, 'apps/web');
+    mkdirSync(join(projectDir, 'src/routes'), { recursive: true });
+    const pagePath = join(projectDir, 'src/routes/+page.svelte');
+    writeFileSync(pagePath, '<h1>hello</h1>\n');
+    git(['add', '.'], repo);
+    git(['commit', '-m', 'init'], repo);
+
+    // Modify a tracked file without committing.
+    writeFileSync(pagePath, '<h1>changed</h1>\n');
+
+    const changed = getChangedFiles(projectDir, { base: 'HEAD' });
+    expect(changed).toEqual(new Set(['src/routes/+page.svelte']));
+  });
+
+  it('reports cwd-relative paths for staged changes when the project is a subdirectory of the repo', () => {
+    const repo = makeRepo();
+    const projectDir = join(repo, 'apps/web');
+    mkdirSync(join(projectDir, 'src/routes'), { recursive: true });
+    const pagePath = join(projectDir, 'src/routes/+page.svelte');
+    writeFileSync(pagePath, '<h1>hello</h1>\n');
+    git(['add', '.'], repo);
+    git(['commit', '-m', 'init'], repo);
+
+    writeFileSync(pagePath, '<h1>changed</h1>\n');
+    git(['add', '.'], repo);
+
+    const changed = getChangedFiles(projectDir, { staged: true });
+    expect(changed).toEqual(new Set(['src/routes/+page.svelte']));
+  });
+
+  it('reports cwd-relative paths for untracked (new) files via the ls-files path', () => {
+    const repo = makeRepo();
+    const projectDir = join(repo, 'apps/web');
+    mkdirSync(join(projectDir, 'src/routes'), { recursive: true });
+    // A committed file so HEAD exists for the merge-base diff.
+    writeFileSync(join(projectDir, 'src/routes/+layout.svelte'), '<slot />\n');
+    git(['add', '.'], repo);
+    git(['commit', '-m', 'init'], repo);
+
+    // A brand-new, untracked file.
+    writeFileSync(join(projectDir, 'src/routes/+page.svelte'), '<h1>new</h1>\n');
+
+    const changed = getChangedFiles(projectDir, { base: 'HEAD' });
+    expect(changed).toEqual(new Set(['src/routes/+page.svelte']));
+  });
+
+  it('still works when run from the repo root (no subdirectory)', () => {
+    const repo = makeRepo();
+    mkdirSync(join(repo, 'src/routes'), { recursive: true });
+    const pagePath = join(repo, 'src/routes/+page.svelte');
+    writeFileSync(pagePath, '<h1>hello</h1>\n');
+    git(['add', '.'], repo);
+    git(['commit', '-m', 'init'], repo);
+
+    writeFileSync(pagePath, '<h1>changed</h1>\n');
+
+    const changed = getChangedFiles(repo, { base: 'HEAD' });
+    expect(changed).toEqual(new Set(['src/routes/+page.svelte']));
   });
 });


### PR DESCRIPTION
## Summary

`svelte-vitals --diff` / `--staged` silently reported **zero findings (exit 0)** whenever the analyzed SvelteKit project was not at the git repository root (e.g. a monorepo's `apps/web/`).

Root cause: a path-basis mismatch. `git diff --name-only` outputs **repo-root-relative** paths (`apps/web/src/routes/+page.svelte`) while findings carry **cwd-relative** locations (`src/routes/+page.svelte`), so `changed.has(location)` never matched — the worst failure mode for a CI/pre-commit gate (silent false pass). Subtly, untracked files merged via `git ls-files --others` were already cwd-relative, so only tracked changes were affected.

## Fix

Add `--relative` to both `git diff` invocations in `getChangedFiles` (`packages/cli/src/changed-files.ts`), making the output cwd-relative and scoped to the analyzed directory — the same basis as `Result.location`. `git ls-files --others` is untouched (already cwd-relative).

## Tests

New regression tests in `packages/cli/test/changed-files.test.ts` using real temporary git repositories:

- tracked change in a repo **subdirectory** → cwd-relative path returned (the regression core)
- `--staged` in a subdirectory
- untracked file via the `ls-files` path
- run from the repo root (previous behavior preserved)

## Verification

- `pnpm typecheck` / `pnpm lint` — clean
- `pnpm test` — 719 tests pass across all packages (core 343 / vite 79 / cli 288 incl. 4 new / mcp 9)
- Changeset included (`svelte-vitals`, patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change detection for projects inside subdirectories, including monorepos, so `--diff` and `--staged` now report the correct changed files instead of missing results.
  * Changed file paths are now resolved relative to the current project directory, making output consistent across staged and unstaged diffs.

* **Tests**
  * Added broader coverage for change detection in repository root and subdirectory setups, including tracked, staged, and new files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->