### PR TITLE
Announce the live UI dashboard's URL on vite dev startup

### DIFF
--- a/.changeset/vite-ui-dashboard-startup-banner.md
+++ b/.changeset/vite-ui-dashboard-startup-banner.md
@@ -1,0 +1,5 @@
+---
+'@svelte-vitals/vite': minor
+---
+
+`svelteVitals({ ui: true })` now prints the live dashboard's URL right after Vite's own `Local:`/`Network:` lines every time `vite dev` starts, so the dashboard is discoverable without knowing the `/__svelte-vitals/` path in advance.

--- a/docs/src/content/docs/guides/dev-overlay.md
+++ b/docs/src/content/docs/guides/dev-overlay.md
@@ -76,6 +76,12 @@ export default {
 };
 ```
 
+Once enabled, `vite dev` prints the dashboard's URL right after its own `Local:`/`Network:` lines every time the server starts, so you don't have to remember the `/__svelte-vitals/` path:
+
+```
+  ➜  svelte-vitals: http://localhost:5173/__svelte-vitals/
+```
+
 From the moment the dev server starts, the dashboard shows the **whole project**: a static analysis of all routes across every category (SEO, Performance, Correctness, Security, Architecture) runs asynchronously at startup — the same analysis as `npx svelte-vitals` — so you get the real project Health without visiting a single page. Saving a source file (anything under `src/` or `static/`, or a `svelte.config.*` / `svelte-vitals.config.*`) triggers a debounced re-analysis, and the dashboard refreshes itself.
 
 On top of that static baseline, browsing your app refines the picture: it is fed by the dev handle (the same one the overlay above uses), so keep `svelteVitalsHandle()` in `src/hooks.server.ts`. Each visited route's rendered `<head>` is analyzed, and those live results replace the static ones for that route — a rendered page is closer to the truth, especially for dynamic values. Route headings carry a provenance badge: `measured` for routes whose findings come from a real rendered page, `static` for routes covered only by source analysis so far.

--- a/docs/src/content/docs/ja/guides/dev-overlay.md
+++ b/docs/src/content/docs/ja/guides/dev-overlay.md
@@ -76,6 +76,12 @@ export default {
 };
 ```
 
+有効にすると、`vite dev` はサーバー起動のたびに本来の `Local:`/`Network:` 表示の直後にダッシュボードのURLを出力するので、`/__svelte-vitals/` というパスを覚えておく必要はありません。
+
+```
+  ➜  svelte-vitals: http://localhost:5173/__svelte-vitals/
+```
+
 dev サーバーの起動直後から、ダッシュボードは**プロジェクト全体**を表示します。起動時に全ルート・全カテゴリ（SEO・Performance・Correctness・Security・Architecture）の静的解析が非同期で実行され（`npx svelte-vitals` と同じ解析です）、ページを1つも訪問しなくても本物のプロジェクト Health が得られます。ソースファイル（`src/` または `static/` 配下、あるいは `svelte.config.*` / `svelte-vitals.config.*`）を保存すると、デバウンス付きの再解析が走り、ダッシュボードが自動的に更新されます。
 
 この静的なベースラインの上に、アプリを操作することで結果が精緻化されます。これは dev handle（上記オーバーレイと同じもの）から供給されるため、`src/hooks.server.ts` の `svelteVitalsHandle()` はそのまま残してください。訪問した各ルートのレンダリング済み `<head>` が解析され、そのライブ結果がそのルートの静的結果を置き換えます — レンダリング済みのページのほうが、特に動的な値については真実に近いためです。ルート見出しには由来を示すバッジが付きます：実際にレンダリングされたページ由来の結果なら `measured`、まだソース解析のみでカバーされているルートなら `static` です。

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -146,6 +146,23 @@ export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin | Plugin
       });
 
       installUiMiddleware(server, config, readPackageVersion(), store, readCoreVersion());
+
+      // The dashboard has no separate CLI entry point (unlike `vitest --ui`) to signal
+      // it exists, so announce it the same way Vite announces its own dev server: as an
+      // extra line appended after Vite's own "Local:/Network:" URL block. Wrapping
+      // printUrls (rather than logging eagerly here) means the line only appears once
+      // the server is actually listening and prints in the same place a developer's eyes
+      // already are on every `vite dev` start.
+      if (typeof server.printUrls === 'function') {
+        const printUrls = server.printUrls.bind(server);
+        server.printUrls = () => {
+          printUrls();
+          const base = server.resolvedUrls?.local[0] ?? server.resolvedUrls?.network[0];
+          if (base) {
+            console.log(`  ➜  svelte-vitals: ${new URL('__svelte-vitals/', base).href}`);
+          }
+        };
+      }
     }
   };
   return [buildPlugin, uiPlugin];

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -157,9 +157,14 @@ export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin | Plugin
         const printUrls = server.printUrls.bind(server);
         server.printUrls = () => {
           printUrls();
-          const base = server.resolvedUrls?.local[0] ?? server.resolvedUrls?.network[0];
-          if (base) {
-            console.log(`  ➜  svelte-vitals: ${new URL('__svelte-vitals/', base).href}`);
+          const printed = server.resolvedUrls?.local?.[0] ?? server.resolvedUrls?.network?.[0];
+          if (printed) {
+            // installUiMiddleware always mounts at the server root ('/__svelte-vitals'),
+            // regardless of a configured `base` — a non-root base makes Vite print a URL
+            // with a path segment (e.g. http://host:5173/my-app/), so resolving
+            // '__svelte-vitals/' relative to that would announce the wrong, 404ing URL.
+            // Use the origin only and always append the root-mounted path ourselves.
+            console.log(`  ➜  svelte-vitals: ${new URL(printed).origin}/__svelte-vitals/`);
           }
         };
       }

