### PR TITLE
refactor(core): extract shared collectComponentFacts from cli/vite

### DIFF
--- a/.changeset/dedupe-collect-component-facts.md
+++ b/.changeset/dedupe-collect-component-facts.md
@@ -1,0 +1,7 @@
+---
+'@svelte-vitals/core': patch
+'svelte-vitals': patch
+'@svelte-vitals/vite': patch
+---
+
+Deduplicate `collectComponentFacts` into `@svelte-vitals/core`; behavior is unchanged.

--- a/packages/cli/src/providers/source/components.ts
+++ b/packages/cli/src/providers/source/components.ts
@@ -1,32 +1,6 @@
-import { parseComponentFacts, type ComponentFacts, type Runtime } from '@svelte-vitals/core';
-
 /**
  * Scan every `.svelte` component under `src/` for Correctness facts (#correctness).
- * Independent of route resolution — covers `$lib` and non-route components too. A
- * file that fails to parse contributes no facts (dev tooling must never throw).
+ * Implementation lives in `@svelte-vitals/core` (plans/003) so the CLI and vite
+ * packages share one definition instead of hand-syncing two copies.
  */
-export async function collectComponentFacts(rt: Runtime, cwd: string): Promise<ComponentFacts[]> {
-  const files = await rt.glob('src/**/*.svelte', cwd);
-  return Promise.all(
-    files.sort().map(async (rel): Promise<ComponentFacts> => {
-      try {
-        const source = await rt.readFile(rt.join(cwd, rel));
-        return { file: rel, ...parseComponentFacts(source, rel) };
-      } catch {
-        return {
-          file: rel,
-          eachBlocks: [],
-          effects: [],
-          htmlTags: [],
-          javascriptUrls: [],
-          loc: 0,
-          propCount: 0,
-          imports: [],
-          namespaceImports: [],
-          constableStates: [],
-          suppressions: []
-        };
-      }
-    })
-  );
-}
+export { collectComponentFacts } from '@svelte-vitals/core';

