### PR TITLE
chore: enforce @svelte-vitals/core runtime-purity with eslint no-restricted-imports

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,5 +25,46 @@ export default ts.config(
         ...globals.node
       }
     }
+  },
+  // @svelte-vitals/core is runtime-agnostic by contract (design §8, see packages/core/src/index.ts):
+  // no node: imports, no I/O, no runtime-specific globals. Enforce it here so a violation
+  // fails `pnpm lint` / CI instead of relying on review. I/O is injected via the Runtime interface.
+  {
+    files: ['packages/core/src/**/*.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: [
+                'node:*',
+                'fs',
+                'fs/*',
+                'path',
+                'os',
+                'url',
+                'child_process',
+                'http',
+                'https',
+                'crypto',
+                'util',
+                'stream',
+                'events'
+              ],
+              message:
+                '@svelte-vitals/core is runtime-agnostic (design §8): no Node builtins here — inject I/O through the Runtime interface (src/runtime.ts).'
+            }
+          ]
+        }
+      ],
+      'no-restricted-globals': [
+        'error',
+        { name: 'process', message: 'core is runtime-agnostic (design §8): no runtime-specific globals.' },
+        { name: '__dirname', message: 'core is runtime-agnostic (design §8): no runtime-specific globals.' },
+        { name: '__filename', message: 'core is runtime-agnostic (design §8): no runtime-specific globals.' },
+        { name: 'Buffer', message: 'core is runtime-agnostic (design §8): no runtime-specific globals.' }
+      ]
+    }
   }
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import js from '@eslint/js';
 import { includeIgnoreFile } from '@eslint/compat';
 import svelte from 'eslint-plugin-svelte';
 import globals from 'globals';
+import { builtinModules } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import ts from 'typescript-eslint';
 
@@ -28,7 +29,9 @@ export default ts.config(
   },
   // @svelte-vitals/core is runtime-agnostic by contract (design §8, see packages/core/src/index.ts):
   // no node: imports, no I/O, no runtime-specific globals. Enforce it here so a violation
-  // fails `pnpm lint` / CI instead of relying on review. I/O is injected via the Runtime interface.
+  // fails `pnpm lint` / CI instead of relying on review. I/O is injected via the Runtime
+  // interface. The bare-builtin ban list is generated from node:module's builtinModules
+  // (plus a `/*` variant for subpaths like `path/posix`) so it can never go stale.
   {
     files: ['packages/core/src/**/*.ts'],
     rules: {
@@ -37,21 +40,7 @@ export default ts.config(
         {
           patterns: [
             {
-              group: [
-                'node:*',
-                'fs',
-                'fs/*',
-                'path',
-                'os',
-                'url',
-                'child_process',
-                'http',
-                'https',
-                'crypto',
-                'util',
-                'stream',
-                'events'
-              ],
+              group: ['node:*', ...builtinModules, ...builtinModules.map((m) => `${m}/*`)],
               message:
                 '@svelte-vitals/core is runtime-agnostic (design §8): no Node builtins here — inject I/O through the Runtime interface (src/runtime.ts).'
             }


### PR DESCRIPTION
## Summary

`@svelte-vitals/core`'s most important contract — "runtime-agnostic: no `node:` imports, no I/O, no runtime-specific globals" (stated at `packages/core/src/index.ts:1-2`) — was previously upheld only by documentation and review. This PR turns it into a CI gate, following the principle that prohibitions should be enforced mechanically rather than documented (see Anthropic's Claude Code steering guide).

## Changes

One scoped block in `eslint.config.js`, applying only to `packages/core/src/**/*.ts`:

- **`no-restricted-imports`**: bans `node:*` plus common bare builtins (`fs`, `path`, `os`, `child_process`, …) with a message pointing to the `Runtime` interface (`src/runtime.ts`) as the injection point
- **`no-restricted-globals`**: bans `process`, `__dirname`, `__filename`, `Buffer`

`packages/core/test/` is deliberately **not** covered — tests run under Node and legitimately use `node:` imports; purity applies to `src/` only.

## Verification

- Pre-check: zero existing violations in `packages/core/src/` (grep for `node:` imports and runtime globals — 0 hits), so the rule lands green
- Positive probe: a temp file with `import 'node:fs'` fails eslint with the `runtime-agnostic` message; same for `process.env` via `no-restricted-globals` (probe removed, not committed)
- `pnpm lint` / `pnpm typecheck` / `pnpm test` (723 tests) — all clean; no other package's lint outcome changed
- No changeset (internal tooling only; no published package behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened code checks in the core package to prevent use of environment-specific APIs, helping keep behavior consistent across runtimes.
  * Added clearer guidance when restricted APIs are used, encouraging safer input/output handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->