### PR TITLE
docs(core): document CORRECT002's mount-flag / hydration-guard limitation

### DIFF
--- a/docs/src/content/docs/ja/rules/correct002.md
+++ b/docs/src/content/docs/ja/rules/correct002.md
@@ -22,3 +22,24 @@ description: 状態を代入するだけの $effect は $derived に置き換え
   let double = $derived(count * 2);
 </script>
 ```
+
+## 既知の制限: mount フラグ / hydration ガードとしての effect
+
+このチェックは「effect の本体が `$state` への代入だけか」という構造的な判定であり、意味的な判定ではありません。そのため、本来の「導出すべき値を effect に書いてしまう」アンチパターンと、SSR/プリレンダー時と hydration 後の不一致を防ぐための「mount signal」イディオムを区別できません。
+
+```svelte
+<script>
+  let mounted = $state(false);
+  $effect(() => {
+    mounted = true;
+  });
+  // SSR/プリレンダー時とクライアントの最初のレンダリングでは false のままである必要があります。
+  // そうしないと hydration 不一致が起きます。$derived(canVibrate()) は hydration 中に
+  // 即座に評価されてしまい、この $effect が防ごうとしているまさにそのちらつきを再発させます。
+  const showVibrationToggle = $derived(mounted && canVibrate());
+</script>
+```
+
+`$derived` は hydration 中も含めて即座に評価されますが、`$effect` は mount の1ティック後に実行されます — それこそがこのパターンの狙いです。この形を `$derived` に置き換えるのは単なるスタイルの好みではなく、`$effect` が防ごうとしていたバグを再発させてしまいます。検出された箇所がこのパターンである場合は「修正」せず、代わりに
+[`svelte-vitals-disable-next-line`](/svelte-vitals/ja/guides/cli/#特定の指摘だけをインラインで抑制する)
+コメントで抑制してください。

--- a/docs/src/content/docs/rules/correct002.md
+++ b/docs/src/content/docs/rules/correct002.md
@@ -22,3 +22,30 @@ Synchronising state with an `$effect` (the "useEffect → $effect" habit from Re
   let double = $derived(count * 2);
 </script>
 ```
+
+## Known limitation: mount-flag / hydration-guard effects
+
+This check is structural — "does the effect body only assign to `$state`?" — not
+semantic, so it can't distinguish a genuine derive-in-an-effect anti-pattern from
+the "mount signal" idiom used to avoid SSR/prerender ↔ hydration mismatches:
+
+```svelte
+<script>
+  let mounted = $state(false);
+  $effect(() => {
+    mounted = true;
+  });
+  // Must stay false during SSR/prerender and on the client's first render, or
+  // hydration mismatches. $derived(canVibrate()) would evaluate eagerly during
+  // hydration, reintroducing the exact flash this $effect exists to avoid.
+  const showVibrationToggle = $derived(mounted && canVibrate());
+</script>
+```
+
+`$derived` is evaluated eagerly, including during hydration; `$effect` runs one
+tick after mount, which is the whole point here. Converting this specific shape
+to `$derived` is not a style preference — it reintroduces the bug the `$effect`
+was added to prevent. If your finding is this pattern, don't "fix" it; suppress
+it instead with a
+[`svelte-vitals-disable-next-line`](/svelte-vitals/guides/cli/#suppressing-a-single-finding-inline)
+comment.

--- a/packages/core/test/component-parse.test.ts
+++ b/packages/core/test/component-parse.test.ts
@@ -66,6 +66,32 @@ describe('parseComponentFacts — $effect (CORRECT002)', () => {
     const e = facts('let count = $state(0); const t = $effect.tracking(); $effect.root(() => {});');
     expect(e).toEqual([]);
   });
+
+  // The "mount signal" idiom (hydration-mismatch guard, issue #92 / #158): a boolean
+  // $state flipped to true in an $effect so a $derived reads false during SSR/prerender
+  // and the client's first render, then its real value after mount. $derived can't
+  // replace this — it evaluates eagerly during hydration, reintroducing the mismatch
+  // the $effect exists to avoid. The check is intentionally structural (only-assigns),
+  // not semantic, so the bare mount-flag effect is flagged (suppress it inline per the
+  // docs) while adding *any* other statement — like mount-time listener setup — already
+  // takes it out of "only assigns state" and it stops being flagged, whether or not that
+  // extra statement happens to also be mount-only bookkeeping.
+  it('flags a bare mount-flag effect (mounted = true) — the known false positive, suppress via inline directive', () => {
+    const e = facts('let mounted = $state(false); $effect(() => { mounted = true; });');
+    expect(e).toEqual([{ line: 1, assignsOnlyState: true, mountOnly: false }]);
+  });
+  it('does not flag the same mount-flag assignment once the effect also does other mount-time setup', () => {
+    const e = facts(
+      `let mounted = $state(false);
+       $effect(() => {
+         mounted = true;
+         const onEvent = (e) => {};
+         window.addEventListener('some-event', onEvent);
+         return () => window.removeEventListener('some-event', onEvent);
+       });`
+    );
+    expect(e[0]!.assignsOnlyState).toBe(false);
+  });
 });
 
 describe('parseComponentFacts — security (SEC001/SEC002)', () => {

--- a/packages/core/test/component-parse.test.ts
+++ b/packages/core/test/component-parse.test.ts
@@ -67,7 +67,7 @@ describe('parseComponentFacts — $effect (CORRECT002)', () => {
     expect(e).toEqual([]);
   });
 
-  // The "mount signal" idiom (hydration-mismatch guard, issue #92 / #158): a boolean
+  // The "mount signal" idiom (hydration-mismatch guard, issue #92): a boolean
   // $state flipped to true in an $effect so a $derived reads false during SSR/prerender
   // and the client's first render, then its real value after mount. $derived can't
   // replace this — it evaluates eagerly during hydration, reintroducing the mismatch


### PR DESCRIPTION
## Summary

- CORRECT002 (`$effect only assigns state — use $derived instead`) correctly flags a legitimate "mount signal" idiom used to guard against SSR/prerender ↔ hydration mismatches (the same shape as issue #92): `let mounted = $state(false); $effect(() => { mounted = true; })`. Converting this to `$derived` reintroduces the exact hydration flash the `$effect` was added to prevent, since `$derived` evaluates eagerly during hydration.
- This was already deliberated (`docs/superpowers/specs/2026-07-04-inline-suppression-directive-design.md`): rather than special-case the detection heuristic, the project added a general `svelte-vitals-disable-next-line` escape hatch. That decision stands — no rule-logic change in this PR.
- The actual gap: the CORRECT002 rule doc page itself never mentioned this limitation or the suppression option, so its "How to fix" read as unconditional advice to always switch to `$derived`.
- Also pins, with a test, the (intentional) asymmetry a reporter flagged as looking inconsistent: a bare mount-flag effect is flagged, but the same assignment stops being flagged once the effect also does other mount-time setup (e.g. registers an event listener) — because at that point the effect has real side effects and genuinely can't become `$derived` regardless of the mount-flag part.

## Changes

- `docs/src/content/docs/rules/correct002.md` / `ja/rules/correct002.md`: new "Known limitation" section explaining the mount-flag/hydration-guard idiom and linking to the inline suppression comment.
- `packages/core/test/component-parse.test.ts`: paired test for the bare mount-flag effect vs. the same effect plus `addEventListener`/cleanup, documenting why only one is flagged.

No changeset — docs + test only, no user-facing behavior change.

## Test plan

- [x] `pnpm test` (packages/core) — 40 files / 381 tests pass
- [x] `prettier --check` on the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)