### PR TITLE
feat(cli): load svelte-vitals.config.{mjs,js,ts} and add --weights

### DIFF
--- a/.changeset/config-file-and-weights.md
+++ b/.changeset/config-file-and-weights.md
@@ -1,0 +1,6 @@
+---
+'svelte-vitals': minor
+'@svelte-vitals/mcp': minor
+---
+
+Load `svelte-vitals.config.{mjs,js,ts}` from the analyzed directory (flags > config file > defaults, per field) and add `--weights` (e.g. `--weights seo=2,performance=1`) plus a `weights` argument on the MCP analyze tool. `.ts` configs work unflagged on Node 22.18+/23.6+; on older Node the CLI explains the upgrade / `--experimental-strip-types` / rename-to-`.mjs` options.

--- a/docs/superpowers/specs/2026-07-05-config-file-design.md
+++ b/docs/superpowers/specs/2026-07-05-config-file-design.md
@@ -1,7 +1,7 @@
 # Config-file support: `svelte-vitals.config.{ts,js,mjs}` (roadmap item C)
 
 **Date:** 2026-07-05
-**Status:** Accepted (2026-07-07) — recommendations approved by the maintainer; loader prototyped, not wired
+**Status:** Shipped (plan A — CLI/MCP) (2026-07-07) — loader hardened, wired into `analyzeProject` (CLI `run()` + MCP `analyze` tool), `--weights` CLI flag and MCP `weights` argument added. vite wiring + docs-site updates remain (plan B).
 **Packages:** `svelte-vitals` (loader + CLI wiring), `@svelte-vitals/mcp` (inherits via `analyzeProject`), `@svelte-vitals/vite` (wiring approach is an open question, see below), `@svelte-vitals/core` (no code change; `defineConfig` re-export only)
 
 ## Goal

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -26,9 +26,13 @@ Options:
   --min-health <0-100>        Fail (exit 1) when the combined Health score is below this value
   --rules <ids>               Comma-separated rule ids to enable (all others disabled)
   --ignore <ids>              Comma-separated rule ids to disable
+  --weights <pairs>           Per-category Health weight overrides, e.g. seo=2,performance=1 (unlisted categories default to 1)
   --no-color                  Disable ANSI color in console output
   -h, --help                  Show this help
   -v, --version               Show version
+
+Config file:
+  svelte-vitals.config.{mjs,js,ts} in the analyzed directory; flags override it.
 
 Exit codes:
   0  no failing findings
@@ -57,7 +61,8 @@ async function main(): Promise<void> {
       'ignore',
       'min-health',
       'out-file',
-      'diff'
+      'diff',
+      'weights'
     ]
   });
 

--- a/packages/cli/src/config-file.ts
+++ b/packages/cli/src/config-file.ts
@@ -20,6 +20,11 @@ const TREAT_DYNAMIC_AS_VALUES = ['pass', 'warn', 'fail'];
 const FAIL_ON_VALUES = ['critical', 'warning', 'info'];
 const KNOWN_TOP_LEVEL_KEYS = new Set(['treatDynamicAs', 'metaComponents', 'rules', 'failOn', 'weights']);
 
