### PR TITLE
fix: pin actions/checkout, show recommendations in Markdown report

### DIFF
--- a/.changeset/checkout-pin-follow-up.md
+++ b/.changeset/checkout-pin-follow-up.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': patch
+---
+
+`ci install`'s generated workflow now pins `actions/checkout` to a commit SHA with a same-line version comment (`actions/checkout@<sha> # v7.0.0`), matching this repo's own convention, instead of a floating `@v4` tag.

--- a/.changeset/recommendation-in-markdown-report.md
+++ b/.changeset/recommendation-in-markdown-report.md
@@ -1,0 +1,5 @@
+---
+'@svelte-vitals/core': patch
+---
+
+The Markdown reporter's findings table (used for the GitHub Actions job summary and sticky PR comment) now appends each finding's `recommendation` to its message, matching what the console/github/agent reporters already show. Previously the table only showed the terse `message` (e.g. "Missing robots.txt"), dropping the actionable "how to fix it" text.

--- a/docs/src/content/docs/guides/ci.md
+++ b/docs/src/content/docs/guides/ci.md
@@ -95,7 +95,7 @@ jobs:
   svelte-vitals:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - uses: oekazuma/svelte-vitals/packages/action@<sha> # @svelte-vitals/action@<version>

--- a/docs/src/content/docs/guides/ci.md
+++ b/docs/src/content/docs/guides/ci.md
@@ -46,6 +46,41 @@ On every `pull_request` event, the generated workflow:
 4. Fails the job if the scan found any gating findings, after the summary/comment have already
    been written — so you always get the PR comment, even on a failing run.
 
