### PR TITLE
docs: add AGENTS.md with repo conventions for agent sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# AGENTS.md
+
+Repository conventions for AI agent sessions. Read this before exploring the codebase — it exists so you don't have to rediscover (or guess) these facts every session.
+
+## What this is
+
+svelte-vitals is a static code-health checker for SvelteKit — not a runtime Web Vitals reporter. It statically analyzes source code (resolved `<head>` metadata and component bodies) across five categories: SEO, Performance, Correctness, Security, Architecture. The project is pre-1.0 (all packages are on `0.x` versions).
+
+## Verify commands
+
+| Purpose        | Command              | Notes                                 |
+| -------------- | -------------------- | ------------------------------------- |
+| Build          | `pnpm build`         | `pnpm -r build`                       |
+| Typecheck      | `pnpm typecheck`     | `pnpm -r typecheck`                   |
+| Test           | `pnpm test`          | `pnpm -r test` (vitest)               |
+| Lint           | `pnpm lint`          | `prettier --check .` + `eslint .`     |
+| Format         | `pnpm format`        | `prettier --write .`                  |
+| Publish checks | `pnpm check:publish` | publint + attw (`--profile esm-only`) |
+
+CI (`.github/workflows/ci.yml`) runs four jobs: `lint`, `check` (build + typecheck + check:publish), `test`, `docs`. Run the relevant verify commands yourself and confirm they pass **before** claiming a task is complete.
+
+## Package map
+
+- `packages/core` — runtime-agnostic rule engine, scorer, and reporter (types + logic only).
+- `packages/cli` — the `svelte-vitals` CLI.
+- `packages/vite` — Vite/SvelteKit plugin + dev overlay; analyzes prerendered HTML during `vite build`.
+- `packages/mcp` — Model Context Protocol server exposing svelte-vitals to agent tool loops.
+- `docs` — Astro Starlight docs site, English + Japanese (`docs/src/content/docs/` and `docs/src/content/docs/ja/`).
+
+## Hard rules
+
+- **Core purity**: `packages/core/src/index.ts` states verbatim: "runtime-agnostic core (design §8). No `node:` imports, no I/O, no runtime-specific globals." All I/O is injected through the `Runtime` interface (`packages/core/src/runtime.ts`). Never add a `node:` import or direct I/O call inside `packages/core`.
+- **Dependencies via catalog**: root `package.json` devDependencies are all pinned as `catalog:`; actual versions live in `pnpm-workspace.yaml`. Add/bump shared devDependencies there, not as literal versions in a package's `package.json`.
+- **Changesets required**: any user-facing change needs `pnpm changeset`. Merging to `main` opens a release PR (Changesets bot). Internal-only / doc-only changes don't need one.
+- **en/ja docs stay in sync**: `docs/src/content/docs/` (English) and `docs/src/content/docs/ja/` (Japanese) are updated together by convention — don't ship an English-only doc change if the Japanese equivalent exists.
+
+## Conventions
+
+- **Conventional commits**, scoped by package, e.g.:
+  - `fix(cli): make --diff/--staged work when the project is not at the git repo root`
+  - `test(cli): pin behavior for malformed .svelte files in both passes`
+  - Other prefixes in use: `feat(vite):`, `docs:`, `chore:`.
+- **Adding a rule**: create `packages/core/src/rules/<category>/xxxNNN-slug.ts`, then register it in `packages/core/src/rules/index.ts` in all three places: the import, the `allRules` array, and the re-export block. Note: for historical reasons performance rules are split across `rules/perf/` (PERF001–008) and `rules/performance/` (PERF009–010) — check both when looking for an existing PERF rule.
+- **Tests**: vitest, per-package `test/` directories; fixtures live under `test/fixtures/`.
+
+## Design docs
+
+`docs/superpowers/specs/` holds design docs, `docs/superpowers/plans/` holds implementation plans, both accumulated with date-prefixed filenames. Before assuming a tradeoff is undecided or reintroducing something that was deliberately removed, check here first — e.g. the a11y category was designed (`2026-06-22-a11y-v0.5-design.md`) and later removed (`docs/superpowers/specs/2026-06-23-remove-a11y-design.md`, `docs/superpowers/plans/2026-06-23-remove-a11y.md`).
+
+## Exit codes
+
+The CLI's contract (`packages/cli/src/bin.ts`):
+
+- `0` — no failing findings
+- `1` — critical finding present (or `--fail-on`/`--min-health` threshold reached)
+- `2` — execution error (not a SvelteKit project / internal error)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See @AGENTS.md for repository conventions, verify commands, and hard rules.

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -1,0 +1,3 @@
+# @svelte-vitals/core constraints
+
+This package is runtime-agnostic by design (design §8): **no `node:` imports, no I/O, no runtime-specific globals** anywhere in `src/`. All I/O is injected through the `Runtime` interface (`src/runtime.ts`). See the repo-root [AGENTS.md](../../AGENTS.md) for full conventions.


### PR DESCRIPTION
## Summary

This repo is developed largely through AI-agent sessions, but had no committed agent-facing conventions doc — `.claude/` and `.superpowers/` are gitignored, so every session rediscovered (or guessed) the same non-obvious facts: the core purity rule, the pnpm `catalog:` dependency pattern, the 3-place rule registration, the changeset requirement, and the en/ja docs-sync convention.

## Changes

- **`AGENTS.md`** (new, ~57 lines, English): verify-commands table, package map, hard rules (core purity quoted verbatim from `packages/core/src/index.ts`, catalog deps, changesets, en/ja sync), conventions (conventional commits with real examples, rule-adding procedure incl. the `rules/perf/` vs `rules/performance/` split), design-docs pointer (`docs/superpowers/specs|plans/` — check decided tradeoffs like the a11y removal before proposing), and the CLI exit-code contract.
- **`CLAUDE.md`** (new): one-line pointer to `AGENTS.md`.

Every stated fact was verified against the current code before writing (file paths, script names, CI jobs, commit examples) — no speculative conventions were added.

## Verification

- `pnpm lint` — clean
- All `pnpm` commands referenced in AGENTS.md cross-checked against root `package.json` scripts — all exist
- No changeset (doc-only; no published package changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)