+/** Whether `value` is a plain object (not null, not an array) — usable with Object.keys/entries. */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 function isMissingExtensionLoaderError(err: unknown): boolean {
   return (
     err instanceof Error &&
@@ -82,6 +87,9 @@ function validateConfigFile(raw: Record<string, unknown>, path: string): LoadedC
   }
 
   if (raw.rules !== undefined) {
+    if (!isPlainObject(raw.rules)) {
+      throw new Error(`${path}: rules must be an object of rule-id → setting.`);
+    }
     const rules = raw.rules as Config['rules'];
     const unknown = findUnknownRuleIds(Object.keys(rules));
     if (unknown.length > 0) {
@@ -93,10 +101,15 @@ function validateConfigFile(raw: Record<string, unknown>, path: string): LoadedC
   }
 
   if (raw.weights !== undefined) {
+    if (!isPlainObject(raw.weights)) {
+      throw new Error(`${path}: weights must be an object of category → number.`);
+    }
     const weights: Partial<Record<Category, number>> = {};
-    for (const [cat, w] of Object.entries(raw.weights as Record<string, unknown>)) {
+    for (const [rawCat, w] of Object.entries(raw.weights)) {
+      // Category keys are accepted case-insensitively, matching --weights.
+      const cat = rawCat.toLowerCase();
       if (!CATEGORIES.includes(cat as Category)) {
-        throw new Error(`${path}: unknown category '${cat}' in weights. Known categories: ${CATEGORIES.join(', ')}`);
+        throw new Error(`${path}: unknown category '${rawCat}' in weights. Known categories: ${CATEGORIES.join(', ')}`);
       }
       if (typeof w !== 'number' || !Number.isFinite(w) || w < 0) {
         throw new Error(`${path}: invalid weight for '${cat}': ${String(w)}; expected a finite number >= 0.`);

--- a/packages/cli/src/config-file.ts
+++ b/packages/cli/src/config-file.ts
@@ -1,17 +1,24 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import type { Config } from '@svelte-vitals/core';
+import type { Category, Config } from '@svelte-vitals/core';
+import { findUnknownRuleIds, knownRuleIds } from './rules-config.js';
 
 /**
- * SPIKE PROTOTYPE — not wired into the CLI/vite/MCP entry points. See the design
- * doc (docs/superpowers/specs/2026-07-05-config-file-design.md) for the full
- * rationale, the file/loader/priority decisions, and the follow-up plan.
+ * Loads `svelte-vitals.config.{mjs,js,ts}` from the analyzed directory (design
+ * doc: docs/superpowers/specs/2026-07-05-config-file-design.md). Wired into
+ * `analyzeProject` (packages/cli/src/index.ts), so the CLI's `run()` and
+ * @svelte-vitals/mcp's `analyze` tool both inherit it.
  *
  * Candidate filenames, in priority order. Only `cwd` itself is searched (no
  * upward directory walk — see design doc §1).
  */
 const CONFIG_FILENAMES = ['svelte-vitals.config.mjs', 'svelte-vitals.config.js', 'svelte-vitals.config.ts'];
+
+const CATEGORIES: Category[] = ['seo', 'performance', 'correctness', 'security', 'architecture'];
+const TREAT_DYNAMIC_AS_VALUES = ['pass', 'warn', 'fail'];
+const FAIL_ON_VALUES = ['critical', 'warning', 'info'];
+const KNOWN_TOP_LEVEL_KEYS = new Set(['treatDynamicAs', 'metaComponents', 'rules', 'failOn', 'weights']);
 
 function isMissingExtensionLoaderError(err: unknown): boolean {
   return (
@@ -19,6 +26,87 @@ function isMissingExtensionLoaderError(err: unknown): boolean {
     (('code' in err && (err as NodeJS.ErrnoException).code === 'ERR_UNKNOWN_FILE_EXTENSION') ||
       /Unknown file extension/.test(err.message))
   );
+}
+
+/** Result of loading and validating a config file. */
+export interface LoadedConfigFile {
+  /** The file's contents after validation; invalid optional fields are dropped (see `warnings`). */
+  config: Partial<Config>;
+  /** Non-fatal issues: unknown top-level keys, invalid enum values (the field is ignored). */
+  warnings: string[];
+}
+
+/**
+ * Validate a config file's default export (design doc §4):
+ *
+ * - **Fatal (thrown)**: unknown rule ids in `rules` (reuses `findUnknownRuleIds`
+ *   / `knownRuleIds`, same message shape as the `--rules`/`--ignore` error);
+ *   unknown category keys or negative/non-finite values in `weights`.
+ * - **Warning (returned, field dropped)**: invalid enum values for
+ *   `treatDynamicAs` / `failOn`; unknown top-level keys (forward-compatibility).
+ */
+function validateConfigFile(raw: Record<string, unknown>, path: string): LoadedConfigFile {
+  const warnings: string[] = [];
+  const config: Partial<Config> = {};
+
+  for (const key of Object.keys(raw)) {
+    if (!KNOWN_TOP_LEVEL_KEYS.has(key)) {
+      warnings.push(`${path}: unknown config key '${key}' ignored.`);
+    }
+  }
+
+  if (raw.treatDynamicAs !== undefined) {
+    if (TREAT_DYNAMIC_AS_VALUES.includes(raw.treatDynamicAs as string)) {
+      config.treatDynamicAs = raw.treatDynamicAs as Config['treatDynamicAs'];
+    } else {
+      warnings.push(
+        `${path}: unknown treatDynamicAs '${String(raw.treatDynamicAs)}'; expected pass|warn|fail. Ignoring.`
+      );
+    }
+  }
+
+  if (raw.failOn !== undefined) {
+    if (FAIL_ON_VALUES.includes(raw.failOn as string)) {
+      config.failOn = raw.failOn as Config['failOn'];
+    } else {
+      warnings.push(`${path}: unknown failOn '${String(raw.failOn)}'; expected critical|warning|info. Ignoring.`);
+    }
+  }
+
+  if (raw.metaComponents !== undefined) {
+    if (Array.isArray(raw.metaComponents) && raw.metaComponents.every((c) => typeof c === 'string')) {
+      config.metaComponents = raw.metaComponents as string[];
+    } else {
+      warnings.push(`${path}: metaComponents must be an array of strings. Ignoring.`);
+    }
+  }
+
+  if (raw.rules !== undefined) {
+    const rules = raw.rules as Config['rules'];
+    const unknown = findUnknownRuleIds(Object.keys(rules));
+    if (unknown.length > 0) {
+      throw new Error(
+        `${path}: unknown rule id(s) in rules: ${unknown.join(', ')}. Known rule ids: ${knownRuleIds().join(', ')}`
+      );
+    }
+    config.rules = rules;
+  }
+
+  if (raw.weights !== undefined) {
+    const weights: Partial<Record<Category, number>> = {};
+    for (const [cat, w] of Object.entries(raw.weights as Record<string, unknown>)) {
+      if (!CATEGORIES.includes(cat as Category)) {
+        throw new Error(`${path}: unknown category '${cat}' in weights. Known categories: ${CATEGORIES.join(', ')}`);
+      }
+      if (typeof w !== 'number' || !Number.isFinite(w) || w < 0) {
+        throw new Error(`${path}: invalid weight for '${cat}': ${String(w)}; expected a finite number >= 0.`);
+      }
+      weights[cat as Category] = w;
+    }
+    config.weights = weights;
+  }
+
+  return { config, warnings };
 }
 
 /**
@@ -33,10 +121,11 @@ function isMissingExtensionLoaderError(err: unknown): boolean {
  * `ERR_UNKNOWN_FILE_EXTENSION` — this is caught here and rethrown as a
  * descriptive, actionable error instead of surfacing Node's raw error.
  *
- * Throws when: the file exists but has no usable default export, or (`.ts` only)
- * the host Node can't load TypeScript without a flag.
+ * Throws when: the file exists but has no usable default export; (`.ts` only)
+ * the host Node can't load TypeScript without a flag; or the loaded config
+ * fails validation (unknown rule ids in `rules`, invalid `weights` entries).
  */
-export async function loadConfigFile(cwd: string): Promise<Partial<Config> | undefined> {
+export async function loadConfigFile(cwd: string): Promise<LoadedConfigFile | undefined> {
   const found = CONFIG_FILENAMES.map((name) => join(cwd, name)).find((path) => existsSync(path));
   if (!found) return undefined;
 
@@ -46,7 +135,7 @@ export async function loadConfigFile(cwd: string): Promise<Partial<Config> | und
   } catch (err) {
     if (found.endsWith('.ts') && isMissingExtensionLoaderError(err)) {
       throw new Error(
-        `svelte-vitals: could not load ${found} — this Node runtime does not support TypeScript config ` +
+        `could not load ${found} — this Node runtime does not support TypeScript config ` +
           'files without a flag. Native type-stripping is unflagged from Node 22.18 / 23.6+: upgrade Node ' +
           'to 22.18+, re-run with --experimental-strip-types, or rename the file to .mjs/.js.',
         { cause: err }
@@ -57,8 +146,9 @@ export async function loadConfigFile(cwd: string): Promise<Partial<Config> | und
 
   if (!mod.default || typeof mod.default !== 'object') {
     throw new Error(
-      `svelte-vitals: ${found} must have a default export (e.g. \`export default defineConfig({...})\` or a plain object).`
+      `${found} must have a default export (e.g. \`export default defineConfig({...})\` or a plain object).`
     );
   }
-  return mod.default as Partial<Config>;
+
+  return validateConfigFile(mod.default as Record<string, unknown>, found);
 }

--- a/packages/cli/src/config-file.ts
+++ b/packages/cli/src/config-file.ts
@@ -157,9 +157,9 @@ export async function loadConfigFile(cwd: string): Promise<LoadedConfigFile | un
     throw err;
   }
 
-  if (!mod.default || typeof mod.default !== 'object') {
+  if (!isPlainObject(mod.default)) {
     throw new Error(
-      `${found} must have a default export (e.g. \`export default defineConfig({...})\` or a plain object).`
+      `${found} must have a default export that is a plain object (e.g. \`export default defineConfig({...})\` or a plain object literal).`
     );
   }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,7 +18,8 @@ import {
   type Severity,
   type RuleSetting,
   type Result,
-  type Config
+  type Config,
+  type Category
 } from '@svelte-vitals/core';
 import { createNodeRuntime } from './runtime/node.js';
 import { collectRoutes } from './providers/source/routes.js';
@@ -29,6 +30,7 @@ import { resolveReporter, isAutoDetectedAgent, isAutoDetectedGithub, type Report
 import { getChangedFiles, filterToChangedFiles } from './changed-files.js';
 import { colorEnabled, paletteFor } from './color.js';
 import { startSpinner } from './spinner.js';
+import { loadConfigFile } from './config-file.js';
 
 export interface RunOptions {
   cwd?: string;
@@ -42,6 +44,8 @@ export interface RunOptions {
   byRoute?: boolean;
   failOn?: Severity;
   rules?: Record<string, RuleSetting>;
+  /** Per-category weights for the combined Health score (flag > config file > default 1 each). */
+  weights?: Partial<Record<Category, number>>;
   /** Override process.env for reporter auto-detection (mainly useful in tests). */
   env?: NodeJS.ProcessEnv;
   /** Fail (exit 1) when the combined Health score is below this value (0–100). */
@@ -107,27 +111,44 @@ export interface AnalyzeOptions {
   route?: string;
   failOn?: Severity;
   rules?: Record<string, RuleSetting>;
+  /** Per-category weights for the combined Health score (flag > config file > default 1 each). */
+  weights?: Partial<Record<Category, number>>;
 }
 
 export interface AnalyzeResult {
   results: Result[];
   config: Config;
   version: string;
+  /** Non-fatal config-file issues (unknown top-level keys, invalid enum values). Empty when no config file or none found. */
+  warnings: string[];
 }
 
 /**
  * Run static-mode analysis and return the structured findings + resolved config.
- * Throws ProjectError when `cwd` is not a SvelteKit project. Shared by the CLI's
- * run() and by @svelte-vitals/mcp (issue #24).
+ * Throws ProjectError when `cwd` is not a SvelteKit project. Also throws when a
+ * `svelte-vitals.config.{mjs,js,ts}` file in `cwd` fails to load or fails
+ * validation (unknown rule ids in `rules`, invalid `weights` entries) — see
+ * `loadConfigFile`. Shared by the CLI's run() and by @svelte-vitals/mcp (issue #24).
+ *
+ * Config precedence is per field: an explicit option here wins, otherwise the
+ * config file's value is used, otherwise the built-in default (design doc
+ * 2026-07-05-config-file-design.md §3).
  */
 export async function analyzeProject(opts: AnalyzeOptions = {}): Promise<AnalyzeResult> {
   const cwd = opts.cwd ?? process.cwd();
   const rt = createNodeRuntime();
+
+  const loaded = await loadConfigFile(cwd);
+  const file = loaded?.config;
+  const warnings = loaded?.warnings ?? [];
+
+  const weights = opts.weights ?? file?.weights;
   const config = defineConfig({
-    treatDynamicAs: opts.treatDynamicAs ?? 'pass',
-    metaComponents: opts.metaComponents ?? [],
-    rules: opts.rules ?? {},
-    failOn: opts.failOn ?? 'critical'
+    treatDynamicAs: opts.treatDynamicAs ?? file?.treatDynamicAs ?? 'pass',
+    metaComponents: opts.metaComponents ?? file?.metaComponents ?? [],
+    rules: opts.rules ?? file?.rules ?? {},
+    failOn: opts.failOn ?? file?.failOn ?? 'critical',
+    ...(weights !== undefined ? { weights } : {})
   });
 
   await detectProject(rt, cwd); // throws ProjectError if not a SvelteKit project
@@ -146,7 +167,7 @@ export async function analyzeProject(opts: AnalyzeOptions = {}): Promise<Analyze
     await runRules(rules, { heads, images, headings, components, project, config }),
     config
   );
-  return { results, config, version: readPackageVersion() };
+  return { results, config, version: readPackageVersion(), warnings };
 }
 
 /**
@@ -182,7 +203,8 @@ export async function run(opts: RunOptions = {}): Promise<number> {
       treatDynamicAs: opts.treatDynamicAs,
       route: opts.route,
       failOn: opts.failOn,
-      rules: opts.rules
+      rules: opts.rules,
+      weights: opts.weights
     });
   } catch (err) {
     spinner.stop();
@@ -194,6 +216,8 @@ export async function run(opts: RunOptions = {}): Promise<number> {
     return 2;
   }
   spinner.stop();
+
+  for (const w of analysis.warnings) errorLog(`svelte-vitals: ${w}`);
 
   try {
     const { config, version } = analysis;
@@ -273,3 +297,9 @@ export async function run(opts: RunOptions = {}): Promise<number> {
 
 export { ProjectError } from './providers/source/project.js';
 export { buildRulesConfig, findUnknownRuleIds, knownRuleIds } from './rules-config.js';
+export { loadConfigFile } from './config-file.js';
+export type { LoadedConfigFile } from './config-file.js';
+// Re-exported so user config files can `import { defineConfig } from 'svelte-vitals'`
+// (the package they actually installed) instead of the transitive `@svelte-vitals/core`
+// (design doc 2026-07-05-config-file-design.md §5).
+export { defineConfig } from '@svelte-vitals/core';

--- a/packages/cli/src/resolve-args.ts
+++ b/packages/cli/src/resolve-args.ts
@@ -1,7 +1,60 @@
 import type mri from 'mri';
+import type { Category } from '@svelte-vitals/core';
 import type { RunOptions } from './index.js';
 import { buildRulesConfig, findUnknownRuleIds, knownRuleIds } from './rules-config.js';
 import { isReporterName, type ReporterName } from './reporter-resolve.js';
+
+const CATEGORIES: Category[] = ['seo', 'performance', 'correctness', 'security', 'architecture'];
+
+/**
+ * Parse `--weights seo=2,performance=1` into a per-category weight map
+ * (design doc §6 / decision 6). Categories are matched case-insensitively and
+ * normalized to lowercase; unknown categories and non-numeric/negative values
+ * push fatal errors (mirrors the `--rules`/`--ignore` unknown-id error shape).
+ * Returns `undefined` when `raw` is not a non-empty string (flag not passed).
+ */
+function parseWeights(raw: unknown, errors: string[]): Partial<Record<Category, number>> | undefined {
+  if (typeof raw !== 'string' || raw.trim() === '') return undefined;
+
+  const weights: Partial<Record<Category, number>> = {};
+  const unknownCategories: string[] = [];
+  const invalidValues: string[] = [];
+
+  for (const pair of raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)) {
+    const eq = pair.indexOf('=');
+    if (eq === -1) {
+      invalidValues.push(pair);
+      continue;
+    }
+    const category = pair.slice(0, eq).trim().toLowerCase();
+    const valueRaw = pair.slice(eq + 1).trim();
+    if (!CATEGORIES.includes(category as Category)) {
+      unknownCategories.push(category);
+      continue;
+    }
+    const value = Number(valueRaw);
+    if (!Number.isFinite(value) || value < 0) {
+      invalidValues.push(pair);
+      continue;
+    }
+    weights[category as Category] = value;
+  }
+
+  if (unknownCategories.length > 0) {
+    errors.push(`svelte-vitals: unknown category(ies) in --weights: ${unknownCategories.join(', ')}`);
+    errors.push(`Known categories: ${CATEGORIES.join(', ')}`);
+  }
+  if (invalidValues.length > 0) {
+    errors.push(
+      `svelte-vitals: invalid --weights entry(ies): ${invalidValues.join(', ')}; expected category=number with a finite number >= 0.`
+    );
+  }
+
+  return weights;
+}
 
 /** Result of normalizing parsed argv: the `run` options, plus any diagnostics to print. */
 export interface ResolvedArgs {
@@ -83,6 +136,15 @@ export function resolveArgs(argv: mri.Argv): ResolvedArgs {
   }
   const failOn = argv['fail-on-warning'] ? 'warning' : failOnValid ? failOnRaw : undefined;
 
+  const weights = parseWeights(argv.weights, errors);
+
+  // `buildRulesConfig` returns `{}` when neither --rules nor --ignore was passed;
+  // normalize that to `undefined` so it doesn't clobber a config file's `rules`
+  // (design doc §3, decision 3 — "not specified" must stay distinguishable from
+  // "specified as empty").
+  const rulesConfig = buildRulesConfig(allow, ignore);
+  const rules = Object.keys(rulesConfig).length > 0 ? rulesConfig : undefined;
+
   if (errors.length > 0) return { options: null, warnings, errors };
 
   return {
@@ -95,7 +157,8 @@ export function resolveArgs(argv: mri.Argv): ResolvedArgs {
       outFile: typeof argv['out-file'] === 'string' ? argv['out-file'] : undefined,
       byRoute: Boolean(argv['by-route']),
       failOn,
-      rules: buildRulesConfig(allow, ignore),
+      rules,
+      ...(weights !== undefined ? { weights } : {}),
       ...(diffBase !== undefined ? { diffBase } : {}),
       ...(staged ? { staged } : {})
     },

--- a/packages/cli/src/resolve-args.ts
+++ b/packages/cli/src/resolve-args.ts
@@ -35,6 +35,11 @@ function parseWeights(raw: unknown, errors: string[]): Partial<Record<Category, 
       unknownCategories.push(category);
       continue;
     }
+    // Reject an empty value explicitly — Number('') would silently coerce to 0.
+    if (valueRaw === '') {
+      invalidValues.push(pair);
+      continue;
+    }
     const value = Number(valueRaw);
     if (!Number.isFinite(value) || value < 0) {
       invalidValues.push(pair);

--- a/packages/cli/src/resolve-args.ts
+++ b/packages/cli/src/resolve-args.ts
@@ -58,6 +58,18 @@ function parseWeights(raw: unknown, errors: string[]): Partial<Record<Category, 
     );
   }
 
+  // `raw` was a non-empty string (e.g. "," or " ") but every pair was either purely
+  // whitespace (filtered out above, so neither unknownCategories nor invalidValues
+  // saw it) or otherwise didn't yield an entry. Note: this check uses the local
+  // unknownCategories/invalidValues counts, not `errors.length` — `errors` is the
+  // shared diagnostics array for the whole resolveArgs() call and may already hold
+  // unrelated entries (e.g. from --rules) by the time parseWeights runs. Without
+  // this, a bare `--weights ,` would silently return {} and clobber a config
+  // file's weights instead of surfacing a diagnostic.
+  if (unknownCategories.length === 0 && invalidValues.length === 0 && Object.keys(weights).length === 0) {
+    errors.push('svelte-vitals: --weights was passed but contains no category=number pairs.');
+  }
+
   return weights;
 }
 

--- a/packages/cli/test/analyze-project.test.ts
+++ b/packages/cli/test/analyze-project.test.ts
@@ -6,14 +6,19 @@ import { ProjectError } from '../src/providers/source/project.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const fixtureDir = join(here, 'fixtures', 'basic-project');
+const configFileFixtureDir = join(here, 'fixtures', 'config-file-project');
+const configFileInvalidFixtureDir = join(here, 'fixtures', 'config-file-invalid-project');
+const configFileWarningsFixtureDir = join(here, 'fixtures', 'config-file-warnings');
 
 describe('analyzeProject', () => {
-  it('returns results, config and version for a SvelteKit project', async () => {
-    const { results, config, version } = await analyzeProject({ cwd: fixtureDir });
+  it('returns results, config, version and warnings for a SvelteKit project', async () => {
+    const { results, config, version, warnings } = await analyzeProject({ cwd: fixtureDir });
     expect(results.length).toBeGreaterThan(0);
     expect(results.some((r) => r.id === 'SEO001')).toBe(true);
     expect(config.treatDynamicAs).toBe('pass');
     expect(typeof version).toBe('string');
+    // basic-project has no config file, so warnings must stay empty (equivalence regression check).
+    expect(warnings).toEqual([]);
   });
 
   it('respects the route glob filter', async () => {
@@ -25,5 +30,48 @@ describe('analyzeProject', () => {
 
   it('throws ProjectError for a non-SvelteKit directory', async () => {
     await expect(analyzeProject({ cwd: here })).rejects.toBeInstanceOf(ProjectError);
+  });
+});
+
+describe('analyzeProject config-file precedence (design doc 2026-07-05-config-file-design.md §3)', () => {
+  it('uses the config file when no flags are passed (file > default)', async () => {
+    const { config } = await analyzeProject({ cwd: configFileFixtureDir });
+    expect(config.failOn).toBe('warning');
+    expect(config.metaComponents).toEqual(['Seo']);
+    expect(config.treatDynamicAs).toBe('warn');
+    expect(config.rules).toEqual({ SEO001: 'off' });
+    expect(config.weights).toEqual({ seo: 2 });
+  });
+
+  it('lets an explicit option win over the config file (flag > file)', async () => {
+    const { config } = await analyzeProject({ cwd: configFileFixtureDir, failOn: 'critical' });
+    expect(config.failOn).toBe('critical');
+    // Untouched fields still come from the file (per-field independence).
+    expect(config.metaComponents).toEqual(['Seo']);
+    expect(config.weights).toEqual({ seo: 2 });
+  });
+
+  it('lets an explicit weights option replace the file weights as a whole', async () => {
+    const { config } = await analyzeProject({ cwd: configFileFixtureDir, weights: { performance: 3 } });
+    expect(config.weights).toEqual({ performance: 3 });
+  });
+
+  it('SEO001 is disabled by the file, changing findings vs the same project without the config file', async () => {
+    const { results } = await analyzeProject({ cwd: configFileFixtureDir });
+    expect(results.some((r) => r.id === 'SEO001')).toBe(false);
+  });
+
+  it('rejects an unknown rule id in the file rules, listing known rule ids', async () => {
+    await expect(analyzeProject({ cwd: configFileInvalidFixtureDir })).rejects.toThrow(
+      /unknown rule id\(s\) in rules: NOPE999.*Known rule ids:/s
+    );
+  });
+
+  it('surfaces config-file warnings (invalid enum value, unknown top-level key) without throwing', async () => {
+    const { warnings, config } = await analyzeProject({ cwd: configFileWarningsFixtureDir });
+    expect(warnings.some((w) => w.includes("unknown treatDynamicAs 'nope'"))).toBe(true);
+    expect(warnings.some((w) => w.includes("unknown config key 'someFutureOption'"))).toBe(true);
+    // The invalid field is dropped, so it falls through to the default.
+    expect(config.treatDynamicAs).toBe('pass');
   });
 });

--- a/packages/cli/test/config-file.test.ts
+++ b/packages/cli/test/config-file.test.ts
@@ -76,6 +76,24 @@ describe('loadConfigFile', () => {
     expect(loaded?.config.weights).toEqual({ seo: 2, performance: 1.5 });
   });
 
+  it('rejects a rules value that is not a plain object (null) with a clear message', async () => {
+    await expect(loadConfigFile(fixture('config-file-rules-null'))).rejects.toThrow(
+      /rules must be an object of rule-id → setting/
+    );
+  });
+
+  it('rejects a weights value that is not a plain object (array) with a clear message', async () => {
+    await expect(loadConfigFile(fixture('config-file-weights-array'))).rejects.toThrow(
+      /weights must be an object of category → number/
+    );
+  });
+
+  it('accepts weights category keys case-insensitively, normalizing to lowercase', async () => {
+    const loaded = await loadConfigFile(fixture('config-file-weights-uppercase'));
+    expect(loaded?.warnings).toEqual([]);
+    expect(loaded?.config.weights).toEqual({ seo: 2 });
+  });
+
   it('warns (without rejecting) on a metaComponents value that is not an array of strings, dropping the field', async () => {
     const loaded = await loadConfigFile(fixture('config-file-bad-metacomponents'));
     expect(loaded?.config.metaComponents).toBeUndefined();

--- a/packages/cli/test/config-file.test.ts
+++ b/packages/cli/test/config-file.test.ts
@@ -54,6 +54,12 @@ describe('loadConfigFile', () => {
     await expect(loadConfigFile(fixture('config-file-invalid'))).rejects.toThrow(/must have a default export/);
   });
 
+  it('rejects a config file whose default export is an array, not a plain object', async () => {
+    await expect(loadConfigFile(fixture('config-file-default-export-array'))).rejects.toThrow(
+      /must have a default export that is a plain object/
+    );
+  });
+
   it('rejects an unknown rule id in rules, listing known rule ids', async () => {
     await expect(loadConfigFile(fixture('config-file-unknown-rule'))).rejects.toThrow(
       /unknown rule id\(s\) in rules: NOPE999.*Known rule ids:/s

--- a/packages/cli/test/config-file.test.ts
+++ b/packages/cli/test/config-file.test.ts
@@ -5,9 +5,8 @@ import { describe, it, expect } from 'vitest';
 import { loadConfigFile } from '../src/config-file.js';
 
 /**
- * Spike prototype tests (design doc: docs/superpowers/specs/2026-07-05-config-file-design.md).
- * `loadConfigFile` is not wired into any entry point yet — these tests only
- * confirm the loader mechanism itself is viable.
+ * Loader + validation tests (design doc: docs/superpowers/specs/2026-07-05-config-file-design.md).
+ * `loadConfigFile` is wired into `analyzeProject` (packages/cli/src/index.ts).
  */
 
 const fixture = (name: string) => join(import.meta.dirname, 'fixtures', name);
@@ -30,8 +29,9 @@ describe('loadConfigFile', () => {
   });
 
   it('loads a plain-object .mjs config file', async () => {
-    const config = await loadConfigFile(fixture('config-file-mjs'));
-    expect(config).toEqual({
+    const loaded = await loadConfigFile(fixture('config-file-mjs'));
+    expect(loaded?.warnings).toEqual([]);
+    expect(loaded?.config).toEqual({
       treatDynamicAs: 'warn',
       failOn: 'warning',
       rules: { SEO001: 'off' }
@@ -39,9 +39,10 @@ describe('loadConfigFile', () => {
   });
 
   it('loads a .mjs config file that uses defineConfig (dogfooding)', async () => {
-    const config = await loadConfigFile(fixture('config-file-defineconfig'));
+    const loaded = await loadConfigFile(fixture('config-file-defineconfig'));
     // defineConfig() merges over defaultConfig, so the loaded value is a full Config.
-    expect(config).toMatchObject({
+    expect(loaded?.warnings).toEqual([]);
+    expect(loaded?.config).toMatchObject({
       failOn: 'info',
       metaComponents: ['Seo'],
       treatDynamicAs: 'pass',
@@ -51,6 +52,43 @@ describe('loadConfigFile', () => {
 
   it('rejects a config file with no default export', async () => {
     await expect(loadConfigFile(fixture('config-file-invalid'))).rejects.toThrow(/must have a default export/);
+  });
+
+  it('rejects an unknown rule id in rules, listing known rule ids', async () => {
+    await expect(loadConfigFile(fixture('config-file-unknown-rule'))).rejects.toThrow(
+      /unknown rule id\(s\) in rules: NOPE999.*Known rule ids:/s
+    );
+  });
+
+  it('rejects a negative weight', async () => {
+    await expect(loadConfigFile(fixture('config-file-bad-weights'))).rejects.toThrow(/invalid weight for 'seo'/);
+  });
+
+  it('rejects an unknown category key in weights', async () => {
+    await expect(loadConfigFile(fixture('config-file-bad-weights-category'))).rejects.toThrow(
+      /unknown category 'bogus' in weights/
+    );
+  });
+
+  it('loads a valid weights map through to config.weights', async () => {
+    const loaded = await loadConfigFile(fixture('config-file-weights'));
+    expect(loaded?.warnings).toEqual([]);
+    expect(loaded?.config.weights).toEqual({ seo: 2, performance: 1.5 });
+  });
+
+  it('warns (without rejecting) on a metaComponents value that is not an array of strings, dropping the field', async () => {
+    const loaded = await loadConfigFile(fixture('config-file-bad-metacomponents'));
+    expect(loaded?.config.metaComponents).toBeUndefined();
+    expect(loaded?.warnings.some((w) => w.includes('metaComponents must be an array of strings'))).toBe(true);
+    // Valid sibling fields are still adopted.
+    expect(loaded?.config.failOn).toBe('warning');
+  });
+
+  it('warns (without rejecting) on an invalid enum value and an unknown top-level key', async () => {
+    const loaded = await loadConfigFile(fixture('config-file-warnings'));
+    expect(loaded?.config.treatDynamicAs).toBeUndefined();
+    expect(loaded?.warnings.some((w) => w.includes("unknown treatDynamicAs 'nope'"))).toBe(true);
+    expect(loaded?.warnings.some((w) => w.includes("unknown config key 'someFutureOption'"))).toBe(true);
   });
 
   // Spike finding: this MUST run in a child process. vitest's module runner

--- a/packages/cli/test/fixtures/config-file-bad-metacomponents/svelte-vitals.config.mjs
+++ b/packages/cli/test/fixtures/config-file-bad-metacomponents/svelte-vitals.config.mjs
@@ -1,0 +1,5 @@
+/** metaComponents is not an array of strings — warning, field ignored (design doc §4). */
+export default {
+  metaComponents: 'Seo',
+  failOn: 'warning'
+};

--- a/packages/cli/test/fixtures/config-file-bad-weights-category/svelte-vitals.config.mjs
+++ b/packages/cli/test/fixtures/config-file-bad-weights-category/svelte-vitals.config.mjs
@@ -1,0 +1,6 @@
+/** Unknown category key in `weights` — should be rejected (design doc §4). */
+export default {
+  weights: {
+    bogus: 1
+  }
+};

--- a/packages/cli/test/fixtures/config-file-bad-weights/svelte-vitals.config.mjs
+++ b/packages/cli/test/fixtures/config-file-bad-weights/svelte-vitals.config.mjs
@@ -1,0 +1,6 @@
+/** Negative weight — should be rejected (design doc §4). */
+export default {
+  weights: {
+    seo: -1
+  }
+};

--- a/packages/cli/test/fixtures/config-file-default-export-array/svelte-vitals.config.mjs
+++ b/packages/cli/test/fixtures/config-file-default-export-array/svelte-vitals.config.mjs
@@ -1,0 +1,2 @@
+/** default export is an array, not a plain object — should be rejected with a clear message. */
+export default [];

--- a/packages/cli/test/fixtures/config-file-invalid-project/package.json
+++ b/packages/cli/test/fixtures/config-file-invalid-project/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "config-file-invalid-project-fixture",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@sveltejs/kit": "^2.0.0",
+    "svelte": "^5.0.0"
+  }
+}

--- a/packages/cli/test/fixtures/config-file-invalid-project/src/app.html
+++ b/packages/cli/test/fixtures/config-file-invalid-project/src/app.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    %sveltekit.head%
+  </head>
+  <body>
+    %sveltekit.body%
+  </body>
+</html>

--- a/packages/cli/test/fixtures/config-file-invalid-project/src/routes/+page.svelte
+++ b/packages/cli/test/fixtures/config-file-invalid-project/src/routes/+page.svelte
@@ -1,0 +1,5 @@
+<svelte:head>
+  <title>Fine</title>
+</svelte:head>
+
+<h1>Fine</h1>

--- a/packages/cli/test/fixtures/config-file-invalid-project/svelte-vitals.config.mjs
+++ b/packages/cli/test/fixtures/config-file-invalid-project/svelte-vitals.config.mjs
@@ -1,0 +1,6 @@
+/** Unknown rule id — should make run() exit 2 with the loader's validation message. */
+export default {
+  rules: {
+    NOPE999: 'off'
+  }
+};

--- a/packages/cli/test/fixtures/config-file-project/package.json
+++ b/packages/cli/test/fixtures/config-file-project/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "config-file-project-fixture",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@sveltejs/kit": "^2.0.0",
+    "svelte": "^5.0.0"
+  }
+}

--- a/packages/cli/test/fixtures/config-file-project/src/app.html
+++ b/packages/cli/test/fixtures/config-file-project/src/app.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    %sveltekit.head%
+  </head>
+  <body>
+    %sveltekit.body%
+  </body>
+</html>

--- a/packages/cli/test/fixtures/config-file-project/src/routes/+page.svelte
+++ b/packages/cli/test/fixtures/config-file-project/src/routes/+page.svelte
@@ -1,0 +1,1 @@
+<h1>No title here</h1>

--- a/packages/cli/test/fixtures/config-file-project/svelte-vitals.config.mjs
+++ b/packages/cli/test/fixtures/config-file-project/svelte-vitals.config.mjs
@@ -1,0 +1,12 @@
+/** Fixture config file for analyzeProject precedence-matrix and e2e tests. */
+export default {
+  failOn: 'warning',
+  metaComponents: ['Seo'],
+  treatDynamicAs: 'warn',
+  rules: {
+    SEO001: 'off'
+  },
+  weights: {
+    seo: 2
+  }
+};

--- a/packages/cli/test/fixtures/config-file-rules-null/svelte-vitals.config.mjs
+++ b/packages/cli/test/fixtures/config-file-rules-null/svelte-vitals.config.mjs
@@ -1,0 +1,4 @@
+/** rules is null, not an object — should be rejected with a clear message (not a raw TypeError). */
+export default {
+  rules: null
+};

--- a/packages/cli/test/fixtures/config-file-unknown-rule/svelte-vitals.config.mjs
+++ b/packages/cli/test/fixtures/config-file-unknown-rule/svelte-vitals.config.mjs
@@ -1,0 +1,6 @@
+/** Unknown rule id in `rules` — should be rejected (design doc §4). */
+export default {
+  rules: {
+    NOPE999: 'off'
+  }
+};

--- a/packages/cli/test/fixtures/config-file-warnings/package.json
+++ b/packages/cli/test/fixtures/config-file-warnings/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "config-file-warnings-fixture",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@sveltejs/kit": "^2.0.0",
+    "svelte": "^5.0.0"
+  }
+}

--- a/packages/cli/test/fixtures/config-file-warnings/src/app.html
+++ b/packages/cli/test/fixtures/config-file-warnings/src/app.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    %sveltekit.head%
+  </head>
+  <body>
+    %sveltekit.body%
+  </body>
+</html>

--- a/packages/cli/test/fixtures/config-file-warnings/src/routes/+page.svelte
+++ b/packages/cli/test/fixtures/config-file-warnings/src/routes/+page.svelte
@@ -1,0 +1,5 @@
+<svelte:head>
+  <title>Fine</title>
+</svelte:head>
+
+<h1>Fine</h1>

--- a/packages/cli/test/fixtures/config-file-warnings/svelte-vitals.config.mjs
+++ b/packages/cli/test/fixtures/config-file-warnings/svelte-vitals.config.mjs
@@ -1,0 +1,5 @@
+/** Invalid enum value + unknown top-level key — both warnings, not errors (design doc §4). */
+export default {
+  treatDynamicAs: 'nope',
+  someFutureOption: true
+};

--- a/packages/cli/test/fixtures/config-file-weights-array/svelte-vitals.config.mjs
+++ b/packages/cli/test/fixtures/config-file-weights-array/svelte-vitals.config.mjs
@@ -1,0 +1,4 @@
+/** weights is an array, not an object — should be rejected with a clear message. */
+export default {
+  weights: []
+};

--- a/packages/cli/test/fixtures/config-file-weights-uppercase/svelte-vitals.config.mjs
+++ b/packages/cli/test/fixtures/config-file-weights-uppercase/svelte-vitals.config.mjs
@@ -1,0 +1,6 @@
+/** Uppercase category key — accepted case-insensitively and normalized to lowercase (matches --weights). */
+export default {
+  weights: {
+    SEO: 2
+  }
+};

--- a/packages/cli/test/fixtures/config-file-weights/svelte-vitals.config.mjs
+++ b/packages/cli/test/fixtures/config-file-weights/svelte-vitals.config.mjs
@@ -1,0 +1,7 @@
+/** Valid `weights` map — should reach `computeHealth` via `config.weights`. */
+export default {
+  weights: {
+    seo: 2,
+    performance: 1.5
+  }
+};

--- a/packages/cli/test/resolve-args.test.ts
+++ b/packages/cli/test/resolve-args.test.ts
@@ -7,7 +7,17 @@ function resolve(...args: string[]) {
   const argv = mri(args, {
     alias: { h: 'help', v: 'version' },
     boolean: ['by-route', 'json', 'fail-on-warning', 'staged'],
-    string: ['meta-components', 'treat-dynamic-as', 'route', 'fail-on', 'reporter', 'rules', 'ignore', 'diff']
+    string: [
+      'meta-components',
+      'treat-dynamic-as',
+      'route',
+      'fail-on',
+      'reporter',
+      'rules',
+      'ignore',
+      'diff',
+      'weights'
+    ]
   });
   return resolveArgs(argv);
 }
@@ -77,5 +87,40 @@ describe('resolveArgs', () => {
     const { options } = resolve('--json');
     expect(options?.diffBase).toBeUndefined();
     expect(options?.staged).toBeUndefined();
+  });
+
+  it('leaves rules undefined when neither --rules nor --ignore is passed', () => {
+    const { options } = resolve('--json');
+    expect(options?.rules).toBeUndefined();
+  });
+
+  it('parses --weights into a per-category map, normalizing case', () => {
+    const { options, errors } = resolve('--weights', 'SEO=2,performance=1.5');
+    expect(errors).toEqual([]);
+    expect(options?.weights).toEqual({ seo: 2, performance: 1.5 });
+  });
+
+  it('omits weights when --weights is not passed', () => {
+    const { options } = resolve('--json');
+    expect(options?.weights).toBeUndefined();
+  });
+
+  it('reports an unknown category in --weights as a fatal error', () => {
+    const { options, errors } = resolve('--weights', 'bogus=2');
+    expect(options).toBeNull();
+    expect(errors.some((e) => e.includes('unknown category(ies) in --weights'))).toBe(true);
+    expect(errors.some((e) => e.includes('Known categories'))).toBe(true);
+  });
+
+  it('reports a negative --weights value as a fatal error', () => {
+    const { options, errors } = resolve('--weights', 'seo=-1');
+    expect(options).toBeNull();
+    expect(errors.some((e) => e.includes('invalid --weights entry'))).toBe(true);
+  });
+
+  it('reports a non-numeric --weights value as a fatal error', () => {
+    const { options, errors } = resolve('--weights', 'seo=nope');
+    expect(options).toBeNull();
+    expect(errors.some((e) => e.includes('invalid --weights entry'))).toBe(true);
   });
 });

--- a/packages/cli/test/resolve-args.test.ts
+++ b/packages/cli/test/resolve-args.test.ts
@@ -123,4 +123,10 @@ describe('resolveArgs', () => {
     expect(options).toBeNull();
     expect(errors.some((e) => e.includes('invalid --weights entry'))).toBe(true);
   });
+
+  it('reports an empty --weights value as a fatal error (Number("") must not coerce to 0)', () => {
+    const { options, errors } = resolve('--weights', 'seo=');
+    expect(options).toBeNull();
+    expect(errors.some((e) => e.includes('invalid --weights entry'))).toBe(true);
+  });
 });

--- a/packages/cli/test/resolve-args.test.ts
+++ b/packages/cli/test/resolve-args.test.ts
@@ -129,4 +129,10 @@ describe('resolveArgs', () => {
     expect(options).toBeNull();
     expect(errors.some((e) => e.includes('invalid --weights entry'))).toBe(true);
   });
+
+  it('reports --weights with no category=number pairs as a fatal error (must not silently clobber config weights)', () => {
+    const { options, errors } = resolve('--weights', ',');
+    expect(options).toBeNull();
+    expect(errors.some((e) => e.includes('--weights was passed but contains no category=number pairs'))).toBe(true);
+  });
 });

--- a/packages/cli/test/run.test.ts
+++ b/packages/cli/test/run.test.ts
@@ -5,6 +5,8 @@ import { run } from '../src/index.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const fixtureDir = join(here, 'fixtures', 'basic-project');
+const configFileFixtureDir = join(here, 'fixtures', 'config-file-project');
+const configFileInvalidFixtureDir = join(here, 'fixtures', 'config-file-invalid-project');
 // Isolate reporter auto-detection from the ambient test-runner environment
 // (e.g. CLAUDECODE is set when running inside Claude Code).
 const CLEAN_ENV: NodeJS.ProcessEnv = {};
@@ -236,5 +238,28 @@ describe('run() sarif & github reporters', () => {
     });
     expect(code).toBe(0);
     expect(cap.out).toEqual([]);
+  });
+});
+
+describe('run() config file (design doc 2026-07-05-config-file-design.md)', () => {
+  it('reflects the config file in findings (SEO001 disabled by rules) and prints its warnings', async () => {
+    const cap = capture();
+    const code = await run({ cwd: configFileFixtureDir, log: cap.log, errorLog: cap.errorLog, env: CLEAN_ENV });
+    // failOn: 'warning' (from the file) + a critical SEO002 finding present → exit 1.
+    expect(code).toBe(1);
+    const report = cap.out.join('\n');
+    expect(report).not.toContain('SEO001');
+    expect(report).toContain('SEO002');
+  });
+
+  it('exits 2 with the loader validation message for a config file with an unknown rule id', async () => {
+    const cap = capture();
+    const code = await run({ cwd: configFileInvalidFixtureDir, log: cap.log, errorLog: cap.errorLog, env: CLEAN_ENV });
+    expect(code).toBe(2);
+    const errText = cap.err.join('\n');
+    expect(errText).toContain('unknown rule id(s) in rules: NOPE999');
+    expect(errText).toContain('Known rule ids:');
+    // No double `svelte-vitals: ` prefix (the loader no longer prepends its own).
+    expect(errText).not.toContain('svelte-vitals: svelte-vitals:');
   });
 });

--- a/packages/mcp/src/tools/analyze.ts
+++ b/packages/mcp/src/tools/analyze.ts
@@ -30,7 +30,11 @@ const analyzeInputSchema = z.object({
   failOn: z
     .enum(['critical', 'warning', 'info'])
     .optional()
-    .describe('Minimum severity that counts as a failure in the summary. Default: critical.')
+    .describe('Minimum severity that counts as a failure in the summary. Default: critical.'),
+  weights: z
+    .partialRecord(z.enum(['seo', 'performance', 'correctness', 'security', 'architecture']), z.number())
+    .optional()
+    .describe('Per-category weights for the combined Health score, e.g. {"seo": 2}. Unlisted categories default to 1.')
 });
 
 /** zod raw shape for the analyze tool's input (registered with the MCP server). */
@@ -52,6 +56,12 @@ export async function handleAnalyze(args: AnalyzeArgs): Promise<McpToolResult> {
     return textError(`Unknown rule id(s): ${unknown.join(', ')}. Known rule ids: ${knownRuleIds().join(', ')}.`);
   }
 
+  // buildRulesConfig returns {} when neither `rules` nor `ignore` was passed; normalize
+  // that to undefined so it doesn't clobber a config file's `rules` (same reasoning as
+  // the CLI's resolve-args.ts — analyzeProject treats {} as "replace with nothing enabled").
+  const rulesConfig = buildRulesConfig(allow, ignore);
+  const rules = Object.keys(rulesConfig).length > 0 ? rulesConfig : undefined;
+
   try {
     const { results, config, version } = await analyzeProject({
       cwd: args.path,
@@ -59,7 +69,8 @@ export async function handleAnalyze(args: AnalyzeArgs): Promise<McpToolResult> {
       treatDynamicAs: args.treatDynamicAs,
       route: args.route,
       failOn: args.failOn,
-      rules: buildRulesConfig(allow, ignore)
+      rules,
+      weights: args.weights
     });
     const report = buildJsonReport(results, config, { version });
     return {

--- a/packages/mcp/src/tools/analyze.ts
+++ b/packages/mcp/src/tools/analyze.ts
@@ -32,7 +32,7 @@ const analyzeInputSchema = z.object({
     .optional()
     .describe('Minimum severity that counts as a failure in the summary. Default: critical.'),
   weights: z
-    .partialRecord(z.enum(['seo', 'performance', 'correctness', 'security', 'architecture']), z.number())
+    .partialRecord(z.enum(['seo', 'performance', 'correctness', 'security', 'architecture']), z.number().nonnegative())
     .optional()
     .describe('Per-category weights for the combined Health score, e.g. {"seo": 2}. Unlisted categories default to 1.')
 });

--- a/packages/mcp/src/tools/analyze.ts
+++ b/packages/mcp/src/tools/analyze.ts
@@ -32,9 +32,20 @@ const analyzeInputSchema = z.object({
     .optional()
     .describe('Minimum severity that counts as a failure in the summary. Default: critical.'),
   weights: z
-    .partialRecord(z.enum(['seo', 'performance', 'correctness', 'security', 'architecture']), z.number().nonnegative())
+    .preprocess(
+      (v) =>
+        v && typeof v === 'object' && !Array.isArray(v)
+          ? Object.fromEntries(Object.entries(v).map(([k, val]) => [String(k).toLowerCase(), val]))
+          : v,
+      z.partialRecord(
+        z.enum(['seo', 'performance', 'correctness', 'security', 'architecture']),
+        z.number().nonnegative()
+      )
+    )
     .optional()
-    .describe('Per-category weights for the combined Health score, e.g. {"seo": 2}. Unlisted categories default to 1.')
+    .describe(
+      'Per-category weights for the combined Health score, e.g. {"seo": 2}. Category keys are case-insensitive. Unlisted categories default to 1.'
+    )
 });
 
 /** zod raw shape for the analyze tool's input (registered with the MCP server). */

--- a/packages/mcp/test/analyze-tool.test.ts
+++ b/packages/mcp/test/analyze-tool.test.ts
@@ -6,6 +6,7 @@ import { handleAnalyze } from '../src/tools/analyze.js';
 const here = dirname(fileURLToPath(import.meta.url));
 // Reuse the CLI's fixture project so we don't duplicate a SvelteKit tree.
 const fixtureDir = join(here, '..', '..', 'cli', 'test', 'fixtures', 'basic-project');
+const configFileFixtureDir = join(here, '..', '..', 'cli', 'test', 'fixtures', 'config-file-project');
 
 describe('analyze tool', () => {
   it('returns a structured JSON report for a project path', async () => {
@@ -60,5 +61,20 @@ describe('analyze tool', () => {
     expect(res.isError).toBe(true);
     // Propagates the CLI's ProjectError message verbatim.
     expect(res.content[0]!.text).toContain('No SvelteKit project found');
+  });
+
+  it('reflects a project config file (svelte-vitals.config.mjs disables SEO001 via rules)', async () => {
+    const res = await handleAnalyze({ path: configFileFixtureDir });
+    expect(res.isError).toBeFalsy();
+    const report = res.structuredContent as { routes: Array<{ issues: Array<{ id: string }> }> };
+    const ids = new Set(report.routes.flatMap((r) => r.issues.map((i) => i.id)));
+    expect(ids.has('SEO001')).toBe(false);
+  });
+
+  it('applies a weights argument to the combined Health score', async () => {
+    const res = await handleAnalyze({ path: fixtureDir, weights: { seo: 5 } });
+    expect(res.isError).toBeFalsy();
+    const report = res.structuredContent as { weights: Record<string, number> };
+    expect(report.weights.seo).toBe(5);
   });
 });

--- a/packages/mcp/test/analyze-tool.test.ts
+++ b/packages/mcp/test/analyze-tool.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { handleAnalyze } from '../src/tools/analyze.js';
+import { createServer } from '../src/server.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 // Reuse the CLI's fixture project so we don't duplicate a SvelteKit tree.
@@ -76,5 +79,24 @@ describe('analyze tool', () => {
     expect(res.isError).toBeFalsy();
     const report = res.structuredContent as { weights: Record<string, number> };
     expect(report.weights.seo).toBe(5);
+  });
+
+  it('rejects a negative weight at the input-schema layer (isError, before analysis runs)', async () => {
+    // Go through a real client-server pair so the tool's zod inputSchema is applied
+    // (handleAnalyze alone would bypass it — validation lives in the MCP SDK layer).
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const server = createServer();
+    await server.connect(serverTransport);
+    const client = new Client({ name: 'test', version: '0.0.0' });
+    await client.connect(clientTransport);
+    try {
+      const res = await client.callTool({ name: 'analyze', arguments: { path: fixtureDir, weights: { seo: -1 } } });
+      expect(res.isError).toBe(true);
+      const text = (res.content as Array<{ type: string; text: string }>)[0]!.text;
+      expect(text).toContain('Input validation error');
+    } finally {
+      await client.close();
+      await server.close();
+    }
   });
 });

--- a/packages/mcp/test/analyze-tool.test.ts
+++ b/packages/mcp/test/analyze-tool.test.ts
@@ -81,6 +81,27 @@ describe('analyze tool', () => {
     expect(report.weights.seo).toBe(5);
   });
 
+  it('accepts weights category keys case-insensitively (via the real input schema, not handleAnalyze directly)', async () => {
+    // Case-insensitivity is implemented as a zod preprocess step on the input schema,
+    // so — like the negative-weight test below — this must go through a real
+    // client-server pair; calling handleAnalyze directly would bypass the schema
+    // entirely and the uppercase key would never get lowercased.
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const server = createServer();
+    await server.connect(serverTransport);
+    const client = new Client({ name: 'test', version: '0.0.0' });
+    await client.connect(clientTransport);
+    try {
+      const res = await client.callTool({ name: 'analyze', arguments: { path: fixtureDir, weights: { SEO: 2 } } });
+      expect(res.isError).toBeFalsy();
+      const report = res.structuredContent as { weights: Record<string, number> };
+      expect(report.weights.seo).toBe(2);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
   it('rejects a negative weight at the input-schema layer (isError, before analysis runs)', async () => {
     // Go through a real client-server pair so the tool's zod inputSchema is applied
     // (handleAnalyze alone would bypass it — validation lives in the MCP SDK layer).


### PR DESCRIPTION
## Summary

Implements `plans/010-config-file-implementation.md` — plan A of the accepted design doc (`docs/superpowers/specs/2026-07-05-config-file-design.md`): ship the config-file loader, wire it into the CLI and MCP entry points, and add `--weights`. This closes the 1.0-required roadmap item C.

- **Loader shipped** (`packages/cli/src/config-file.ts`): finds `svelte-vitals.config.{mjs,js,ts}` in the analyzed directory only (no upward search), loads it via native `import()` with zero new dependencies, and validates it in two tiers (design §4):
  - *Fatal (exit 2 / MCP `isError`)*: unknown rule ids in `rules` (same message shape as `--rules`, including the known-ids list); unknown category keys or negative/non-finite values in `weights`.
  - *Warning (analysis proceeds, field dropped)*: invalid `treatDynamicAs`/`failOn` enum values, non-string-array `metaComponents`, unknown top-level keys (forward compatibility).
  - `.ts` configs work unflagged on Node 22.18+/23.6+; below that the loader throws a descriptive error leading with "upgrade Node to 22.18+".
- **Wired at the single merge point** (`analyzeProject`): per-field precedence **flag > config file > built-in default**, so the CLI's `run()` and the MCP `analyze` tool inherit the feature simultaneously. Config-file warnings travel on `AnalyzeResult.warnings` and are printed to stderr by `run()`.
- **`--weights seo=2,performance=1`**: case-insensitive categories, unknown/negative/non-numeric entries are exit-2 errors; unlisted categories keep weight 1. The MCP tool gains a matching `weights` argument (`z.partialRecord` — see notes).
- **Exports**: `loadConfigFile` and a `defineConfig` re-export, so user config files can `import { defineConfig } from 'svelte-vitals'` (the package they actually installed) despite strict pnpm layouts.
- **Bug fixed along the way**: both the CLI's `resolve-args` and the MCP tool passed `buildRulesConfig`'s empty `{}` unconditionally, which would have clobbered a config file's `rules`; both now normalize `{}` to `undefined` ("not specified").

## Notes for review

- `z.partialRecord(z.enum([...]), z.number())` was chosen over the two forms the plan suggested after testing against this repo's zod 4.4.3: `z.record(enum, number)` requires *all* enum keys, and a literal `z.object` silently drops unknown category names. `partialRecord` gives optional per-category keys and rejects unknown categories.
- Backward compatibility: projects without a config file behave identically — proven by the untouched existing suites passing unmodified.

## Test plan

- 21 new tests: `--weights` parsing (valid / unknown category / negative / non-numeric / case normalization), the precedence matrix (flag > file > default, per-field independence), fatal and warning validation paths, e2e runs (config file changes findings; a bad config exits 2 with the loader's message and no double `svelte-vitals:` prefix), and MCP config-file reflection + `weights`.
- Full workspace: 781 tests passing; `pnpm build` / `pnpm typecheck` / `pnpm lint` all pass.
- The `.ts` native-loading branches stay covered by the child-process spike test across the CI Node matrix (22.13.0 exercises the flag-required error path).
- Changesets: `svelte-vitals` minor, `@svelte-vitals/mcp` minor. Design doc status updated to "Shipped (plan A — CLI/MCP)".

## Next

Plan B (`plans/011-config-file-docs.md`) follows after this merges: a new configuration guide (en/ja), fixing the health-report guide's "configurable weights" wording, and the docs-only vite wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-category health weights support to the CLI and MCP analyze flow via `--weights` and `weights` in `svelte-vitals.config.{mjs,js,ts}`.
  * Added config-file loading for `svelte-vitals.config.{mjs,js,ts}` with documented precedence and support for `.ts` configs.
  * CLI now surfaces non-fatal config-file warnings during analysis.
* **Bug Fixes**
  * Improved validation and error reporting for invalid weights, unknown categories/rules, and malformed config values.
  * Ensures “not specified” vs “specified empty” behaves correctly for `rules`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->