+## What the comment looks like
+
+Before you install anything, here's a preview of the sticky PR comment `@svelte-vitals/action`
+posts — this is what a real one renders as (the finding rows below are real rule output, just
+assembled here for illustration; the bold lines below render as actual headings in a real GitHub
+comment):
+
+> **svelte-vitals — Health 78/100**
+>
+> | Category    | Score |
+> | ----------- | ----- |
+> | seo         | 65    |
+> | performance | 90    |
+>
+> **1 critical · 1 warning · 1 info** (44 checks passed)
+>
+> **Findings**
+>
+> | Severity    | Rule                                                              | Location                     | Message                                                                                                                          |
+> | ----------- | ----------------------------------------------------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+> | 🔴 critical | [SEO001](https://oekazuma.github.io/svelte-vitals/rules/seo001)   | src/routes/blog/+page.svelte | Missing `<title>` Add a `<title>` inside `<svelte:head>`, e.g. `<title>{data.title}</title>`, or set it via your meta component. |
+> | 🟡 warning  | [PERF001](https://oekazuma.github.io/svelte-vitals/rules/perf001) | src/routes/+page.svelte:12   | Missing `<img>` width/height Set explicit width and height on `<img>` to reserve space and avoid layout shift (CLS).             |
+> | 🔵 info     | [PERF009](https://oekazuma.github.io/svelte-vitals/rules/perf009) | src/routes/+page.svelte:3    | Heavy import "lodash" — 71 KB Import a submodule or switch to a lighter, tree-shakeable alternative.                             |
+
+A few things worth knowing before you see the real thing:
+
+- **It updates in place.** Every push to the PR re-scans and edits this same comment (via its
+  hidden marker) instead of posting a new one each time.
+- **The message column includes the fix.** Each row is the finding's message _and_ its
+  recommendation together, so you don't have to open the full report to know what to do.
+- **Rule IDs link to the docs** for that specific rule.
+- **A clean PR gets a short comment too** — `✅ No issues found.` in place of the findings table.
+- The same content (minus the table) also appears in the job's **step summary**, and the
+  underlying findings get **inline annotations** directly on the diff.
+
 ## Action inputs
 
 `ci install` scaffolds a call to `@svelte-vitals/action` with these inputs:

--- a/docs/src/content/docs/ja/guides/ci.md
+++ b/docs/src/content/docs/ja/guides/ci.md
@@ -100,7 +100,7 @@ jobs:
   svelte-vitals:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - uses: oekazuma/svelte-vitals/packages/action@<sha> # @svelte-vitals/action@<version>

--- a/docs/src/content/docs/ja/guides/ci.md
+++ b/docs/src/content/docs/ja/guides/ci.md
@@ -49,6 +49,42 @@ svelte-vitals が生成したワークフローが既にある場合は、`--for
 4. スキャンでゲート対象の検出結果が見つかった場合、サマリー/コメントが既に書き込まれた
    **後に**ジョブを失敗させます — そのため、失敗した実行でも常に PR コメントを得られます。
 
+## コメントの見た目
+
+何もインストールする前に、`@svelte-vitals/action` が投稿するスティッキー PR コメントの
+プレビューを示します — 実際に生成されるコメントはこのようにレンダリングされます
+（以下の行は実際のルール出力を、説明のためにまとめたものです。太字の行は、実際の GitHub の
+コメント上では見出しとして表示されます）：
+
+> **svelte-vitals — Health 78/100**
+>
+> | Category    | Score |
+> | ----------- | ----- |
+> | seo         | 65    |
+> | performance | 90    |
+>
+> **1 critical · 1 warning · 1 info** (44 checks passed)
+>
+> **Findings**
+>
+> | Severity    | Rule                                                              | Location                     | Message                                                                                                                          |
+> | ----------- | ----------------------------------------------------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+> | 🔴 critical | [SEO001](https://oekazuma.github.io/svelte-vitals/rules/seo001)   | src/routes/blog/+page.svelte | Missing `<title>` Add a `<title>` inside `<svelte:head>`, e.g. `<title>{data.title}</title>`, or set it via your meta component. |
+> | 🟡 warning  | [PERF001](https://oekazuma.github.io/svelte-vitals/rules/perf001) | src/routes/+page.svelte:12   | Missing `<img>` width/height Set explicit width and height on `<img>` to reserve space and avoid layout shift (CLS).             |
+> | 🔵 info     | [PERF009](https://oekazuma.github.io/svelte-vitals/rules/perf009) | src/routes/+page.svelte:3    | Heavy import "lodash" — 71 KB Import a submodule or switch to a lighter, tree-shakeable alternative.                             |
+
+実際のコメントを見る前に知っておくとよい点：
+
+- **その場で更新されます。** PR へのプッシュのたびに再スキャンし、隠しマーカーを使って
+  同じコメントを編集します。新しいコメントが積み上がることはありません。
+- **Message 列に修正方法まで含まれます。** 各行は検出結果のメッセージと推奨対応を
+  合わせたものなので、詳細を確認するために完全なレポートを開く必要はありません。
+- **ルール ID はそのルールのドキュメントへのリンクになっています。**
+- **問題がない PR にも短いコメントが付きます** — 検出結果テーブルの代わりに
+  `✅ No issues found.` と表示されます。
+- 同じ内容（テーブル部分を除く）はジョブの**ステップサマリー**にも表示され、
+  元となった検出結果は diff 上に**インラインアノテーション**として直接表示されます。
+
 ## Action の入力
 
 `ci install` は `@svelte-vitals/action` の呼び出しを、以下の入力とともに生成します：

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -56899,6 +56899,9 @@ function locationOf(issue2, route) {
   if (issue2.location) return issue2.line !== void 0 ? `${issue2.location}:${issue2.line}` : issue2.location;
   return route ?? "-";
 }
+function messageWithRecommendation(issue2) {
+  return issue2.recommendation ? `${issue2.title} ${issue2.recommendation}` : issue2.title;
+}
 function flattenFindings(report2) {
   const findings = [];
   for (const r of report2.routes) {
@@ -56907,7 +56910,7 @@ function flattenFindings(report2) {
         severity: issue2.severity,
         id: issue2.id,
         location: locationOf(issue2, r.route),
-        message: issue2.title
+        message: messageWithRecommendation(issue2)
       });
     }
   }
@@ -56916,7 +56919,7 @@ function flattenFindings(report2) {
       severity: issue2.severity,
       id: issue2.id,
       location: locationOf(issue2, void 0),
-      message: issue2.title
+      message: messageWithRecommendation(issue2)
     });
   }
   return findings.map((f, index) => ({ f, index })).sort((a, b) => SEVERITY_RANK2[a.f.severity] - SEVERITY_RANK2[b.f.severity] || a.index - b.index).map(({ f }) => f);

--- a/packages/cli/src/ci/workflow.ts
+++ b/packages/cli/src/ci/workflow.ts
@@ -1,5 +1,10 @@
 export const WORKFLOW_PATH = '.github/workflows/svelte-vitals.yml';
 
+// Kept in lockstep with the pin this repo's own workflows use (.github/workflows/ci.yml,
+// release.yml, deploy-docs.yml) — bump both together when actions/checkout cuts a new release.
+const CHECKOUT_SHA = '9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0';
+const CHECKOUT_VERSION = 'v7.0.0';
+
 export interface WorkflowPlan {
   status: 'created' | 'exists' | 'updated';
   content?: string;
@@ -22,7 +27,9 @@ export function planWorkflowWrite(existing: string | undefined, force: boolean):
  * replaces the old ~60-line inline template; see plans/020-reusable-github-action.md).
  * The action itself owns annotations, the job summary, the sticky PR comment, and the
  * gate — `ci install` only scaffolds the call, pinned to a commit SHA with a same-line
- * version comment (matching this repo's own `actions/checkout@<sha> # v4` convention).
+ * version comment. `actions/checkout` is pinned the same way, matching this repo's own
+ * `actions/checkout@<sha> # vX.Y.Z` convention (.github/workflows/ci.yml etc.) rather than
+ * a floating tag.
  */
 export function buildWorkflowYaml(opts: { actionSha: string; actionVersion: string }): string {
   const { actionSha, actionVersion } = opts;
@@ -42,7 +49,7 @@ export function buildWorkflowYaml(opts: { actionSha: string; actionVersion: stri
     '  svelte-vitals:',
     '    runs-on: ubuntu-latest',
     '    steps:',
-    '      - uses: actions/checkout@v4',
+    `      - uses: actions/checkout@${CHECKOUT_SHA} # ${CHECKOUT_VERSION}`,
     '        with:',
     '          fetch-depth: 0',
     `      - uses: oekazuma/svelte-vitals/packages/action@${actionSha} # @svelte-vitals/action@${actionVersion}`,

--- a/packages/cli/test/ci/workflow.test.ts
+++ b/packages/cli/test/ci/workflow.test.ts
@@ -34,6 +34,11 @@ describe('buildWorkflowYaml', () => {
     expect(yaml).toContain(`uses: oekazuma/svelte-vitals/packages/action@${sha} # @svelte-vitals/action@1.2.3`);
   });
 
+  it('pins actions/checkout to a commit SHA with a same-line version comment, not a floating tag', () => {
+    expect(yaml).toMatch(/uses: actions\/checkout@[0-9a-f]{40} # v\d+\.\d+\.\d+/);
+    expect(yaml).not.toContain('actions/checkout@v4');
+  });
+
   it('passes diff and baseline scoped to the PR base ref', () => {
     expect(yaml).toContain('diff: origin/${{ github.base_ref }}');
     expect(yaml).toContain('baseline: origin/${{ github.base_ref }}');

--- a/packages/core/src/reporter/markdown.ts
+++ b/packages/core/src/reporter/markdown.ts
@@ -25,6 +25,15 @@ function locationOf(issue: { location?: string; line?: number }, route: string |
   return route ?? '-';
 }
 
+/**
+ * `title` alone is often a terse label ("Missing robots.txt") — append `recommendation` (the
+ * actionable fix, when present) so a reader doesn't have to open the full report to learn what
+ * to do. Mirrors `messageText` (reporter/shared.ts), which does the same for `Result.message`.
+ */
+function messageWithRecommendation(issue: { title: string; recommendation?: string }): string {
+  return issue.recommendation ? `${issue.title} ${issue.recommendation}` : issue.title;
+}
+
 function flattenFindings(report: JsonReport): FlatFinding[] {
   const findings: FlatFinding[] = [];
   for (const r of report.routes) {
@@ -33,7 +42,7 @@ function flattenFindings(report: JsonReport): FlatFinding[] {
         severity: issue.severity,
         id: issue.id,
         location: locationOf(issue, r.route),
-        message: issue.title
+        message: messageWithRecommendation(issue)
       });
     }
   }
@@ -42,7 +51,7 @@ function flattenFindings(report: JsonReport): FlatFinding[] {
       severity: issue.severity,
       id: issue.id,
       location: locationOf(issue, undefined),
-      message: issue.title
+      message: messageWithRecommendation(issue)
     });
   }
   // Most severe first (stable within a severity) so truncation at MAX_FINDINGS keeps the

--- a/packages/core/test/markdown-report.test.ts
+++ b/packages/core/test/markdown-report.test.ts
@@ -102,6 +102,21 @@ describe('formatMarkdownReport', () => {
     expect(out).toContain('…and 10 more (run `npx svelte-vitals` locally for the full report)');
   });
 
+  it('appends the recommendation to the message cell when present, for actionable context', () => {
+    const results: Result[] = [
+      {
+        id: 'SEO006',
+        severity: 'warning',
+        detection: { presence: 'none', value: 'absent' },
+        route: '/a',
+        message: 'Missing robots.txt',
+        recommendation: 'Add static/robots.txt or a src/routes/robots.txt/+server endpoint.'
+      }
+    ];
+    const out = formatMarkdownReport(results, config, { version: '1.0.0' });
+    expect(out).toContain('Missing robots.txt Add static/robots.txt or a src/routes/robots.txt/+server endpoint.');
+  });
+
   it('escapes pipes and newlines inside message cells', () => {
     const results: Result[] = [
       {


### PR DESCRIPTION
## Summary

Two follow-ups from real-world use of `@svelte-vitals/action` (#155):

1. **`actions/checkout@v4` → SHA-pinned.** `ci install`'s generated workflow used a floating tag, and `v4` is behind this repo's own `actions/checkout` pin (`v7.0.0`, SHA-pinned in `ci.yml`/`release.yml`/`deploy-docs.yml`). The generated workflow now uses the same SHA + version comment, defined once in `workflow.ts` so both stay in sync.
2. **Markdown report findings table now shows `recommendation`.** The job summary / sticky PR comment table only rendered each finding's terse `message` (e.g. "Missing robots.txt"), silently dropping `recommendation` (e.g. "Add static/robots.txt or a src/routes/robots.txt/+server endpoint.") — the console/github/agent reporters already include it via `messageText`; the Markdown reporter's `flattenFindings` just didn't. Fixed to match.

## Test plan

- [x] `pnpm build && pnpm typecheck && pnpm test && pnpm lint` all exit 0 (978 tests)
- [x] New test: `buildWorkflowYaml` output matches `actions/checkout@<40-hex-sha> # vX.Y.Z`, not a floating tag
- [x] New test: `formatMarkdownReport` appends `recommendation` to the message cell when present
- [x] `packages/action/dist` rebuilt and committed (bundles the markdown reporter fix transitively) — `git diff --exit-code -- packages/action/dist` clean
- [x] `docs/src/content/docs/guides/ci.md` and `ja/guides/ci.md` updated to match the real generated output
- [x] Two changesets (`svelte-vitals` patch, `@svelte-vitals/core` patch — `@svelte-vitals/action`/`mcp`/`vite` will pick up automatic patch bumps via internal dependency propagation, confirmed via `pnpm changeset status`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)