### PR TITLE
fix(cli): detect svelte-meta-tags MetaTags/JsonLd tags in static mode (#91)

### DIFF
--- a/.changeset/fix-smt-metatags-jsonld-detection.md
+++ b/.changeset/fix-smt-metatags-jsonld-detection.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': patch
+---
+
+Detect Open Graph (`og:description`, `og:url`), `twitter:card`, and JSON-LD tags emitted by `svelte-meta-tags` (`MetaTags` / `JsonLd`) in static mode. Inline `openGraph` / `twitter` object literals are now introspected key-by-key, non-literal configs fall back to broad coverage, and the `JsonLd` component is recognized — resolving SEO008/011/012/013 false positives (#91). The same `openGraph`/`twitter` introspection applies to `svelte-seo`.

--- a/docs/superpowers/plans/2026-07-06-smt-metatags-jsonld-detection.md
+++ b/docs/superpowers/plans/2026-07-06-smt-metatags-jsonld-detection.md
@@ -28,10 +28,12 @@ Issue: https://github.com/oekazuma/svelte-vitals/issues/91
 `openGraph` / `twitter` のインラインオブジェクトリテラルからキーを列挙し、対応する head タグを emit するヘルパーを新設する。両 adapter がこれを共有する。
 
 **Files:**
+
 - Create: `packages/cli/src/providers/source/adapters/meta-object.ts`
 - Test: `packages/cli/test/meta-object.test.ts`
 
 **Interfaces:**
+
 - Consumes: `ParsedTag`（`../parse.js`）, `Value`（`@svelte-vitals/core`）
 - Produces:
   - `exprValue(node: Node): Value` — ESTree 式ノードの値種別（文字列リテラル非空→`'static'`、他リテラル→`'static'`、`Identifier`/`Member`/`Array`/`Object` 等→`'dynamic'`、null→`'absent'`）
@@ -224,40 +226,42 @@ git commit -m "feat(cli): add shared openGraph/twitter object-literal introspect
 `MetaTags` の `openGraph` / `twitter` をヘルパーで解析し、`broad` を精密化する。
 
 **Files:**
+
 - Modify: `packages/cli/src/providers/source/adapters/svelte-meta-tags.ts:50-55`
 - Test: `packages/cli/test/adapters-smt.test.ts`（ケース追加）
 
 **Interfaces:**
+
 - Consumes: `resolveMetaObject`, `OPEN_GRAPH_KEYS`, `TWITTER_KEYS`（Task 1）
-- Produces: 変更後の `svelteMetaTagsAdapter.resolve` は openGraph/twitter リテラルから og:*/twitter:card タグを含み、`broad = hasSpread || openGraph opaque || twitter opaque`
+- Produces: 変更後の `svelteMetaTagsAdapter.resolve` は openGraph/twitter リテラルから og:\*/twitter:card タグを含み、`broad = hasSpread || openGraph opaque || twitter opaque`
 
 - [ ] **Step 1: 失敗するテストを書く**
 
 `packages/cli/test/adapters-smt.test.ts` の `describe` 内末尾に追加:
 
 ```typescript
-  it('emits og:url / og:description / og:image tags from an inline openGraph literal', () => {
-    const r = svelteMetaTagsAdapter.resolve(
-      useOf('<MetaTags openGraph={{ type: "website", url: u, description: "d", images: [{ url: i }], title: t }} />')
-    );
-    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:url', value: 'dynamic' });
-    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:description', value: 'static' });
-    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:image', value: 'dynamic' });
-    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:title', value: 'dynamic' });
-    expect(r.broad).toBe(false);
-  });
+it('emits og:url / og:description / og:image tags from an inline openGraph literal', () => {
+  const r = svelteMetaTagsAdapter.resolve(
+    useOf('<MetaTags openGraph={{ type: "website", url: u, description: "d", images: [{ url: i }], title: t }} />')
+  );
+  expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:url', value: 'dynamic' });
+  expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:description', value: 'static' });
+  expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:image', value: 'dynamic' });
+  expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:title', value: 'dynamic' });
+  expect(r.broad).toBe(false);
+});
 
-  it('emits twitter:card from an inline twitter literal', () => {
-    const r = svelteMetaTagsAdapter.resolve(useOf('<MetaTags twitter={{ cardType: "summary_large_image" }} />'));
-    expect(r.tags).toContainEqual({ kind: 'meta', name: 'twitter:card', value: 'static' });
-    expect(r.broad).toBe(false);
-  });
+it('emits twitter:card from an inline twitter literal', () => {
+  const r = svelteMetaTagsAdapter.resolve(useOf('<MetaTags twitter={{ cardType: "summary_large_image" }} />'));
+  expect(r.tags).toContainEqual({ kind: 'meta', name: 'twitter:card', value: 'static' });
+  expect(r.broad).toBe(false);
+});
 
-  it('falls back to broad when openGraph is a variable (not an inline literal)', () => {
-    const r = svelteMetaTagsAdapter.resolve(useOf('<MetaTags openGraph={cfg} />'));
-    expect(r.broad).toBe(true);
-    expect(r.tags.some((t) => t.kind === 'meta' && t.property === 'og:url')).toBe(false);
-  });
+it('falls back to broad when openGraph is a variable (not an inline literal)', () => {
+  const r = svelteMetaTagsAdapter.resolve(useOf('<MetaTags openGraph={cfg} />'));
+  expect(r.broad).toBe(true);
+  expect(r.tags.some((t) => t.kind === 'meta' && t.property === 'og:url')).toBe(false);
+});
 ```
 
 - [ ] **Step 2: テストが失敗することを確認**
@@ -278,25 +282,25 @@ import { resolveMetaObject, OPEN_GRAPH_KEYS, TWITTER_KEYS } from './meta-object.
 現在の該当ブロック（50-55 行付近）:
 
 ```typescript
-    // openGraph is an object prop we don't introspect; treat it as a broad og:* source.
-    const openGraph = findAttr(attrs, 'openGraph');
-    const broad = use.hasSpread || Boolean(openGraph);
+// openGraph is an object prop we don't introspect; treat it as a broad og:* source.
+const openGraph = findAttr(attrs, 'openGraph');
+const broad = use.hasSpread || Boolean(openGraph);
 
-    return { tags, broad };
+return { tags, broad };
 ```
 
 を次に置き換える:
 
 ```typescript
-    // Introspect inline openGraph / twitter object literals into specific og:*/twitter:card
-    // tags. A variable-passed object (openGraph={cfg}) or a spread is unreadable → fall back
-    // to broad coverage (BROAD_KINDS fills the og family + twitter:card).
-    const og = resolveMetaObject(findAttr(attrs, 'openGraph'), OPEN_GRAPH_KEYS);
-    const tw = resolveMetaObject(findAttr(attrs, 'twitter'), TWITTER_KEYS);
-    tags.push(...og.tags, ...tw.tags);
-    const broad = use.hasSpread || og.opaque || tw.opaque;
+// Introspect inline openGraph / twitter object literals into specific og:*/twitter:card
+// tags. A variable-passed object (openGraph={cfg}) or a spread is unreadable → fall back
+// to broad coverage (BROAD_KINDS fills the og family + twitter:card).
+const og = resolveMetaObject(findAttr(attrs, 'openGraph'), OPEN_GRAPH_KEYS);
+const tw = resolveMetaObject(findAttr(attrs, 'twitter'), TWITTER_KEYS);
+tags.push(...og.tags, ...tw.tags);
+const broad = use.hasSpread || og.opaque || tw.opaque;
 
-    return { tags, broad };
+return { tags, broad };
 ```
 
 - [ ] **Step 4: テストが通ることを確認**
@@ -318,37 +322,39 @@ git commit -m "fix(cli): introspect svelte-meta-tags openGraph/twitter literals 
 `svelte-seo` も同一の `openGraph` / `twitter` 解析を共有する。
 
 **Files:**
+
 - Modify: `packages/cli/src/providers/source/adapters/svelte-seo.ts:39-42`
 - Test: `packages/cli/test/adapters-registry.test.ts`（ケース追加）
 
 **Interfaces:**
+
 - Consumes: `resolveMetaObject`, `OPEN_GRAPH_KEYS`, `TWITTER_KEYS`（Task 1）
-- Produces: `svelteSeoAdapter.resolve` が og:*/twitter:card タグを含み、`broad = hasSpread || openGraph opaque || twitter opaque`
+- Produces: `svelteSeoAdapter.resolve` が og:\*/twitter:card タグを含み、`broad = hasSpread || openGraph opaque || twitter opaque`
 
 - [ ] **Step 1: 失敗するテストを書く**
 
 `packages/cli/test/adapters-registry.test.ts` の `describe('adapter registry', ...)` 内に追加:
 
 ```typescript
-  it('introspects the svelte-seo openGraph/twitter literals', () => {
-    const adapter = findAdapter({ source: 'svelte-seo', imported: 'default' })!;
-    const r = adapter.resolve(
-      useOf(
-        `import Seo from 'svelte-seo';`,
-        '<Seo openGraph={{ url: u, description: "d" }} twitter={{ card: "summary" }} />'
-      )
-    );
-    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:url', value: 'dynamic' });
-    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:description', value: 'static' });
-    expect(r.tags).toContainEqual({ kind: 'meta', name: 'twitter:card', value: 'static' });
-    expect(r.broad).toBe(false);
-  });
+it('introspects the svelte-seo openGraph/twitter literals', () => {
+  const adapter = findAdapter({ source: 'svelte-seo', imported: 'default' })!;
+  const r = adapter.resolve(
+    useOf(
+      `import Seo from 'svelte-seo';`,
+      '<Seo openGraph={{ url: u, description: "d" }} twitter={{ card: "summary" }} />'
+    )
+  );
+  expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:url', value: 'dynamic' });
+  expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:description', value: 'static' });
+  expect(r.tags).toContainEqual({ kind: 'meta', name: 'twitter:card', value: 'static' });
+  expect(r.broad).toBe(false);
+});
 
-  it('falls back to broad when svelte-seo openGraph is a variable', () => {
-    const adapter = findAdapter({ source: 'svelte-seo', imported: 'default' })!;
-    const r = adapter.resolve(useOf(`import Seo from 'svelte-seo';`, '<Seo openGraph={cfg} />'));
-    expect(r.broad).toBe(true);
-  });
+it('falls back to broad when svelte-seo openGraph is a variable', () => {
+  const adapter = findAdapter({ source: 'svelte-seo', imported: 'default' })!;
+  const r = adapter.resolve(useOf(`import Seo from 'svelte-seo';`, '<Seo openGraph={cfg} />'));
+  expect(r.broad).toBe(true);
+});
 ```
 
 - [ ] **Step 2: テストが失敗することを確認**
@@ -369,21 +375,21 @@ import { resolveMetaObject, OPEN_GRAPH_KEYS, TWITTER_KEYS } from './meta-object.
 現在の該当ブロック（39-42 行付近）:
 
 ```typescript
-    const openGraph = findAttr(attrs, 'openGraph');
-    const broad = use.hasSpread || Boolean(openGraph);
+const openGraph = findAttr(attrs, 'openGraph');
+const broad = use.hasSpread || Boolean(openGraph);
 
-    return { tags, broad };
+return { tags, broad };
 ```
 
 を次に置き換える:
 
 ```typescript
-    const og = resolveMetaObject(findAttr(attrs, 'openGraph'), OPEN_GRAPH_KEYS);
-    const tw = resolveMetaObject(findAttr(attrs, 'twitter'), TWITTER_KEYS);
-    tags.push(...og.tags, ...tw.tags);
-    const broad = use.hasSpread || og.opaque || tw.opaque;
+const og = resolveMetaObject(findAttr(attrs, 'openGraph'), OPEN_GRAPH_KEYS);
+const tw = resolveMetaObject(findAttr(attrs, 'twitter'), TWITTER_KEYS);
+tags.push(...og.tags, ...tw.tags);
+const broad = use.hasSpread || og.opaque || tw.opaque;
 
-    return { tags, broad };
+return { tags, broad };
 ```
 
 - [ ] **Step 4: テストが通ることを確認**
@@ -405,11 +411,13 @@ git commit -m "fix(cli): introspect svelte-seo openGraph/twitter literals"
 `svelte-meta-tags` の `JsonLd` コンポーネントを検出し、`jsonld` タグを emit する（SEO008 解消）。
 
 **Files:**
+
 - Create: `packages/cli/src/providers/source/adapters/svelte-meta-tags-jsonld.ts`
 - Modify: `packages/cli/src/providers/source/adapters/index.ts:3-9`
 - Test: `packages/cli/test/adapters-jsonld.test.ts`
 
 **Interfaces:**
+
 - Consumes: `Adapter`, `AdapterResult`（`./types.js`）, `ImportInfo`（`../imports.js`）, `ComponentUse`, `ParsedTag`（`../parse.js`）
 - Produces: `svelteMetaTagsJsonLdAdapter: Adapter`。`builtinAdapters` に登録され、`JsonLd`（named）/ `svelte-meta-tags/JsonLd.svelte`（default）にマッチ、`{ kind: 'jsonld', value: 'dynamic' }` を emit。
 
@@ -521,10 +529,12 @@ git commit -m "fix(cli): detect svelte-meta-tags JsonLd component (SEO008)"
 不透明ソース（`config.metaComponents`・spread・変数 openGraph）でも og:description / og:url / twitter:card を dynamic 補完する。
 
 **Files:**
+
 - Modify: `packages/cli/src/providers/source/resolve.ts:11-19`
 - Test: `packages/cli/test/resolve.test.ts`（ケース追加）
 
 **Interfaces:**
+
 - Produces: 拡張後の `BROAD_KINDS` に `{ kind: 'meta', property: 'og:description', value: 'dynamic' }` / `{ kind: 'meta', property: 'og:url', value: 'dynamic' }` / `{ kind: 'meta', name: 'twitter:card', value: 'dynamic' }` を含む（`jsonld` は含まない）
 
 - [ ] **Step 1: 失敗するテストを書く**
@@ -532,15 +542,15 @@ git commit -m "fix(cli): detect svelte-meta-tags JsonLd component (SEO008)"
 `packages/cli/test/resolve.test.ts` の `describe` 内に追加:
 
 ```typescript
-  it('BROAD_KINDS covers og:description, og:url and twitter:card', () => {
-    expect(BROAD_KINDS).toContainEqual({ kind: 'meta', property: 'og:description', value: 'dynamic' });
-    expect(BROAD_KINDS).toContainEqual({ kind: 'meta', property: 'og:url', value: 'dynamic' });
-    expect(BROAD_KINDS).toContainEqual({ kind: 'meta', name: 'twitter:card', value: 'dynamic' });
-  });
+it('BROAD_KINDS covers og:description, og:url and twitter:card', () => {
+  expect(BROAD_KINDS).toContainEqual({ kind: 'meta', property: 'og:description', value: 'dynamic' });
+  expect(BROAD_KINDS).toContainEqual({ kind: 'meta', property: 'og:url', value: 'dynamic' });
+  expect(BROAD_KINDS).toContainEqual({ kind: 'meta', name: 'twitter:card', value: 'dynamic' });
+});
 
-  it('BROAD_KINDS does NOT cover jsonld (structured data is a separate concern)', () => {
-    expect(BROAD_KINDS.some((t) => t.kind === 'jsonld')).toBe(false);
-  });
+it('BROAD_KINDS does NOT cover jsonld (structured data is a separate concern)', () => {
+  expect(BROAD_KINDS.some((t) => t.kind === 'jsonld')).toBe(false);
+});
 ```
 
 （`BROAD_KINDS` は既に import 済み。broad 判定自体は既存テスト「marks broad for a metaComponents-declared component」でカバー済みのため追加不要。）
@@ -590,10 +600,12 @@ git commit -m "fix(cli): broaden BROAD_KINDS to cover og:description/og:url/twit
 `/smt` フィクスチャに openGraph / twitter / JsonLd を追加し、実 Node ランタイムで全タグが検出されることを検証する。
 
 **Files:**
+
 - Modify: `packages/cli/test/fixtures/basic-project/src/routes/smt/+page.svelte`
 - Modify: `packages/cli/test/source-provider.test.ts`（import に `HeadTag` 追加、ケース追加）
 
 **Interfaces:**
+
 - Consumes: Task 2・4・5 の成果（adapter 解析 + JsonLd adapter + BROAD_KINDS）
 - Produces: `/smt` の `ResolvedHead.tags` に og:url / og:description / twitter:card / jsonld を含む
 
@@ -643,16 +655,16 @@ import {
 `describe('SourceHeadProvider (Node runtime, real fixture)', ...)` 内に追加:
 
 ```typescript
-  it('detects svelte-meta-tags openGraph/twitter/JsonLd tags on the /smt route (issue #91)', async () => {
-    const rt = createNodeRuntime();
-    const heads = await sourceHeadProvider.collect(rt, fixtureDir);
-    const smt = new Map(heads.map((h) => [h.route, h])).get('/smt')!;
-    const has = (pred: (t: HeadTag) => boolean) => smt.tags.some(pred);
-    expect(has((t) => t.kind === 'meta' && t.property === 'og:url')).toBe(true);
-    expect(has((t) => t.kind === 'meta' && t.property === 'og:description')).toBe(true);
-    expect(has((t) => t.kind === 'meta' && t.name === 'twitter:card')).toBe(true);
-    expect(has((t) => t.kind === 'jsonld')).toBe(true);
-  });
+it('detects svelte-meta-tags openGraph/twitter/JsonLd tags on the /smt route (issue #91)', async () => {
+  const rt = createNodeRuntime();
+  const heads = await sourceHeadProvider.collect(rt, fixtureDir);
+  const smt = new Map(heads.map((h) => [h.route, h])).get('/smt')!;
+  const has = (pred: (t: HeadTag) => boolean) => smt.tags.some(pred);
+  expect(has((t) => t.kind === 'meta' && t.property === 'og:url')).toBe(true);
+  expect(has((t) => t.kind === 'meta' && t.property === 'og:description')).toBe(true);
+  expect(has((t) => t.kind === 'meta' && t.name === 'twitter:card')).toBe(true);
+  expect(has((t) => t.kind === 'jsonld')).toBe(true);
+});
 ```
 
 - [ ] **Step 3: テストが失敗しない（実装済みなので通る）ことを確認 / 回帰チェック**
@@ -674,6 +686,7 @@ git commit -m "test(cli): cover svelte-meta-tags og/twitter/JsonLd detection on 
 ### Task 7: Changeset ＋ 全体 Verify
 
 **Files:**
+
 - Create: `.changeset/fix-smt-metatags-jsonld-detection.md`
 
 - [ ] **Step 1: changeset を作成**

--- a/docs/superpowers/plans/2026-07-06-smt-metatags-jsonld-detection.md
+++ b/docs/superpowers/plans/2026-07-06-smt-metatags-jsonld-detection.md
@@ -1,0 +1,716 @@
+# svelte-meta-tags (MetaTags / JsonLd) 検出修正 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** static モード（CLI）で `svelte-meta-tags` の `MetaTags` / `JsonLd` が出力するタグ（og:description / og:url / twitter:card / JSON-LD）を検出し、SEO008/011/012/013 の false positive を解消する。
+
+**Architecture:** adapter に `openGraph`/`twitter` のインラインオブジェクトリテラル解析を追加（共通ヘルパー化、svelte-meta-tags と svelte-seo で共有）。静的に読めない場合は `broad` 判定にフォールバックし、拡張した `BROAD_KINDS`（og:description / og:url / twitter:card を追加）でカバー。`JsonLd` 用の新規 adapter を追加して JSON-LD を検出する。
+
+**Tech Stack:** TypeScript, Svelte compiler AST (`svelte/compiler`), vitest, pnpm workspace。
+
+Spec: `docs/superpowers/specs/2026-07-06-smt-metatags-jsonld-detection-design.md`
+Issue: https://github.com/oekazuma/svelte-vitals/issues/91
+
+## Global Constraints
+
+- **変更範囲は `packages/cli` のみ**。ルール本体（SEO008/011/012/013）は `packages/core` にあるが変更しない。
+- **Core purity**（#119 で eslint 強制）: `packages/core` に `node:` import / I/O を追加しない。本プランは core を触らないため該当なし。
+- **Conventional commits**、パッケージスコープ付き: `fix(cli): ...` / `test(cli): ...`。
+- **Changeset 必須**: user-facing なバグ修正のため `pnpm changeset`（`svelte-vitals`: patch）。
+- **Verify（完了前に必須）**: `pnpm build` / `pnpm typecheck` / `pnpm test` / `pnpm lint` が pass すること。
+- AST ノードは既存パターンに合わせ `type Node = any;` ＋ ファイル先頭に `/* eslint-disable @typescript-eslint/no-explicit-any */`。
+- テストは vitest、`packages/cli/test/`。テスト実行は `pnpm --filter svelte-vitals test`（または `pnpm -r test`）。
+
+---
+
+### Task 1: 共通メタオブジェクト解析ヘルパー
+
+`openGraph` / `twitter` のインラインオブジェクトリテラルからキーを列挙し、対応する head タグを emit するヘルパーを新設する。両 adapter がこれを共有する。
+
+**Files:**
+- Create: `packages/cli/src/providers/source/adapters/meta-object.ts`
+- Test: `packages/cli/test/meta-object.test.ts`
+
+**Interfaces:**
+- Consumes: `ParsedTag`（`../parse.js`）, `Value`（`@svelte-vitals/core`）
+- Produces:
+  - `exprValue(node: Node): Value` — ESTree 式ノードの値種別（文字列リテラル非空→`'static'`、他リテラル→`'static'`、`Identifier`/`Member`/`Array`/`Object` 等→`'dynamic'`、null→`'absent'`）
+  - `resolveMetaObject(attr: Node | undefined, keyMap: Record<string, (value: Value) => ParsedTag>): { tags: ParsedTag[]; opaque: boolean }` — attr が無ければ `{tags:[], opaque:false}`、インラインオブジェクトリテラルなら各キーを `keyMap` で変換、リテラルでない（変数渡し等）なら `{tags:[], opaque:true}`、オブジェクト内 spread があれば `opaque:true`
+  - `OPEN_GRAPH_KEYS: Record<string, (value: Value) => ParsedTag>` — title→og:title, description→og:description, url→og:url, images→og:image, type→og:type
+  - `TWITTER_KEYS: Record<string, (value: Value) => ParsedTag>` — cardType→twitter:card, card→twitter:card
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`packages/cli/test/meta-object.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { parse } from 'svelte/compiler';
+import {
+  exprValue,
+  resolveMetaObject,
+  OPEN_GRAPH_KEYS,
+  TWITTER_KEYS
+} from '../src/providers/source/adapters/meta-object.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function attrOf(tag: string, name: string): any {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ast = parse(`<script></script>${tag}`, { modern: true, filename: 'x.svelte' }) as any;
+  const component = ast.fragment.nodes.find((n: any) => n.type === 'Component');
+  return component.attributes.find((a: any) => a.type === 'Attribute' && a.name === name);
+}
+
+describe('resolveMetaObject', () => {
+  it('emits og:url / og:description tags from an inline openGraph literal', () => {
+    const attr = attrOf('<MetaTags openGraph={{ type: "website", url: SITE, description: "d" }} />', 'openGraph');
+    const r = resolveMetaObject(attr, OPEN_GRAPH_KEYS);
+    expect(r.opaque).toBe(false);
+    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:url', value: 'dynamic' });
+    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:description', value: 'static' });
+    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:type', value: 'static' });
+  });
+
+  it('does NOT emit a tag for a key the literal omits (precise)', () => {
+    const attr = attrOf('<MetaTags openGraph={{ url: SITE }} />', 'openGraph');
+    const r = resolveMetaObject(attr, OPEN_GRAPH_KEYS);
+    expect(r.tags.some((t) => t.kind === 'meta' && t.property === 'og:image')).toBe(false);
+  });
+
+  it('marks opaque when openGraph is a variable (not an inline literal)', () => {
+    const attr = attrOf('<MetaTags openGraph={cfg} />', 'openGraph');
+    const r = resolveMetaObject(attr, OPEN_GRAPH_KEYS);
+    expect(r.opaque).toBe(true);
+    expect(r.tags).toHaveLength(0);
+  });
+
+  it('marks opaque when the object literal contains a spread', () => {
+    const attr = attrOf('<MetaTags openGraph={{ ...defaults, url: SITE }} />', 'openGraph');
+    const r = resolveMetaObject(attr, OPEN_GRAPH_KEYS);
+    expect(r.opaque).toBe(true);
+    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:url', value: 'dynamic' });
+  });
+
+  it('returns nothing (not opaque) when the prop is absent', () => {
+    const r = resolveMetaObject(undefined, OPEN_GRAPH_KEYS);
+    expect(r).toEqual({ tags: [], opaque: false });
+  });
+
+  it('maps twitter cardType and card to twitter:card', () => {
+    const smt = resolveMetaObject(attrOf('<MetaTags twitter={{ cardType: "summary" }} />', 'twitter'), TWITTER_KEYS);
+    expect(smt.tags).toContainEqual({ kind: 'meta', name: 'twitter:card', value: 'static' });
+    const seo = resolveMetaObject(attrOf('<Seo twitter={{ card: "summary" }} />', 'twitter'), TWITTER_KEYS);
+    expect(seo.tags).toContainEqual({ kind: 'meta', name: 'twitter:card', value: 'static' });
+  });
+});
+
+describe('exprValue', () => {
+  it('classifies a non-empty string literal as static', () => {
+    const attr = attrOf('<MetaTags openGraph={{ url: "https://x" }} />', 'openGraph');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const prop = (attr.value.expression.properties as any[])[0];
+    expect(exprValue(prop.value)).toBe('static');
+  });
+
+  it('classifies an identifier as dynamic', () => {
+    const attr = attrOf('<MetaTags openGraph={{ url: SITE }} />', 'openGraph');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const prop = (attr.value.expression.properties as any[])[0];
+    expect(exprValue(prop.value)).toBe('dynamic');
+  });
+});
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/meta-object.test.ts`
+Expected: FAIL（`meta-object.js` が存在しない / import エラー）
+
+- [ ] **Step 3: ヘルパーを実装**
+
+`packages/cli/src/providers/source/adapters/meta-object.ts`:
+
+```typescript
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { Value } from '@svelte-vitals/core';
+import type { ParsedTag } from '../parse.js';
+
+type Node = any;
+
+/** Value kind of an ESTree expression used as a prop or object-property value. */
+export function exprValue(node: Node): Value {
+  if (!node) return 'absent';
+  if (node.type === 'Literal') {
+    // A non-empty string literal is a concrete static value; other literals
+    // (number/boolean) are static-present too. An empty string is absent.
+    if (typeof node.value === 'string') return node.value.trim().length > 0 ? 'static' : 'absent';
+    return 'static';
+  }
+  // Identifier / MemberExpression / TemplateLiteral / ArrayExpression / ObjectExpression / CallExpression …
+  return 'dynamic';
+}
+
+export interface MetaObjectResult {
+  /** Tags derived from the inline object literal's keys. */
+  tags: ParsedTag[];
+  /**
+   * True when the prop is present but not fully readable as an inline literal
+   * (a variable, or an object with a spread) — the caller should fall back to
+   * broad coverage. False when absent or fully enumerated.
+   */
+  opaque: boolean;
+}
+
+/**
+ * Introspect an inline object-literal prop (`openGraph` / `twitter`). Each known
+ * key is mapped to a ParsedTag via `keyMap`. A non-literal prop (`openGraph={cfg}`)
+ * or an object with a spread (`{...d, url}`) can't be fully enumerated, so it is
+ * reported opaque for the caller to broaden.
+ */
+export function resolveMetaObject(
+  attr: Node | undefined,
+  keyMap: Record<string, (value: Value) => ParsedTag>
+): MetaObjectResult {
+  if (!attr) return { tags: [], opaque: false };
+  const expr = attr.value?.type === 'ExpressionTag' ? attr.value.expression : undefined;
+  if (!expr || expr.type !== 'ObjectExpression') return { tags: [], opaque: true };
+
+  const tags: ParsedTag[] = [];
+  let opaque = false;
+  for (const prop of expr.properties ?? []) {
+    if (prop?.type !== 'Property') {
+      opaque = true; // SpreadElement — unknown extra keys
+      continue;
+    }
+    const key = prop.key?.name ?? prop.key?.value;
+    const make = typeof key === 'string' ? keyMap[key] : undefined;
+    if (make) tags.push(make(exprValue(prop.value)));
+  }
+  return { tags, opaque };
+}
+
+/** openGraph keys → tags. Shared by svelte-meta-tags and svelte-seo (both mirror OG names). */
+export const OPEN_GRAPH_KEYS: Record<string, (value: Value) => ParsedTag> = {
+  title: (value) => ({ kind: 'meta', property: 'og:title', value }),
+  description: (value) => ({ kind: 'meta', property: 'og:description', value }),
+  url: (value) => ({ kind: 'meta', property: 'og:url', value }),
+  images: (value) => ({ kind: 'meta', property: 'og:image', value }),
+  type: (value) => ({ kind: 'meta', property: 'og:type', value })
+};
+
+/** twitter keys → twitter:card. svelte-meta-tags uses `cardType`; svelte-seo uses `card`. */
+export const TWITTER_KEYS: Record<string, (value: Value) => ParsedTag> = {
+  cardType: (value) => ({ kind: 'meta', name: 'twitter:card', value }),
+  card: (value) => ({ kind: 'meta', name: 'twitter:card', value })
+};
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/meta-object.test.ts`
+Expected: PASS（全 8 ケース）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add packages/cli/src/providers/source/adapters/meta-object.ts packages/cli/test/meta-object.test.ts
+git commit -m "feat(cli): add shared openGraph/twitter object-literal introspection helper"
+```
+
+---
+
+### Task 2: svelte-meta-tags adapter を配線
+
+`MetaTags` の `openGraph` / `twitter` をヘルパーで解析し、`broad` を精密化する。
+
+**Files:**
+- Modify: `packages/cli/src/providers/source/adapters/svelte-meta-tags.ts:50-55`
+- Test: `packages/cli/test/adapters-smt.test.ts`（ケース追加）
+
+**Interfaces:**
+- Consumes: `resolveMetaObject`, `OPEN_GRAPH_KEYS`, `TWITTER_KEYS`（Task 1）
+- Produces: 変更後の `svelteMetaTagsAdapter.resolve` は openGraph/twitter リテラルから og:*/twitter:card タグを含み、`broad = hasSpread || openGraph opaque || twitter opaque`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`packages/cli/test/adapters-smt.test.ts` の `describe` 内末尾に追加:
+
+```typescript
+  it('emits og:url / og:description / og:image tags from an inline openGraph literal', () => {
+    const r = svelteMetaTagsAdapter.resolve(
+      useOf('<MetaTags openGraph={{ type: "website", url: u, description: "d", images: [{ url: i }], title: t }} />')
+    );
+    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:url', value: 'dynamic' });
+    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:description', value: 'static' });
+    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:image', value: 'dynamic' });
+    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:title', value: 'dynamic' });
+    expect(r.broad).toBe(false);
+  });
+
+  it('emits twitter:card from an inline twitter literal', () => {
+    const r = svelteMetaTagsAdapter.resolve(useOf('<MetaTags twitter={{ cardType: "summary_large_image" }} />'));
+    expect(r.tags).toContainEqual({ kind: 'meta', name: 'twitter:card', value: 'static' });
+    expect(r.broad).toBe(false);
+  });
+
+  it('falls back to broad when openGraph is a variable (not an inline literal)', () => {
+    const r = svelteMetaTagsAdapter.resolve(useOf('<MetaTags openGraph={cfg} />'));
+    expect(r.broad).toBe(true);
+    expect(r.tags.some((t) => t.kind === 'meta' && t.property === 'og:url')).toBe(false);
+  });
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/adapters-smt.test.ts`
+Expected: FAIL（`og:url` タグが出ない / broad が旧ロジックで true）
+
+- [ ] **Step 3: adapter を実装**
+
+`packages/cli/src/providers/source/adapters/svelte-meta-tags.ts` — import 追加とロジック差し替え。
+
+ファイル上部の import に追加:
+
+```typescript
+import { resolveMetaObject, OPEN_GRAPH_KEYS, TWITTER_KEYS } from './meta-object.js';
+```
+
+現在の該当ブロック（50-55 行付近）:
+
+```typescript
+    // openGraph is an object prop we don't introspect; treat it as a broad og:* source.
+    const openGraph = findAttr(attrs, 'openGraph');
+    const broad = use.hasSpread || Boolean(openGraph);
+
+    return { tags, broad };
+```
+
+を次に置き換える:
+
+```typescript
+    // Introspect inline openGraph / twitter object literals into specific og:*/twitter:card
+    // tags. A variable-passed object (openGraph={cfg}) or a spread is unreadable → fall back
+    // to broad coverage (BROAD_KINDS fills the og family + twitter:card).
+    const og = resolveMetaObject(findAttr(attrs, 'openGraph'), OPEN_GRAPH_KEYS);
+    const tw = resolveMetaObject(findAttr(attrs, 'twitter'), TWITTER_KEYS);
+    tags.push(...og.tags, ...tw.tags);
+    const broad = use.hasSpread || og.opaque || tw.opaque;
+
+    return { tags, broad };
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/adapters-smt.test.ts`
+Expected: PASS（既存ケース + 追加 3 ケース）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add packages/cli/src/providers/source/adapters/svelte-meta-tags.ts packages/cli/test/adapters-smt.test.ts
+git commit -m "fix(cli): introspect svelte-meta-tags openGraph/twitter literals (SEO011/012/013)"
+```
+
+---
+
+### Task 3: svelte-seo adapter を配線
+
+`svelte-seo` も同一の `openGraph` / `twitter` 解析を共有する。
+
+**Files:**
+- Modify: `packages/cli/src/providers/source/adapters/svelte-seo.ts:39-42`
+- Test: `packages/cli/test/adapters-registry.test.ts`（ケース追加）
+
+**Interfaces:**
+- Consumes: `resolveMetaObject`, `OPEN_GRAPH_KEYS`, `TWITTER_KEYS`（Task 1）
+- Produces: `svelteSeoAdapter.resolve` が og:*/twitter:card タグを含み、`broad = hasSpread || openGraph opaque || twitter opaque`
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`packages/cli/test/adapters-registry.test.ts` の `describe('adapter registry', ...)` 内に追加:
+
+```typescript
+  it('introspects the svelte-seo openGraph/twitter literals', () => {
+    const adapter = findAdapter({ source: 'svelte-seo', imported: 'default' })!;
+    const r = adapter.resolve(
+      useOf(
+        `import Seo from 'svelte-seo';`,
+        '<Seo openGraph={{ url: u, description: "d" }} twitter={{ card: "summary" }} />'
+      )
+    );
+    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:url', value: 'dynamic' });
+    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:description', value: 'static' });
+    expect(r.tags).toContainEqual({ kind: 'meta', name: 'twitter:card', value: 'static' });
+    expect(r.broad).toBe(false);
+  });
+
+  it('falls back to broad when svelte-seo openGraph is a variable', () => {
+    const adapter = findAdapter({ source: 'svelte-seo', imported: 'default' })!;
+    const r = adapter.resolve(useOf(`import Seo from 'svelte-seo';`, '<Seo openGraph={cfg} />'));
+    expect(r.broad).toBe(true);
+  });
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/adapters-registry.test.ts`
+Expected: FAIL（og:url タグが出ない）
+
+- [ ] **Step 3: adapter を実装**
+
+`packages/cli/src/providers/source/adapters/svelte-seo.ts` — import 追加とロジック差し替え。
+
+ファイル上部の import に追加:
+
+```typescript
+import { resolveMetaObject, OPEN_GRAPH_KEYS, TWITTER_KEYS } from './meta-object.js';
+```
+
+現在の該当ブロック（39-42 行付近）:
+
+```typescript
+    const openGraph = findAttr(attrs, 'openGraph');
+    const broad = use.hasSpread || Boolean(openGraph);
+
+    return { tags, broad };
+```
+
+を次に置き換える:
+
+```typescript
+    const og = resolveMetaObject(findAttr(attrs, 'openGraph'), OPEN_GRAPH_KEYS);
+    const tw = resolveMetaObject(findAttr(attrs, 'twitter'), TWITTER_KEYS);
+    tags.push(...og.tags, ...tw.tags);
+    const broad = use.hasSpread || og.opaque || tw.opaque;
+
+    return { tags, broad };
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/adapters-registry.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add packages/cli/src/providers/source/adapters/svelte-seo.ts packages/cli/test/adapters-registry.test.ts
+git commit -m "fix(cli): introspect svelte-seo openGraph/twitter literals"
+```
+
+---
+
+### Task 4: JsonLd adapter を新設・登録
+
+`svelte-meta-tags` の `JsonLd` コンポーネントを検出し、`jsonld` タグを emit する（SEO008 解消）。
+
+**Files:**
+- Create: `packages/cli/src/providers/source/adapters/svelte-meta-tags-jsonld.ts`
+- Modify: `packages/cli/src/providers/source/adapters/index.ts:3-9`
+- Test: `packages/cli/test/adapters-jsonld.test.ts`
+
+**Interfaces:**
+- Consumes: `Adapter`, `AdapterResult`（`./types.js`）, `ImportInfo`（`../imports.js`）, `ComponentUse`, `ParsedTag`（`../parse.js`）
+- Produces: `svelteMetaTagsJsonLdAdapter: Adapter`。`builtinAdapters` に登録され、`JsonLd`（named）/ `svelte-meta-tags/JsonLd.svelte`（default）にマッチ、`{ kind: 'jsonld', value: 'dynamic' }` を emit。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`packages/cli/test/adapters-jsonld.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { svelteMetaTagsJsonLdAdapter } from '../src/providers/source/adapters/svelte-meta-tags-jsonld.js';
+import { findAdapter } from '../src/providers/source/adapters/index.js';
+import { parseFile } from '../src/providers/source/parse.js';
+
+function useOf(imp: string, tag: string) {
+  return parseFile(`<script>${imp}</script>${tag}`, 'x.svelte').components[0]!;
+}
+
+describe('svelteMetaTagsJsonLdAdapter', () => {
+  it('matches the JsonLd named import', () => {
+    expect(svelteMetaTagsJsonLdAdapter.match({ source: 'svelte-meta-tags', imported: 'JsonLd' })).toBe(true);
+    expect(svelteMetaTagsJsonLdAdapter.match({ source: 'svelte-meta-tags', imported: 'MetaTags' })).toBe(false);
+  });
+
+  it('matches the JsonLd.svelte default import subpath', () => {
+    expect(svelteMetaTagsJsonLdAdapter.match({ source: 'svelte-meta-tags/JsonLd.svelte', imported: 'default' })).toBe(
+      true
+    );
+  });
+
+  it('emits a dynamic jsonld tag', () => {
+    const r = svelteMetaTagsJsonLdAdapter.resolve(
+      useOf(`import { JsonLd } from 'svelte-meta-tags';`, '<JsonLd schema={s} />')
+    );
+    expect(r.broad).toBe(false);
+    expect(r.tags).toContainEqual({ kind: 'jsonld', value: 'dynamic' });
+  });
+
+  it('is discoverable via findAdapter', () => {
+    expect(findAdapter({ source: 'svelte-meta-tags', imported: 'JsonLd' })).toBe(svelteMetaTagsJsonLdAdapter);
+  });
+});
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/adapters-jsonld.test.ts`
+Expected: FAIL（`svelte-meta-tags-jsonld.js` が存在しない）
+
+- [ ] **Step 3: adapter を実装**
+
+`packages/cli/src/providers/source/adapters/svelte-meta-tags-jsonld.ts`:
+
+```typescript
+import type { ImportInfo } from '../imports.js';
+import type { ComponentUse, ParsedTag } from '../parse.js';
+import type { Adapter, AdapterResult } from './types.js';
+
+/**
+ * svelte-meta-tags <JsonLd> (named import) or the JsonLd.svelte subpath (default import).
+ * It renders a <script type="application/ld+json"> via a split-string {@html}, so it
+ * can't be caught statically as literal JSON — model it as a dynamic jsonld tag so SEO008 passes.
+ */
+export const svelteMetaTagsJsonLdAdapter: Adapter = {
+  match(info: ImportInfo): boolean {
+    if (info.source === 'svelte-meta-tags') return info.imported === 'JsonLd';
+    if (info.source === 'svelte-meta-tags/JsonLd.svelte') return info.imported === 'default';
+    return false;
+  },
+
+  resolve(_use: ComponentUse): AdapterResult {
+    const tags: ParsedTag[] = [{ kind: 'jsonld', value: 'dynamic' }];
+    return { tags, broad: false };
+  }
+};
+```
+
+- [ ] **Step 4: レジストリに登録**
+
+`packages/cli/src/providers/source/adapters/index.ts` を編集。
+
+import 行に追加:
+
+```typescript
+import { svelteMetaTagsJsonLdAdapter } from './svelte-meta-tags-jsonld.js';
+```
+
+`builtinAdapters` 配列を更新:
+
+```typescript
+export const builtinAdapters: Adapter[] = [svelteMetaTagsAdapter, svelteMetaTagsJsonLdAdapter, svelteSeoAdapter];
+```
+
+- [ ] **Step 5: テストが通ることを確認**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/adapters-jsonld.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add packages/cli/src/providers/source/adapters/svelte-meta-tags-jsonld.ts packages/cli/src/providers/source/adapters/index.ts packages/cli/test/adapters-jsonld.test.ts
+git commit -m "fix(cli): detect svelte-meta-tags JsonLd component (SEO008)"
+```
+
+---
+
+### Task 5: BROAD_KINDS を拡張
+
+不透明ソース（`config.metaComponents`・spread・変数 openGraph）でも og:description / og:url / twitter:card を dynamic 補完する。
+
+**Files:**
+- Modify: `packages/cli/src/providers/source/resolve.ts:11-19`
+- Test: `packages/cli/test/resolve.test.ts`（ケース追加）
+
+**Interfaces:**
+- Produces: 拡張後の `BROAD_KINDS` に `{ kind: 'meta', property: 'og:description', value: 'dynamic' }` / `{ kind: 'meta', property: 'og:url', value: 'dynamic' }` / `{ kind: 'meta', name: 'twitter:card', value: 'dynamic' }` を含む（`jsonld` は含まない）
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`packages/cli/test/resolve.test.ts` の `describe` 内に追加:
+
+```typescript
+  it('BROAD_KINDS covers og:description, og:url and twitter:card', () => {
+    expect(BROAD_KINDS).toContainEqual({ kind: 'meta', property: 'og:description', value: 'dynamic' });
+    expect(BROAD_KINDS).toContainEqual({ kind: 'meta', property: 'og:url', value: 'dynamic' });
+    expect(BROAD_KINDS).toContainEqual({ kind: 'meta', name: 'twitter:card', value: 'dynamic' });
+  });
+
+  it('BROAD_KINDS does NOT cover jsonld (structured data is a separate concern)', () => {
+    expect(BROAD_KINDS.some((t) => t.kind === 'jsonld')).toBe(false);
+  });
+```
+
+（`BROAD_KINDS` は既に import 済み。broad 判定自体は既存テスト「marks broad for a metaComponents-declared component」でカバー済みのため追加不要。）
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/resolve.test.ts`
+Expected: FAIL（og:description / og:url / twitter:card が BROAD_KINDS に無い）
+
+- [ ] **Step 3: BROAD_KINDS を拡張**
+
+`packages/cli/src/providers/source/resolve.ts` の `BROAD_KINDS` を次に置き換える:
+
+```typescript
+/** Tag kinds a broad (opaque) meta source is assumed to possibly set, all dynamic. */
+export const BROAD_KINDS: ParsedTag[] = [
+  { kind: 'title', value: 'dynamic' },
+  { kind: 'meta', name: 'description', value: 'dynamic' },
+  { kind: 'link', rel: 'canonical', value: 'dynamic' },
+  { kind: 'meta', property: 'og:title', value: 'dynamic' },
+  { kind: 'meta', property: 'og:description', value: 'dynamic' },
+  { kind: 'meta', property: 'og:image', value: 'dynamic' },
+  { kind: 'meta', property: 'og:url', value: 'dynamic' },
+  { kind: 'meta', name: 'twitter:card', value: 'dynamic' },
+  { kind: 'meta', name: 'robots', value: 'dynamic' }
+  // jsonld is intentionally omitted: structured data is a distinct concern, not a
+  // meta-tag family a broad meta source implies (JsonLd has its own adapter).
+];
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/resolve.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add packages/cli/src/providers/source/resolve.ts packages/cli/test/resolve.test.ts
+git commit -m "fix(cli): broaden BROAD_KINDS to cover og:description/og:url/twitter:card"
+```
+
+---
+
+### Task 6: 統合テスト（実フィクスチャ）
+
+`/smt` フィクスチャに openGraph / twitter / JsonLd を追加し、実 Node ランタイムで全タグが検出されることを検証する。
+
+**Files:**
+- Modify: `packages/cli/test/fixtures/basic-project/src/routes/smt/+page.svelte`
+- Modify: `packages/cli/test/source-provider.test.ts`（import に `HeadTag` 追加、ケース追加）
+
+**Interfaces:**
+- Consumes: Task 2・4・5 の成果（adapter 解析 + JsonLd adapter + BROAD_KINDS）
+- Produces: `/smt` の `ResolvedHead.tags` に og:url / og:description / twitter:card / jsonld を含む
+
+- [ ] **Step 1: フィクスチャを更新**
+
+`packages/cli/test/fixtures/basic-project/src/routes/smt/+page.svelte` を次の内容に置き換える:
+
+```svelte
+<script>
+  import { JsonLd, MetaTags } from 'svelte-meta-tags';
+  let { data } = $props();
+  const jsonLd = { '@context': 'https://schema.org', '@type': 'WebPage', name: 'SMT' };
+</script>
+
+<MetaTags
+  title={data.title}
+  description="A page"
+  openGraph={{
+    type: 'website',
+    url: data.url,
+    description: data.description,
+    images: [{ url: data.image }],
+    title: data.title
+  }}
+  twitter={{ cardType: 'summary_large_image' }}
+/>
+<JsonLd schema={jsonLd} />
+```
+
+- [ ] **Step 2: 失敗するテストを書く**
+
+`packages/cli/test/source-provider.test.ts` の import 文（4-12 行）の型 import に `HeadTag` を追加:
+
+```typescript
+import {
+  seo001Title,
+  type Detection,
+  type HeadTag,
+  type ImageInfo,
+  type ResolvedHead,
+  defaultConfig,
+  defaultProject,
+  defineConfig
+} from '@svelte-vitals/core';
+```
+
+`describe('SourceHeadProvider (Node runtime, real fixture)', ...)` 内に追加:
+
+```typescript
+  it('detects svelte-meta-tags openGraph/twitter/JsonLd tags on the /smt route (issue #91)', async () => {
+    const rt = createNodeRuntime();
+    const heads = await sourceHeadProvider.collect(rt, fixtureDir);
+    const smt = new Map(heads.map((h) => [h.route, h])).get('/smt')!;
+    const has = (pred: (t: HeadTag) => boolean) => smt.tags.some(pred);
+    expect(has((t) => t.kind === 'meta' && t.property === 'og:url')).toBe(true);
+    expect(has((t) => t.kind === 'meta' && t.property === 'og:description')).toBe(true);
+    expect(has((t) => t.kind === 'meta' && t.name === 'twitter:card')).toBe(true);
+    expect(has((t) => t.kind === 'jsonld')).toBe(true);
+  });
+```
+
+- [ ] **Step 3: テストが失敗しない（実装済みなので通る）ことを確認 / 回帰チェック**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/source-provider.test.ts`
+Expected: PASS（新規ケース含む。既存の `/smt` title 判定 `{presence:'own', value:'dynamic'}` とルート一覧も維持）
+
+注: Task 2・4・5 が先に完了しているため本ケースは実装済み。ここは統合レベルの回帰確認。もし FAIL する場合は Task 2/4/5 の配線漏れを疑う。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add packages/cli/test/fixtures/basic-project/src/routes/smt/+page.svelte packages/cli/test/source-provider.test.ts
+git commit -m "test(cli): cover svelte-meta-tags og/twitter/JsonLd detection on /smt fixture"
+```
+
+---
+
+### Task 7: Changeset ＋ 全体 Verify
+
+**Files:**
+- Create: `.changeset/fix-smt-metatags-jsonld-detection.md`
+
+- [ ] **Step 1: changeset を作成**
+
+`.changeset/fix-smt-metatags-jsonld-detection.md`:
+
+```markdown
+---
+'svelte-vitals': patch
+---
+
+Detect Open Graph (`og:description`, `og:url`), `twitter:card`, and JSON-LD tags emitted by `svelte-meta-tags` (`MetaTags` / `JsonLd`) in static mode. Inline `openGraph` / `twitter` object literals are now introspected key-by-key, non-literal configs fall back to broad coverage, and the `JsonLd` component is recognized — resolving SEO008/011/012/013 false positives (#91). The same `openGraph`/`twitter` introspection applies to `svelte-seo`.
+```
+
+- [ ] **Step 2: 全体 Verify を実行**
+
+```bash
+pnpm build
+pnpm typecheck
+pnpm test
+pnpm lint
+```
+
+Expected: 4 コマンドすべて成功（exit 0）。lint が Prettier 整形を要求したら `pnpm format` を実行して差分をコミットに含める。
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add .changeset/fix-smt-metatags-jsonld-detection.md
+git commit -m "chore(cli): add changeset for svelte-meta-tags detection fix (#91)"
+```
+
+---
+
+## 完了条件
+
+- SEO008 / SEO011 / SEO012 / SEO013 が svelte-meta-tags 使用ルートで false positive を出さない
+- 新規・既存テストがすべて pass、`pnpm build` / `typecheck` / `test` / `lint` が緑
+- changeset 追加済み
+- 変更は `packages/cli` に限定（core purity 維持）

--- a/docs/superpowers/specs/2026-07-06-smt-metatags-jsonld-detection-design.md
+++ b/docs/superpowers/specs/2026-07-06-smt-metatags-jsonld-detection-design.md
@@ -54,18 +54,18 @@ title / description / canonical / og:title / og:image / robots
 
 openGraph キー → タグ:
 
-| openGraph キー | タグ |
-| --- | --- |
-| `title` | og:title |
-| `description` | og:description |
-| `url` | og:url |
-| `images` | og:image |
-| `type` | og:type |
+| openGraph キー | タグ           |
+| -------------- | -------------- |
+| `title`        | og:title       |
+| `description`  | og:description |
+| `url`          | og:url         |
+| `images`       | og:image       |
+| `type`         | og:type        |
 
 twitter キー → タグ:
 
-| twitter キー | タグ |
-| --- | --- |
+| twitter キー                                         | タグ         |
+| ---------------------------------------------------- | ------------ |
 | `cardType`（svelte-meta-tags）/ `card`（svelte-seo） | twitter:card |
 
 - 各タグの `value` は該当プロパティ値が静的なら `static`、式なら `dynamic`。
@@ -118,7 +118,7 @@ twitter キー → タグ:
 
 ## テスト
 
-- `adapters-smt.test.ts`: openGraph / twitter インラインリテラル解析ケースを追加（キーが有る場合に og:*/twitter:card を emit、無い場合に emit しないこと、静的値/式で value が変わること）。
+- `adapters-smt.test.ts`: openGraph / twitter インラインリテラル解析ケースを追加（キーが有る場合に og:\*/twitter:card を emit、無い場合に emit しないこと、静的値/式で value が変わること）。
 - JsonLd adapter の新規テストファイル（named import / default import のマッチと jsonld emit）。
 - svelte-seo adapter テスト（既存が無ければ新設。openGraph/twitter リテラル解析と `card` キーの差異）。
 - `resolve.test.ts`: `BROAD_KINDS` 拡張の検証（不透明ソースで og:description / og:url / twitter:card が dynamic 補完されること、jsonld は補完されないこと）。

--- a/docs/superpowers/specs/2026-07-06-smt-metatags-jsonld-detection-design.md
+++ b/docs/superpowers/specs/2026-07-06-smt-metatags-jsonld-detection-design.md
@@ -1,0 +1,125 @@
+# Design: svelte-meta-tags (MetaTags / JsonLd) の false positive 解消
+
+Issue: [#91](https://github.com/oekazuma/svelte-vitals/issues/91)
+
+## 問題
+
+`svelte-meta-tags` の `MetaTags` / `JsonLd` が出力するタグが static モード（CLI）で検出されず、prerender された HTML には存在するにもかかわらず「Missing」と報告される。
+
+- SEO012 (og:description)
+- SEO013 (og:url)
+- SEO011 (twitter:card)
+- SEO008 (JSON-LD)
+
+一方、同じ `MetaTags` の `openGraph` config から来る SEO002 (description) / SEO003 (canonical) / SEO004 (og:image) / SEO005 (og:title) は `↯ dynamic` として通っている。
+
+## 根本原因
+
+static モードには 4 層の head 検出がある（`packages/cli/src/providers/source/resolve.ts`）。
+
+- Layer 1: ファイル内の `<svelte:head>` リテラル
+- Layer 2: 既知ライブラリの adapter（svelte-meta-tags / svelte-seo）
+- Layer 3: `src/` 内のユーザーコンポーネントを再帰解析（`MAX_DEPTH` まで）
+- Layer 4: `config.metaComponents` 宣言の不透明コンポーネント → broad 扱い
+
+なお `↯ dynamic`（reporter 上は "verified at runtime"）は「静的解析で値が動的と判定されたが、タグの存在は確認できた」の意味で、実行時検証ではない。
+
+2 つのギャップがある。
+
+### ギャップ 1: broad ソースのカバレッジ不足
+
+`MetaTags` に `openGraph`（オブジェクト prop）を渡すと adapter が `broad: true` を返し（`adapters/svelte-meta-tags.ts:52`）、`routes.ts:170` がこの broad ソースに対して `BROAD_KINDS` の 6 種類だけを `dynamic` タグとして補完する。
+
+```
+title / description / canonical / og:title / og:image / robots
+```
+
+`og:description` / `og:url` / `twitter:card` はこのリストに無いため「Missing」になる。
+
+### ギャップ 2: JsonLd が未モデル化
+
+`svelte-meta-tags` の `JsonLd` 用 adapter が存在せず（`adapters/index.ts` は MetaTags と svelte-seo のみ）、`jsonld` も `BROAD_KINDS` に無いため SEO008 も Missing になる。
+
+## 方針
+
+「インラインオブジェクトリテラルは精密に解析し、静的に読めない場合は broad 補完でフォールバック」の 2 段構え。ライブラリ名には依存せず、Layer 3 の再帰解析で自作 wrapper も自動でカバーする。
+
+## 変更点
+
+### ① adapter にオブジェクトリテラル解析を追加（共通ヘルパー化）
+
+対象: `adapters/svelte-meta-tags.ts` / `adapters/svelte-seo.ts`
+
+`openGraph` / `twitter` prop がインラインの `{{ ... }}`（AST 上 `ExpressionTag` の `expression.type === 'ObjectExpression'`）のとき、`properties[].key.name` を列挙して対応タグを個別に emit する。
+
+openGraph キー → タグ:
+
+| openGraph キー | タグ |
+| --- | --- |
+| `title` | og:title |
+| `description` | og:description |
+| `url` | og:url |
+| `images` | og:image |
+| `type` | og:type |
+
+twitter キー → タグ:
+
+| twitter キー | タグ |
+| --- | --- |
+| `cardType`（svelte-meta-tags）/ `card`（svelte-seo） | twitter:card |
+
+- 各タグの `value` は該当プロパティ値が静的なら `static`、式なら `dynamic`。
+- キーが存在しないプロパティのタグは emit しない（精密）。例: `openGraph` に `url` が無ければ SEO013 は正しく Missing のまま。
+- ライブラリごとにキーマップを差し込む共通ヘルパー `resolveMetaObject()` を新設し、両 adapter で共有する。svelte-meta-tags と svelte-seo で twitter card のキー名が異なる（`cardType` vs `card`）ため、キーマップは引数で渡す。
+- ヘルパーは AST（`ObjectExpression`）を読むため、プロパティ値の kind 判定は `parse.ts` に置く小ヘルパー（例: プロパティ node の value から `Value` を返す）を再利用/新設する。
+
+### ② `broad` の判定を精密化
+
+`broad = hasSpread || (openGraph が非リテラル式) || (twitter が非リテラル式)`
+
+インラインリテラルを解析できた場合は broad に頼らない。spread や変数渡し（`openGraph={someVar}`）のときだけ broad にフォールバックする。
+
+**挙動変更（精密化）**: 従来は「openGraph があれば broad」で `BROAD_KINDS` が og:title / og:image を無条件に補完していた。本変更後、openGraph がリテラルの場合は broad=false になり `BROAD_KINDS` による補完は効かないため、リテラルに `images` / `title` キーが**無ければ** SEO004 / SEO005 は正しく Missing として surface する。これは Q1 で選択した「リテラル解析＝精密」の意図通りの変更であり、従来の false negative（未設定の og:image が pass していた）を是正する。Issue #91 の repro は `images` を含む想定のため og:image は引き続き pass する。
+
+### ③ `BROAD_KINDS` の拡張 ＋ JsonLd adapter 新設
+
+`resolve.ts`:
+
+- `BROAD_KINDS` に `og:description` / `og:url` / `twitter:card` を追加。中身が不透明なメタソース（`config.metaComponents` 宣言・spread・変数渡しの openGraph）でもライブラリ非依存でカバーする。
+- `jsonld` は「メタソースとは別概念（構造化データ）」なので `BROAD_KINDS` には含めない。
+
+`adapters/`:
+
+- 新規 `svelteMetaTagsJsonLdAdapter` を追加。
+  - match: `source === 'svelte-meta-tags' && imported === 'JsonLd'`、または `source === 'svelte-meta-tags/JsonLd.svelte' && imported === 'default'`。
+  - resolve: `{ kind: 'jsonld', value: 'dynamic' }` を emit、`broad: false`。
+  - `builtinAdapters`（`adapters/index.ts`）に登録。
+- 自作 wrapper 内の `<JsonLd>` は Layer 3 の再帰解析で自動カバーされる。
+
+## 解決する範囲
+
+- SEO012 (og:description) / SEO013 (og:url) / SEO011 (twitter:card): ① で精密に検出、③ でフォールバックカバー
+- SEO008 (JSON-LD): ③ の JsonLd adapter で検出
+- svelte-seo 利用者の同種 false positive も同時解消
+- 自作 wrapper コンポーネント（内部で MetaTags / JsonLd 使用）は Layer 3 で自動対応
+
+## トレードオフ
+
+- リテラル解析はインライン `{{ ... }}` のみ。変数渡し（`openGraph={cfg}`）は ③ のフォールバック（broad）で拾うため、その場合は「未設定の og:url」等を見逃す可能性がある（承認済み。対象ルールは warning/info で低致命度、false positive 抑制を優先）。
+- ② の精密化により、リテラル openGraph で `images` / `title` キーを省いていた既存ユーザーは、これまで pass していた SEO004 / SEO005 が Missing に変わる可能性がある（false negative の是正だが、出力は変化する）。テストの期待値も併せて更新する。
+
+## 規約遵守（AGENTS.md）
+
+- **変更範囲は `packages/cli` のみ**（adapters / parse / resolve）。ルール本体（SEO008/011/012/013）は `packages/core` にあるが変更しない。core purity（`node:` import 禁止・I/O 禁止、#119 で eslint 強制）には抵触しない。
+- **Changeset 必須**: user-facing なバグ修正のため `pnpm changeset` を追加する（patch、`@svelte-vitals/cli` 対象）。
+- **Conventional commits**: パッケージスコープ付きで `fix(cli): ...`。
+- **docs**: 検出挙動のコード修正のみで en/ja docs の更新は不要（該当ドキュメントがある場合のみ同期）。
+- **Verify**: 完了前に `pnpm build` / `pnpm typecheck` / `pnpm test` / `pnpm lint` を実行して pass を確認する。
+
+## テスト
+
+- `adapters-smt.test.ts`: openGraph / twitter インラインリテラル解析ケースを追加（キーが有る場合に og:*/twitter:card を emit、無い場合に emit しないこと、静的値/式で value が変わること）。
+- JsonLd adapter の新規テストファイル（named import / default import のマッチと jsonld emit）。
+- svelte-seo adapter テスト（既存が無ければ新設。openGraph/twitter リテラル解析と `card` キーの差異）。
+- `resolve.test.ts`: `BROAD_KINDS` 拡張の検証（不透明ソースで og:description / og:url / twitter:card が dynamic 補完されること、jsonld は補完されないこと）。
+- フィクスチャ `smt/+page.svelte` に openGraph / twitter / JsonLd を含む統合ケースを追加し、run レベルで SEO008/011/012/013 が Missing にならないことを検証。

--- a/docs/superpowers/specs/2026-07-06-smt-metatags-jsonld-detection-design.md
+++ b/docs/superpowers/specs/2026-07-06-smt-metatags-jsonld-detection-design.md
@@ -81,6 +81,8 @@ twitter キー → タグ:
 
 **挙動変更（精密化）**: 従来は「openGraph があれば broad」で `BROAD_KINDS` が og:title / og:image を無条件に補完していた。本変更後、openGraph がリテラルの場合は broad=false になり `BROAD_KINDS` による補完は効かないため、リテラルに `images` / `title` キーが**無ければ** SEO004 / SEO005 は正しく Missing として surface する。これは Q1 で選択した「リテラル解析＝精密」の意図通りの変更であり、従来の false negative（未設定の og:image が pass していた）を是正する。Issue #91 の repro は `images` を含む想定のため og:image は引き続き pass する。
 
+**挙動変更（twitter の broad 発火）**: 従来 `broad` は openGraph の有無のみで決まり `twitter` prop は関与しなかった。本変更で `twitter` が非リテラル式（`twitter={cfg}`）の場合も broad を発火させる。broad は `BROAD_KINDS` 全体（title/description/canonical/og:\*/twitter:card 等）を dynamic 補完するため、`<MetaTags twitter={cfg} />` のように twitter だけを不透明に渡すレアケースでは、そのルートの title/description 等も「dynamic 存在」と見なされ SEO001/002 等が抑制され得る。これは既存の opaque-openGraph の broad セマンティクスと対称であり、false positive 抑制優先の方針に沿う（かつ本変更全体では、リテラル openGraph を broad から外したことで抑制範囲はむしろ縮小している）。granular な部分 broad は本スコープ外。
+
 ### ③ `BROAD_KINDS` の拡張 ＋ JsonLd adapter 新設
 
 `resolve.ts`:

--- a/docs/superpowers/specs/2026-07-06-smt-metatags-jsonld-detection-design.md
+++ b/docs/superpowers/specs/2026-07-06-smt-metatags-jsonld-detection-design.md
@@ -30,7 +30,7 @@ static モードには 4 層の head 検出がある（`packages/cli/src/provide
 
 `MetaTags` に `openGraph`（オブジェクト prop）を渡すと adapter が `broad: true` を返し（`adapters/svelte-meta-tags.ts:52`）、`routes.ts:170` がこの broad ソースに対して `BROAD_KINDS` の 6 種類だけを `dynamic` タグとして補完する。
 
-```
+```text
 title / description / canonical / og:title / og:image / robots
 ```
 

--- a/packages/cli/src/providers/source/adapters/index.ts
+++ b/packages/cli/src/providers/source/adapters/index.ts
@@ -1,12 +1,13 @@
 import type { ImportInfo } from '../imports.js';
 import type { Adapter } from './types.js';
 import { svelteMetaTagsAdapter } from './svelte-meta-tags.js';
+import { svelteMetaTagsJsonLdAdapter } from './svelte-meta-tags-jsonld.js';
 import { svelteSeoAdapter } from './svelte-seo.js';
 
 export type { Adapter, AdapterResult } from './types.js';
 
 /** Built-in known-package adapters (design §11 layer 2). */
-export const builtinAdapters: Adapter[] = [svelteMetaTagsAdapter, svelteSeoAdapter];
+export const builtinAdapters: Adapter[] = [svelteMetaTagsAdapter, svelteMetaTagsJsonLdAdapter, svelteSeoAdapter];
 
 export function findAdapter(info: ImportInfo): Adapter | undefined {
   return builtinAdapters.find((adapter) => adapter.match(info));

--- a/packages/cli/src/providers/source/adapters/meta-object.ts
+++ b/packages/cli/src/providers/source/adapters/meta-object.ts
@@ -45,8 +45,11 @@ export function resolveMetaObject(
   const tags: ParsedTag[] = [];
   let opaque = false;
   for (const prop of expr.properties ?? []) {
-    if (prop?.type !== 'Property') {
-      opaque = true; // SpreadElement — unknown extra keys
+    // A SpreadElement (`{...d}`) or a computed key (`{ [k]: v }`) can't be
+    // enumerated statically — fall back to broad coverage rather than silently
+    // under-reporting a key we can't resolve.
+    if (prop?.type !== 'Property' || prop.computed) {
+      opaque = true;
       continue;
     }
     const key = prop.key?.name ?? prop.key?.value;

--- a/packages/cli/src/providers/source/adapters/meta-object.ts
+++ b/packages/cli/src/providers/source/adapters/meta-object.ts
@@ -1,0 +1,72 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { Value } from '@svelte-vitals/core';
+import type { ParsedTag } from '../parse.js';
+
+type Node = any;
+
+/** Value kind of an ESTree expression used as a prop or object-property value. */
+export function exprValue(node: Node): Value {
+  if (!node) return 'absent';
+  if (node.type === 'Literal') {
+    // A non-empty string literal is a concrete static value; other literals
+    // (number/boolean) are static-present too. An empty string is absent.
+    if (typeof node.value === 'string') return node.value.trim().length > 0 ? 'static' : 'absent';
+    return 'static';
+  }
+  // Identifier / MemberExpression / TemplateLiteral / ArrayExpression / ObjectExpression / CallExpression …
+  return 'dynamic';
+}
+
+export interface MetaObjectResult {
+  /** Tags derived from the inline object literal's keys. */
+  tags: ParsedTag[];
+  /**
+   * True when the prop is present but not fully readable as an inline literal
+   * (a variable, or an object with a spread) — the caller should fall back to
+   * broad coverage. False when absent or fully enumerated.
+   */
+  opaque: boolean;
+}
+
+/**
+ * Introspect an inline object-literal prop (`openGraph` / `twitter`). Each known
+ * key is mapped to a ParsedTag via `keyMap`. A non-literal prop (`openGraph={cfg}`)
+ * or an object with a spread (`{...d, url}`) can't be fully enumerated, so it is
+ * reported opaque for the caller to broaden.
+ */
+export function resolveMetaObject(
+  attr: Node | undefined,
+  keyMap: Record<string, (value: Value) => ParsedTag>
+): MetaObjectResult {
+  if (!attr) return { tags: [], opaque: false };
+  const expr = attr.value?.type === 'ExpressionTag' ? attr.value.expression : undefined;
+  if (!expr || expr.type !== 'ObjectExpression') return { tags: [], opaque: true };
+
+  const tags: ParsedTag[] = [];
+  let opaque = false;
+  for (const prop of expr.properties ?? []) {
+    if (prop?.type !== 'Property') {
+      opaque = true; // SpreadElement — unknown extra keys
+      continue;
+    }
+    const key = prop.key?.name ?? prop.key?.value;
+    const make = typeof key === 'string' ? keyMap[key] : undefined;
+    if (make) tags.push(make(exprValue(prop.value)));
+  }
+  return { tags, opaque };
+}
+
+/** openGraph keys → tags. Shared by svelte-meta-tags and svelte-seo (both mirror OG names). */
+export const OPEN_GRAPH_KEYS: Record<string, (value: Value) => ParsedTag> = {
+  title: (value) => ({ kind: 'meta', property: 'og:title', value }),
+  description: (value) => ({ kind: 'meta', property: 'og:description', value }),
+  url: (value) => ({ kind: 'meta', property: 'og:url', value }),
+  images: (value) => ({ kind: 'meta', property: 'og:image', value }),
+  type: (value) => ({ kind: 'meta', property: 'og:type', value })
+};
+
+/** twitter keys → twitter:card. svelte-meta-tags uses `cardType`; svelte-seo uses `card`. */
+export const TWITTER_KEYS: Record<string, (value: Value) => ParsedTag> = {
+  cardType: (value) => ({ kind: 'meta', name: 'twitter:card', value }),
+  card: (value) => ({ kind: 'meta', name: 'twitter:card', value })
+};

--- a/packages/cli/src/providers/source/adapters/svelte-meta-tags-jsonld.ts
+++ b/packages/cli/src/providers/source/adapters/svelte-meta-tags-jsonld.ts
@@ -1,0 +1,21 @@
+import type { ImportInfo } from '../imports.js';
+import type { ComponentUse, ParsedTag } from '../parse.js';
+import type { Adapter, AdapterResult } from './types.js';
+
+/**
+ * svelte-meta-tags <JsonLd> (named import) or the JsonLd.svelte subpath (default import).
+ * It renders a <script type="application/ld+json"> via a split-string {@html}, so it
+ * can't be caught statically as literal JSON — model it as a dynamic jsonld tag so SEO008 passes.
+ */
+export const svelteMetaTagsJsonLdAdapter: Adapter = {
+  match(info: ImportInfo): boolean {
+    if (info.source === 'svelte-meta-tags') return info.imported === 'JsonLd';
+    if (info.source === 'svelte-meta-tags/JsonLd.svelte') return info.imported === 'default';
+    return false;
+  },
+
+  resolve(_use: ComponentUse): AdapterResult {
+    const tags: ParsedTag[] = [{ kind: 'jsonld', value: 'dynamic' }];
+    return { tags, broad: false };
+  }
+};

--- a/packages/cli/src/providers/source/adapters/svelte-meta-tags-jsonld.ts
+++ b/packages/cli/src/providers/source/adapters/svelte-meta-tags-jsonld.ts
@@ -1,5 +1,5 @@
 import type { ImportInfo } from '../imports.js';
-import type { ComponentUse, ParsedTag } from '../parse.js';
+import type { ParsedTag } from '../parse.js';
 import type { Adapter, AdapterResult } from './types.js';
 
 /**
@@ -14,7 +14,7 @@ export const svelteMetaTagsJsonLdAdapter: Adapter = {
     return false;
   },
 
-  resolve(_use: ComponentUse): AdapterResult {
+  resolve(): AdapterResult {
     const tags: ParsedTag[] = [{ kind: 'jsonld', value: 'dynamic' }];
     return { tags, broad: false };
   }

--- a/packages/cli/src/providers/source/adapters/svelte-meta-tags.ts
+++ b/packages/cli/src/providers/source/adapters/svelte-meta-tags.ts
@@ -2,6 +2,7 @@
 import type { ImportInfo } from '../imports.js';
 import type { ComponentUse, ParsedTag } from '../parse.js';
 import { attrValueOf, attrTextOf } from '@svelte-vitals/core';
+import { resolveMetaObject, OPEN_GRAPH_KEYS, TWITTER_KEYS } from './meta-object.js';
 import type { Adapter, AdapterResult } from './types.js';
 
 type Node = any;
@@ -47,9 +48,13 @@ export const svelteMetaTagsAdapter: Adapter = {
     const robots = findAttr(attrs, 'robots');
     if (robots) tags.push({ kind: 'meta', name: 'robots', value: attrValueOf(robots) });
 
-    // openGraph is an object prop we don't introspect; treat it as a broad og:* source.
-    const openGraph = findAttr(attrs, 'openGraph');
-    const broad = use.hasSpread || Boolean(openGraph);
+    // Introspect inline openGraph / twitter object literals into specific og:*/twitter:card
+    // tags. A variable-passed object (openGraph={cfg}) or a spread is unreadable → fall back
+    // to broad coverage (BROAD_KINDS fills the og family + twitter:card).
+    const og = resolveMetaObject(findAttr(attrs, 'openGraph'), OPEN_GRAPH_KEYS);
+    const tw = resolveMetaObject(findAttr(attrs, 'twitter'), TWITTER_KEYS);
+    tags.push(...og.tags, ...tw.tags);
+    const broad = use.hasSpread || og.opaque || tw.opaque;
 
     return { tags, broad };
   }

--- a/packages/cli/src/providers/source/adapters/svelte-seo.ts
+++ b/packages/cli/src/providers/source/adapters/svelte-seo.ts
@@ -2,6 +2,7 @@
 import type { ImportInfo } from '../imports.js';
 import type { ComponentUse, ParsedTag } from '../parse.js';
 import { attrValueOf, attrTextOf } from '@svelte-vitals/core';
+import { resolveMetaObject, OPEN_GRAPH_KEYS, TWITTER_KEYS } from './meta-object.js';
 import type { Adapter, AdapterResult } from './types.js';
 
 type Node = any;
@@ -36,8 +37,10 @@ export const svelteSeoAdapter: Adapter = {
     const canonical = findAttr(attrs, 'canonical');
     if (canonical) tags.push({ kind: 'link', rel: 'canonical', value: attrValueOf(canonical) });
 
-    const openGraph = findAttr(attrs, 'openGraph');
-    const broad = use.hasSpread || Boolean(openGraph);
+    const og = resolveMetaObject(findAttr(attrs, 'openGraph'), OPEN_GRAPH_KEYS);
+    const tw = resolveMetaObject(findAttr(attrs, 'twitter'), TWITTER_KEYS);
+    tags.push(...og.tags, ...tw.tags);
+    const broad = use.hasSpread || og.opaque || tw.opaque;
 
     return { tags, broad };
   }

--- a/packages/cli/src/providers/source/resolve.ts
+++ b/packages/cli/src/providers/source/resolve.ts
@@ -14,8 +14,13 @@ export const BROAD_KINDS: ParsedTag[] = [
   { kind: 'meta', name: 'description', value: 'dynamic' },
   { kind: 'link', rel: 'canonical', value: 'dynamic' },
   { kind: 'meta', property: 'og:title', value: 'dynamic' },
+  { kind: 'meta', property: 'og:description', value: 'dynamic' },
   { kind: 'meta', property: 'og:image', value: 'dynamic' },
+  { kind: 'meta', property: 'og:url', value: 'dynamic' },
+  { kind: 'meta', name: 'twitter:card', value: 'dynamic' },
   { kind: 'meta', name: 'robots', value: 'dynamic' }
+  // jsonld is intentionally omitted: structured data is a distinct concern, not a
+  // meta-tag family a broad meta source implies (JsonLd has its own adapter).
 ];
 
 /** Stable identity for a tag (matches routes.ts keyOf). */

--- a/packages/cli/test/adapters-jsonld.test.ts
+++ b/packages/cli/test/adapters-jsonld.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { svelteMetaTagsJsonLdAdapter } from '../src/providers/source/adapters/svelte-meta-tags-jsonld.js';
+import { findAdapter } from '../src/providers/source/adapters/index.js';
+import { parseFile } from '../src/providers/source/parse.js';
+
+function useOf(imp: string, tag: string) {
+  return parseFile(`<script>${imp}</script>${tag}`, 'x.svelte').components[0]!;
+}
+
+describe('svelteMetaTagsJsonLdAdapter', () => {
+  it('matches the JsonLd named import', () => {
+    expect(svelteMetaTagsJsonLdAdapter.match({ source: 'svelte-meta-tags', imported: 'JsonLd' })).toBe(true);
+    expect(svelteMetaTagsJsonLdAdapter.match({ source: 'svelte-meta-tags', imported: 'MetaTags' })).toBe(false);
+  });
+
+  it('matches the JsonLd.svelte default import subpath', () => {
+    expect(svelteMetaTagsJsonLdAdapter.match({ source: 'svelte-meta-tags/JsonLd.svelte', imported: 'default' })).toBe(
+      true
+    );
+  });
+
+  it('emits a dynamic jsonld tag', () => {
+    const r = svelteMetaTagsJsonLdAdapter.resolve(
+      useOf(`import { JsonLd } from 'svelte-meta-tags';`, '<JsonLd schema={s} />')
+    );
+    expect(r.broad).toBe(false);
+    expect(r.tags).toContainEqual({ kind: 'jsonld', value: 'dynamic' });
+  });
+
+  it('is discoverable via findAdapter', () => {
+    expect(findAdapter({ source: 'svelte-meta-tags', imported: 'JsonLd' })).toBe(svelteMetaTagsJsonLdAdapter);
+  });
+});

--- a/packages/cli/test/adapters-registry.test.ts
+++ b/packages/cli/test/adapters-registry.test.ts
@@ -21,6 +21,26 @@ describe('adapter registry', () => {
     expect(r.tags).toContainEqual({ kind: 'meta', name: 'description', value: 'static', text: 'A concise summary.' });
   });
 
+  it('introspects the svelte-seo openGraph/twitter literals', () => {
+    const adapter = findAdapter({ source: 'svelte-seo', imported: 'default' })!;
+    const r = adapter.resolve(
+      useOf(
+        `import Seo from 'svelte-seo';`,
+        '<Seo openGraph={{ url: u, description: "d" }} twitter={{ card: "summary" }} />'
+      )
+    );
+    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:url', value: 'dynamic' });
+    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:description', value: 'static' });
+    expect(r.tags).toContainEqual({ kind: 'meta', name: 'twitter:card', value: 'static' });
+    expect(r.broad).toBe(false);
+  });
+
+  it('falls back to broad when svelte-seo openGraph is a variable', () => {
+    const adapter = findAdapter({ source: 'svelte-seo', imported: 'default' })!;
+    const r = adapter.resolve(useOf(`import Seo from 'svelte-seo';`, '<Seo openGraph={cfg} />'));
+    expect(r.broad).toBe(true);
+  });
+
   it('returns undefined for unknown modules', () => {
     expect(findAdapter({ source: 'lodash', imported: 'default' })).toBeUndefined();
   });

--- a/packages/cli/test/adapters-smt.test.ts
+++ b/packages/cli/test/adapters-smt.test.ts
@@ -51,4 +51,27 @@ describe('svelteMetaTagsAdapter', () => {
     expect(r.tags.some((t) => t.kind === 'title')).toBe(false);
     expect(r.tags).toContainEqual({ kind: 'meta', name: 'description', value: 'static', text: 'd' });
   });
+
+  it('emits og:url / og:description / og:image tags from an inline openGraph literal', () => {
+    const r = svelteMetaTagsAdapter.resolve(
+      useOf('<MetaTags openGraph={{ type: "website", url: u, description: "d", images: [{ url: i }], title: t }} />')
+    );
+    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:url', value: 'dynamic' });
+    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:description', value: 'static' });
+    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:image', value: 'dynamic' });
+    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:title', value: 'dynamic' });
+    expect(r.broad).toBe(false);
+  });
+
+  it('emits twitter:card from an inline twitter literal', () => {
+    const r = svelteMetaTagsAdapter.resolve(useOf('<MetaTags twitter={{ cardType: "summary_large_image" }} />'));
+    expect(r.tags).toContainEqual({ kind: 'meta', name: 'twitter:card', value: 'static' });
+    expect(r.broad).toBe(false);
+  });
+
+  it('falls back to broad when openGraph is a variable (not an inline literal)', () => {
+    const r = svelteMetaTagsAdapter.resolve(useOf('<MetaTags openGraph={cfg} />'));
+    expect(r.broad).toBe(true);
+    expect(r.tags.some((t) => t.kind === 'meta' && t.property === 'og:url')).toBe(false);
+  });
 });

--- a/packages/cli/test/fixtures/basic-project/src/routes/smt/+page.svelte
+++ b/packages/cli/test/fixtures/basic-project/src/routes/smt/+page.svelte
@@ -1,6 +1,19 @@
 <script>
-  import { MetaTags } from 'svelte-meta-tags';
+  import { JsonLd, MetaTags } from 'svelte-meta-tags';
   let { data } = $props();
+  const jsonLd = { '@context': 'https://schema.org', '@type': 'WebPage', name: 'SMT' };
 </script>
 
-<MetaTags title={data.title} description="A page" />
+<MetaTags
+  title={data.title}
+  description="A page"
+  openGraph={{
+    type: 'website',
+    url: data.url,
+    description: data.description,
+    images: [{ url: data.image }],
+    title: data.title
+  }}
+  twitter={{ cardType: 'summary_large_image' }}
+/>
+<JsonLd schema={jsonLd} />

--- a/packages/cli/test/meta-object.test.ts
+++ b/packages/cli/test/meta-object.test.ts
@@ -45,6 +45,13 @@ describe('resolveMetaObject', () => {
     expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:url', value: 'dynamic' });
   });
 
+  it('marks opaque when a key is computed (not statically resolvable)', () => {
+    const attr = attrOf('<MetaTags openGraph={{ [k]: SITE }} />', 'openGraph');
+    const r = resolveMetaObject(attr, OPEN_GRAPH_KEYS);
+    expect(r.opaque).toBe(true);
+    expect(r.tags).toHaveLength(0);
+  });
+
   it('returns nothing (not opaque) when the prop is absent', () => {
     const r = resolveMetaObject(undefined, OPEN_GRAPH_KEYS);
     expect(r).toEqual({ tags: [], opaque: false });

--- a/packages/cli/test/meta-object.test.ts
+++ b/packages/cli/test/meta-object.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { parse } from 'svelte/compiler';
+import {
+  exprValue,
+  resolveMetaObject,
+  OPEN_GRAPH_KEYS,
+  TWITTER_KEYS
+} from '../src/providers/source/adapters/meta-object.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function attrOf(tag: string, name: string): any {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ast = parse(`<script></script>${tag}`, { modern: true, filename: 'x.svelte' }) as any;
+  const component = ast.fragment.nodes.find((n: any) => n.type === 'Component');
+  return component.attributes.find((a: any) => a.type === 'Attribute' && a.name === name);
+}
+
+describe('resolveMetaObject', () => {
+  it('emits og:url / og:description tags from an inline openGraph literal', () => {
+    const attr = attrOf('<MetaTags openGraph={{ type: "website", url: SITE, description: "d" }} />', 'openGraph');
+    const r = resolveMetaObject(attr, OPEN_GRAPH_KEYS);
+    expect(r.opaque).toBe(false);
+    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:url', value: 'dynamic' });
+    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:description', value: 'static' });
+    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:type', value: 'static' });
+  });
+
+  it('does NOT emit a tag for a key the literal omits (precise)', () => {
+    const attr = attrOf('<MetaTags openGraph={{ url: SITE }} />', 'openGraph');
+    const r = resolveMetaObject(attr, OPEN_GRAPH_KEYS);
+    expect(r.tags.some((t) => t.kind === 'meta' && t.property === 'og:image')).toBe(false);
+  });
+
+  it('marks opaque when openGraph is a variable (not an inline literal)', () => {
+    const attr = attrOf('<MetaTags openGraph={cfg} />', 'openGraph');
+    const r = resolveMetaObject(attr, OPEN_GRAPH_KEYS);
+    expect(r.opaque).toBe(true);
+    expect(r.tags).toHaveLength(0);
+  });
+
+  it('marks opaque when the object literal contains a spread', () => {
+    const attr = attrOf('<MetaTags openGraph={{ ...defaults, url: SITE }} />', 'openGraph');
+    const r = resolveMetaObject(attr, OPEN_GRAPH_KEYS);
+    expect(r.opaque).toBe(true);
+    expect(r.tags).toContainEqual({ kind: 'meta', property: 'og:url', value: 'dynamic' });
+  });
+
+  it('returns nothing (not opaque) when the prop is absent', () => {
+    const r = resolveMetaObject(undefined, OPEN_GRAPH_KEYS);
+    expect(r).toEqual({ tags: [], opaque: false });
+  });
+
+  it('maps twitter cardType and card to twitter:card', () => {
+    const smt = resolveMetaObject(attrOf('<MetaTags twitter={{ cardType: "summary" }} />', 'twitter'), TWITTER_KEYS);
+    expect(smt.tags).toContainEqual({ kind: 'meta', name: 'twitter:card', value: 'static' });
+    const seo = resolveMetaObject(attrOf('<Seo twitter={{ card: "summary" }} />', 'twitter'), TWITTER_KEYS);
+    expect(seo.tags).toContainEqual({ kind: 'meta', name: 'twitter:card', value: 'static' });
+  });
+});
+
+describe('exprValue', () => {
+  it('classifies a non-empty string literal as static', () => {
+    const attr = attrOf('<MetaTags openGraph={{ url: "https://x" }} />', 'openGraph');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const prop = (attr.value.expression.properties as any[])[0];
+    expect(exprValue(prop.value)).toBe('static');
+  });
+
+  it('classifies an identifier as dynamic', () => {
+    const attr = attrOf('<MetaTags openGraph={{ url: SITE }} />', 'openGraph');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const prop = (attr.value.expression.properties as any[])[0];
+    expect(exprValue(prop.value)).toBe('dynamic');
+  });
+});

--- a/packages/cli/test/meta-object.test.ts
+++ b/packages/cli/test/meta-object.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect } from 'vitest';
 import { parse } from 'svelte/compiler';
 import {
@@ -7,9 +8,8 @@ import {
   TWITTER_KEYS
 } from '../src/providers/source/adapters/meta-object.js';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// The Svelte AST is only partially typed for our needs, so this test helper traverses with `any`.
 function attrOf(tag: string, name: string): any {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const ast = parse(`<script></script>${tag}`, { modern: true, filename: 'x.svelte' }) as any;
   const component = ast.fragment.nodes.find((n: any) => n.type === 'Component');
   return component.attributes.find((a: any) => a.type === 'Attribute' && a.name === name);

--- a/packages/cli/test/resolve.test.ts
+++ b/packages/cli/test/resolve.test.ts
@@ -49,4 +49,14 @@ describe('resolveFileTags (layers 2 & 4)', () => {
     expect(tagKey({ kind: 'title', value: 'static' })).toBe('title');
     expect(tagKey({ kind: 'meta', name: 'description', value: 'static' })).toBe('meta:name=description');
   });
+
+  it('BROAD_KINDS covers og:description, og:url and twitter:card', () => {
+    expect(BROAD_KINDS).toContainEqual({ kind: 'meta', property: 'og:description', value: 'dynamic' });
+    expect(BROAD_KINDS).toContainEqual({ kind: 'meta', property: 'og:url', value: 'dynamic' });
+    expect(BROAD_KINDS).toContainEqual({ kind: 'meta', name: 'twitter:card', value: 'dynamic' });
+  });
+
+  it('BROAD_KINDS does NOT cover jsonld (structured data is a separate concern)', () => {
+    expect(BROAD_KINDS.some((t) => t.kind === 'jsonld')).toBe(false);
+  });
 });

--- a/packages/cli/test/source-provider.test.ts
+++ b/packages/cli/test/source-provider.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path';
 import {
   seo001Title,
   type Detection,
+  type HeadTag,
   type ImageInfo,
   type ResolvedHead,
   defaultConfig,
@@ -53,6 +54,17 @@ describe('SourceHeadProvider (Node runtime, real fixture)', () => {
     const failing = results.filter((r) => r.detection.presence === 'none');
     expect(failing).toHaveLength(2);
     expect(failing.map((r) => r.route).sort()).toEqual(['/none', '/widget']);
+  });
+
+  it('detects svelte-meta-tags openGraph/twitter/JsonLd tags on the /smt route (issue #91)', async () => {
+    const rt = createNodeRuntime();
+    const heads = await sourceHeadProvider.collect(rt, fixtureDir);
+    const smt = new Map(heads.map((h) => [h.route, h])).get('/smt')!;
+    const has = (pred: (t: HeadTag) => boolean) => smt.tags.some(pred);
+    expect(has((t) => t.kind === 'meta' && t.property === 'og:url')).toBe(true);
+    expect(has((t) => t.kind === 'meta' && t.property === 'og:description')).toBe(true);
+    expect(has((t) => t.kind === 'meta' && t.name === 'twitter:card')).toBe(true);
+    expect(has((t) => t.kind === 'jsonld')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #91 — in static (CLI) mode, tags emitted by `svelte-meta-tags` (`MetaTags` / `JsonLd`) were falsely reported as missing even though they are present in the prerendered HTML:

- **SEO012** (og:description)
- **SEO013** (og:url)
- **SEO011** (twitter:card)
- **SEO008** (JSON-LD)

## Root cause

Static mode resolves head tags through a 4-layer detection in `packages/cli/src/providers/source/resolve.ts`. Two gaps caused the false positives:

1. **Broad-source coverage gap.** When `<MetaTags openGraph={...}>` was used, the adapter returned `broad: true`, and only the 6 tag kinds in `BROAD_KINDS` (title, description, canonical, og:title, og:image, robots) were filled as dynamic. `og:description`, `og:url`, and `twitter:card` were absent from that list, so they were reported "Missing".
2. **`JsonLd` was never modeled.** No adapter matched the `JsonLd` component and `jsonld` was not in `BROAD_KINDS`, so SEO008 always reported missing.

## Approach

Two-tier: precisely introspect inline object literals, fall back to broad coverage when the config can't be read statically. Library-agnostic — the 4-layer resolver's transitive pass means custom wrapper components that use these libraries internally are covered automatically.

- **Object-literal introspection** (new shared helper `adapters/meta-object.ts`, used by both the `svelte-meta-tags` and `svelte-seo` adapters): inline `openGraph` / `twitter` literals are read key-by-key and mapped to specific `og:*` / `twitter:card` tags. `broad` is now precise: `hasSpread || openGraph-opaque || twitter-opaque` (opaque = present but a variable/spread rather than an inline literal).
- **`JsonLd` adapter** (`adapters/svelte-meta-tags-jsonld.ts`): matches the `JsonLd` named import and the `svelte-meta-tags/JsonLd.svelte` default import, emitting a dynamic `jsonld` tag (resolves SEO008). Registered in `builtinAdapters`.
- **Expanded `BROAD_KINDS`** with `og:description`, `og:url`, `twitter:card` so opaque meta sources (variable-passed configs, spreads, declared `metaComponents`) are covered library-agnostically. `jsonld` is intentionally excluded (structured data is a separate concern).

See the design spec and plan under `docs/superpowers/` for the full rationale, including the deliberate SEO004/SEO005 precision behavior change (a literal `openGraph` omitting `images`/`title` now correctly surfaces those as missing rather than being silently suppressed).

## Scope & constraints

- Changes confined to `packages/cli` — `packages/core` (rule bodies) untouched, so core runtime-purity is preserved.
- Also resolves the same class of false positives for `svelte-seo` users.
- Changeset added (`svelte-vitals`: patch).

## Testing

- New unit tests for the shared helper, both adapters, and the `JsonLd` adapter.
- `BROAD_KINDS` expansion tests (including that `jsonld` is not covered).
- Integration test on the `/smt` fixture via the real Node runtime asserting og:url / og:description / twitter:card / jsonld are detected.
- Full CLI test suite green (41 files / 312 tests); CLI typecheck and Prettier clean.
- Note: eslint, the `tsup` build, and cross-package (core/vite/mcp) tests were not run in the local sandbox (dev-dependency limitation) — they run in CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)