### PR TITLE
perf(cli): parse each source file once per run via a per-run parse cache

### DIFF
--- a/.changeset/parse-cache-per-run.md
+++ b/.changeset/parse-cache-per-run.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': patch
+---
+
+Parse each source file at most once per static-mode run: shared layouts and components imported by many routes were previously re-parsed per route.

--- a/packages/cli/src/providers/source/resolve.ts
+++ b/packages/cli/src/providers/source/resolve.ts
@@ -8,6 +8,33 @@ export interface ResolveResult {
   broad: boolean;
 }
 
+/**
+ * Per-run read+parse memo, keyed by project-root-relative path (as normalized by
+ * chainFiles / resolveComponentPath). Shared across routes so a file imported by
+ * many pages (a root layout, a common $lib component) is only parsed once per run.
+ */
+export type ParseCache = Map<string, Promise<ParsedFile>>;
+
+/**
+ * Read and parse `rel` at most once per cache. The cached value is a Promise (not
+ * the resolved ParsedFile) so that concurrent callers racing on the same file
+ * (collectRoutes resolves all routes in parallel) share a single in-flight parse
+ * instead of triggering duplicate reads/parses.
+ *
+ * If the read or parse rejects, the rejected promise stays cached: every caller
+ * that shares the file sees the same failure. This matches pre-cache behavior,
+ * where a single malformed route file already failed the whole run (exit 2, see
+ * Plan 002's characterization tests) — the cache does not change that contract.
+ */
+export function readAndParse(rt: Runtime, cwd: string, rel: string, cache: ParseCache): Promise<ParsedFile> {
+  let hit = cache.get(rel);
+  if (!hit) {
+    hit = rt.readFile(rt.join(cwd, rel)).then((source) => parseFile(source, rel));
+    cache.set(rel, hit);
+  }
+  return hit;
+}
+
 /** Tag kinds a broad (opaque) meta source is assumed to possibly set, all dynamic. */
 export const BROAD_KINDS: ParsedTag[] = [
   { kind: 'title', value: 'dynamic' },
@@ -77,7 +104,11 @@ export async function resolveFileTags(
   parsed: ParsedFile,
   config: Config,
   depth: number,
-  visited: Set<string>
+  visited: Set<string>,
+  // Defaults to a fresh, single-call cache so existing direct callers (e.g. unit
+  // tests exercising this function in isolation) don't need to pass one; real
+  // callers (routes.ts) always pass the shared per-run cache explicitly.
+  cache: ParseCache = new Map()
 ): Promise<ResolveResult> {
   const tags: ParsedTag[] = [...parsed.headTags];
   let broad = false;
@@ -105,9 +136,9 @@ export async function resolveFileTags(
     if (childRel && depth > 0 && !visited.has(childRel)) {
       const abs = rt.join(cwd, childRel);
       if (await rt.exists(abs)) {
-        const childParsed = parseFile(await rt.readFile(abs), childRel);
+        const childParsed = await readAndParse(rt, cwd, childRel, cache);
         const childVisited = new Set(visited).add(childRel);
-        const child = await resolveFileTags(rt, cwd, childRel, childParsed, config, depth - 1, childVisited);
+        const child = await resolveFileTags(rt, cwd, childRel, childParsed, config, depth - 1, childVisited, cache);
         tags.push(...child.tags);
         broad = broad || child.broad;
       }

--- a/packages/cli/src/providers/source/routes.ts
+++ b/packages/cli/src/providers/source/routes.ts
@@ -11,8 +11,7 @@ import type {
 } from '@svelte-vitals/core';
 import { defaultConfig } from '@svelte-vitals/core';
 import { enumerateRoutePages } from './project.js';
-import { parseFile } from './parse.js';
-import { resolveFileTags, BROAD_KINDS, tagKey } from './resolve.js';
+import { resolveFileTags, readAndParse, BROAD_KINDS, tagKey, type ParseCache } from './resolve.js';
 
 const ROUTES_DIR = 'src/routes';
 const MAX_DEPTH = 5;
@@ -134,7 +133,8 @@ async function resolveRoute(
   cwd: string,
   pageRel: string,
   config: Config,
-  layouts: Map<string, string>
+  layouts: Map<string, string>,
+  cache: ParseCache
 ): Promise<RouteFacts> {
   const files = chainFiles(pageRel, layouts);
   const composed = new Map<string, HeadTag>();
@@ -144,8 +144,7 @@ async function resolveRoute(
   const headings: HeadingInfo[] = [];
 
   for (const { rel, isPage } of files) {
-    const source = await rt.readFile(rt.join(cwd, rel));
-    const parsed = parseFile(source, rel);
+    const parsed = await readAndParse(rt, cwd, rel, cache);
 
     for (const img of parsed.images) {
       images.push({ ...img, file: rel });
@@ -154,7 +153,7 @@ async function resolveRoute(
       headings.push({ ...heading, file: rel });
     }
 
-    const resolved = await resolveFileTags(rt, cwd, rel, parsed, config, MAX_DEPTH, new Set([rel]));
+    const resolved = await resolveFileTags(rt, cwd, rel, parsed, config, MAX_DEPTH, new Set([rel]), cache);
     for (const tag of resolved.tags) {
       composed.set(tagKey(tag), { ...tag, presence: isPage ? 'own' : 'inherited', file: rel });
     }
@@ -193,7 +192,8 @@ export async function collectRoutes(
   config: Config = defaultConfig
 ): Promise<{ heads: ResolvedHead[]; images: ResolvedImages[]; headings: ResolvedHeadings[] }> {
   const [pages, layouts] = await Promise.all([enumerateRoutePages(rt, cwd), collectLayouts(rt, cwd)]);
-  const facts = await Promise.all(pages.map((page) => resolveRoute(rt, cwd, page, config, layouts)));
+  const cache: ParseCache = new Map();
+  const facts = await Promise.all(pages.map((page) => resolveRoute(rt, cwd, page, config, layouts, cache)));
   return {
     heads: facts.map((f) => f.head),
     images: facts.map((f) => f.images),

--- a/packages/cli/test/parse-cache.test.ts
+++ b/packages/cli/test/parse-cache.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import type { Runtime } from '@svelte-vitals/core';
+import { collectRoutes } from '../src/providers/source/routes.js';
+import { createMemoryRuntime } from './helpers/memory-runtime.js';
+
+/** Wraps a Runtime's readFile to count calls per path, proving the parse cache dedupes reads. */
+function withReadSpy(rt: Runtime): { rt: Runtime; counts: Map<string, number> } {
+  const counts = new Map<string, number>();
+  return {
+    rt: {
+      ...rt,
+      async readFile(path: string) {
+        counts.set(path, (counts.get(path) ?? 0) + 1);
+        return rt.readFile(path);
+      }
+    },
+    counts
+  };
+}
+
+describe('parse cache (per-run readFile dedup)', () => {
+  it('reads a shared root layout and a shared $lib component exactly once across routes', async () => {
+    const base = createMemoryRuntime({
+      'src/routes/+layout.svelte': `<script>import Seo from '$lib/Seo.svelte';</script><Seo /><img src="/logo.png" />`,
+      'src/routes/a/+page.svelte': `<h1>A</h1>`,
+      'src/routes/b/+page.svelte': `<h1>B</h1>`,
+      'src/lib/Seo.svelte': `<svelte:head><title>{data.title}</title><meta name="description" content={data.desc} /></svelte:head>`
+    });
+    const { rt, counts } = withReadSpy(base);
+
+    const { heads, images, headings } = await collectRoutes(rt, '');
+
+    // Root layout and the shared component are each on both routes' chains, but
+    // must be read+parsed exactly once for the whole run.
+    expect(counts.get('src/routes/+layout.svelte')).toBe(1);
+    expect(counts.get('src/lib/Seo.svelte')).toBe(1);
+    // Each page is still read once (never merged across distinct route files).
+    expect(counts.get('src/routes/a/+page.svelte')).toBe(1);
+    expect(counts.get('src/routes/b/+page.svelte')).toBe(1);
+
+    // Output is unaffected by caching: both routes see the composed title/description
+    // (inherited from the layout's Seo usage) and the layout's <img>/page's <h1>.
+    const byRoute = new Map(heads.map((h) => [h.route, h]));
+    for (const route of ['/a', '/b']) {
+      const head = byRoute.get(route)!;
+      expect(head.tags).toContainEqual({
+        kind: 'title',
+        value: 'dynamic',
+        presence: 'inherited',
+        file: 'src/routes/+layout.svelte'
+      });
+      expect(head.tags.some((t) => t.kind === 'meta' && t.name === 'description' && t.presence === 'inherited')).toBe(
+        true
+      );
+    }
+
+    const imagesByRoute = new Map(images.map((i) => [i.route, i]));
+    expect(imagesByRoute.get('/a')!.images).toHaveLength(1);
+    expect(imagesByRoute.get('/a')!.images[0]).toMatchObject({ file: 'src/routes/+layout.svelte' });
+    expect(imagesByRoute.get('/b')!.images).toHaveLength(1);
+
+    const headingsByRoute = new Map(headings.map((h) => [h.route, h]));
+    expect(headingsByRoute.get('/a')!.headings).toEqual([
+      { level: 1, line: expect.any(Number), file: 'src/routes/a/+page.svelte' }
+    ]);
+    expect(headingsByRoute.get('/b')!.headings).toEqual([
+      { level: 1, line: expect.any(Number), file: 'src/routes/b/+page.svelte' }
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Implements `plans/007-route-parse-cache.md`: eliminate redundant re-parsing of shared files during static-mode route resolution.

Route resolution previously read and parsed every file in each route's layout chain independently. The root `+layout.svelte` sits on *every* route's chain, so a project with N routes ran `svelte/compiler`'s `parse()` on it N times; a shared component (`$lib/Seo.svelte` etc.) imported by N pages was likewise parsed N times. `parse()` is the dominant cost of the analyzer, so large SvelteKit apps with deep shared layouts paid several times the necessary parse work on every run.

- **`ParseCache` + `readAndParse()`** (`resolve.ts`): a per-run `Map<relPath, Promise<ParsedFile>>` memo. Caching the *Promise* (not the resolved value) means concurrent callers racing on the same file — `collectRoutes` resolves all routes in parallel — share a single in-flight parse.
- **Failure semantics preserved**: a rejected promise stays cached, so every route sharing the file sees the same failure. This matches pre-cache behavior (a single malformed route file already failed the whole run with exit 2, pinned by the Plan 002 characterization tests), documented in a code comment.
- `collectRoutes` creates one cache per run and threads it through both the layout-chain walk (`resolveRoute`) and the transitive component resolution (`resolveFileTags`, including its recursion). Cache keys are project-root-relative paths, already normalized by `chainFiles` / `resolveComponentPath`.
- `resolveFileTags` takes the cache as a defaulted parameter (`= new Map()`), so existing direct callers (isolation unit tests) stay unmodified while the production path always passes the shared per-run cache explicitly.

## Test plan

- New `packages/cli/test/parse-cache.test.ts`: an in-memory Runtime with a readFile-counting spy asserts that a shared root layout and a shared `$lib` component are each read exactly once across two routes, and that heads/images/headings output is unchanged.
- Behavioral equivalence is proven by the untouched existing suites (`resolve`, `resolve-transitive`, `layout-breakouts`, `source-provider`, `malformed-svelte`) all passing unmodified — 314 cli tests, 754 total across the workspace.
- `pnpm build` / `pnpm typecheck` / `pnpm lint` all pass.
- Patch changeset for `svelte-vitals` included.

## Maintenance note

The cache lives for one `collectRoutes` call. If a future watch mode / live UI re-analyzes repeatedly, it must create a fresh cache per run to avoid stale hits after file edits. The next optimization in this area (deliberately out of scope here) is the double parse between route-pass `parseFile` and component-pass `parseComponentFacts` — that needs a core API change and more characterization tests first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved route generation performance by reusing parsed source files during a single run, reducing repeated work across shared layouts and components.
  * Kept route metadata and composed head output unchanged while making processing more efficient.
* **Tests**
  * Added coverage to verify shared files are only processed once per run and results remain correct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->