### PR TITLE
fix(vite): validate origin/host and complete ingest validation in the dev UI middleware

### DIFF
--- a/.changeset/harden-dev-ui-middleware.md
+++ b/.changeset/harden-dev-ui-middleware.md
@@ -1,0 +1,5 @@
+---
+'@svelte-vitals/vite': patch
+---
+
+Harden the dev UI middleware: reject non-loopback origins/hosts, fully validate ingested findings against what the dashboard renderer dereferences, and never let a malformed payload crash the dashboard.

--- a/packages/vite/src/hooks/handle.ts
+++ b/packages/vite/src/hooks/handle.ts
@@ -15,18 +15,9 @@ import {
   type Rule
 } from '@svelte-vitals/core';
 import { parseHtmlHead } from '../providers/rendered/parse-html.js';
+import { isLoopbackOrigin } from '../loopback.js';
 import { findingSignature, formatDevReport } from './format.js';
 import type { SvelteVitalsHookOptions } from './options.js';
-
-/** Only the local dev server hosts the ingest endpoint, so never POST off-box. */
-function isLoopbackOrigin(origin: string): boolean {
-  try {
-    const host = new URL(origin).hostname;
-    return host === 'localhost' || host === '127.0.0.1' || host === '[::1]' || host === '::1';
-  } catch {
-    return false;
-  }
-}
 
 async function postIngest(origin: string, route: string, results: Result[]): Promise<void> {
   // `origin` comes from the request (Host header), so a spoofed Host must not

--- a/packages/vite/src/loopback.ts
+++ b/packages/vite/src/loopback.ts
@@ -1,0 +1,19 @@
+/** Only the local dev server hosts the ingest endpoint, so never POST off-box. */
+export function isLoopbackOrigin(origin: string): boolean {
+  try {
+    const host = new URL(origin).hostname;
+    return host === 'localhost' || host === '127.0.0.1' || host === '[::1]' || host === '::1';
+  } catch {
+    return false;
+  }
+}
+
+/** Same loopback check as `isLoopbackOrigin`, but for a raw `Host` header (may carry a port). */
+export function isLoopbackHost(host: string | undefined): boolean {
+  if (host === undefined) return false;
+  try {
+    return isLoopbackOrigin(`http://${host}`);
+  } catch {
+    return false;
+  }
+}

--- a/packages/vite/src/loopback.ts
+++ b/packages/vite/src/loopback.ts
@@ -2,7 +2,8 @@
 export function isLoopbackOrigin(origin: string): boolean {
   try {
     const host = new URL(origin).hostname;
-    return host === 'localhost' || host === '127.0.0.1' || host === '[::1]' || host === '::1';
+    // WHATWG URL keeps the brackets on IPv6 hostnames ('[::1]'); a bare '::1' never parses.
+    return host === 'localhost' || host === '127.0.0.1' || host === '[::1]';
   } catch {
     return false;
   }

--- a/packages/vite/src/ui/middleware.ts
+++ b/packages/vite/src/ui/middleware.ts
@@ -3,18 +3,28 @@ import type { ViteDevServer } from 'vite';
 import type { Config, Result } from '@svelte-vitals/core';
 import { createStore } from './store.js';
 import { renderDashboard } from './serve.js';
+import { isLoopbackHost, isLoopbackOrigin } from '../loopback.js';
 
 const SEVERITIES = new Set(['critical', 'warning', 'info']);
+const CATEGORIES = new Set(['seo', 'performance', 'correctness', 'security', 'architecture']);
+
+function isOptionalString(v: unknown): v is string | undefined {
+  return v === undefined || typeof v === 'string';
+}
 
 /**
- * The fields the dashboard renderer dereferences, so malformed ingest can't crash it:
- * `escapeHtml(id|message)` need strings, `effectiveSeverity`/`classify` read
- * `detection.presence|value` and `severity`. Real engine findings always carry these.
+ * Every field the dashboard renderer dereferences, so malformed ingest can't crash it:
+ * `escapeHtml` needs strings for `id`/`message`/`category`/`location`/`recommendation`/
+ * `docsUrl`/`fix.*`/`route`, `effectiveSeverity`/`classify` read `detection.presence|value`
+ * and `severity`, and `line` is interpolated as a number. Optional fields must be absent
+ * or well-typed — `category: 123` would pass `?? 'seo'` and then throw inside `escapeHtml`.
+ * Real engine findings always satisfy all of this.
  */
 function isResultLike(x: unknown): x is Result {
   if (typeof x !== 'object' || x === null) return false;
   const r = x as Record<string, unknown>;
   const d = r.detection as Record<string, unknown> | undefined;
+  const f = r.fix as Record<string, unknown> | undefined;
   return (
     typeof r.id === 'string' &&
     typeof r.message === 'string' &&
@@ -23,7 +33,19 @@ function isResultLike(x: unknown): x is Result {
     typeof d === 'object' &&
     d !== null &&
     typeof d.presence === 'string' &&
-    typeof d.value === 'string'
+    typeof d.value === 'string' &&
+    (r.category === undefined || (typeof r.category === 'string' && CATEGORIES.has(r.category))) &&
+    isOptionalString(r.location) &&
+    isOptionalString(r.recommendation) &&
+    isOptionalString(r.docsUrl) &&
+    (f === undefined ||
+      (typeof f === 'object' &&
+        f !== null &&
+        typeof f.description === 'string' &&
+        isOptionalString(f.snippet) &&
+        isOptionalString(f.lang))) &&
+    (r.line === undefined || typeof r.line === 'number') &&
+    isOptionalString(r.route)
   );
 }
 
@@ -54,6 +76,19 @@ export function installUiMiddleware(server: ViteDevServer, config: Config, versi
   // connect strips the mount path, so req.url is relative ('/', '/ingest', '/events').
   server.middlewares.use('/__svelte-vitals', (req: IncomingMessage, res: ServerResponse) => {
     const url = req.url ?? '/';
+
+    // Same boundary as the sending side's postIngest (hooks/handle.ts): the dev UI is
+    // loopback-only. Cross-site form POSTs carry an Origin header (same-origin GET
+    // navigations don't), so rejecting only "Origin present AND non-loopback" never
+    // breaks legitimate use. Host validation mitigates DNS rebinding (LAN use via
+    // --host is already blocked on the sending side too).
+    const origin = req.headers.origin;
+    const host = req.headers.host;
+    if ((typeof origin === 'string' && !isLoopbackOrigin(origin)) || !isLoopbackHost(host)) {
+      res.statusCode = 403;
+      res.end('svelte-vitals dev UI is only available from localhost');
+      return;
+    }
 
     if (req.method === 'POST' && url.startsWith('/ingest')) {
       // Collect raw Buffers and decode once: per-chunk toString() would corrupt a
@@ -87,7 +122,15 @@ export function installUiMiddleware(server: ViteDevServer, config: Config, versi
       return;
     }
 
-    res.setHeader('Content-Type', 'text/html');
-    res.end(renderDashboard(store.snapshot(), config, { version }));
+    // Last line of defense that validated data should never reach: if the renderer
+    // throws anyway, return a plain-text 500 and never take down the dev server.
+    try {
+      const html = renderDashboard(store.snapshot(), config, { version });
+      res.setHeader('Content-Type', 'text/html');
+      res.end(html);
+    } catch {
+      res.statusCode = 500;
+      res.end('svelte-vitals dashboard failed to render');
+    }
   });
 }

--- a/packages/vite/src/ui/middleware.ts
+++ b/packages/vite/src/ui/middleware.ts
@@ -85,6 +85,8 @@ export function installUiMiddleware(server: ViteDevServer, config: Config, versi
     const origin = req.headers.origin;
     const host = req.headers.host;
     if ((typeof origin === 'string' && !isLoopbackOrigin(origin)) || !isLoopbackHost(host)) {
+      // drain any unread body so the client reliably receives the 403 (unread data kills the socket)
+      req.resume();
       res.statusCode = 403;
       res.end('svelte-vitals dev UI is only available from localhost');
       return;

--- a/packages/vite/test/ui-middleware.test.ts
+++ b/packages/vite/test/ui-middleware.test.ts
@@ -54,11 +54,13 @@ function res(): MockRes & ServerResponse {
   };
   return r as unknown as MockRes & ServerResponse;
 }
-function postReq(url: string): IncomingMessage {
-  return Object.assign(new EventEmitter(), { method: 'POST', url }) as unknown as IncomingMessage;
+// A real IncomingMessage always carries a headers object (the http parser initializes it),
+// and HTTP/1.1 requires Host — default to a loopback Host to model real dev-server traffic.
+function postReq(url: string, headers: Record<string, string> = { host: 'localhost:5173' }): IncomingMessage {
+  return Object.assign(new EventEmitter(), { method: 'POST', url, headers }) as unknown as IncomingMessage;
 }
-function getReq(url: string): IncomingMessage {
-  return Object.assign(new EventEmitter(), { method: 'GET', url }) as unknown as IncomingMessage;
+function getReq(url: string, headers: Record<string, string> = { host: 'localhost:5173' }): IncomingMessage {
+  return Object.assign(new EventEmitter(), { method: 'GET', url, headers }) as unknown as IncomingMessage;
 }
 
 const ingestBody = JSON.stringify({
@@ -177,5 +179,106 @@ describe('installUiMiddleware', () => {
     expect(sse.ended).toBe(false);
     closeServer();
     expect(sse.ended).toBe(true); // connection released so httpServer.close() can finish
+  });
+
+  it('rejects a cross-site ingest POST carrying a non-loopback Origin', async () => {
+    const { call } = setup();
+    const ir = res();
+    const ireq = postReq('/ingest', { host: 'localhost:5173', origin: 'https://evil.example' });
+    call(ireq, ir);
+    expect(ir.statusCode).toBe(403); // rejected before the body is even read
+    // even if the body still arrives, no listener consumes it — the store must not change
+    ireq.emit('data', Buffer.from(ingestBody));
+    ireq.emit('end');
+    await new Promise((r) => setTimeout(r, 0));
+    const gr = res();
+    call(getReq('/'), gr);
+    expect(gr.statusCode).not.toBe(403);
+    expect(gr.chunks.join('')).not.toContain('SEO001');
+  });
+
+  it('accepts an ingest POST without an Origin header (server-side postIngest behavior)', async () => {
+    const { call } = setup();
+    const ir = res();
+    const ireq = postReq('/ingest', { host: 'localhost:5173' }); // node fetch sends no Origin
+    call(ireq, ir);
+    ireq.emit('data', Buffer.from(ingestBody));
+    ireq.emit('end');
+    await new Promise((r) => setTimeout(r, 0));
+    expect(ir.statusCode).toBe(204);
+    const gr = res();
+    call(getReq('/'), gr);
+    expect(gr.chunks.join('')).toContain('SEO001'); // stored and rendered
+  });
+
+  it('rejects a dashboard GET with a non-loopback Host (DNS rebinding)', () => {
+    const { call } = setup();
+    const gr = res();
+    call(getReq('/', { host: 'evil.example' }), gr);
+    expect(gr.statusCode).toBe(403);
+    expect(gr.chunks.join('')).not.toContain('<!doctype html>');
+  });
+
+  it('filters a finding with a non-string category so the dashboard still renders', async () => {
+    const { call } = setup();
+    const ireq = postReq('/ingest');
+    call(ireq, res());
+    ireq.emit(
+      'data',
+      Buffer.from(
+        JSON.stringify({
+          route: '/x',
+          results: [
+            {
+              id: 'SEO009',
+              message: 'm',
+              category: 123, // would pass `?? 'seo'` and throw inside escapeHtml
+              detection: { presence: 'none', value: 'absent' },
+              severity: 'critical'
+            }
+          ]
+        })
+      )
+    );
+    ireq.emit('end');
+    await new Promise((r) => setTimeout(r, 0));
+    const gr = res();
+    call(getReq('/'), gr);
+    const html = gr.chunks.join('');
+    expect(gr.statusCode).not.toBe(500); // dashboard did not crash
+    expect(html.startsWith('<!doctype html>')).toBe(true);
+    expect(html).not.toContain('SEO009'); // malformed finding was filtered out
+  });
+
+  it('filters a finding with a malformed fix shape so the dashboard still renders', async () => {
+    const { call } = setup();
+    const ireq = postReq('/ingest');
+    call(ireq, res());
+    ireq.emit(
+      'data',
+      Buffer.from(
+        JSON.stringify({
+          route: '/x',
+          results: [
+            {
+              id: 'SEO010',
+              message: 'm',
+              category: 'seo',
+              detection: { presence: 'none', value: 'absent' },
+              severity: 'critical',
+              fix: { description: 5 } // non-string description would throw inside escapeHtml
+            }
+          ]
+        })
+      )
+    );
+    ireq.emit('end');
+    await new Promise((r) => setTimeout(r, 0));
+    const gr = res();
+    call(getReq('/'), gr);
+    const html = gr.chunks.join('');
+    expect(gr.statusCode).not.toBe(500); // dashboard did not crash
+    expect(html.startsWith('<!doctype html>')).toBe(true);
+    expect(html).not.toContain('SEO010'); // malformed finding was filtered out
   });
 });

--- a/packages/vite/test/ui-middleware.test.ts
+++ b/packages/vite/test/ui-middleware.test.ts
@@ -56,11 +56,22 @@ function res(): MockRes & ServerResponse {
 }
 // A real IncomingMessage always carries a headers object (the http parser initializes it),
 // and HTTP/1.1 requires Host — default to a loopback Host to model real dev-server traffic.
+// It is also a Readable, so resume() always exists (the middleware drains rejected bodies).
 function postReq(url: string, headers: Record<string, string> = { host: 'localhost:5173' }): IncomingMessage {
-  return Object.assign(new EventEmitter(), { method: 'POST', url, headers }) as unknown as IncomingMessage;
+  return Object.assign(new EventEmitter(), {
+    method: 'POST',
+    url,
+    headers,
+    resume: () => {}
+  }) as unknown as IncomingMessage;
 }
 function getReq(url: string, headers: Record<string, string> = { host: 'localhost:5173' }): IncomingMessage {
-  return Object.assign(new EventEmitter(), { method: 'GET', url, headers }) as unknown as IncomingMessage;
+  return Object.assign(new EventEmitter(), {
+    method: 'GET',
+    url,
+    headers,
+    resume: () => {}
+  }) as unknown as IncomingMessage;
 }
 
 const ingestBody = JSON.stringify({


### PR DESCRIPTION
## Summary

Implements `plans/006-dev-ui-hardening.md`: fix three defensive gaps in the `/__svelte-vitals` middleware mounted on the dev server.

- **Origin/Host loopback guard**: every path (including `POST /ingest`) now rejects non-loopback requests with 403. The sending side (`postIngest` in `hooks/handle.ts`) already refused to POST anywhere but loopback, yet the receiving side accepted anyone — and cross-site form POSTs arrive without a CORS preflight, so any web page the developer had open could inject fake findings into the dashboard (a CSRF write). Host validation additionally mitigates DNS rebinding.
  - The check rejects only "Origin present AND non-loopback": same-origin GET navigations and server-side fetches don't carry an Origin header, so legitimate use is unaffected.
  - `isLoopbackOrigin` moved from the sending side into a shared `src/loopback.ts`, joined by `isLoopbackHost`, which handles ported hosts like `[::1]:5173` via URL parsing.
- **Complete `isResultLike` validation**: the ingest type guard now checks every field the dashboard renderer dereferences (`category` / `location` / `recommendation` / `docsUrl` / `fix` / `line` / `route`). Previously a payload like `category: 123` slipped past `?? 'seo'` and threw inside `escapeHtml`.
- **Last line of defense for `GET /`**: `renderDashboard` is wrapped in try/catch, returning a plain-text 500 instead of crashing the dashboard if the renderer ever throws.

## Test plan

- 5 new tests: cross-site Origin → 403 with the store unchanged; no Origin (the sending side's real behavior) → 204; non-loopback Host GET → 403; invalid `category` and invalid `fix` shape → filtered out while the dashboard keeps rendering.
- Existing test mocks now default to a loopback Host header, matching real HTTP (a real `IncomingMessage` always carries a headers object, and HTTP/1.1 requires Host).
- `pnpm --filter @svelte-vitals/vite test`: 84/84 passing; `pnpm build` / `pnpm typecheck` / `pnpm lint` all pass.
- Patch changeset for `@svelte-vitals/vite` included.

## Maintenance note

If dev-UI use over LAN (`--host`) is ever requested, this guard and the sending side's loopback check in `postIngest` must be relaxed together — loosening only one of them won't work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)