### PR TITLE
feat(cli): add --category filter and --score output

### DIFF
--- a/.changeset/cli-category-score-flags.md
+++ b/.changeset/cli-category-score-flags.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': minor
+---
+
+Add `--category <cats>` to restrict analysis to rules in the given categories (intersects with `--rules`/`--ignore`/config-file selection), and `--score` to print only the combined Health score to stdout, suppressing reporter output — handy for shell prompts or scripts that just want the number, especially combined with `--min-health` for gating.

--- a/docs/src/content/docs/guides/cli.md
+++ b/docs/src/content/docs/guides/cli.md
@@ -71,6 +71,17 @@ svelte-vitals --min-health 80
 
 See [Health report](/svelte-vitals/guides/health-report/) for how the score is calculated.
 
+### `--score`
+
+Print only the combined Health score (an integer) to stdout, suppressing all other reporter output. Useful in shell prompts or scripts that just want the number without parsing JSON.
+
+```bash
+svelte-vitals --score
+svelte-vitals --score --min-health 80   # gate on the score; exit code still reflects pass/fail
+```
+
+Combining `--score` with `--reporter`/`--json` is not an error, but the reporter output is suppressed and a warning is printed to stderr. The exit code is unaffected by `--score` — it still reflects `--fail-on` and `--min-health` as usual.
+
 ### `--route <glob>`
 
 Only analyze routes whose path matches the given glob pattern.
@@ -130,6 +141,17 @@ Disable the specified rules. Accepts a comma-separated list of rule IDs.
 ```bash
 svelte-vitals --ignore PERF001
 ```
+
+### `--category <cats>`
+
+Restrict analysis to rules in the given categories. Accepts a comma-separated list, matched case-insensitively: `seo`, `performance`, `correctness`, `security`, `architecture`.
+
+```bash
+svelte-vitals --category seo
+svelte-vitals --category seo,performance
+```
+
+`--category` intersects with `--rules`/`--ignore`/config-file rule selection — a rule only runs if it survives both. Narrowing to a subset of categories also narrows the [Health score](/svelte-vitals/guides/health-report/): the combined score becomes the weighted average of only the categories that have findings, so it isn't directly comparable to an unfiltered run. An unknown category is an error (exit `2`).
 
 ### `--weights <pairs>`
 

--- a/docs/src/content/docs/ja/guides/cli.md
+++ b/docs/src/content/docs/ja/guides/cli.md
@@ -71,6 +71,17 @@ svelte-vitals --min-health 80
 
 スコアの計算方法については [Health レポート](/svelte-vitals/ja/guides/health-report/) を参照してください。
 
+### `--score`
+
+組み合わせた Health スコア(整数)のみを stdout に出力し、他のレポーター出力をすべて抑制します。数値をパースせずにシェルプロンプトやスクリプトから使いたい場合に便利です。
+
+```bash
+svelte-vitals --score
+svelte-vitals --score --min-health 80   # スコアでゲートする。終了コードは通常どおり pass/fail を反映
+```
+
+`--score` を `--reporter`/`--json` と組み合わせてもエラーにはなりませんが、レポーター出力は抑制され、stderr に警告が表示されます。終了コードは `--score` の影響を受けず、`--fail-on` と `--min-health` を通常どおり反映します。
+
 ### `--route <glob>`
 
 指定した glob パターンに一致するルートのみを分析します。
@@ -130,6 +141,17 @@ svelte-vitals --rules SEO001,SEO002
 ```bash
 svelte-vitals --ignore PERF001
 ```
+
+### `--category <cats>`
+
+指定したカテゴリのルールのみに分析を限定します。カンマ区切りのリストを受け付け、大文字小文字は区別しません: `seo`、`performance`、`correctness`、`security`、`architecture`。
+
+```bash
+svelte-vitals --category seo
+svelte-vitals --category seo,performance
+```
+
+`--category` は `--rules`/`--ignore`/設定ファイルのルール選択と積集合になります — ルールは両方を通過した場合のみ実行されます。カテゴリを絞り込むと [Health スコア](/svelte-vitals/ja/guides/health-report/) も絞り込まれます。組み合わせたスコアは、検出結果が存在するカテゴリのみの加重平均になるため、フィルタなしの実行結果と直接比較することはできません。未知のカテゴリを指定するとエラーになります(終了コード `2`)。
 
 ### `--weights <pairs>`
 

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -29,7 +29,9 @@ Options:
   --min-health <0-100>        Fail (exit 1) when the combined Health score is below this value
   --rules <ids>               Comma-separated rule ids to enable (all others disabled)
   --ignore <ids>              Comma-separated rule ids to disable
