### PR TITLE
ci(release): auto-tag private package releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+      - name: Tag private package releases
+        # @changesets/cli@2.31.0 (latest stable; the tag-only-for-private-packages behavior
+        # only exists in the unreleased 3.0 line) only tags packages it publishes to npm, so
+        # our private, changesets-versioned packages (currently just @svelte-vitals/action,
+        # distributed via git tag/SHA instead of npm) never get tagged by the step above.
+        # Idempotent: skips any package whose tag already exists on origin.
+        run: |
+          for pkg_dir in packages/action; do
+            name=$(node -p "require('./$pkg_dir/package.json').name")
+            version=$(node -p "require('./$pkg_dir/package.json').version")
+            tag="$name@$version"
+            if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+              echo "$tag already exists on origin, skipping"
+            else
+              git config user.name "github-actions[bot]"
+              git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+              git tag "$tag"
+              git push origin "$tag"
+              echo "created and pushed $tag"
+            fi
+          done


### PR DESCRIPTION
## Summary

Follow-up to #155. `@changesets/cli@2.31.0` (latest stable — the tag-only-for-private-packages behavior only exists in the unreleased 3.0 line) only creates git tags for packages it actually publishes to npm. `@svelte-vitals/action` is private and distributed via git tag/SHA instead of npm, so its first release (`0.2.0`) shipped with a version bump + CHANGELOG but no git tag — I had to create `@svelte-vitals/action@0.2.0` manually as a one-off after noticing `ci install`'s generated version comment pointed at a non-existent tag.

Adds an idempotent step to `.github/workflows/release.yml`, right after the changesets publish step: for `packages/action`, check whether its current `package.json` version already has a matching tag on `origin`; if not, create and push it. Safe to run on every push to `main` (most runs are no-ops since the tag already exists or the version hasn't changed).

## Test plan

- [x] `pnpm exec prettier --check .github/workflows/release.yml` passes
- [x] Dry-ran the tag-existence check locally against the current `@svelte-vitals/action@0.2.0` tag — correctly reports "already exists, skip"
- [ ] Next real release involving a `packages/action` version bump is the actual end-to-end proof; no changeset needed (CI-only change, not user-facing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Private package releases are now automatically tagged during the release process, improving release tracking and consistency.
  * Existing release tags are detected and skipped to avoid duplicate tagging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->