--- a/packages/vite/test/ui-plugin.test.ts
+++ b/packages/vite/test/ui-plugin.test.ts
@@ -65,11 +65,40 @@ describe('svelteVitals({ ui })', () => {
     (hook as (s: ViteDevServer) => void).call({}, server);
 
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    server.printUrls();
+    try {
+      server.printUrls();
+      expect(originalPrintUrls).toHaveBeenCalledTimes(1);
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('http://localhost:5173/__svelte-vitals/'));
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
 
-    expect(originalPrintUrls).toHaveBeenCalledTimes(1);
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('http://localhost:5173/__svelte-vitals/'));
-    logSpy.mockRestore();
+  it('announces the dashboard at the server root even when Vite prints a URL with a configured base path', () => {
+    const plugins = svelteVitals({ ui: true }) as Plugin[];
+    const ui = plugins.find((p) => p.name === 'svelte-vitals:ui')!;
+    const originalPrintUrls = vi.fn();
+    const server = {
+      config: { root: '/tmp/does-not-exist-svelte-vitals-ui-plugin-test' },
+      watcher: { on: () => {} },
+      middlewares: { use: () => {} },
+      printUrls: originalPrintUrls,
+      // A non-root `base` in vite.config makes Vite print a URL with a path
+      // segment (e.g. /my-app/), but installUiMiddleware always mounts at
+      // the server root — the announced URL must not inherit that path.
+      resolvedUrls: { local: ['http://localhost:5173/my-app/'], network: [] }
+    } as unknown as ViteDevServer;
+    const hook = typeof ui.configureServer === 'function' ? ui.configureServer : ui.configureServer!.handler;
+    (hook as (s: ViteDevServer) => void).call({}, server);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      server.printUrls();
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('http://localhost:5173/__svelte-vitals/'));
+      expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('/my-app/__svelte-vitals/'));
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 
   it('printUrls wrapper still calls the original and does not throw when resolvedUrls is unavailable', () => {

--- a/packages/vite/test/ui-plugin.test.ts
+++ b/packages/vite/test/ui-plugin.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import type { Plugin, ViteDevServer } from 'vite';
 import { svelteVitals } from '../src/index.js';
 
@@ -48,6 +48,46 @@ describe('svelteVitals({ ui })', () => {
     const hook = typeof ui.configureServer === 'function' ? ui.configureServer : ui.configureServer!.handler;
     (hook as (s: ViteDevServer) => void).call({}, server);
     expect(watcherEvents).toContain('all');
+  });
+
+  it('configureServer wraps printUrls to also announce the dashboard URL', () => {
+    const plugins = svelteVitals({ ui: true }) as Plugin[];
+    const ui = plugins.find((p) => p.name === 'svelte-vitals:ui')!;
+    const originalPrintUrls = vi.fn();
+    const server = {
+      config: { root: '/tmp/does-not-exist-svelte-vitals-ui-plugin-test' },
+      watcher: { on: () => {} },
+      middlewares: { use: () => {} },
+      printUrls: originalPrintUrls,
+      resolvedUrls: { local: ['http://localhost:5173/'], network: [] }
+    } as unknown as ViteDevServer;
+    const hook = typeof ui.configureServer === 'function' ? ui.configureServer : ui.configureServer!.handler;
+    (hook as (s: ViteDevServer) => void).call({}, server);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    server.printUrls();
+
+    expect(originalPrintUrls).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('http://localhost:5173/__svelte-vitals/'));
+    logSpy.mockRestore();
+  });
+
+  it('printUrls wrapper still calls the original and does not throw when resolvedUrls is unavailable', () => {
+    const plugins = svelteVitals({ ui: true }) as Plugin[];
+    const ui = plugins.find((p) => p.name === 'svelte-vitals:ui')!;
+    const originalPrintUrls = vi.fn();
+    const server = {
+      config: { root: '/tmp/does-not-exist-svelte-vitals-ui-plugin-test' },
+      watcher: { on: () => {} },
+      middlewares: { use: () => {} },
+      printUrls: originalPrintUrls,
+      resolvedUrls: null
+    } as unknown as ViteDevServer;
+    const hook = typeof ui.configureServer === 'function' ? ui.configureServer : ui.configureServer!.handler;
+    (hook as (s: ViteDevServer) => void).call({}, server);
+
+    expect(() => server.printUrls()).not.toThrow();
+    expect(originalPrintUrls).toHaveBeenCalledTimes(1);
   });
 
   it('configureServer works without a watcher or httpServer on the mock server (defensive)', () => {


### PR DESCRIPTION
## Summary
- Follow-up to #162. The redesigned live UI dashboard (`svelteVitals({ ui: true })`) had no discoverability signal — unlike `vitest --ui`, which is its own CLI entry point, `vite dev` gave no indication the dashboard exists at `/__svelte-vitals/`.
- Wraps Vite's own `server.printUrls` so the dashboard's URL is printed right after Vite's `Local:`/`Network:` lines on every dev-server start:
  ```
    ➜  svelte-vitals: http://localhost:5173/__svelte-vitals/
  ```
- No auto-open — only prints the URL, matching `vite dev`'s own non-intrusive default (auto-opening a second browser tab alongside the app on every restart was considered and intentionally left out).
- Docs (en/ja) and a changeset are included.

## Test plan
- [x] `pnpm --filter @svelte-vitals/vite test` — 132/132 passing (2 new tests: the wrapped `printUrls` announces the URL when `resolvedUrls` is available, and doesn't throw when it isn't — matching the existing mock `ViteDevServer` objects used elsewhere in this test file, which don't define `printUrls` at all)
- [x] `pnpm --filter @svelte-vitals/vite typecheck`, `pnpm lint` — clean
- [x] `pnpm --filter docs build` — clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>