+  --category <cats>           Comma-separated categories to analyze: seo | performance | correctness | security | architecture
   --weights <pairs>           Per-category Health weight overrides, e.g. seo=2,performance=1 (unlisted categories default to 1)
+  --score                     Print only the combined Health score (works with --min-health for gating)
   --no-color                  Disable ANSI color in console output
   -h, --help                  Show this help
   -v, --version               Show version
@@ -57,7 +59,7 @@ async function main(): Promise<void> {
 
   const argv = mri(process.argv.slice(2), {
     alias: { h: 'help', v: 'version' },
-    boolean: ['by-route', 'json', 'fail-on-warning', 'staged', 'no-color'],
+    boolean: ['by-route', 'json', 'fail-on-warning', 'staged', 'no-color', 'score'],
     string: [
       'meta-components',
       'treat-dynamic-as',
@@ -70,7 +72,8 @@ async function main(): Promise<void> {
       'out-file',
       'diff',
       'baseline',
-      'weights'
+      'weights',
+      'category'
     ]
   });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -48,10 +48,14 @@ export interface RunOptions {
   rules?: Record<string, RuleSetting>;
   /** Per-category weights for the combined Health score (flag > config file > default 1 each). */
   weights?: Partial<Record<Category, number>>;
+  /** Restrict analysis to rules in these categories (applied after rules/ignore selection). */
+  categories?: Category[];
   /** Override process.env for reporter auto-detection (mainly useful in tests). */
   env?: NodeJS.ProcessEnv;
   /** Fail (exit 1) when the combined Health score is below this value (0–100). */
   minHealth?: number;
+  /** Print only the combined Health score (integer) to stdout. */
+  score?: boolean;
   /** Output path for --reporter html (default 'svelte-vitals-report.html'; '-' = stdout). */
   outFile?: string;
   /** Injected file writer for --reporter html (defaults to node:fs writeFileSync). Mainly for tests. */
@@ -117,6 +121,8 @@ export interface AnalyzeOptions {
   rules?: Record<string, RuleSetting>;
   /** Per-category weights for the combined Health score (flag > config file > default 1 each). */
   weights?: Partial<Record<Category, number>>;
+  /** Restrict analysis to rules in these categories (applied after rules/ignore selection). */
+  categories?: Category[];
 }
 
 export interface AnalyzeResult {
@@ -166,7 +172,8 @@ export async function analyzeProject(opts: AnalyzeOptions = {}): Promise<Analyze
   // Component (Correctness) facts are file-scoped with no route attribution yet, so a
   // route-filtered run skips them rather than reporting unrelated components (#68 review).
   const components = opts.route ? [] : await collectComponentFacts(rt, cwd);
-  const rules = selectRules(allRules, config);
+  const selected = selectRules(allRules, config);
+  const rules = opts.categories ? selected.filter((r) => opts.categories!.includes(r.category)) : selected;
   const results = applyRuleSeverities(
     await runRules(rules, { heads, images, headings, components, project, config }),
     config
@@ -190,13 +197,15 @@ export async function run(opts: RunOptions = {}): Promise<number> {
   const env = opts.env ?? process.env;
   const reporter = resolveReporter(opts.reporter, env);
   const spinner = startSpinner('Analyzing…', {
-    enabled: spinnerEnabled({
-      reporter,
-      rawReporter: opts.reporter,
-      stderrIsTTY: opts.stderrIsTTY ?? !!process.stderr.isTTY,
-      env,
-      noColorFlag: opts.noColor
-    })
+    enabled:
+      !opts.score &&
+      spinnerEnabled({
+        reporter,
+        rawReporter: opts.reporter,
+        stderrIsTTY: opts.stderrIsTTY ?? !!process.stderr.isTTY,
+        env,
+        noColorFlag: opts.noColor
+      })
   });
 
   let analysis: AnalyzeResult;
@@ -208,7 +217,8 @@ export async function run(opts: RunOptions = {}): Promise<number> {
       route: opts.route,
       failOn: opts.failOn,
       rules: opts.rules,
-      weights: opts.weights
+      weights: opts.weights,
+      categories: opts.categories
     });
   } catch (err) {
     spinner.stop();
@@ -258,7 +268,8 @@ export async function run(opts: RunOptions = {}): Promise<number> {
             route: opts.route,
             failOn: opts.failOn,
             rules: opts.rules,
-            weights: opts.weights
+            weights: opts.weights,
+            categories: opts.categories
           });
           results = filterToNewFindings(results, base.results);
         } catch {
@@ -269,54 +280,58 @@ export async function run(opts: RunOptions = {}): Promise<number> {
       }
     }
 
-    if (reporter === 'agent' && isAutoDetectedAgent(opts.reporter, env)) {
-      errorLog(
-        'svelte-vitals: agent reporter auto-selected (AI-agent env detected); override with --reporter console|json.'
-      );
-    }
-    if (reporter === 'github' && isAutoDetectedGithub(opts.reporter, env)) {
-      errorLog(
-        'svelte-vitals: github reporter auto-selected (GitHub Actions detected); override with --reporter console|json|sarif.'
-      );
-    }
-    if (reporter === 'json') {
-      log(formatJsonReport(results, config, { version }));
-    } else if (reporter === 'agent') {
-      log(formatAgentReport(results, config));
-    } else if (reporter === 'sarif') {
-      log(formatSarifReport(results, config, { version }));
-    } else if (reporter === 'github') {
-      // The github reporter returns '' when there are no findings; skip logging so
-      // a clean run emits no stray blank line into the Actions log.
-      const output = formatGithubReport(results, config);
-      if (output) log(output);
-    } else if (reporter === 'html') {
-      const html = formatHtmlReport(results, config, { version });
-      if (opts.outFile === '-') {
-        log(html);
-      } else {
-        // `||` (not `??`) so an empty --out-file (mri yields '' for a value-less
-        // flag) falls back to the default instead of writing to an empty path.
-        const path = opts.outFile || 'svelte-vitals-report.html';
-        const write =
-          opts.writeFile ??
-          ((p: string, c: string) => {
-            mkdirSync(dirname(p), { recursive: true });
-            writeFileSync(p, c);
-          });
-        write(path, html);
-        errorLog(`svelte-vitals: wrote report to ${path}`);
-      }
-    } else if (reporter === 'md') {
-      log(formatMarkdownReport(results, config, { version }));
+    if (opts.score) {
+      log(String(computeHealth(results, config).health));
     } else {
-      const colorOn = colorEnabled({
-        reporter,
-        isTTY: opts.stdoutIsTTY ?? !!process.stdout.isTTY,
-        env,
-        noColorFlag: opts.noColor
-      });
-      log(formatConsoleReport(results, config, { byRoute: opts.byRoute ?? false, palette: paletteFor(colorOn) }));
+      if (reporter === 'agent' && isAutoDetectedAgent(opts.reporter, env)) {
+        errorLog(
+          'svelte-vitals: agent reporter auto-selected (AI-agent env detected); override with --reporter console|json.'
+        );
+      }
+      if (reporter === 'github' && isAutoDetectedGithub(opts.reporter, env)) {
+        errorLog(
+          'svelte-vitals: github reporter auto-selected (GitHub Actions detected); override with --reporter console|json|sarif.'
+        );
+      }
+      if (reporter === 'json') {
+        log(formatJsonReport(results, config, { version }));
+      } else if (reporter === 'agent') {
+        log(formatAgentReport(results, config));
+      } else if (reporter === 'sarif') {
+        log(formatSarifReport(results, config, { version }));
+      } else if (reporter === 'github') {
+        // The github reporter returns '' when there are no findings; skip logging so
+        // a clean run emits no stray blank line into the Actions log.
+        const output = formatGithubReport(results, config);
+        if (output) log(output);
+      } else if (reporter === 'html') {
+        const html = formatHtmlReport(results, config, { version });
+        if (opts.outFile === '-') {
+          log(html);
+        } else {
+          // `||` (not `??`) so an empty --out-file (mri yields '' for a value-less
+          // flag) falls back to the default instead of writing to an empty path.
+          const path = opts.outFile || 'svelte-vitals-report.html';
+          const write =
+            opts.writeFile ??
+            ((p: string, c: string) => {
+              mkdirSync(dirname(p), { recursive: true });
+              writeFileSync(p, c);
+            });
+          write(path, html);
+          errorLog(`svelte-vitals: wrote report to ${path}`);
+        }
+      } else if (reporter === 'md') {
+        log(formatMarkdownReport(results, config, { version }));
+      } else {
+        const colorOn = colorEnabled({
+          reporter,
+          isTTY: opts.stdoutIsTTY ?? !!process.stdout.isTTY,
+          env,
+          noColorFlag: opts.noColor
+        });
+        log(formatConsoleReport(results, config, { byRoute: opts.byRoute ?? false, palette: paletteFor(colorOn) }));
+      }
     }
     const summary = summarize(results, config);
     const failBySeverity = hasFailureAtOrAbove(summary, config.failOn);

--- a/packages/cli/src/resolve-args.ts
+++ b/packages/cli/src/resolve-args.ts
@@ -73,6 +73,42 @@ function parseWeights(raw: unknown, errors: string[]): Partial<Record<Category, 
   return weights;
 }
 
+/**
+ * Parse `--category seo,SECURITY` into a de-duplicated list of categories
+ * (mirrors `parseWeights`'s validation shape). Categories are matched
+ * case-insensitively and normalized to lowercase; unknown categories push a
+ * fatal error. Returns `undefined` when `raw` is not a non-empty string (flag
+ * not passed).
+ */
+function parseCategories(raw: unknown, errors: string[]): Category[] | undefined {
+  if (typeof raw !== 'string' || raw.trim() === '') return undefined;
+
+  const categories: Category[] = [];
+  const unknownCategories: string[] = [];
+
+  for (const entry of raw
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean)) {
+    if (!CATEGORIES.includes(entry as Category)) {
+      unknownCategories.push(entry);
+      continue;
+    }
+    if (!categories.includes(entry as Category)) categories.push(entry as Category);
+  }
+
+  if (unknownCategories.length > 0) {
+    errors.push(`svelte-vitals: unknown category(ies) in --category: ${unknownCategories.join(', ')}`);
+    errors.push(`Known categories: ${CATEGORIES.join(', ')}`);
+  }
+
+  if (unknownCategories.length === 0 && categories.length === 0) {
+    errors.push('svelte-vitals: --category was passed but contains no categories.');
+  }
+
+  return categories;
+}
+
 /** Result of normalizing parsed argv: the `run` options, plus any diagnostics to print. */
 export interface ResolvedArgs {
   /** Options to pass to `run`, or `null` when a fatal (exit-2) error was found. */
@@ -166,6 +202,12 @@ export function resolveArgs(argv: mri.Argv): ResolvedArgs {
   const failOn = argv['fail-on-warning'] ? 'warning' : failOnValid ? failOnRaw : undefined;
 
   const weights = parseWeights(argv.weights, errors);
+  const categories = parseCategories(argv.category, errors);
+
+  const score = Boolean(argv.score);
+  if (score && (argv.json || typeof argv.reporter === 'string')) {
+    warnings.push('svelte-vitals: --score overrides --reporter; reporter output suppressed.');
+  }
 
   // `buildRulesConfig` returns `{}` when neither --rules nor --ignore was passed;
   // normalize that to `undefined` so it doesn't clobber a config file's `rules`
@@ -188,6 +230,8 @@ export function resolveArgs(argv: mri.Argv): ResolvedArgs {
       failOn,
       rules,
       ...(weights !== undefined ? { weights } : {}),
+      ...(categories !== undefined ? { categories } : {}),
+      ...(score ? { score } : {}),
       ...(diffBase !== undefined ? { diffBase } : {}),
       ...(staged ? { staged } : {}),
       ...(baselineRef !== undefined ? { baseline: baselineRef } : {})

--- a/packages/cli/test/resolve-args.test.ts
+++ b/packages/cli/test/resolve-args.test.ts
@@ -6,7 +6,7 @@ import { resolveArgs } from '../src/resolve-args.js';
 function resolve(...args: string[]) {
   const argv = mri(args, {
     alias: { h: 'help', v: 'version' },
-    boolean: ['by-route', 'json', 'fail-on-warning', 'staged'],
+    boolean: ['by-route', 'json', 'fail-on-warning', 'staged', 'score'],
     string: [
       'meta-components',
       'treat-dynamic-as',
@@ -17,7 +17,8 @@ function resolve(...args: string[]) {
       'ignore',
       'diff',
       'baseline',
-      'weights'
+      'weights',
+      'category'
     ]
   });
   return resolveArgs(argv);
@@ -147,5 +148,52 @@ describe('resolveArgs', () => {
     const { options, errors } = resolve('--weights', ',');
     expect(options).toBeNull();
     expect(errors.some((e) => e.includes('--weights was passed but contains no category=number pairs'))).toBe(true);
+  });
+
+  it('parses --category into a normalized, de-duplicated list, mixing case', () => {
+    const { options, errors } = resolve('--category', 'seo,SECURITY,seo');
+    expect(errors).toEqual([]);
+    expect(options?.categories).toEqual(['seo', 'security']);
+  });
+
+  it('omits categories when --category is not passed', () => {
+    const { options } = resolve('--json');
+    expect(options?.categories).toBeUndefined();
+  });
+
+  it('reports an unknown category in --category as a fatal error', () => {
+    const { options, errors } = resolve('--category', 'bogus');
+    expect(options).toBeNull();
+    expect(errors.some((e) => e.includes('unknown category(ies) in --category'))).toBe(true);
+    expect(errors.some((e) => e.includes('Known categories'))).toBe(true);
+  });
+
+  it('reports --category with no categories (e.g. a bare comma) as a fatal error', () => {
+    const { options, errors } = resolve('--category', ',');
+    expect(options).toBeNull();
+    expect(errors.some((e) => e.includes('--category was passed but contains no categories'))).toBe(true);
+  });
+
+  it('sets score:true when --score is passed', () => {
+    const { options, warnings } = resolve('--score');
+    expect(options?.score).toBe(true);
+    expect(warnings).toEqual([]);
+  });
+
+  it('omits score when --score is not passed', () => {
+    const { options } = resolve('--json');
+    expect(options?.score).toBeUndefined();
+  });
+
+  it('warns when --score is combined with --json', () => {
+    const { options, warnings } = resolve('--score', '--json');
+    expect(options?.score).toBe(true);
+    expect(warnings.some((w) => w.includes('--score overrides --reporter'))).toBe(true);
+  });
+
+  it('warns when --score is combined with --reporter', () => {
+    const { options, warnings } = resolve('--score', '--reporter', 'md');
+    expect(options?.score).toBe(true);
+    expect(warnings.some((w) => w.includes('--score overrides --reporter'))).toBe(true);
   });
 });

--- a/packages/cli/test/run.test.ts
+++ b/packages/cli/test/run.test.ts
@@ -263,3 +263,50 @@ describe('run() config file (design doc 2026-07-05-config-file-design.md)', () =
     expect(errText).not.toContain('svelte-vitals: svelte-vitals:');
   });
 });
+
+describe('run() --category', () => {
+  it('restricts findings to the given category, excluding other categories', async () => {
+    const cap = capture();
+    await run({
+      cwd: fixtureDir,
+      reporter: 'json',
+      log: cap.log,
+      errorLog: cap.errorLog,
+      categories: ['seo'],
+      env: CLEAN_ENV
+    });
+    const json = JSON.parse(cap.out.join('\n'));
+    expect(Object.keys(json.categories)).toEqual(['seo']);
+    const allIds: string[] = [];
+    for (const r of json.routes) for (const i of r.issues) allIds.push(i.id);
+    expect(allIds.every((id: string) => id.startsWith('SEO'))).toBe(true);
+    // PERF001 (missing <img> dimensions) is present without a category filter (see
+    // 'run() performance rules' above); it must not survive a seo-only filter.
+    expect(allIds).not.toContain('PERF001');
+  });
+});
+
+describe('run() --score', () => {
+  it('prints only the combined Health score as a single line', async () => {
+    const cap = capture();
+    const code = await run({ cwd: fixtureDir, log: cap.log, errorLog: cap.errorLog, score: true, env: CLEAN_ENV });
+    expect(cap.out).toHaveLength(1);
+    expect(cap.out[0]).toMatch(/^\d+$/);
+    expect(code).toBe(1); // the fixture still has a critical SEO finding, so exit stays 1
+  });
+
+  it('gates on --min-health while suppressing reporter output (basic-project cannot reach 100)', async () => {
+    const cap = capture();
+    const code = await run({
+      cwd: fixtureDir,
+      log: cap.log,
+      errorLog: cap.errorLog,
+      score: true,
+      minHealth: 100,
+      env: CLEAN_ENV
+    });
+    expect(code).toBe(1);
+    expect(cap.out).toHaveLength(1);
+    expect(cap.out[0]).toMatch(/^\d+$/);
+  });
+});


### PR DESCRIPTION
## Summary

Implements plan `plans/018-cli-category-score-flags.md` — two small quality-of-life flags:

- **`--category <cats>`** — restrict analysis to whole categories (`seo | performance | correctness | security | architecture`, comma-separated, case-insensitive). Previously "just check SEO" meant enumerating 30 rule ids with `--rules`. Applied as an intersection after `--rules`/`--ignore`/config selection, and threaded into the `--baseline` pass too, so category-scoped PR gates stay consistent. Health becomes the weighted average of the categories present (existing `computeHealth` behavior).
- **`--score`** — print only the combined Health score (one integer line on stdout, spinner and reporter output suppressed) for scripts and shell prompts. Exit-code semantics are unchanged, so `--score --min-health 80` works as a quiet gate. Passing `--reporter`/`--json` alongside warns on stderr that reporter output is suppressed.

## Notes

- Validation mirrors the `--weights` precedent (case-insensitive, de-duplicated, unknown categories are a fatal exit-2 error listing the known set). A value-less `--category` is ignored like a value-less `--weights`; a value with zero valid entries (e.g. `--category ,`) is a fatal error.
- `resolve-args.ts`'s `CATEGORIES` list remains the single source both `--weights` and `--category` validate against.
- Out of scope (deliberately): a `categories` input on the MCP `analyze` tool — `analyzeProject` already accepts it, so that's a two-line follow-up if demand shows up.

## Changes

- `packages/cli/src/resolve-args.ts` (`parseCategories`, `--score` wiring), `index.ts` (options + rule filtering + score-only output path), `bin.ts` (flags + help)
- 12 new test cases across `resolve-args.test.ts` and `run.test.ts`
- Docs: `--category` and `--score` sections in the CLI guide (en/ja)
- Changeset: minor for `svelte-vitals`

## Verification

- `pnpm typecheck`, `pnpm --filter svelte-vitals test` (424 tests), `pnpm lint` — all green
- Live checks on the test fixture: `--score` prints exactly one integer line (exit 1 with findings present, exit gate honors `--min-health`); `--category seo --json` reports only SEO-prefixed rule ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--category` flag to limit analysis to selected rule categories.
  * Added a `--score` flag to output only the overall Health score for scripting.

* **Bug Fixes**
  * Improved filtering so category-based analysis respects existing rule selection and configuration.
  * Suppresses reporter output when score-only mode is used, with a warning if combined with other output formats.

* **Documentation**
  * Updated CLI docs in English and Japanese to describe the new flags and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->