--- a/packages/core/src/component-collect.ts
+++ b/packages/core/src/component-collect.ts
@@ -1,0 +1,45 @@
+import { parseComponentFacts } from './component-parse.js';
+import type { ComponentFacts } from './component.js';
+import type { Runtime } from './runtime.js';
+
+/**
+ * Fallback facts for a file that fails to read or parse (dev tooling must never
+ * throw). This is the single source of truth for the empty-facts shape — add new
+ * `ComponentFacts` fields HERE so TypeScript catches every call site that still
+ * needs updating.
+ */
+export function emptyComponentFacts(file: string): ComponentFacts {
+  return {
+    file,
+    eachBlocks: [],
+    effects: [],
+    htmlTags: [],
+    javascriptUrls: [],
+    loc: 0,
+    propCount: 0,
+    imports: [],
+    namespaceImports: [],
+    constableStates: [],
+    suppressions: []
+  };
+}
+
+/**
+ * Scan every `.svelte` component under `src/` for Correctness/Security/Architecture/
+ * Bundle-Performance facts. Independent of route resolution — covers `$lib` and
+ * non-route components too. A file that fails to read or parse contributes empty
+ * facts instead of aborting the whole scan (dev tooling must never throw).
+ */
+export async function collectComponentFacts(rt: Runtime, cwd: string): Promise<ComponentFacts[]> {
+  const files = await rt.glob('src/**/*.svelte', cwd);
+  return Promise.all(
+    files.sort().map(async (rel): Promise<ComponentFacts> => {
+      try {
+        const source = await rt.readFile(rt.join(cwd, rel));
+        return { file: rel, ...parseComponentFacts(source, rel) };
+      } catch {
+        return emptyComponentFacts(rel);
+      }
+    })
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export type { ImageInfo, ResolvedImages } from './images.js';
 export type { HeadingInfo, ResolvedHeadings } from './headings.js';
 export type { EachBlockFact, EffectFact, SourceSpan, ComponentFacts, SuppressionDirective } from './component.js';
 export { parseComponentFacts } from './component-parse.js';
+export { collectComponentFacts, emptyComponentFacts } from './component-collect.js';
 export {
   CHILD_NODE_KEYS,
   lineOf,

--- a/packages/core/test/component-collect.test.ts
+++ b/packages/core/test/component-collect.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import type { Runtime } from '../src/runtime.js';
+import { collectComponentFacts, emptyComponentFacts } from '../src/component-collect.js';
+
+/** Minimal in-memory Runtime for tests (design §8) — no real filesystem needed. */
+function createMemoryRuntime(files: Record<string, string>, unreadable: Set<string> = new Set()): Runtime {
+  const map = new Map(Object.entries(files));
+  return {
+    async readFile(path) {
+      if (unreadable.has(path)) throw new Error(`EACCES: ${path}`);
+      const content = map.get(path);
+      if (content === undefined) throw new Error(`ENOENT: ${path}`);
+      return content;
+    },
+    async exists(path) {
+      return map.has(path);
+    },
+    async glob() {
+      return [...map.keys()].filter((key) => key.endsWith('.svelte'));
+    },
+    join(...parts) {
+      return parts.filter((p) => p.length > 0).join('/');
+    }
+  };
+}
+
+describe('emptyComponentFacts', () => {
+  it('returns the empty-facts shape for the given file', () => {
+    expect(emptyComponentFacts('src/lib/Broken.svelte')).toEqual({
+      file: 'src/lib/Broken.svelte',
+      eachBlocks: [],
+      effects: [],
+      htmlTags: [],
+      javascriptUrls: [],
+      loc: 0,
+      propCount: 0,
+      imports: [],
+      namespaceImports: [],
+      constableStates: [],
+      suppressions: []
+    });
+  });
+});
+
+describe('collectComponentFacts', () => {
+  it('parses a well-formed file into real facts', async () => {
+    const rt = createMemoryRuntime({
+      'src/routes/+page.svelte': '{#each xs as x}<i>{x}</i>{/each}'
+    });
+    const facts = await collectComponentFacts(rt, '');
+    expect(facts).toHaveLength(1);
+    expect(facts[0]!.file).toBe('src/routes/+page.svelte');
+    expect(facts[0]!.eachBlocks).toEqual([{ hasKey: false, line: 1 }]);
+  });
+
+  it('falls back to emptyComponentFacts when readFile rejects', async () => {
+    const rt = createMemoryRuntime(
+      { 'src/lib/Unreadable.svelte': '<div></div>' },
+      new Set(['src/lib/Unreadable.svelte'])
+    );
+    const facts = await collectComponentFacts(rt, '');
+    expect(facts).toEqual([emptyComponentFacts('src/lib/Unreadable.svelte')]);
+  });
+
+  it('sorts results by file path regardless of glob order', async () => {
+    const rt: Runtime = {
+      async readFile(path) {
+        return `<!-- ${path} -->`;
+      },
+      async exists() {
+        return true;
+      },
+      async glob() {
+        return ['src/routes/z.svelte', 'src/lib/a.svelte', 'src/lib/m.svelte'];
+      },
+      join(...parts) {
+        return parts.filter((p) => p.length > 0).join('/');
+      }
+    };
+    const facts = await collectComponentFacts(rt, '');
+    expect(facts.map((f) => f.file)).toEqual(['src/lib/a.svelte', 'src/lib/m.svelte', 'src/routes/z.svelte']);
+  });
+});

--- a/packages/vite/src/providers/source/components.ts
+++ b/packages/vite/src/providers/source/components.ts
@@ -1,36 +1,32 @@
-import { readFile } from 'node:fs/promises';
+import { readFile, access } from 'node:fs/promises';
 import { join } from 'node:path';
 import { glob } from 'tinyglobby';
-import { parseComponentFacts, type ComponentFacts } from '@svelte-vitals/core';
+import { collectComponentFacts as collect, type ComponentFacts, type Runtime } from '@svelte-vitals/core';
+
+/**
+ * Node-backed Runtime adapter (design §8). vite always runs in Node, so no
+ * swappable runtime is needed here — this just satisfies the interface the
+ * shared core implementation expects.
+ */
+const nodeRuntime: Runtime = {
+  readFile: (path) => readFile(path, 'utf8'),
+  async exists(path) {
+    try {
+      await access(path);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  glob: (pattern, cwd) => glob(pattern, { cwd, dot: false }),
+  join: (...parts) => join(...parts)
+};
 
 /**
  * Scan every `.svelte` component under `src/` for Correctness/Security/Architecture/
- * Bundle-Performance facts (build mode only). Mirrors the CLI's `collectComponentFacts`,
- * but implemented directly against `node:fs` + `tinyglobby` instead of the CLI's
- * injectable `Runtime` — vite always runs in Node, so no swappable runtime is needed.
+ * Bundle-Performance facts (build mode only). Implementation lives in
+ * `@svelte-vitals/core` (plans/003) and is shared with the CLI package.
  */
-export async function collectComponentFacts(root: string): Promise<ComponentFacts[]> {
-  const files = await glob('src/**/*.svelte', { cwd: root, dot: false });
-  return Promise.all(
-    files.sort().map(async (rel): Promise<ComponentFacts> => {
-      try {
-        const source = await readFile(join(root, rel), 'utf8');
-        return { file: rel, ...parseComponentFacts(source, rel) };
-      } catch {
-        return {
-          file: rel,
-          eachBlocks: [],
-          effects: [],
-          htmlTags: [],
-          javascriptUrls: [],
-          loc: 0,
-          propCount: 0,
-          imports: [],
-          namespaceImports: [],
-          constableStates: [],
-          suppressions: []
-        };
-      }
-    })
-  );
+export function collectComponentFacts(root: string): Promise<ComponentFacts[]> {
+  return collect(nodeRuntime, root);
 }


### PR DESCRIPTION
## Summary

`collectComponentFacts` (glob `src/**/*.svelte` → `parseComponentFacts` → empty facts on failure) was duplicated nearly byte-for-byte between `packages/cli` and `packages/vite`, including the hand-synced 12-field empty-facts literal. Every `ComponentFacts` field addition (`suppressions`, `constableStates`, `namespaceImports` recently) required lockstep edits in two files.

This PR moves the implementation to `@svelte-vitals/core` — **behavior is unchanged**.

## Changes

- **core**: new `component-collect.ts` exporting `collectComponentFacts(rt, cwd)` and `emptyComponentFacts(file)` — the empty-facts shape now exists in exactly one place, so TypeScript catches any missed field addition. Uses the injected `Runtime` interface only (no `node:` imports — core purity preserved; publint clean).
- **cli**: `providers/source/components.ts` becomes a one-line re-export from core. Call sites unchanged.
- **vite**: `providers/source/components.ts` delegates through a small Node-backed `Runtime` adapter (`fs.access`-based `exists`, same `dot: false` glob semantics — verified identical to the CLI's `createNodeRuntime`).

## Tests

- New `packages/core/test/component-collect.test.ts` (3 cases): real parse facts via an in-memory `Runtime`, `readFile`-rejection falling back to `emptyComponentFacts`, and stable sort order regardless of glob order.
- **Equivalence proof**: the existing `collect-component-facts` tests (cli + vite) and the malformed-`.svelte` characterization tests from #116 all pass **unmodified**.

## Verification

- `pnpm build` / `pnpm typecheck` / `pnpm test` (727 tests) / `pnpm lint` — all clean
- `publint` — all 4 packages clean; `attw` runs in CI only (no npm in the local environment)
- Changeset: patch for `@svelte-vitals/core`, `svelte-vitals`, `@svelte-vitals/vite`

🤖 Generated with [Claude Code](https://claude.com/claude-code)