### PR TITLE
feat(cli): redesign mascot as half-block pixel-art fox, simplify to 3 states

### DIFF
--- a/.changeset/cli-mascot-animation.md
+++ b/.changeset/cli-mascot-animation.md
@@ -2,4 +2,4 @@
 'svelte-vitals': minor
 ---
 
-Add a small mascot to the CLI's interactive terminal output: it replaces the analysis spinner with an idle loop, then reacts to the Health-score reveal (critical findings always read as concerned; a perfect 100 gets a confetti bonus). Disable with `--no-animation`, same as the existing score-reveal animation.
+Add a small pixel-art fox mascot to the CLI's interactive terminal output: it replaces the analysis spinner with an idle loop, then reacts to the Health-score reveal (a perfect 100 gets a confetti bonus). Disable with `--no-animation`, same as the existing score-reveal animation.

--- a/.changeset/mascot-speech-bubble.md
+++ b/.changeset/mascot-speech-bubble.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': minor
+---
+
+Give the CLI's pixel-art fox mascot a speech bubble: a random greeting line at startup, and a reaction line matching the Health-score band at the score reveal (on terminals wide enough for both). Falls back to the fox alone on narrower terminals, same as before.

--- a/docs/superpowers/plans/2026-07-11-mascot-speech-bubble.md
+++ b/docs/superpowers/plans/2026-07-11-mascot-speech-bubble.md
@@ -32,7 +32,7 @@
 
 - Produces: `bubbleFitsWidth(columns: number | undefined): boolean`, `renderSpeechBubble(text: string): string[]`, `withSpeechBubble(mascotBlock: string, bubbleLines: readonly string[]): string`
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 Create `packages/cli/test/speech-bubble.test.ts`:
 
@@ -95,12 +95,12 @@ describe('bubbleFitsWidth', () => {
 });
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 Run: `pnpm --filter svelte-vitals exec vitest run test/speech-bubble.test.ts`
 Expected: FAIL — `Cannot find module '../src/speech-bubble.js'`
 
-- [ ] **Step 3: Create `packages/cli/src/speech-bubble.ts`**
+- [x] **Step 3: Create `packages/cli/src/speech-bubble.ts`**
 
 ```ts
 const MIN_BUBBLE_COLUMNS = 55;
@@ -147,12 +147,12 @@ export function withSpeechBubble(mascotBlock: string, bubbleLines: readonly stri
 }
 ```
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
 Run: `pnpm --filter svelte-vitals exec vitest run test/speech-bubble.test.ts`
 Expected: PASS (7 tests)
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add packages/cli/src/speech-bubble.ts packages/cli/test/speech-bubble.test.ts
@@ -173,7 +173,7 @@ git commit -m "feat(cli): add speech bubble rendering primitives"
 - Consumes: `withSpeechBubble`, `renderSpeechBubble` (Task 1, same file); `MascotState` (`packages/cli/src/mascot.ts`)
 - Produces: `GREETING_MESSAGES: readonly string[]`, `REACTION_MESSAGES: Record<MascotState, readonly string[]>`, `pickMessage(pool, random?): string`, `renderMascotWithSpeech(mascotBlock: string, message: string): string`
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 In `packages/cli/test/speech-bubble.test.ts`, replace the existing `import { renderSpeechBubble, withSpeechBubble, bubbleFitsWidth } from '../src/speech-bubble.js';` line (do not add a second import from the same path) with:
 
@@ -231,12 +231,12 @@ describe('renderMascotWithSpeech', () => {
 });
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 Run: `pnpm --filter svelte-vitals exec vitest run test/speech-bubble.test.ts`
 Expected: FAIL — `pickMessage`/`renderMascotWithSpeech`/`GREETING_MESSAGES`/`REACTION_MESSAGES` are not exported
 
-- [ ] **Step 3: Add to `packages/cli/src/speech-bubble.ts`**
+- [x] **Step 3: Add to `packages/cli/src/speech-bubble.ts`**
 
 Add this import at the very top of the file:
 
@@ -275,12 +275,12 @@ export function renderMascotWithSpeech(mascotBlock: string, message: string): st
 }
 ```
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
 Run: `pnpm --filter svelte-vitals exec vitest run test/speech-bubble.test.ts`
 Expected: PASS (13 tests)
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add packages/cli/src/speech-bubble.ts packages/cli/test/speech-bubble.test.ts
@@ -301,7 +301,7 @@ git commit -m "feat(cli): add speech bubble message pools and random selection"
 - Consumes: `renderMascotAnticipating` (`packages/cli/src/mascot.ts`); `renderMascotWithSpeech`, `pickMessage`, `GREETING_MESSAGES` (Task 1/2, same file)
 - Produces: `playMascotGreeting(opts: { enabled: boolean; stream: NodeJS.WriteStream; holdMs?: number }): Promise<void>`
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 In `packages/cli/test/speech-bubble.test.ts`, add `playMascotGreeting` to the existing `../src/speech-bubble.js` import list (do not add a second import from the same path):
 
@@ -346,12 +346,12 @@ describe('playMascotGreeting', () => {
 });
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 Run: `pnpm --filter svelte-vitals exec vitest run test/speech-bubble.test.ts`
 Expected: FAIL — `playMascotGreeting` is not exported
 
-- [ ] **Step 3: Add to `packages/cli/src/speech-bubble.ts`**
+- [x] **Step 3: Add to `packages/cli/src/speech-bubble.ts`**
 
 Replace the top-of-file import block (from Task 2's `import type { MascotState } from './mascot.js';`) with:
 
@@ -391,12 +391,12 @@ export async function playMascotGreeting(opts: {
 }
 ```
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
 Run: `pnpm --filter svelte-vitals exec vitest run test/speech-bubble.test.ts`
 Expected: PASS (15 tests)
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add packages/cli/src/speech-bubble.ts packages/cli/test/speech-bubble.test.ts
@@ -416,7 +416,7 @@ git commit -m "feat(cli): add mascot startup greeting playback"
 
 - Consumes: `bubbleFitsWidth`, `pickMessage`, `renderMascotWithSpeech`, `REACTION_MESSAGES` (`packages/cli/src/speech-bubble.ts`, Tasks 1-2)
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 Add this import to `packages/cli/test/pulse-animation.test.ts`'s import block:
 
@@ -446,12 +446,12 @@ it('omits the speech bubble (but keeps the fox) when the terminal fits the masco
 });
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 Run: `pnpm --filter svelte-vitals exec vitest run test/pulse-animation.test.ts`
 Expected: FAIL — the first new test fails because no reaction message is ever written yet
 
-- [ ] **Step 3: Modify `packages/cli/src/pulse-animation.ts`**
+- [x] **Step 3: Modify `packages/cli/src/pulse-animation.ts`**
 
 Add this import after the existing `import { ... } from './mascot.js';` block:
 
@@ -498,12 +498,12 @@ if (showMascot && state === 'ecstatic') {
 
 (The lines above and below this block — the `frameDelayMs`/`holdMs`/`confettiDelayMs` consts at the top, and the trailing `render.done();` — are unchanged.)
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
 Run: `pnpm --filter svelte-vitals exec vitest run test/pulse-animation.test.ts`
 Expected: PASS (14 tests)
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add packages/cli/src/pulse-animation.ts packages/cli/test/pulse-animation.test.ts
@@ -523,7 +523,7 @@ git commit -m "feat(cli): show a reaction speech bubble at the score reveal"
 
 - Consumes: `playMascotGreeting`, `bubbleFitsWidth`, `GREETING_MESSAGES` (`packages/cli/src/speech-bubble.ts`, Tasks 1-3)
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Add this import to `packages/cli/test/run.test.ts`'s top import block:
 
@@ -577,12 +577,12 @@ it('shows a one-off greeting speech bubble before the idle loop, on a wide inter
 });
 ```
 
-- [ ] **Step 2: Run tests to verify the new one fails**
+- [x] **Step 2: Run tests to verify the new one fails**
 
 Run: `pnpm --filter svelte-vitals exec vitest run test/run.test.ts`
 Expected: FAIL — the new "shows a one-off greeting" test fails (no greeting is played yet); the updated idle-loop test still passes (the added option is inert until Step 3)
 
-- [ ] **Step 3: Modify `packages/cli/src/index.ts`**
+- [x] **Step 3: Modify `packages/cli/src/index.ts`**
 
 Add this import after the existing `import { startMascotSpinner, mascotFitsWidth } from './mascot.js';` line:
 
@@ -613,12 +613,12 @@ const spinner = useMascotSpinner
   : startSpinner('Analyzing…', { enabled: spinnerBaseEnabled, stream: stderrStream });
 ```
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
 Run: `pnpm --filter svelte-vitals exec vitest run test/run.test.ts`
 Expected: PASS (all tests in the file)
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add packages/cli/src/index.ts packages/cli/test/run.test.ts
@@ -638,7 +638,7 @@ git commit -m "feat(cli): play a startup greeting speech bubble before analysis"
 
 - None (docs/metadata only; no code interfaces produced or consumed)
 
-- [ ] **Step 1: Update `packages/cli/README.md`**
+- [x] **Step 1: Update `packages/cli/README.md`**
 
 Find the existing mascot paragraph:
 
@@ -652,7 +652,7 @@ Replace it with:
 On an interactive terminal, a small pixel-art fox mascot appears alongside both the analysis spinner and the Health-score reveal, reacting to the score (a perfect 100 gets a confetti flourish). On a wide enough terminal it also greets you with a short line in a speech bubble at startup, and again with a matching reaction line at the score reveal. `--no-animation` disables all of it, falling back to the plain spinner and plain score animation.
 ```
 
-- [ ] **Step 2: Create the changeset**
+- [x] **Step 2: Create the changeset**
 
 Create `.changeset/mascot-speech-bubble.md`:
 
@@ -664,7 +664,7 @@ Create `.changeset/mascot-speech-bubble.md`:
 Give the CLI's pixel-art fox mascot a speech bubble: a random greeting line at startup, and a reaction line matching the Health-score band at the score reveal (on terminals wide enough for both). Falls back to the fox alone on narrower terminals, same as before.
 ```
 
-- [ ] **Step 3: Run full verification**
+- [x] **Step 3: Run full verification**
 
 Run, in order, from the repo root of this worktree:
 
@@ -680,14 +680,14 @@ Expected: all five commands exit 0. If `pnpm lint`'s `prettier --check` flags `s
 
 If `packages/action/dist/index.js` shows as changed in `git status` after `pnpm build` (it bundles the CLI source), that is expected — stage it in the final commit.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add packages/cli/README.md .changeset/mascot-speech-bubble.md packages/action/dist/index.js
 git commit -m "docs(cli): document the mascot speech bubble; add changeset"
 ```
 
-- [ ] **Step 5: Final check**
+- [x] **Step 5: Final check**
 
 Run: `git status --short`
 Expected: clean (nothing uncommitted) except any files intentionally left for the finishing-a-development-branch workflow.

--- a/docs/superpowers/plans/2026-07-11-mascot-speech-bubble.md
+++ b/docs/superpowers/plans/2026-07-11-mascot-speech-bubble.md
@@ -1,0 +1,683 @@
+# Mascot Speech Bubble Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the CLI's pixel-art fox mascot a bordered speech-bubble line of text next to it, at two moments: a random greeting at startup, and a random reaction line (matching the score band) at the Health-score reveal.
+
+**Architecture:** A new, self-contained module `packages/cli/src/speech-bubble.ts` owns bubble rendering, message pools, random selection, and the greeting playback. `mascot.ts` is untouched. `pulse-animation.ts` and `index.ts` each gain a few lines to call into the new module at their existing mascot-rendering points.
+
+**Tech Stack:** No new dependencies — plain Unicode box-drawing characters, the same `log-update` already used by `mascot.ts`/`pulse-animation.ts`.
+
+## Global Constraints
+
+- Speech bubble appears only at (a) CLI startup, before analysis begins, and (b) the Health-score reveal's final/reaction frame. It never appears during the analysis-phase idle loop (`startMascotSpinner` in `mascot.ts` — do not modify this function).
+- New width gate `bubbleFitsWidth`: `MIN_BUBBLE_COLUMNS = 55`, same shape as `mascotFitsWidth`'s existing `MIN_MASCOT_COLUMNS = 40` (defaults `columns ?? 80`). Below 55 columns, render the fox alone (no bubble) — never hide the fox because the bubble doesn't fit.
+- The startup greeting only plays when `bubbleFitsWidth` is also true (not just `mascotFitsWidth`) — a wordless greeting isn't worth a dedicated hold before the idle loop.
+- Messages are English only, each ≤26 characters, matching the existing spinner copy ("Analyzing…") and `README.md` conventions.
+- Message selection is uniformly random per pool via `pickMessage(pool, random = Math.random)` — `random` is only ever overridden in `speech-bubble.test.ts`'s own unit tests; production call sites and other test files never pass it, and instead assert "one of the pool's messages appears" to stay robust against actual randomness.
+- Reaction messages are split per `MascotState` (`ecstatic`/`happy`/`content`, from `mascot.ts` — do not add new states). Greeting messages are one shared pool (score isn't known yet at startup).
+- Greeting hold defaults to 800ms real playback; both the greeting (`playMascotGreeting`'s `holdMs`) and the score reveal (`playScoreAnimation`'s existing `frameDelayMs`) accept a test override that makes playback near-instant, following the pattern already established by `pulse-animation.ts`.
+- Full spec: `docs/superpowers/specs/2026-07-11-mascot-speech-bubble-design.md`.
+
+---
+
+### Task 1: Speech bubble rendering + width gate
+
+**Files:**
+- Create: `packages/cli/src/speech-bubble.ts`
+- Test: `packages/cli/test/speech-bubble.test.ts`
+
+**Interfaces:**
+- Produces: `bubbleFitsWidth(columns: number | undefined): boolean`, `renderSpeechBubble(text: string): string[]`, `withSpeechBubble(mascotBlock: string, bubbleLines: readonly string[]): string`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/cli/test/speech-bubble.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { renderSpeechBubble, withSpeechBubble, bubbleFitsWidth } from '../src/speech-bubble.js';
+import { renderMascotReaction } from '../src/mascot.js';
+
+describe('renderSpeechBubble', () => {
+  it('returns exactly 3 lines: top border, text, bottom border', () => {
+    const lines = renderSpeechBubble('Hi there!');
+    expect(lines).toHaveLength(3);
+    expect(lines[0]!.startsWith('┌')).toBe(true);
+    expect(lines[0]!.endsWith('┐')).toBe(true);
+    expect(lines[2]!.startsWith('└')).toBe(true);
+    expect(lines[2]!.endsWith('┘')).toBe(true);
+    expect(lines[1]).toBe('│ Hi there! │');
+  });
+
+  it('all 3 lines have equal width regardless of text length', () => {
+    const lines = renderSpeechBubble('Welcome to Svelte Vitals!');
+    const widths = new Set(lines.map((l) => l.length));
+    expect(widths.size).toBe(1);
+  });
+});
+
+describe('withSpeechBubble', () => {
+  it('combines a 7-line mascot block with a 3-line bubble into 7 lines total', () => {
+    const mascot = renderMascotReaction('content');
+    const bubble = renderSpeechBubble('Keep going!');
+    const combined = withSpeechBubble(mascot, bubble).split('\n');
+    expect(combined).toHaveLength(7);
+  });
+
+  it('vertically centers the bubble: blank on the outer rows, bubble content on the middle 3', () => {
+    const mascot = renderMascotReaction('content');
+    const bubble = renderSpeechBubble('Keep going!');
+    const combined = withSpeechBubble(mascot, bubble).split('\n');
+    expect(combined[0]).not.toContain('┌');
+    expect(combined[1]).not.toContain('┌');
+    expect(combined[2]).toContain('┌');
+    expect(combined[3]).toContain('Keep going!');
+    expect(combined[4]).toContain('└');
+    expect(combined[5]).not.toContain('└');
+    expect(combined[6]).not.toContain('└');
+  });
+});
+
+describe('bubbleFitsWidth', () => {
+  it('fits at 55 columns and above', () => {
+    expect(bubbleFitsWidth(55)).toBe(true);
+    expect(bubbleFitsWidth(80)).toBe(true);
+  });
+  it('does not fit below 55 columns', () => {
+    expect(bubbleFitsWidth(54)).toBe(false);
+  });
+  it('treats an unknown width (undefined columns) as fitting (defaults to 80)', () => {
+    expect(bubbleFitsWidth(undefined)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/speech-bubble.test.ts`
+Expected: FAIL — `Cannot find module '../src/speech-bubble.js'`
+
+- [ ] **Step 3: Create `packages/cli/src/speech-bubble.ts`**
+
+```ts
+const MIN_BUBBLE_COLUMNS = 55;
+
+/**
+ * Whether the terminal is wide enough for the mascot + speech bubble combination —
+ * a stricter gate than `mascotFitsWidth` (mascot.ts), which only covers the fox
+ * sprite alone. Below this, callers render the mascot without a bubble (or skip a
+ * bubble-only moment like the greeting entirely) rather than hiding the fox itself.
+ */
+export function bubbleFitsWidth(columns: number | undefined): boolean {
+  return (columns ?? 80) >= MIN_BUBBLE_COLUMNS;
+}
+
+/**
+ * Renders `text` inside a Unicode box-drawing border, sized to the text (1-space
+ * padding on each side). Always exactly 3 lines: top border, text line, bottom
+ * border. Plain terminal-default colors — unlike the fox sprite, this is readable
+ * text, not pixel art, so it doesn't need a fixed color identity.
+ */
+export function renderSpeechBubble(text: string): string[] {
+  const border = '─'.repeat(text.length + 2);
+  return [`┌${border}┐`, `│ ${text} │`, `└${border}┘`];
+}
+
+/**
+ * Places `bubbleLines` to the right of `mascotBlock`, vertically centered against
+ * it. `mascotBlock` is a `renderPixelGrid` output (mascot.ts) — its lines already
+ * end in an ANSI reset, so appending plain text after a space is safe (no color
+ * bleed into the bubble).
+ */
+export function withSpeechBubble(mascotBlock: string, bubbleLines: readonly string[]): string {
+  const mascotLines = mascotBlock.split('\n');
+  const bubbleWidth = bubbleLines[0]?.length ?? 0;
+  const blankBubbleLine = ' '.repeat(bubbleWidth);
+  const padTop = Math.floor((mascotLines.length - bubbleLines.length) / 2);
+  const padBottom = mascotLines.length - bubbleLines.length - padTop;
+  const paddedBubble = [
+    ...Array<string>(Math.max(padTop, 0)).fill(blankBubbleLine),
+    ...bubbleLines,
+    ...Array<string>(Math.max(padBottom, 0)).fill(blankBubbleLine)
+  ];
+  return mascotLines.map((line, i) => `${line} ${paddedBubble[i] ?? blankBubbleLine}`).join('\n');
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/speech-bubble.test.ts`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/speech-bubble.ts packages/cli/test/speech-bubble.test.ts
+git commit -m "feat(cli): add speech bubble rendering primitives"
+```
+
+---
+
+### Task 2: Message pools, random selection, composition helper
+
+**Files:**
+- Modify: `packages/cli/src/speech-bubble.ts`
+- Modify: `packages/cli/test/speech-bubble.test.ts`
+
+**Interfaces:**
+- Consumes: `withSpeechBubble`, `renderSpeechBubble` (Task 1, same file); `MascotState` (`packages/cli/src/mascot.ts`)
+- Produces: `GREETING_MESSAGES: readonly string[]`, `REACTION_MESSAGES: Record<MascotState, readonly string[]>`, `pickMessage(pool, random?): string`, `renderMascotWithSpeech(mascotBlock: string, message: string): string`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `packages/cli/test/speech-bubble.test.ts`, replace the existing `import { renderSpeechBubble, withSpeechBubble, bubbleFitsWidth } from '../src/speech-bubble.js';` line (do not add a second import from the same path) with:
+
+```ts
+import {
+  renderSpeechBubble,
+  withSpeechBubble,
+  bubbleFitsWidth,
+  pickMessage,
+  renderMascotWithSpeech,
+  GREETING_MESSAGES,
+  REACTION_MESSAGES
+} from '../src/speech-bubble.js';
+```
+
+And append these new `describe` blocks at the end of the file:
+
+```ts
+describe('pickMessage', () => {
+  it('picks the first item when random() returns 0', () => {
+    expect(pickMessage(['a', 'b', 'c'], () => 0)).toBe('a');
+  });
+  it('picks the last item when random() returns just under 1', () => {
+    expect(pickMessage(['a', 'b', 'c'], () => 0.999)).toBe('c');
+  });
+  it('defaults to Math.random and always returns a pool member', () => {
+    const pool = ['a', 'b', 'c'];
+    for (let i = 0; i < 20; i++) {
+      expect(pool).toContain(pickMessage(pool));
+    }
+  });
+});
+
+describe('message pools', () => {
+  it('all greeting messages fit a compact bubble (<=26 chars)', () => {
+    for (const m of GREETING_MESSAGES) expect(m.length).toBeLessThanOrEqual(26);
+  });
+  it('all reaction messages fit a compact bubble (<=26 chars)', () => {
+    for (const pool of Object.values(REACTION_MESSAGES)) {
+      for (const m of pool) expect(m.length).toBeLessThanOrEqual(26);
+    }
+  });
+  it('has a reaction pool for every mascot state', () => {
+    expect(Object.keys(REACTION_MESSAGES).sort()).toEqual(['content', 'ecstatic', 'happy']);
+  });
+});
+
+describe('renderMascotWithSpeech', () => {
+  it('composes a mascot pose and a message into a single bubbled block', () => {
+    const block = renderMascotWithSpeech(renderMascotReaction('happy'), 'Nice work!');
+    expect(block.split('\n')).toHaveLength(7);
+    expect(block).toContain('Nice work!');
+    expect(block).toContain('\x1b[38;2;255;62;0m'); // still the fox, orange present
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/speech-bubble.test.ts`
+Expected: FAIL — `pickMessage`/`renderMascotWithSpeech`/`GREETING_MESSAGES`/`REACTION_MESSAGES` are not exported
+
+- [ ] **Step 3: Add to `packages/cli/src/speech-bubble.ts`**
+
+Add this import at the very top of the file:
+
+```ts
+import type { MascotState } from './mascot.js';
+```
+
+Then append after `withSpeechBubble`:
+
+```ts
+export const GREETING_MESSAGES: readonly string[] = [
+  'Welcome to Svelte Vitals!',
+  "Let's check your project!",
+  'Ready when you are!',
+  "Hi there! Let's dig in."
+];
+
+export const REACTION_MESSAGES: Record<MascotState, readonly string[]> = {
+  ecstatic: ['Perfect score!', 'Flawless!', 'You nailed it!'],
+  happy: ['Nice work!', 'Looking great!', 'Almost perfect!'],
+  content: ['Keep going!', 'Room to grow!', "Let's improve this!"]
+};
+
+/**
+ * Picks one message uniformly at random from `pool`. `random` defaults to
+ * `Math.random` — only overridden by this module's own unit tests below, for
+ * deterministic selection; other call sites and their tests never pass it.
+ */
+export function pickMessage(pool: readonly string[], random: () => number = Math.random): string {
+  return pool[Math.floor(random() * pool.length)]!;
+}
+
+/** Composes a mascot pose with a speech bubble to its right — the shared shape both the startup greeting and the score-reveal reaction use. */
+export function renderMascotWithSpeech(mascotBlock: string, message: string): string {
+  return withSpeechBubble(mascotBlock, renderSpeechBubble(message));
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/speech-bubble.test.ts`
+Expected: PASS (13 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/speech-bubble.ts packages/cli/test/speech-bubble.test.ts
+git commit -m "feat(cli): add speech bubble message pools and random selection"
+```
+
+---
+
+### Task 3: Startup greeting playback
+
+**Files:**
+- Modify: `packages/cli/src/speech-bubble.ts`
+- Modify: `packages/cli/test/speech-bubble.test.ts`
+
+**Interfaces:**
+- Consumes: `renderMascotAnticipating` (`packages/cli/src/mascot.ts`); `renderMascotWithSpeech`, `pickMessage`, `GREETING_MESSAGES` (Task 1/2, same file)
+- Produces: `playMascotGreeting(opts: { enabled: boolean; stream: NodeJS.WriteStream; holdMs?: number }): Promise<void>`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `packages/cli/test/speech-bubble.test.ts`, add `playMascotGreeting` to the existing `../src/speech-bubble.js` import list (do not add a second import from the same path):
+
+```ts
+import {
+  renderSpeechBubble,
+  withSpeechBubble,
+  bubbleFitsWidth,
+  pickMessage,
+  renderMascotWithSpeech,
+  playMascotGreeting,
+  GREETING_MESSAGES,
+  REACTION_MESSAGES
+} from '../src/speech-bubble.js';
+```
+
+Append at the end of the file:
+
+```ts
+function fakeStream() {
+  const writes: string[] = [];
+  return { writes, stream: { write: (s: string) => writes.push(s) } as unknown as NodeJS.WriteStream };
+}
+
+describe('playMascotGreeting', () => {
+  it('writes nothing when disabled', async () => {
+    const { writes, stream } = fakeStream();
+    await playMascotGreeting({ enabled: false, stream, holdMs: 0 });
+    expect(writes).toEqual([]);
+  });
+
+  it('writes a frame containing the fox and one of the greeting messages, then clears', async () => {
+    const { writes, stream } = fakeStream();
+    await playMascotGreeting({ enabled: true, stream, holdMs: 0 });
+    expect(writes.length).toBeGreaterThan(0);
+    const allWrites = writes.join('');
+    expect(allWrites).toContain('\x1b[38;2;255;62;0m'); // the fox
+    expect(GREETING_MESSAGES.some((m) => allWrites.includes(m))).toBe(true);
+    const last = writes[writes.length - 1]!;
+    expect(GREETING_MESSAGES.some((m) => last.includes(m))).toBe(false); // cleared on the last write
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/speech-bubble.test.ts`
+Expected: FAIL — `playMascotGreeting` is not exported
+
+- [ ] **Step 3: Add to `packages/cli/src/speech-bubble.ts`**
+
+Replace the top-of-file import block (from Task 2's `import type { MascotState } from './mascot.js';`) with:
+
+```ts
+import { createLogUpdate } from 'log-update';
+import { renderMascotAnticipating, type MascotState } from './mascot.js';
+```
+
+Then append at the end of the file:
+
+```ts
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const GREETING_HOLD_MS = 800;
+
+/**
+ * Plays a one-shot greeting: the fox's idle-open pose with a random greeting
+ * message in a speech bubble, held for `holdMs`, then cleared — called once
+ * before analysis starts (index.ts), never repeated within a single run. Uses
+ * `log-update` for the same reason mascot.ts's `startMascotSpinner` and
+ * pulse-animation.ts's `playScoreAnimation` do: accurate multi-line redraw/clear.
+ */
+export async function playMascotGreeting(opts: {
+  enabled: boolean;
+  stream: NodeJS.WriteStream;
+  /** Override for tests — real playback uses GREETING_HOLD_MS; 0 completes near-instantly. */
+  holdMs?: number;
+}): Promise<void> {
+  if (!opts.enabled) return;
+  const holdMs = opts.holdMs ?? GREETING_HOLD_MS;
+  const render = createLogUpdate(opts.stream);
+  render(renderMascotWithSpeech(renderMascotAnticipating(), pickMessage(GREETING_MESSAGES)));
+  if (holdMs > 0) await sleep(holdMs);
+  render.clear();
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/speech-bubble.test.ts`
+Expected: PASS (15 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/speech-bubble.ts packages/cli/test/speech-bubble.test.ts
+git commit -m "feat(cli): add mascot startup greeting playback"
+```
+
+---
+
+### Task 4: Score-reveal reaction bubble
+
+**Files:**
+- Modify: `packages/cli/src/pulse-animation.ts`
+- Modify: `packages/cli/test/pulse-animation.test.ts`
+
+**Interfaces:**
+- Consumes: `bubbleFitsWidth`, `pickMessage`, `renderMascotWithSpeech`, `REACTION_MESSAGES` (`packages/cli/src/speech-bubble.ts`, Tasks 1-2)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this import to `packages/cli/test/pulse-animation.test.ts`'s import block:
+
+```ts
+import { REACTION_MESSAGES } from '../src/speech-bubble.js';
+```
+
+Append inside the `describe('playScoreAnimation', ...)` block (after the existing `'omits the mascot entirely on a narrow terminal...'` test):
+
+```ts
+  it('shows a reaction speech bubble matching the final state, on a wide enough terminal', async () => {
+    const { writes, stream } = fakeStream();
+    await playScoreAnimation({ score: 95, palette: ansiPalette, stream, frameDelayMs: 0 }); // happy
+    const allWrites = writes.join('');
+    expect(REACTION_MESSAGES.happy.some((m) => allWrites.includes(m))).toBe(true);
+  });
+
+  it('omits the speech bubble (but keeps the fox) when the terminal fits the mascot but not the bubble', async () => {
+    const { writes, stream } = fakeStream();
+    Object.defineProperty(stream, 'columns', { value: 45 }); // >= 40 (mascot) but < 55 (bubble)
+    await playScoreAnimation({ score: 95, palette: ansiPalette, stream, frameDelayMs: 0 });
+    const allWrites = writes.join('');
+    expect(allWrites).toContain('\x1b[38;2;255;62;0m'); // fox still present
+    for (const pool of Object.values(REACTION_MESSAGES)) {
+      for (const m of pool) expect(allWrites).not.toContain(m);
+    }
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/pulse-animation.test.ts`
+Expected: FAIL — the first new test fails because no reaction message is ever written yet
+
+- [ ] **Step 3: Modify `packages/cli/src/pulse-animation.ts`**
+
+Add this import after the existing `import { ... } from './mascot.js';` block:
+
+```ts
+import { bubbleFitsWidth, pickMessage, renderMascotWithSpeech, REACTION_MESSAGES } from './speech-bubble.js';
+```
+
+Replace the body of `playScoreAnimation` (from `const render = createLogUpdate(opts.stream);` through the confetti loop) with:
+
+```ts
+  const render = createLogUpdate(opts.stream);
+  const showMascot = mascotFitsWidth(opts.stream.columns);
+  const state = mascotStateFor(opts.score);
+  const reactionMessage =
+    showMascot && bubbleFitsWidth(opts.stream.columns) ? pickMessage(REACTION_MESSAGES[state]) : undefined;
+  const finalMascotBlock = reactionMessage
+    ? renderMascotWithSpeech(renderMascotReaction(state), reactionMessage)
+    : renderMascotReaction(state);
+
+  for (let frame = 0; frame < FRAME_COUNT; frame++) {
+    const progress = frame / (FRAME_COUNT - 1);
+    const displayScore = Math.round(opts.score * progress);
+    const isFinalFrame = frame === FRAME_COUNT - 1;
+    const wave = WAVE_FRAMES[frame]!;
+    const scoreText = isFinalFrame
+      ? scoreColor(opts.palette, opts.score)(`${displayScore}/100`)
+      : opts.palette.dim(`${displayScore}/100`);
+    const waveBlock = `  ${wave}\n  Health: ${scoreText}`;
+    const mascotBlock = showMascot
+      ? (isFinalFrame ? finalMascotBlock : renderMascotAnticipating()) + '\n'
+      : '';
+    render(`${mascotBlock}${waveBlock}`);
+    if (!isFinalFrame) await sleep(frameDelayMs);
+  }
+
+  if (holdMs > 0) await sleep(holdMs);
+
+  if (showMascot && state === 'ecstatic') {
+    for (let i = 0; i < CONFETTI_FRAME_COUNT; i++) {
+      const waveBlock = `  ${WAVE_FRAMES[FRAME_COUNT - 1]!}\n  Health: ${scoreColor(opts.palette, opts.score)('100/100')}`;
+      render(`${renderConfettiFrame(i, finalMascotBlock)}\n${waveBlock}`);
+      if (i < CONFETTI_FRAME_COUNT - 1 && confettiDelayMs > 0) await sleep(confettiDelayMs);
+    }
+  }
+```
+
+(The lines above and below this block — the `frameDelayMs`/`holdMs`/`confettiDelayMs` consts at the top, and the trailing `render.done();` — are unchanged.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/pulse-animation.test.ts`
+Expected: PASS (14 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/pulse-animation.ts packages/cli/test/pulse-animation.test.ts
+git commit -m "feat(cli): show a reaction speech bubble at the score reveal"
+```
+
+---
+
+### Task 5: Startup greeting integration
+
+**Files:**
+- Modify: `packages/cli/src/index.ts`
+- Modify: `packages/cli/test/run.test.ts`
+
+**Interfaces:**
+- Consumes: `playMascotGreeting`, `bubbleFitsWidth`, `GREETING_MESSAGES` (`packages/cli/src/speech-bubble.ts`, Tasks 1-3)
+
+- [ ] **Step 1: Write the failing test**
+
+Add this import to `packages/cli/test/run.test.ts`'s top import block:
+
+```ts
+import { GREETING_MESSAGES } from '../src/speech-bubble.js';
+```
+
+Update the existing test `'shows the mascot idle loop on stderr during analysis on a wide interactive terminal'` (in the same `describe` block as the other mascot/spinner tests) — add `animationFrameDelayMs: 0` to its `run()` call so the new greeting's hold doesn't slow the test down:
+
+```ts
+  it('shows the mascot idle loop on stderr during analysis on a wide interactive terminal', async () => {
+    const cap = capture();
+    const stderrWrites: string[] = [];
+    const stderrStream = { write: (s: string) => stderrWrites.push(s) } as unknown as NodeJS.WriteStream;
+    await run({
+      cwd: fixtureDir,
+      log: cap.log,
+      errorLog: cap.errorLog,
+      env: CLEAN_ENV,
+      stderrIsTTY: true,
+      stderrStream,
+      stdoutIsTTY: false, // isolate: only exercise the analysis-phase mascot here
+      animationFrameDelayMs: 0 // keep the greeting's hold near-instant in tests
+    });
+    expect(stderrWrites.length).toBeGreaterThan(0);
+    // The mascot's orange truecolor escape is a reliable "this is mascot art, not the
+    // plain braille spinner" marker — the braille spinner never emits color.
+    expect(stderrWrites.join('')).toContain('\x1b[38;2;255;62;0m');
+  });
+```
+
+Then add a new test immediately after it:
+
+```ts
+  it('shows a one-off greeting speech bubble before the idle loop, on a wide interactive terminal', async () => {
+    const cap = capture();
+    const stderrWrites: string[] = [];
+    const stderrStream = { write: (s: string) => stderrWrites.push(s) } as unknown as NodeJS.WriteStream;
+    await run({
+      cwd: fixtureDir,
+      log: cap.log,
+      errorLog: cap.errorLog,
+      env: CLEAN_ENV,
+      stderrIsTTY: true,
+      stderrStream,
+      stdoutIsTTY: false,
+      animationFrameDelayMs: 0
+    });
+    const allWrites = stderrWrites.join('');
+    expect(GREETING_MESSAGES.some((m) => allWrites.includes(m))).toBe(true);
+  });
+```
+
+- [ ] **Step 2: Run tests to verify the new one fails**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/run.test.ts`
+Expected: FAIL — the new "shows a one-off greeting" test fails (no greeting is played yet); the updated idle-loop test still passes (the added option is inert until Step 3)
+
+- [ ] **Step 3: Modify `packages/cli/src/index.ts`**
+
+Add this import after the existing `import { startMascotSpinner, mascotFitsWidth } from './mascot.js';` line:
+
+```ts
+import { playMascotGreeting, bubbleFitsWidth } from './speech-bubble.js';
+```
+
+Replace:
+
+```ts
+  const useMascotSpinner = spinnerBaseEnabled && !opts.noAnimation && mascotFitsWidth(stderrStream.columns);
+  const spinner = useMascotSpinner
+    ? startMascotSpinner('Analyzing…', { enabled: true, stream: stderrStream })
+    : startSpinner('Analyzing…', { enabled: spinnerBaseEnabled, stream: stderrStream });
+```
+
+with:
+
+```ts
+  const useMascotSpinner = spinnerBaseEnabled && !opts.noAnimation && mascotFitsWidth(stderrStream.columns);
+  if (useMascotSpinner && bubbleFitsWidth(stderrStream.columns)) {
+    // A wordless greeting isn't worth a dedicated hold before the idle loop, so this
+    // only plays when there's room for the speech bubble too — not just the fox alone.
+    await playMascotGreeting({ enabled: true, stream: stderrStream, holdMs: opts.animationFrameDelayMs });
+  }
+  const spinner = useMascotSpinner
+    ? startMascotSpinner('Analyzing…', { enabled: true, stream: stderrStream })
+    : startSpinner('Analyzing…', { enabled: spinnerBaseEnabled, stream: stderrStream });
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/run.test.ts`
+Expected: PASS (all tests in the file)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/index.ts packages/cli/test/run.test.ts
+git commit -m "feat(cli): play a startup greeting speech bubble before analysis"
+```
+
+---
+
+### Task 6: Docs, changeset, and full verification
+
+**Files:**
+- Modify: `packages/cli/README.md`
+- Create: `.changeset/mascot-speech-bubble.md`
+
+**Interfaces:**
+- None (docs/metadata only; no code interfaces produced or consumed)
+
+- [ ] **Step 1: Update `packages/cli/README.md`**
+
+Find the existing mascot paragraph:
+
+```md
+On an interactive terminal, a small pixel-art fox mascot appears alongside both the analysis spinner and the Health-score reveal, reacting to the score (a perfect 100 gets a confetti flourish). `--no-animation` disables it, falling back to the plain spinner and plain score animation.
+```
+
+Replace it with:
+
+```md
+On an interactive terminal, a small pixel-art fox mascot appears alongside both the analysis spinner and the Health-score reveal, reacting to the score (a perfect 100 gets a confetti flourish). On a wide enough terminal it also greets you with a short line in a speech bubble at startup, and again with a matching reaction line at the score reveal. `--no-animation` disables all of it, falling back to the plain spinner and plain score animation.
+```
+
+- [ ] **Step 2: Create the changeset**
+
+Create `.changeset/mascot-speech-bubble.md`:
+
+```md
+---
+'svelte-vitals': minor
+---
+
+Give the CLI's pixel-art fox mascot a speech bubble: a random greeting line at startup, and a reaction line matching the Health-score band at the score reveal (on terminals wide enough for both). Falls back to the fox alone on narrower terminals, same as before.
+```
+
+- [ ] **Step 3: Run full verification**
+
+Run, in order, from the repo root of this worktree:
+
+```bash
+pnpm --filter @svelte-vitals/core build && pnpm --filter svelte-vitals build
+pnpm build
+pnpm typecheck
+pnpm test
+pnpm lint
+```
+
+Expected: all five commands exit 0. If `pnpm lint`'s `prettier --check` flags `speech-bubble.ts` or any modified file, run `pnpm exec prettier --write <file>` and re-run `pnpm lint`.
+
+If `packages/action/dist/index.js` shows as changed in `git status` after `pnpm build` (it bundles the CLI source), that is expected — stage it in the final commit.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cli/README.md .changeset/mascot-speech-bubble.md packages/action/dist/index.js
+git commit -m "docs(cli): document the mascot speech bubble; add changeset"
+```
+
+- [ ] **Step 5: Final check**
+
+Run: `git status --short`
+Expected: clean (nothing uncommitted) except any files intentionally left for the finishing-a-development-branch workflow.

--- a/docs/superpowers/plans/2026-07-11-mascot-speech-bubble.md
+++ b/docs/superpowers/plans/2026-07-11-mascot-speech-bubble.md
@@ -24,10 +24,12 @@
 ### Task 1: Speech bubble rendering + width gate
 
 **Files:**
+
 - Create: `packages/cli/src/speech-bubble.ts`
 - Test: `packages/cli/test/speech-bubble.test.ts`
 
 **Interfaces:**
+
 - Produces: `bubbleFitsWidth(columns: number | undefined): boolean`, `renderSpeechBubble(text: string): string[]`, `withSpeechBubble(mascotBlock: string, bubbleLines: readonly string[]): string`
 
 - [ ] **Step 1: Write the failing tests**
@@ -162,10 +164,12 @@ git commit -m "feat(cli): add speech bubble rendering primitives"
 ### Task 2: Message pools, random selection, composition helper
 
 **Files:**
+
 - Modify: `packages/cli/src/speech-bubble.ts`
 - Modify: `packages/cli/test/speech-bubble.test.ts`
 
 **Interfaces:**
+
 - Consumes: `withSpeechBubble`, `renderSpeechBubble` (Task 1, same file); `MascotState` (`packages/cli/src/mascot.ts`)
 - Produces: `GREETING_MESSAGES: readonly string[]`, `REACTION_MESSAGES: Record<MascotState, readonly string[]>`, `pickMessage(pool, random?): string`, `renderMascotWithSpeech(mascotBlock: string, message: string): string`
 
@@ -288,10 +292,12 @@ git commit -m "feat(cli): add speech bubble message pools and random selection"
 ### Task 3: Startup greeting playback
 
 **Files:**
+
 - Modify: `packages/cli/src/speech-bubble.ts`
 - Modify: `packages/cli/test/speech-bubble.test.ts`
 
 **Interfaces:**
+
 - Consumes: `renderMascotAnticipating` (`packages/cli/src/mascot.ts`); `renderMascotWithSpeech`, `pickMessage`, `GREETING_MESSAGES` (Task 1/2, same file)
 - Produces: `playMascotGreeting(opts: { enabled: boolean; stream: NodeJS.WriteStream; holdMs?: number }): Promise<void>`
 
@@ -402,10 +408,12 @@ git commit -m "feat(cli): add mascot startup greeting playback"
 ### Task 4: Score-reveal reaction bubble
 
 **Files:**
+
 - Modify: `packages/cli/src/pulse-animation.ts`
 - Modify: `packages/cli/test/pulse-animation.test.ts`
 
 **Interfaces:**
+
 - Consumes: `bubbleFitsWidth`, `pickMessage`, `renderMascotWithSpeech`, `REACTION_MESSAGES` (`packages/cli/src/speech-bubble.ts`, Tasks 1-2)
 
 - [ ] **Step 1: Write the failing tests**
@@ -419,23 +427,23 @@ import { REACTION_MESSAGES } from '../src/speech-bubble.js';
 Append inside the `describe('playScoreAnimation', ...)` block (after the existing `'omits the mascot entirely on a narrow terminal...'` test):
 
 ```ts
-  it('shows a reaction speech bubble matching the final state, on a wide enough terminal', async () => {
-    const { writes, stream } = fakeStream();
-    await playScoreAnimation({ score: 95, palette: ansiPalette, stream, frameDelayMs: 0 }); // happy
-    const allWrites = writes.join('');
-    expect(REACTION_MESSAGES.happy.some((m) => allWrites.includes(m))).toBe(true);
-  });
+it('shows a reaction speech bubble matching the final state, on a wide enough terminal', async () => {
+  const { writes, stream } = fakeStream();
+  await playScoreAnimation({ score: 95, palette: ansiPalette, stream, frameDelayMs: 0 }); // happy
+  const allWrites = writes.join('');
+  expect(REACTION_MESSAGES.happy.some((m) => allWrites.includes(m))).toBe(true);
+});
 
-  it('omits the speech bubble (but keeps the fox) when the terminal fits the mascot but not the bubble', async () => {
-    const { writes, stream } = fakeStream();
-    Object.defineProperty(stream, 'columns', { value: 45 }); // >= 40 (mascot) but < 55 (bubble)
-    await playScoreAnimation({ score: 95, palette: ansiPalette, stream, frameDelayMs: 0 });
-    const allWrites = writes.join('');
-    expect(allWrites).toContain('\x1b[38;2;255;62;0m'); // fox still present
-    for (const pool of Object.values(REACTION_MESSAGES)) {
-      for (const m of pool) expect(allWrites).not.toContain(m);
-    }
-  });
+it('omits the speech bubble (but keeps the fox) when the terminal fits the mascot but not the bubble', async () => {
+  const { writes, stream } = fakeStream();
+  Object.defineProperty(stream, 'columns', { value: 45 }); // >= 40 (mascot) but < 55 (bubble)
+  await playScoreAnimation({ score: 95, palette: ansiPalette, stream, frameDelayMs: 0 });
+  const allWrites = writes.join('');
+  expect(allWrites).toContain('\x1b[38;2;255;62;0m'); // fox still present
+  for (const pool of Object.values(REACTION_MESSAGES)) {
+    for (const m of pool) expect(allWrites).not.toContain(m);
+  }
+});
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
@@ -454,40 +462,38 @@ import { bubbleFitsWidth, pickMessage, renderMascotWithSpeech, REACTION_MESSAGES
 Replace the body of `playScoreAnimation` (from `const render = createLogUpdate(opts.stream);` through the confetti loop) with:
 
 ```ts
-  const render = createLogUpdate(opts.stream);
-  const showMascot = mascotFitsWidth(opts.stream.columns);
-  const state = mascotStateFor(opts.score);
-  const reactionMessage =
-    showMascot && bubbleFitsWidth(opts.stream.columns) ? pickMessage(REACTION_MESSAGES[state]) : undefined;
-  const finalMascotBlock = reactionMessage
-    ? renderMascotWithSpeech(renderMascotReaction(state), reactionMessage)
-    : renderMascotReaction(state);
+const render = createLogUpdate(opts.stream);
+const showMascot = mascotFitsWidth(opts.stream.columns);
+const state = mascotStateFor(opts.score);
+const reactionMessage =
+  showMascot && bubbleFitsWidth(opts.stream.columns) ? pickMessage(REACTION_MESSAGES[state]) : undefined;
+const finalMascotBlock = reactionMessage
+  ? renderMascotWithSpeech(renderMascotReaction(state), reactionMessage)
+  : renderMascotReaction(state);
 
-  for (let frame = 0; frame < FRAME_COUNT; frame++) {
-    const progress = frame / (FRAME_COUNT - 1);
-    const displayScore = Math.round(opts.score * progress);
-    const isFinalFrame = frame === FRAME_COUNT - 1;
-    const wave = WAVE_FRAMES[frame]!;
-    const scoreText = isFinalFrame
-      ? scoreColor(opts.palette, opts.score)(`${displayScore}/100`)
-      : opts.palette.dim(`${displayScore}/100`);
-    const waveBlock = `  ${wave}\n  Health: ${scoreText}`;
-    const mascotBlock = showMascot
-      ? (isFinalFrame ? finalMascotBlock : renderMascotAnticipating()) + '\n'
-      : '';
-    render(`${mascotBlock}${waveBlock}`);
-    if (!isFinalFrame) await sleep(frameDelayMs);
+for (let frame = 0; frame < FRAME_COUNT; frame++) {
+  const progress = frame / (FRAME_COUNT - 1);
+  const displayScore = Math.round(opts.score * progress);
+  const isFinalFrame = frame === FRAME_COUNT - 1;
+  const wave = WAVE_FRAMES[frame]!;
+  const scoreText = isFinalFrame
+    ? scoreColor(opts.palette, opts.score)(`${displayScore}/100`)
+    : opts.palette.dim(`${displayScore}/100`);
+  const waveBlock = `  ${wave}\n  Health: ${scoreText}`;
+  const mascotBlock = showMascot ? (isFinalFrame ? finalMascotBlock : renderMascotAnticipating()) + '\n' : '';
+  render(`${mascotBlock}${waveBlock}`);
+  if (!isFinalFrame) await sleep(frameDelayMs);
+}
+
+if (holdMs > 0) await sleep(holdMs);
+
+if (showMascot && state === 'ecstatic') {
+  for (let i = 0; i < CONFETTI_FRAME_COUNT; i++) {
+    const waveBlock = `  ${WAVE_FRAMES[FRAME_COUNT - 1]!}\n  Health: ${scoreColor(opts.palette, opts.score)('100/100')}`;
+    render(`${renderConfettiFrame(i, finalMascotBlock)}\n${waveBlock}`);
+    if (i < CONFETTI_FRAME_COUNT - 1 && confettiDelayMs > 0) await sleep(confettiDelayMs);
   }
-
-  if (holdMs > 0) await sleep(holdMs);
-
-  if (showMascot && state === 'ecstatic') {
-    for (let i = 0; i < CONFETTI_FRAME_COUNT; i++) {
-      const waveBlock = `  ${WAVE_FRAMES[FRAME_COUNT - 1]!}\n  Health: ${scoreColor(opts.palette, opts.score)('100/100')}`;
-      render(`${renderConfettiFrame(i, finalMascotBlock)}\n${waveBlock}`);
-      if (i < CONFETTI_FRAME_COUNT - 1 && confettiDelayMs > 0) await sleep(confettiDelayMs);
-    }
-  }
+}
 ```
 
 (The lines above and below this block — the `frameDelayMs`/`holdMs`/`confettiDelayMs` consts at the top, and the trailing `render.done();` — are unchanged.)
@@ -509,10 +515,12 @@ git commit -m "feat(cli): show a reaction speech bubble at the score reveal"
 ### Task 5: Startup greeting integration
 
 **Files:**
+
 - Modify: `packages/cli/src/index.ts`
 - Modify: `packages/cli/test/run.test.ts`
 
 **Interfaces:**
+
 - Consumes: `playMascotGreeting`, `bubbleFitsWidth`, `GREETING_MESSAGES` (`packages/cli/src/speech-bubble.ts`, Tasks 1-3)
 
 - [ ] **Step 1: Write the failing test**
@@ -526,47 +534,47 @@ import { GREETING_MESSAGES } from '../src/speech-bubble.js';
 Update the existing test `'shows the mascot idle loop on stderr during analysis on a wide interactive terminal'` (in the same `describe` block as the other mascot/spinner tests) — add `animationFrameDelayMs: 0` to its `run()` call so the new greeting's hold doesn't slow the test down:
 
 ```ts
-  it('shows the mascot idle loop on stderr during analysis on a wide interactive terminal', async () => {
-    const cap = capture();
-    const stderrWrites: string[] = [];
-    const stderrStream = { write: (s: string) => stderrWrites.push(s) } as unknown as NodeJS.WriteStream;
-    await run({
-      cwd: fixtureDir,
-      log: cap.log,
-      errorLog: cap.errorLog,
-      env: CLEAN_ENV,
-      stderrIsTTY: true,
-      stderrStream,
-      stdoutIsTTY: false, // isolate: only exercise the analysis-phase mascot here
-      animationFrameDelayMs: 0 // keep the greeting's hold near-instant in tests
-    });
-    expect(stderrWrites.length).toBeGreaterThan(0);
-    // The mascot's orange truecolor escape is a reliable "this is mascot art, not the
-    // plain braille spinner" marker — the braille spinner never emits color.
-    expect(stderrWrites.join('')).toContain('\x1b[38;2;255;62;0m');
+it('shows the mascot idle loop on stderr during analysis on a wide interactive terminal', async () => {
+  const cap = capture();
+  const stderrWrites: string[] = [];
+  const stderrStream = { write: (s: string) => stderrWrites.push(s) } as unknown as NodeJS.WriteStream;
+  await run({
+    cwd: fixtureDir,
+    log: cap.log,
+    errorLog: cap.errorLog,
+    env: CLEAN_ENV,
+    stderrIsTTY: true,
+    stderrStream,
+    stdoutIsTTY: false, // isolate: only exercise the analysis-phase mascot here
+    animationFrameDelayMs: 0 // keep the greeting's hold near-instant in tests
   });
+  expect(stderrWrites.length).toBeGreaterThan(0);
+  // The mascot's orange truecolor escape is a reliable "this is mascot art, not the
+  // plain braille spinner" marker — the braille spinner never emits color.
+  expect(stderrWrites.join('')).toContain('\x1b[38;2;255;62;0m');
+});
 ```
 
 Then add a new test immediately after it:
 
 ```ts
-  it('shows a one-off greeting speech bubble before the idle loop, on a wide interactive terminal', async () => {
-    const cap = capture();
-    const stderrWrites: string[] = [];
-    const stderrStream = { write: (s: string) => stderrWrites.push(s) } as unknown as NodeJS.WriteStream;
-    await run({
-      cwd: fixtureDir,
-      log: cap.log,
-      errorLog: cap.errorLog,
-      env: CLEAN_ENV,
-      stderrIsTTY: true,
-      stderrStream,
-      stdoutIsTTY: false,
-      animationFrameDelayMs: 0
-    });
-    const allWrites = stderrWrites.join('');
-    expect(GREETING_MESSAGES.some((m) => allWrites.includes(m))).toBe(true);
+it('shows a one-off greeting speech bubble before the idle loop, on a wide interactive terminal', async () => {
+  const cap = capture();
+  const stderrWrites: string[] = [];
+  const stderrStream = { write: (s: string) => stderrWrites.push(s) } as unknown as NodeJS.WriteStream;
+  await run({
+    cwd: fixtureDir,
+    log: cap.log,
+    errorLog: cap.errorLog,
+    env: CLEAN_ENV,
+    stderrIsTTY: true,
+    stderrStream,
+    stdoutIsTTY: false,
+    animationFrameDelayMs: 0
   });
+  const allWrites = stderrWrites.join('');
+  expect(GREETING_MESSAGES.some((m) => allWrites.includes(m))).toBe(true);
+});
 ```
 
 - [ ] **Step 2: Run tests to verify the new one fails**
@@ -585,24 +593,24 @@ import { playMascotGreeting, bubbleFitsWidth } from './speech-bubble.js';
 Replace:
 
 ```ts
-  const useMascotSpinner = spinnerBaseEnabled && !opts.noAnimation && mascotFitsWidth(stderrStream.columns);
-  const spinner = useMascotSpinner
-    ? startMascotSpinner('Analyzing…', { enabled: true, stream: stderrStream })
-    : startSpinner('Analyzing…', { enabled: spinnerBaseEnabled, stream: stderrStream });
+const useMascotSpinner = spinnerBaseEnabled && !opts.noAnimation && mascotFitsWidth(stderrStream.columns);
+const spinner = useMascotSpinner
+  ? startMascotSpinner('Analyzing…', { enabled: true, stream: stderrStream })
+  : startSpinner('Analyzing…', { enabled: spinnerBaseEnabled, stream: stderrStream });
 ```
 
 with:
 
 ```ts
-  const useMascotSpinner = spinnerBaseEnabled && !opts.noAnimation && mascotFitsWidth(stderrStream.columns);
-  if (useMascotSpinner && bubbleFitsWidth(stderrStream.columns)) {
-    // A wordless greeting isn't worth a dedicated hold before the idle loop, so this
-    // only plays when there's room for the speech bubble too — not just the fox alone.
-    await playMascotGreeting({ enabled: true, stream: stderrStream, holdMs: opts.animationFrameDelayMs });
-  }
-  const spinner = useMascotSpinner
-    ? startMascotSpinner('Analyzing…', { enabled: true, stream: stderrStream })
-    : startSpinner('Analyzing…', { enabled: spinnerBaseEnabled, stream: stderrStream });
+const useMascotSpinner = spinnerBaseEnabled && !opts.noAnimation && mascotFitsWidth(stderrStream.columns);
+if (useMascotSpinner && bubbleFitsWidth(stderrStream.columns)) {
+  // A wordless greeting isn't worth a dedicated hold before the idle loop, so this
+  // only plays when there's room for the speech bubble too — not just the fox alone.
+  await playMascotGreeting({ enabled: true, stream: stderrStream, holdMs: opts.animationFrameDelayMs });
+}
+const spinner = useMascotSpinner
+  ? startMascotSpinner('Analyzing…', { enabled: true, stream: stderrStream })
+  : startSpinner('Analyzing…', { enabled: spinnerBaseEnabled, stream: stderrStream });
 ```
 
 - [ ] **Step 4: Run tests to verify they pass**
@@ -622,10 +630,12 @@ git commit -m "feat(cli): play a startup greeting speech bubble before analysis"
 ### Task 6: Docs, changeset, and full verification
 
 **Files:**
+
 - Modify: `packages/cli/README.md`
 - Create: `.changeset/mascot-speech-bubble.md`
 
 **Interfaces:**
+
 - None (docs/metadata only; no code interfaces produced or consumed)
 
 - [ ] **Step 1: Update `packages/cli/README.md`**

--- a/docs/superpowers/specs/2026-07-11-cli-mascot-pixel-fox-redesign.md
+++ b/docs/superpowers/specs/2026-07-11-cli-mascot-pixel-fox-redesign.md
@@ -1,0 +1,99 @@
+# Design: CLI mascot pixel-art fox redesign
+
+**Date:** 2026-07-11
+**Status:** Implemented
+**Packages:** `svelte-vitals` (CLI) only — no `@svelte-vitals/core` changes
+
+## Context
+
+`docs/superpowers/specs/2026-07-10-cli-mascot-animation-design.md` shipped a
+thin-line ASCII-art mascot with five emotional states
+(ecstatic/happy/content/discouraged/alarmed) in PR #172. Once running for
+real, the project owner judged the line art too unsettling to ship as the
+CLI's marketing-facing centerpiece: "マスコットが不気味すぎますねw ...
+Claude Codeのマスコットみたいに密度があってかわいいキャラがいいですね" (too
+creepy; wants something dense and cute like Claude Code's own mascot, not
+"mediocre ASCII art"). This design replaces the rendering technique and
+scales the state set back down.
+
+## Rendering technique: half-block pixel art
+
+Line art was replaced with a fox sprite rendered using the terminal
+half-block technique: the `▀` (upper half block) character packs two
+logical pixel rows into one printed row, with independently set 24-bit
+truecolor ANSI foreground (top pixel) and background (bottom pixel) codes.
+No new dependency — this is plain ANSI escape sequences
+(`\x1b[38;2;R;G;Bm` / `\x1b[48;2;R;G;Bm}`), same "earn its place" bar as the
+original design's library decision, just resolved as "hand-rolling wins"
+this time since the technique itself is a handful of lines.
+
+**Per-cell transparency.** An early prototype hardcoded a fill color for
+"empty" pixels, tuned to look right against one specific `vhs` recording's
+background theme — that would render as a visible mismatched box on any
+real terminal with a different (especially light) background. Fixed in
+`renderPixelGrid` (`packages/cli/src/mascot.ts`) by choosing per cell: `▀`
+with an explicit default background when only the bottom pixel is
+transparent, `▄` with an explicit default background when only the top
+pixel is transparent, a plain space + reset when both are transparent, and
+the standard `▀` (fg=top, bg=bottom) when both are opaque. Verified against
+a `vhs` recording with a deliberately unusual bright-green terminal
+background — no artifact box.
+
+## Visual design
+
+Iterated with the project owner through several rounds (dog → fox, a
+user-provided reference sprite, ear/cheek/mouth proportion passes), then
+handed to a `fable`-model subagent for further refinement per the owner's
+explicit instruction ("よくはなりましたが、もっとよくできそうです。Fableに頼
+んでもいいよ" — Fable for design iteration, Sonnet for implementation). The
+approved mood-signaling strategy: mouth shape is the primary signal;
+blush is a secondary accent, applied only for the two positive states.
+
+## Scope simplification: five states → three
+
+The original design's `discouraged`/`alarmed` states (and the
+`hasCritical` override in `mascotStateFor`) needed the most redesign
+iteration to get the frown shape looking intentional rather than
+accidental — and once that was finally right, the project owner cut both
+states from scope entirely: "OKです。ただし、discouraged と alarmedは使用し
+なくてOKです。そこまでバリエーション増やさなくてもいいので" (don't need that
+many variations). Confirmed via a follow-up choice to also simplify the
+decision logic itself, not just hide the states visually.
+
+`mascotStateFor(score: number): MascotState` (`'ecstatic' | 'happy' |
+'content'`) now takes only the score — no `hasCritical` parameter, no
+critical-finding override:
+
+- `100` → `ecstatic`
+- `90–99` → `happy`
+- everything else (including a low score with critical findings present) →
+  `content`
+
+This is a genuine behavior change from the merged PR #172: a critical
+finding no longer forces a distinct "alarmed" reaction. The mascot's role
+is narrowed to "reacts to the numeric score," not "also signals
+finding severity" — severity is already fully conveyed by the report body
+above it and the process exit code, so the mascot lost no unique
+information by dropping the override.
+
+## `Palette` decoupling
+
+The pixel-art sprite uses its own fixed RGB palette
+(`packages/cli/src/mascot.ts`), not `@svelte-vitals/core`'s `Palette`
+abstraction used elsewhere in the CLI for text coloring. A filled pixel
+sprite has no meaningful "no-color" fallback — dropping ANSI would leave
+meaningless block characters, not readable text — so there was nothing for
+a `Palette` parameter to abstract over. This is safe because every call
+site (`startMascotSpinner`, and the score-reveal path in
+`pulse-animation.ts`) only ever renders the mascot once color is already
+confirmed enabled (`spinnerEnabled`/`scoreAnimationEnabled` both require
+`colorEnabled(...)`) — the mascot itself is never reached otherwise.
+`ScoreAnimationOptions` also lost its `hasCritical` field as a result.
+
+## Non-goals
+
+- Re-recording the docs homepage demo GIF (PR #174) to show the new fox —
+  known follow-up, explicitly deferred by the project owner until raised
+  again.
+- Any change to `@svelte-vitals/core` — this is entirely a CLI-package
+  presentation change.

--- a/docs/superpowers/specs/2026-07-11-mascot-speech-bubble-design.md
+++ b/docs/superpowers/specs/2026-07-11-mascot-speech-bubble-design.md
@@ -1,0 +1,141 @@
+# Design: Mascot speech bubble
+
+**Date:** 2026-07-11
+**Status:** Proposed
+**Packages:** `svelte-vitals` (CLI) only — no `@svelte-vitals/core` changes
+**Depends on:** `docs/superpowers/specs/2026-07-11-cli-mascot-pixel-fox-redesign.md` (unmerged, PR #175) — this branch stacks on `feat/mascot-pixel-fox`.
+
+## Goal
+
+Give the pixel-art fox mascot a short line of speech in a bordered box next
+to it, at two moments: once at CLI startup (a greeting) and once at the
+Health-score reveal (a reaction comment matching the score band). The
+project owner's own framing: "吹き出して喋るようにしてもいいですね！
+Welcome Svelte Vitals！とかいろんなバリエーションで" — a talking speech
+bubble with several message variations.
+
+## Where it appears (and where it doesn't)
+
+Two moments only:
+
+1. **Startup greeting** — shown once, before analysis begins, for a fixed
+   hold duration regardless of how fast analysis actually finishes.
+2. **Score reveal** — shown alongside the existing reaction pose, riding
+   the same hold window `playScoreAnimation` already uses
+   (`REACTION_HOLD_MS`, 500ms in real playback).
+
+Explicitly **not** shown during the analysis-phase idle loop
+(`startMascotSpinner`): the project owner ruled this out directly —
+analysis can finish fast enough that a message would flash by unreadably
+("解析中は早く終わる場合だと読めない文字が一瞬出ることになるからいらないと
+思う"). The idle loop is unchanged by this design.
+
+## Message selection
+
+Random, not fixed or deterministic-by-score — confirmed as the project
+owner's preference over a single fixed line per state. Each display picks
+one message uniformly at random from the relevant pool:
+
+- **Greeting pool** — one shared pool, shown at startup (score isn't known
+  yet, so no state-based split here):
+  ```
+  Welcome to Svelte Vitals!
+  Let's check your project!
+  Ready when you are!
+  Hi there! Let's dig in.
+  ```
+- **Reaction pools** — one pool per `MascotState`, so the message tone
+  matches the fox's expression:
+  - `ecstatic`: `Perfect score!` / `Flawless!` / `You nailed it!`
+  - `happy`: `Nice work!` / `Looking great!` / `Almost perfect!`
+  - `content`: `Keep going!` / `Room to grow!` / `Let's improve this!`
+
+All messages are English (matches the existing spinner copy, `README.md`,
+and the original mascot design's explicit marketing intent — shareable
+screenshots/clips aimed at a global audience, not localized CLI chrome)
+and kept to ≤26 characters so the bubble stays compact.
+
+## Rendering
+
+New file `packages/cli/src/speech-bubble.ts`, kept separate from
+`mascot.ts` (pixel-art rendering) — one clear responsibility each.
+
+```ts
+function renderSpeechBubble(text: string): string[] {
+  // Unicode box-drawing border (┌─┐│└─┘), sized to `text.length + 2`
+  // interior padding. Returns exactly 3 lines: top border, "│ text │",
+  // bottom border.
+}
+
+function withSpeechBubble(mascotBlock: string, bubbleLines: string[]): string {
+  // Zips mascotBlock's lines (always 7, uniform 14-cell visible width —
+  // see mascot.ts's renderPixelGrid) with bubbleLines to their right,
+  // separated by one space. bubbleLines (3 lines) is vertically centered
+  // against the 7 mascot lines: 2 blank-padded lines above, 3 bubble
+  // lines, 2 blank-padded lines below.
+}
+```
+
+Bubble width is dynamic per message (`text.length + 2` interior + 2 border
+columns), not a fixed constant — each display is a static, non-animating
+render, so there's no visual "jump" to avoid between frames the way there
+would be in an animated sequence.
+
+**Width gating.** A new `bubbleFitsWidth(columns): boolean` sits above the
+existing `mascotFitsWidth` (40 columns) — the fox itself doesn't need the
+extra space, but the fox+bubble combination does. Worst case (longest
+message "Welcome to Svelte Vitals!", 26 chars): 14 (fox) + 1 (gap) + 30
+(26 + 2 padding + 2 border) = 45 columns. `MIN_BUBBLE_COLUMNS = 55` gives
+comfortable margin. Below that threshold, the bubble is skipped and the
+fox renders alone (existing behavior, unchanged) — the mascot doesn't
+disappear just because the bubble doesn't fit.
+
+**Randomness injection.** Message pickers accept an optional
+`random?: () => number` (default `Math.random`), so tests can inject a
+fixed value and assert deterministically which message was chosen:
+
+```ts
+function pickMessage(pool: readonly string[], random: () => number = Math.random): string {
+  return pool[Math.floor(random() * pool.length)]!;
+}
+```
+
+## Integration points
+
+- **`mascot.ts`**: no changes — `speech-bubble.ts` composes on top of its
+  existing exports (`renderMascotReaction`, `renderMascotAnticipating`'s
+  idle-open pose reused for the greeting frame).
+- **`pulse-animation.ts`**: on the final frame, if `bubbleFitsWidth`, wrap
+  the reaction block with a randomly-picked message from
+  `REACTION_MESSAGES[state]` via `withSpeechBubble` before rendering. No
+  change to frame timing — rides the existing hold window.
+- **`index.ts`**: new one-shot greeting step before `startMascotSpinner`
+  is called — reuses `spinnerEnabled`'s result and stderr stream (no new
+  gating function). Holds for a fixed duration via `log-update`, then
+  clears, then proceeds to the (unchanged, bubble-free) idle spinner.
+
+## Testing
+
+- `speech-bubble.test.ts` (new): `renderSpeechBubble` border/line-count/
+  content correctness; `withSpeechBubble` line-count and width
+  consistency against a real `renderMascotReaction` output;
+  `bubbleFitsWidth` boundary; `pickMessage` determinism with an injected
+  `random`.
+- `pulse-animation.test.ts`: extend the final-frame assertions to check a
+  reaction message appears in the last write when width allows, and is
+  absent below `MIN_BUBBLE_COLUMNS`.
+- `run.test.ts` / `index.ts`-level test (wherever the existing spinner
+  start-up is exercised): assert the greeting renders once, holds, then
+  clears before the idle loop's first tick.
+
+## Non-goals
+
+- A literal comic-style bubble with a tail pointing at the fox (rejected
+  in favor of the simpler side-by-side box, the project owner's explicit
+  pick).
+- Bubble text during the idle analysis loop (explicitly ruled out — see
+  "Where it appears").
+- Localized (ja) message variants — English only, matching existing CLI
+  copy conventions.
+- Re-recording docs demo GIFs — separate, already-tracked follow-up
+  (PR #174), unaffected by this change.

--- a/docs/superpowers/specs/2026-07-11-mascot-speech-bubble-design.md
+++ b/docs/superpowers/specs/2026-07-11-mascot-speech-bubble-design.md
@@ -38,7 +38,7 @@ one message uniformly at random from the relevant pool:
 
 - **Greeting pool** — one shared pool, shown at startup (score isn't known
   yet, so no state-based split here):
-  ```
+  ```text
   Welcome to Svelte Vitals!
   Let's check your project!
   Ready when you are!

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -32286,8 +32286,8 @@ var Summary = class {
    * @returns {Summary} summary instance
    */
   addTable(rows) {
-    const tableBody = rows.map((row) => {
-      const cells = row.map((cell) => {
+    const tableBody = rows.map((row2) => {
+      const cells = row2.map((cell) => {
         if (typeof cell === "string") {
           return this.wrap("td", cell);
         }
@@ -56976,7 +56976,7 @@ function applyRuleSeverities(results, config) {
   });
 }
 
-// ../cli/dist/chunk-4LAUKQJ2.js
+// ../cli/dist/chunk-YGQV6XN3.js
 import { readFile, access as access2 } from "fs/promises";
 import { join } from "path";
 
@@ -57754,7 +57754,7 @@ async function glob(globInput, options) {
   return crawler ? formatPaths(await crawler.withPromise(), relative2) : [];
 }
 
-// ../cli/dist/chunk-4LAUKQJ2.js
+// ../cli/dist/chunk-YGQV6XN3.js
 import { readFileSync as readFileSync2 } from "fs";
 import { execFileSync } from "child_process";
 import { execFileSync as execFileSync2 } from "child_process";
@@ -58426,6 +58426,70 @@ var ansiPalette = {
   green: wrap(32, 39),
   cyan: wrap(36, 39)
 };
+var row = (s) => s.replace(/ /g, "");
+var HEAD_EYES_OPEN = [
+  row(". . X X . . . . . . X X . ."),
+  row(". . X I X . . . . X I X . ."),
+  row(". X X I I X . . X I I X X ."),
+  row("X X X X X X X X X X X X X X"),
+  row("X X X X X X X X X X X X X X"),
+  row("X X X E E X X X X E E X X X"),
+  row("X X X E E X X X X E E X X X"),
+  row("W X X W W W X X W W W X X W"),
+  row("W W X W W W X X W W W X W W"),
+  row("W W W W W W N N W W W W W W"),
+  row(". W W W W W N N W W W W W .")
+];
+var HEAD_EYES_CLOSED = [
+  row(". . X X . . . . . . X X . ."),
+  row(". . X I X . . . . X I X . ."),
+  row(". X X I I X . . X I I X X ."),
+  row("X X X X X X X X X X X X X X"),
+  row("X X X X X X X X X X X X X X"),
+  row("X X X X X X X X X X X X X X"),
+  row("X X X E E X X X X E E X X X"),
+  row("W X X W W W X X W W W X X W"),
+  row("W W X W W W X X W W W X W W"),
+  row("W W W W W W N N W W W W W W"),
+  row(". W W W W W N N W W W W W .")
+];
+var MOUTH_NEUTRAL = [
+  row(". . W W W W W W W W W W . ."),
+  row(". . W W W W N N W W W W . ."),
+  row(". . . W W W W W W W W . . .")
+];
+var MOUTH_SMALL_SMILE = [
+  // content
+  row(". . W W W W W W W W W W . ."),
+  row(". . W W W N W W N W W W . ."),
+  row(". . . W W W N N W W W . . .")
+];
+var MOUTH_BIG_SMILE = [
+  // happy / ecstatic
+  row(". . W W N W W W W N W W . ."),
+  row(". . W W W N N N N W W W . ."),
+  row(". . . W W W W W W W . . . .")
+];
+function withBlush(head, bright) {
+  const ch = bright ? "C" : "B";
+  const rows = head.map((r) => r.split(""));
+  rows[8][1] = ch;
+  rows[9][1] = ch;
+  rows[8][12] = ch;
+  rows[9][12] = ch;
+  if (bright) {
+    rows[9][2] = ch;
+    rows[9][11] = ch;
+  }
+  return rows.map((r) => r.join(""));
+}
+var REACTION_GRIDS = {
+  content: [...HEAD_EYES_OPEN, ...MOUTH_SMALL_SMILE],
+  happy: [...withBlush(HEAD_EYES_OPEN, false), ...MOUTH_BIG_SMILE],
+  ecstatic: [...withBlush(HEAD_EYES_OPEN, true), ...MOUTH_BIG_SMILE]
+};
+var IDLE_OPEN_GRID = [...HEAD_EYES_OPEN, ...MOUTH_NEUTRAL];
+var IDLE_BLINK_GRID = [...HEAD_EYES_CLOSED, ...MOUTH_NEUTRAL];
 var KNOWN_IDS = new Set(allRules.map((r) => r.id));
 function findUnknownRuleIds(ids) {
   return [...new Set(ids.filter((id2) => !KNOWN_IDS.has(id2)))];

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -56976,7 +56976,7 @@ function applyRuleSeverities(results, config) {
   });
 }
 
-// ../cli/dist/chunk-YGQV6XN3.js
+// ../cli/dist/chunk-RVZZNMTI.js
 import { readFile, access as access2 } from "fs/promises";
 import { join } from "path";
 
@@ -57754,7 +57754,7 @@ async function glob(globInput, options) {
   return crawler ? formatPaths(await crawler.withPromise(), relative2) : [];
 }
 
-// ../cli/dist/chunk-YGQV6XN3.js
+// ../cli/dist/chunk-RVZZNMTI.js
 import { readFileSync as readFileSync2 } from "fs";
 import { execFileSync } from "child_process";
 import { execFileSync as execFileSync2 } from "child_process";

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -40,7 +40,7 @@ Passed (3)
 
 By default, console output groups failures by rule (top 5 per severity, each with one example location and an "…and N more" count) and collapses the Passed section to a bare count, so large projects don't flood the terminal. Pass `--verbose` to see every finding uncapped and ungrouped, with each passed item listed individually. On an interactive, color-capable terminal the Health score plays a short reveal animation; pass `--no-animation` to disable it.
 
-On an interactive terminal, a small mascot appears alongside both the analysis spinner and the Health-score reveal, reacting to the result (a critical finding always reads as concerned, regardless of the numeric score; a perfect 100 gets a confetti flourish). `--no-animation` disables it, falling back to the plain spinner and plain score animation.
+On an interactive terminal, a small pixel-art fox mascot appears alongside both the analysis spinner and the Health-score reveal, reacting to the score (a perfect 100 gets a confetti flourish). `--no-animation` disables it, falling back to the plain spinner and plain score animation.
 
 ### Exit codes
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -40,7 +40,7 @@ Passed (3)
 
 By default, console output groups failures by rule (top 5 per severity, each with one example location and an "…and N more" count) and collapses the Passed section to a bare count, so large projects don't flood the terminal. Pass `--verbose` to see every finding uncapped and ungrouped, with each passed item listed individually. On an interactive, color-capable terminal the Health score plays a short reveal animation; pass `--no-animation` to disable it.
 
-On an interactive terminal, a small pixel-art fox mascot appears alongside both the analysis spinner and the Health-score reveal, reacting to the score (a perfect 100 gets a confetti flourish). On a wide enough terminal it also greets you with a short line in a speech bubble at startup, and again with a matching reaction line at the score reveal. `--no-animation` disables all of it, falling back to the plain spinner and plain score animation.
+On an interactive terminal wide enough for the mascot (40+ columns), a small pixel-art fox appears alongside both the analysis spinner and the Health-score reveal, reacting to the score (a perfect 100 gets a confetti flourish). On a wider terminal still (55+ columns) it also greets you with a short line in a speech bubble at startup, and again with a matching reaction line at the score reveal. `--no-animation` disables all of it, falling back to the plain spinner and plain score animation.
 
 ### Exit codes
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -40,7 +40,7 @@ Passed (3)
 
 By default, console output groups failures by rule (top 5 per severity, each with one example location and an "…and N more" count) and collapses the Passed section to a bare count, so large projects don't flood the terminal. Pass `--verbose` to see every finding uncapped and ungrouped, with each passed item listed individually. On an interactive, color-capable terminal the Health score plays a short reveal animation; pass `--no-animation` to disable it.
 
-On an interactive terminal, a small pixel-art fox mascot appears alongside both the analysis spinner and the Health-score reveal, reacting to the score (a perfect 100 gets a confetti flourish). `--no-animation` disables it, falling back to the plain spinner and plain score animation.
+On an interactive terminal, a small pixel-art fox mascot appears alongside both the analysis spinner and the Health-score reveal, reacting to the score (a perfect 100 gets a confetti flourish). On a wide enough terminal it also greets you with a short line in a speech bubble at startup, and again with a matching reaction line at the score reveal. `--no-animation` disables all of it, falling back to the plain spinner and plain score animation.
 
 ### Exit codes
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -280,7 +280,7 @@ export async function run(opts: RunOptions = {}): Promise<number> {
     });
   const useMascotSpinner = spinnerBaseEnabled && !opts.noAnimation && mascotFitsWidth(stderrStream.columns);
   const spinner = useMascotSpinner
-    ? startMascotSpinner('Analyzing…', { enabled: true, palette: paletteFor(true), stream: stderrStream })
+    ? startMascotSpinner('Analyzing…', { enabled: true, stream: stderrStream })
     : startSpinner('Analyzing…', { enabled: spinnerBaseEnabled, stream: stderrStream });
 
   let cwd = opts.cwd ?? process.cwd();
@@ -445,7 +445,6 @@ export async function run(opts: RunOptions = {}): Promise<number> {
         if (animate) {
           await playScoreAnimation({
             score: computeHealth(results, config).health,
-            hasCritical: summary.critical > 0,
             palette,
             stream: opts.stdoutStream ?? process.stdout,
             frameDelayMs: opts.animationFrameDelayMs

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -34,6 +34,7 @@ import { checkoutBaseline, filterToNewFindings } from './baseline.js';
 import { colorEnabled, paletteFor } from './color.js';
 import { startSpinner } from './spinner.js';
 import { startMascotSpinner, mascotFitsWidth } from './mascot.js';
+import { playMascotGreeting, bubbleFitsWidth } from './speech-bubble.js';
 import { loadConfigFile } from './config-file.js';
 import { playScoreAnimation, scoreAnimationEnabled } from './pulse-animation.js';
 
@@ -279,6 +280,11 @@ export async function run(opts: RunOptions = {}): Promise<number> {
       noColorFlag: opts.noColor
     });
   const useMascotSpinner = spinnerBaseEnabled && !opts.noAnimation && mascotFitsWidth(stderrStream.columns);
+  if (useMascotSpinner && bubbleFitsWidth(stderrStream.columns)) {
+    // A wordless greeting isn't worth a dedicated hold before the idle loop, so this
+    // only plays when there's room for the speech bubble too — not just the fox alone.
+    await playMascotGreeting({ enabled: true, stream: stderrStream, holdMs: opts.animationFrameDelayMs });
+  }
   const spinner = useMascotSpinner
     ? startMascotSpinner('Analyzing…', { enabled: true, stream: stderrStream })
     : startSpinner('Analyzing…', { enabled: spinnerBaseEnabled, stream: stderrStream });

--- a/packages/cli/src/mascot.ts
+++ b/packages/cli/src/mascot.ts
@@ -1,23 +1,17 @@
-import type { Palette } from '@svelte-vitals/core';
 import { createLogUpdate } from 'log-update';
 
-export type MascotState = 'ecstatic' | 'happy' | 'alarmed' | 'content' | 'discouraged';
+export type MascotState = 'ecstatic' | 'happy' | 'content';
 
 /**
- * Reaction state for the score-reveal pose. `hasCritical` is checked first,
- * defensively: `CRITICAL_CAP` in packages/core/src/scoring/score.ts caps any score
- * with a critical finding at <=79, so 'ecstatic'/'happy' and hasCritical:true never
- * both hold for real (score, hasCritical) pairs derived from the same results — but
- * checking hasCritical first means this function never celebrates a critical finding
- * even if a future caller passes an inconsistent pair (e.g. a stale score computed
- * before hasCritical), rather than relying solely on callers upholding the invariant.
+ * Reaction state for the score-reveal pose. Score bands only — deliberately no
+ * critical-finding override and no "discouraged"/"alarmed" states (an earlier design
+ * had five states including those; scoped down to three on the project owner's call,
+ * to keep the mascot upbeat rather than growing a full sad/worried repertoire).
  */
-export function mascotStateFor(score: number, hasCritical: boolean): MascotState {
-  if (hasCritical) return 'alarmed';
+export function mascotStateFor(score: number): MascotState {
   if (score === 100) return 'ecstatic';
   if (score >= 90) return 'happy';
-  if (score >= 70) return 'content';
-  return 'discouraged';
+  return 'content';
 }
 
 const MIN_MASCOT_COLUMNS = 40;
@@ -27,78 +21,193 @@ export function mascotFitsWidth(columns: number | undefined): boolean {
   return (columns ?? 80) >= MIN_MASCOT_COLUMNS;
 }
 
-// Svelte's brand accent (#ff3e00) as 24-bit truecolor. Mascot-only: not part of the
-// shared core Palette (packages/core/src/reporter/palette.ts), which core's console
-// reporter never uses this mascot in, so it never needs an 'orange' entry.
+// ---- pixel art ----
 //
-// `colorEnabled` is derived from the caller's `faceColor` function (probed below) rather
-// than threaded as a separate parameter, so that passing a no-color Palette suppresses
-// ALL color in the frame, including the body — not just the face. Without this, the body
-// would always emit ANSI truecolor codes even under `noColorPalette`/`NO_COLOR`.
-const svelteOrange =
-  (colorEnabled: boolean) =>
-  (s: string): string =>
-    colorEnabled ? `\x1b[38;2;255;62;0m${s}\x1b[39m` : s;
+// Rendered as a fixed-palette half-block pixel-art sprite (a fox), not colorable
+// text — unlike the CLI's other color output, these colors are never derived from
+// the console reporter's `Palette` (packages/core/src/reporter/palette.ts): a
+// pixel-art sprite has no meaningful "no-color" rendering (dropping ANSI would
+// leave meaningless block characters, not readable text), so this module doesn't
+// try to support one. That's safe because every call site (`startMascotSpinner`,
+// and the score-reveal path in pulse-animation.ts) only ever renders the mascot
+// once color is already confirmed enabled (`spinnerEnabled`/`scoreAnimationEnabled`
+// both require `colorEnabled(...)`) — the mascot itself is never reached otherwise.
+type RGB = readonly [number, number, number];
+const ORANGE: RGB = [255, 62, 0]; // Svelte's brand accent (#ff3e00) — the fur
+const EAR_INNER: RGB = [153, 45, 10]; // darker inner-ear shading
+const DARK: RGB = [17, 24, 39]; // eyes, nose, mouth line
+const WHITE: RGB = [255, 255, 255]; // muzzle/cheek fur
+const BLUSH: RGB = [255, 145, 175]; // happy cheek accent
+const BLUSH_BRIGHT: RGB = [255, 105, 150]; // ecstatic cheek accent (bigger + brighter, see withBlush)
 
-const TOP = ' .---. ';
-const TOP_ARMS_UP = '\\.---./';
-const BOTTOM = " '---' ";
+/** Pixel-grid character alphabet. '.' is transparent (shows the real terminal background). */
+type Pixel = '.' | 'X' | 'I' | 'E' | 'W' | 'N' | 'B' | 'C';
+const PIXEL_COLOR: Record<Exclude<Pixel, '.'>, RGB> = {
+  X: ORANGE,
+  I: EAR_INNER,
+  E: DARK,
+  W: WHITE,
+  N: DARK,
+  B: BLUSH,
+  C: BLUSH_BRIGHT
+};
 
-function renderFace(top: string, eyes: string, mouth: string, faceColor: (s: string) => string): string {
-  // Assumes faceColor wraps its input in ANSI codes when color is enabled, even for a
-  // whitespace-only string (true for every Palette color fn in this codebase — see
-  // packages/core/src/reporter/palette.ts's noColorPalette vs. ansiPalette in color.ts).
-  const colorEnabled = faceColor(' ') !== ' ';
-  const orange = svelteOrange(colorEnabled);
-  return [
-    orange(top),
-    orange('(') + faceColor(eyes) + orange(')'),
-    orange(' \\') + faceColor(mouth) + orange('/ '),
-    orange(BOTTOM)
-  ].join('\n');
+const fg = (rgb: RGB): string => `\x1b[38;2;${rgb[0]};${rgb[1]};${rgb[2]}m`;
+const bg = (rgb: RGB): string => `\x1b[48;2;${rgb[0]};${rgb[1]};${rgb[2]}m`;
+const BG_DEFAULT = '\x1b[49m';
+const RESET = '\x1b[0m';
+
+/**
+ * Renders a pixel-art grid (an array of equal-length row strings, alphabet above) to a
+ * multi-line ANSI string. Each printed line packs two logical pixel-rows using the
+ * upper/lower half-block characters (▀/▄) — the standard terminal half-block pixel-art
+ * technique — with independently set 24-bit truecolor foreground/background per cell.
+ * `.` cells fall back to the terminal's own default fg/bg per cell (not a fixed fill
+ * color), so the sprite's silhouette (ear notches, the gap between the ears, etc.)
+ * looks correct on any real terminal background, not just one specific theme.
+ */
+function renderPixelGrid(grid: readonly string[]): string {
+  const lines: string[] = [];
+  for (let r = 0; r < grid.length; r += 2) {
+    const top = grid[r]!;
+    const bottom = grid[r + 1] ?? '.'.repeat(top.length);
+    let line = '';
+    for (let c = 0; c < top.length; c++) {
+      const t = top[c] as Pixel;
+      const b = bottom[c] as Pixel;
+      if (t === '.' && b === '.') {
+        line += RESET + ' ';
+      } else if (t === '.') {
+        line += fg(PIXEL_COLOR[b as Exclude<Pixel, '.'>]) + BG_DEFAULT + '▄';
+      } else if (b === '.') {
+        line += fg(PIXEL_COLOR[t]) + BG_DEFAULT + '▀';
+      } else {
+        line += fg(PIXEL_COLOR[t]) + bg(PIXEL_COLOR[b]) + '▀';
+      }
+    }
+    lines.push(line + RESET);
+  }
+  return lines.join('\n');
 }
+
+const row = (s: string): string => s.replace(/ /g, '');
+
+// Shared head (rows 0-10, 14 pixels wide): pointy ears with inner shading, eyes, and
+// the white muzzle starting to flare in. Two variants: eyes open (default) and eyes
+// closed (the idle-loop blink — same head, the eye rows become plain fur plus a thin
+// lash line).
+const HEAD_EYES_OPEN = [
+  row('. . X X . . . . . . X X . .'),
+  row('. . X I X . . . . X I X . .'),
+  row('. X X I I X . . X I I X X .'),
+  row('X X X X X X X X X X X X X X'),
+  row('X X X X X X X X X X X X X X'),
+  row('X X X E E X X X X E E X X X'),
+  row('X X X E E X X X X E E X X X'),
+  row('W X X W W W X X W W W X X W'),
+  row('W W X W W W X X W W W X W W'),
+  row('W W W W W W N N W W W W W W'),
+  row('. W W W W W N N W W W W W .')
+];
+
+const HEAD_EYES_CLOSED = [
+  row('. . X X . . . . . . X X . .'),
+  row('. . X I X . . . . X I X . .'),
+  row('. X X I I X . . X I I X X .'),
+  row('X X X X X X X X X X X X X X'),
+  row('X X X X X X X X X X X X X X'),
+  row('X X X X X X X X X X X X X X'),
+  row('X X X E E X X X X E E X X X'),
+  row('W X X W W W X X W W W X X W'),
+  row('W W X W W W X X W W W X W W'),
+  row('W W W W W W N N W W W W W W'),
+  row('. W W W W W N N W W W W W .')
+];
+
+// Mouths (rows 11-13, 14 pixels wide). Mood is conveyed primarily through mouth shape,
+// not color — the fixed orange/white/black palette stays constant; blush is the only
+// accent color, and only for the two positive states (see withBlush below).
+const MOUTH_NEUTRAL = [
+  row('. . W W W W W W W W W W . .'),
+  row('. . W W W W N N W W W W . .'),
+  row('. . . W W W W W W W W . . .')
+];
+
+const MOUTH_SMALL_SMILE = [
+  // content
+  row('. . W W W W W W W W W W . .'),
+  row('. . W W W N W W N W W W . .'),
+  row('. . . W W W N N W W W . . .')
+];
+
+const MOUTH_BIG_SMILE = [
+  // happy / ecstatic
+  row('. . W W N W W W W N W W . .'),
+  row('. . W W W N N N N W W W . .'),
+  row('. . . W W W W W W W . . . .')
+];
+
+/** Pokes blush accent pixels onto both cheeks. `bright` (ecstatic) is a larger, brighter patch than the plain happy blush. */
+function withBlush(head: readonly string[], bright: boolean): string[] {
+  const ch: Pixel = bright ? 'C' : 'B';
+  const rows = head.map((r) => r.split(''));
+  rows[8]![1] = ch;
+  rows[9]![1] = ch;
+  rows[8]![12] = ch;
+  rows[9]![12] = ch;
+  if (bright) {
+    rows[9]![2] = ch;
+    rows[9]![11] = ch;
+  }
+  return rows.map((r) => r.join(''));
+}
+
+const REACTION_GRIDS: Record<MascotState, readonly string[]> = {
+  content: [...HEAD_EYES_OPEN, ...MOUTH_SMALL_SMILE],
+  happy: [...withBlush(HEAD_EYES_OPEN, false), ...MOUTH_BIG_SMILE],
+  ecstatic: [...withBlush(HEAD_EYES_OPEN, true), ...MOUTH_BIG_SMILE]
+};
+
+/** The settled pose for the given reaction state — the "payoff" frame of the reveal. */
+export function renderMascotReaction(state: MascotState): string {
+  return renderPixelGrid(REACTION_GRIDS[state]);
+}
+
+/** The neutral "watching the score count up" pose shown before the reveal cut. */
+export function renderMascotAnticipating(): string {
+  return renderPixelGrid([...HEAD_EYES_OPEN, ...MOUTH_NEUTRAL]);
+}
+
+const IDLE_OPEN_GRID = [...HEAD_EYES_OPEN, ...MOUTH_NEUTRAL];
+const IDLE_BLINK_GRID = [...HEAD_EYES_CLOSED, ...MOUTH_NEUTRAL];
 
 // Mostly-open with a brief blink, matching a ~1s full cycle at IDLE_TICK_MS (160ms x 5 = 800ms).
 const IDLE_FRAME_SEQUENCE = [0, 0, 0, 0, 1];
 
 /** One frame of the analysis-phase idle loop. `frameIndex` is taken mod the sequence length. */
-export function renderMascotIdleFrame(frameIndex: number, palette: Palette): string {
+export function renderMascotIdleFrame(frameIndex: number): string {
   const isBlink = IDLE_FRAME_SEQUENCE[frameIndex % IDLE_FRAME_SEQUENCE.length] === 1;
-  return renderFace(TOP, isBlink ? ' -   - ' : ' o   o ', '  ---  ', palette.cyan);
+  return renderPixelGrid(isBlink ? IDLE_BLINK_GRID : IDLE_OPEN_GRID);
 }
 
-/** The neutral "watching the score count up" pose shown before the reveal cut. */
-export function renderMascotAnticipating(palette: Palette): string {
-  return renderFace(TOP, ' o   o ', '   o   ', palette.dim);
-}
-
-const REACTION_FACES: Record<
-  MascotState,
-  { top: string; eyes: string; mouth: string; colorKey: 'green' | 'yellow' | 'red' }
-> = {
-  ecstatic: { top: TOP_ARMS_UP, eyes: ' ^   ^ ', mouth: '  \\_/  ', colorKey: 'green' },
-  happy: { top: TOP, eyes: ' ^   ^ ', mouth: '  \\_/  ', colorKey: 'green' },
-  alarmed: { top: TOP, eyes: ' O   O ', mouth: '   o   ', colorKey: 'red' },
-  content: { top: TOP, eyes: ' o   o ', mouth: '  ---  ', colorKey: 'yellow' },
-  discouraged: { top: TOP, eyes: ' -   - ', mouth: '  ,-,  ', colorKey: 'red' }
-};
-
-/** The settled pose for the given reaction state — the "payoff" frame of the reveal. */
-export function renderMascotReaction(state: MascotState, palette: Palette): string {
-  const f = REACTION_FACES[state];
-  return renderFace(f.top, f.eyes, f.mouth, palette[f.colorKey]);
-}
-
+// A small set of festive colors for the 100/100 confetti bonus, distinct from the
+// mascot's own fixed identity palette above (confetti is meant to look varied/colorful,
+// unlike the fox itself, which is deliberately a constant, recognizable color scheme).
+const CONFETTI_COLORS: readonly RGB[] = [
+  [255, 62, 0], // orange (identity accent)
+  [255, 145, 175], // blush pink
+  [255, 214, 0], // gold
+  [255, 255, 255] // white
+];
 const CONFETTI_CHARS = ['*', '.', '·', '+'];
 const CONFETTI_WIDTH = 24;
 
-function confettiRow(offset: number, palette: Palette): string {
-  const colors: Array<(s: string) => string> = [palette.green, palette.yellow, palette.cyan, palette.red];
+function confettiRow(offset: number): string {
   let out = '';
   for (let col = 0; col < CONFETTI_WIDTH; col++) {
     if ((col + offset) % 5 === 0) {
       const glyph = CONFETTI_CHARS[(col + offset) % CONFETTI_CHARS.length]!;
-      out += colors[(col + offset) % colors.length]!(glyph);
+      out += fg(CONFETTI_COLORS[(col + offset) % CONFETTI_COLORS.length]!) + glyph + RESET;
     } else {
       out += ' ';
     }
@@ -107,12 +216,13 @@ function confettiRow(offset: number, palette: Palette): string {
 }
 
 /**
- * Wraps `mascotBlock` (a `renderMascotReaction` output) with a particle row above and
- * below. `offset` shifts the deterministic particle pattern between successive calls
- * for a "twinkling" effect — no RNG, so the same offset always renders the same frame.
+ * Wraps `mascotBlock` (a `renderMascotReaction('ecstatic')` output) with a particle row
+ * above and below. `offset` shifts the deterministic particle pattern between
+ * successive calls for a "twinkling" effect — no RNG, so the same offset always
+ * renders the same frame.
  */
-export function renderConfettiFrame(offset: number, mascotBlock: string, palette: Palette): string {
-  return [confettiRow(offset, palette), mascotBlock, confettiRow(offset + 2, palette)].join('\n');
+export function renderConfettiFrame(offset: number, mascotBlock: string): string {
+  return [confettiRow(offset), mascotBlock, confettiRow(offset + 2)].join('\n');
 }
 
 export interface MascotSpinner {
@@ -130,14 +240,14 @@ const IDLE_TICK_MS = 160;
  */
 export function startMascotSpinner(
   text: string,
-  opts: { enabled: boolean; palette: Palette; stream?: NodeJS.WriteStream }
+  opts: { enabled: boolean; stream?: NodeJS.WriteStream }
 ): MascotSpinner {
   if (!opts.enabled) return { stop() {} };
   const stream = opts.stream ?? process.stderr;
   const render = createLogUpdate(stream);
   let i = 0;
   const tick = (): void => {
-    render(`${renderMascotIdleFrame(i, opts.palette)}\n${text}`);
+    render(`${renderMascotIdleFrame(i)}\n${text}`);
     i++;
   };
   tick();

--- a/packages/cli/src/pulse-animation.ts
+++ b/packages/cli/src/pulse-animation.ts
@@ -9,6 +9,7 @@ import {
   renderMascotReaction,
   renderConfettiFrame
 } from './mascot.js';
+import { bubbleFitsWidth, pickMessage, renderMascotWithSpeech, REACTION_MESSAGES } from './speech-bubble.js';
 
 const FRAME_COUNT = 6;
 const FRAME_DELAY_MS = 200;
@@ -57,6 +58,11 @@ export async function playScoreAnimation(opts: ScoreAnimationOptions): Promise<v
   const render = createLogUpdate(opts.stream);
   const showMascot = mascotFitsWidth(opts.stream.columns);
   const state = mascotStateFor(opts.score);
+  const reactionMessage =
+    showMascot && bubbleFitsWidth(opts.stream.columns) ? pickMessage(REACTION_MESSAGES[state]) : undefined;
+  const finalMascotBlock = reactionMessage
+    ? renderMascotWithSpeech(renderMascotReaction(state), reactionMessage)
+    : renderMascotReaction(state);
 
   for (let frame = 0; frame < FRAME_COUNT; frame++) {
     const progress = frame / (FRAME_COUNT - 1);
@@ -67,9 +73,7 @@ export async function playScoreAnimation(opts: ScoreAnimationOptions): Promise<v
       ? scoreColor(opts.palette, opts.score)(`${displayScore}/100`)
       : opts.palette.dim(`${displayScore}/100`);
     const waveBlock = `  ${wave}\n  Health: ${scoreText}`;
-    const mascotBlock = showMascot
-      ? (isFinalFrame ? renderMascotReaction(state) : renderMascotAnticipating()) + '\n'
-      : '';
+    const mascotBlock = showMascot ? (isFinalFrame ? finalMascotBlock : renderMascotAnticipating()) + '\n' : '';
     render(`${mascotBlock}${waveBlock}`);
     if (!isFinalFrame) await sleep(frameDelayMs);
   }
@@ -77,10 +81,9 @@ export async function playScoreAnimation(opts: ScoreAnimationOptions): Promise<v
   if (holdMs > 0) await sleep(holdMs);
 
   if (showMascot && state === 'ecstatic') {
-    const mascotBlock = renderMascotReaction('ecstatic');
     for (let i = 0; i < CONFETTI_FRAME_COUNT; i++) {
       const waveBlock = `  ${WAVE_FRAMES[FRAME_COUNT - 1]!}\n  Health: ${scoreColor(opts.palette, opts.score)('100/100')}`;
-      render(`${renderConfettiFrame(i, mascotBlock)}\n${waveBlock}`);
+      render(`${renderConfettiFrame(i, finalMascotBlock)}\n${waveBlock}`);
       if (i < CONFETTI_FRAME_COUNT - 1 && confettiDelayMs > 0) await sleep(confettiDelayMs);
     }
   }

--- a/packages/cli/src/pulse-animation.ts
+++ b/packages/cli/src/pulse-animation.ts
@@ -35,8 +35,6 @@ const CONFETTI_FRAME_DELAY_MS = 220;
 
 export interface ScoreAnimationOptions {
   score: number;
-  /** Whether any critical-severity finding is present — determines the 'alarmed' reaction regardless of score. */
-  hasCritical: boolean;
   palette: Palette;
   stream: NodeJS.WriteStream;
   /** Override for tests — real playback uses FRAME_DELAY_MS/REACTION_HOLD_MS/CONFETTI_FRAME_DELAY_MS; 0 runs every phase near-instantly. */
@@ -58,7 +56,7 @@ export async function playScoreAnimation(opts: ScoreAnimationOptions): Promise<v
   const confettiDelayMs = opts.frameDelayMs ?? CONFETTI_FRAME_DELAY_MS;
   const render = createLogUpdate(opts.stream);
   const showMascot = mascotFitsWidth(opts.stream.columns);
-  const state = mascotStateFor(opts.score, opts.hasCritical);
+  const state = mascotStateFor(opts.score);
 
   for (let frame = 0; frame < FRAME_COUNT; frame++) {
     const progress = frame / (FRAME_COUNT - 1);
@@ -70,7 +68,7 @@ export async function playScoreAnimation(opts: ScoreAnimationOptions): Promise<v
       : opts.palette.dim(`${displayScore}/100`);
     const waveBlock = `  ${wave}\n  Health: ${scoreText}`;
     const mascotBlock = showMascot
-      ? (isFinalFrame ? renderMascotReaction(state, opts.palette) : renderMascotAnticipating(opts.palette)) + '\n'
+      ? (isFinalFrame ? renderMascotReaction(state) : renderMascotAnticipating()) + '\n'
       : '';
     render(`${mascotBlock}${waveBlock}`);
     if (!isFinalFrame) await sleep(frameDelayMs);
@@ -79,10 +77,10 @@ export async function playScoreAnimation(opts: ScoreAnimationOptions): Promise<v
   if (holdMs > 0) await sleep(holdMs);
 
   if (showMascot && state === 'ecstatic') {
-    const mascotBlock = renderMascotReaction('ecstatic', opts.palette);
+    const mascotBlock = renderMascotReaction('ecstatic');
     for (let i = 0; i < CONFETTI_FRAME_COUNT; i++) {
       const waveBlock = `  ${WAVE_FRAMES[FRAME_COUNT - 1]!}\n  Health: ${scoreColor(opts.palette, opts.score)('100/100')}`;
-      render(`${renderConfettiFrame(i, mascotBlock, opts.palette)}\n${waveBlock}`);
+      render(`${renderConfettiFrame(i, mascotBlock)}\n${waveBlock}`);
       if (i < CONFETTI_FRAME_COUNT - 1 && confettiDelayMs > 0) await sleep(confettiDelayMs);
     }
   }

--- a/packages/cli/src/speech-bubble.ts
+++ b/packages/cli/src/speech-bubble.ts
@@ -1,0 +1,42 @@
+const MIN_BUBBLE_COLUMNS = 55;
+
+/**
+ * Whether the terminal is wide enough for the mascot + speech bubble combination —
+ * a stricter gate than `mascotFitsWidth` (mascot.ts), which only covers the fox
+ * sprite alone. Below this, callers render the mascot without a bubble (or skip a
+ * bubble-only moment like the greeting entirely) rather than hiding the fox itself.
+ */
+export function bubbleFitsWidth(columns: number | undefined): boolean {
+  return (columns ?? 80) >= MIN_BUBBLE_COLUMNS;
+}
+
+/**
+ * Renders `text` inside a Unicode box-drawing border, sized to the text (1-space
+ * padding on each side). Always exactly 3 lines: top border, text line, bottom
+ * border. Plain terminal-default colors — unlike the fox sprite, this is readable
+ * text, not pixel art, so it doesn't need a fixed color identity.
+ */
+export function renderSpeechBubble(text: string): string[] {
+  const border = '─'.repeat(text.length + 2);
+  return [`┌${border}┐`, `│ ${text} │`, `└${border}┘`];
+}
+
+/**
+ * Places `bubbleLines` to the right of `mascotBlock`, vertically centered against
+ * it. `mascotBlock` is a `renderPixelGrid` output (mascot.ts) — its lines already
+ * end in an ANSI reset, so appending plain text after a space is safe (no color
+ * bleed into the bubble).
+ */
+export function withSpeechBubble(mascotBlock: string, bubbleLines: readonly string[]): string {
+  const mascotLines = mascotBlock.split('\n');
+  const bubbleWidth = bubbleLines[0]?.length ?? 0;
+  const blankBubbleLine = ' '.repeat(bubbleWidth);
+  const padTop = Math.floor((mascotLines.length - bubbleLines.length) / 2);
+  const padBottom = mascotLines.length - bubbleLines.length - padTop;
+  const paddedBubble = [
+    ...Array<string>(Math.max(padTop, 0)).fill(blankBubbleLine),
+    ...bubbleLines,
+    ...Array<string>(Math.max(padBottom, 0)).fill(blankBubbleLine)
+  ];
+  return mascotLines.map((line, i) => `${line} ${paddedBubble[i] ?? blankBubbleLine}`).join('\n');
+}

--- a/packages/cli/src/speech-bubble.ts
+++ b/packages/cli/src/speech-bubble.ts
@@ -1,3 +1,5 @@
+import type { MascotState } from './mascot.js';
+
 const MIN_BUBBLE_COLUMNS = 55;
 
 /**
@@ -39,4 +41,31 @@ export function withSpeechBubble(mascotBlock: string, bubbleLines: readonly stri
     ...Array<string>(Math.max(padBottom, 0)).fill(blankBubbleLine)
   ];
   return mascotLines.map((line, i) => `${line} ${paddedBubble[i] ?? blankBubbleLine}`).join('\n');
+}
+
+export const GREETING_MESSAGES: readonly string[] = [
+  'Welcome to Svelte Vitals!',
+  "Let's check your project!",
+  'Ready when you are!',
+  "Hi there! Let's dig in."
+];
+
+export const REACTION_MESSAGES: Record<MascotState, readonly string[]> = {
+  ecstatic: ['Perfect score!', 'Flawless!', 'You nailed it!'],
+  happy: ['Nice work!', 'Looking great!', 'Almost perfect!'],
+  content: ['Keep going!', 'Room to grow!', "Let's improve this!"]
+};
+
+/**
+ * Picks one message uniformly at random from `pool`. `random` defaults to
+ * `Math.random` — only overridden by this module's own unit tests below, for
+ * deterministic selection; other call sites and their tests never pass it.
+ */
+export function pickMessage(pool: readonly string[], random: () => number = Math.random): string {
+  return pool[Math.floor(random() * pool.length)]!;
+}
+
+/** Composes a mascot pose with a speech bubble to its right — the shared shape both the startup greeting and the score-reveal reaction use. */
+export function renderMascotWithSpeech(mascotBlock: string, message: string): string {
+  return withSpeechBubble(mascotBlock, renderSpeechBubble(message));
 }

--- a/packages/cli/src/speech-bubble.ts
+++ b/packages/cli/src/speech-bubble.ts
@@ -1,4 +1,5 @@
-import type { MascotState } from './mascot.js';
+import { createLogUpdate } from 'log-update';
+import { renderMascotAnticipating, type MascotState } from './mascot.js';
 
 const MIN_BUBBLE_COLUMNS = 55;
 
@@ -68,4 +69,31 @@ export function pickMessage(pool: readonly string[], random: () => number = Math
 /** Composes a mascot pose with a speech bubble to its right — the shared shape both the startup greeting and the score-reveal reaction use. */
 export function renderMascotWithSpeech(mascotBlock: string, message: string): string {
   return withSpeechBubble(mascotBlock, renderSpeechBubble(message));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const GREETING_HOLD_MS = 800;
+
+/**
+ * Plays a one-shot greeting: the fox's idle-open pose with a random greeting
+ * message in a speech bubble, held for `holdMs`, then cleared — called once
+ * before analysis starts (index.ts), never repeated within a single run. Uses
+ * `log-update` for the same reason mascot.ts's `startMascotSpinner` and
+ * pulse-animation.ts's `playScoreAnimation` do: accurate multi-line redraw/clear.
+ */
+export async function playMascotGreeting(opts: {
+  enabled: boolean;
+  stream: NodeJS.WriteStream;
+  /** Override for tests — real playback uses GREETING_HOLD_MS; 0 completes near-instantly. */
+  holdMs?: number;
+}): Promise<void> {
+  if (!opts.enabled) return;
+  const holdMs = opts.holdMs ?? GREETING_HOLD_MS;
+  const render = createLogUpdate(opts.stream);
+  render(renderMascotWithSpeech(renderMascotAnticipating(), pickMessage(GREETING_MESSAGES)));
+  if (holdMs > 0) await sleep(holdMs);
+  render.clear();
 }

--- a/packages/cli/test/mascot.test.ts
+++ b/packages/cli/test/mascot.test.ts
@@ -8,7 +8,6 @@ import {
   renderConfettiFrame,
   startMascotSpinner
 } from '../src/mascot.js';
-import { noColorPalette, ansiPalette } from '../src/color.js';
 
 function fakeStream() {
   const writes: string[] = [];
@@ -17,31 +16,17 @@ function fakeStream() {
 
 describe('mascotStateFor', () => {
   it('is ecstatic at exactly 100', () => {
-    expect(mascotStateFor(100, false)).toBe('ecstatic');
+    expect(mascotStateFor(100)).toBe('ecstatic');
   });
   it('is happy from 90 up to (not including) 100', () => {
-    expect(mascotStateFor(90, false)).toBe('happy');
-    expect(mascotStateFor(99, false)).toBe('happy');
+    expect(mascotStateFor(90)).toBe('happy');
+    expect(mascotStateFor(99)).toBe('happy');
   });
-  it('is alarmed whenever a critical finding is present, regardless of score, below 90', () => {
-    expect(mascotStateFor(79, true)).toBe('alarmed');
-    expect(mascotStateFor(0, true)).toBe('alarmed');
-  });
-  it('is content from 70 to 89 with no critical finding', () => {
-    expect(mascotStateFor(70, false)).toBe('content');
-    expect(mascotStateFor(89, false)).toBe('content');
-  });
-  it('is discouraged below 70 with no critical finding', () => {
-    expect(mascotStateFor(69, false)).toBe('discouraged');
-    expect(mascotStateFor(0, false)).toBe('discouraged');
-  });
-  it('a critical finding at a boundary still reads as alarmed, not content/discouraged', () => {
-    expect(mascotStateFor(80, true)).toBe('alarmed');
-    expect(mascotStateFor(69, true)).toBe('alarmed');
-  });
-  it('a critical finding always wins over ecstatic/happy too — defensive, since real callers never actually pass this combination (CRITICAL_CAP=79 makes it unreachable in practice)', () => {
-    expect(mascotStateFor(100, true)).toBe('alarmed');
-    expect(mascotStateFor(95, true)).toBe('alarmed');
+  it('is content below 90, including 0', () => {
+    expect(mascotStateFor(89)).toBe('content');
+    expect(mascotStateFor(70)).toBe('content');
+    expect(mascotStateFor(69)).toBe('content');
+    expect(mascotStateFor(0)).toBe('content');
   });
 });
 
@@ -60,60 +45,68 @@ describe('mascotFitsWidth', () => {
 });
 
 describe('mascot rendering', () => {
-  it('renders 4-line frames for idle, anticipating, and every reaction state', () => {
-    expect(renderMascotIdleFrame(0, noColorPalette).split('\n')).toHaveLength(4);
-    expect(renderMascotAnticipating(noColorPalette).split('\n')).toHaveLength(4);
-    for (const state of ['ecstatic', 'happy', 'alarmed', 'content', 'discouraged'] as const) {
-      expect(renderMascotReaction(state, noColorPalette).split('\n')).toHaveLength(4);
+  it('renders 7-line frames (14-pixel head+mouth grid packed 2-per-line via half-blocks) for idle, anticipating, and every reaction state', () => {
+    expect(renderMascotIdleFrame(0).split('\n')).toHaveLength(7);
+    expect(renderMascotAnticipating().split('\n')).toHaveLength(7);
+    for (const state of ['ecstatic', 'happy', 'content'] as const) {
+      expect(renderMascotReaction(state).split('\n')).toHaveLength(7);
     }
   });
   it('the idle frame alternates an open-eyed and a blinking face', () => {
-    const open = renderMascotIdleFrame(0, noColorPalette);
-    const blink = renderMascotIdleFrame(4, noColorPalette); // index 4 is the blink in the 5-tick cycle
+    const open = renderMascotIdleFrame(0);
+    const blink = renderMascotIdleFrame(4); // index 4 is the blink in the 5-tick cycle
     expect(open).not.toBe(blink);
   });
-  it('colors the reaction face with the palette (ansiPalette produces ANSI codes, noColorPalette does not)', () => {
-    const colored = renderMascotReaction('happy', ansiPalette);
-    const plain = renderMascotReaction('happy', noColorPalette);
-    expect(colored).toContain('\x1b[32m'); // green
-    expect(plain).not.toContain('\x1b[');
+  it('always renders in color (24-bit truecolor escape codes) — the mascot has no no-color fallback, since it is only ever reached once color is already confirmed enabled by its callers', () => {
+    expect(renderMascotReaction('happy')).toContain('\x1b[38;2;255;62;0m'); // Svelte-orange foreground
   });
-  it('alarmed and discouraged both render red; content renders yellow; ecstatic/happy render green', () => {
-    expect(renderMascotReaction('alarmed', ansiPalette)).toContain('\x1b[31m');
-    expect(renderMascotReaction('discouraged', ansiPalette)).toContain('\x1b[31m');
-    expect(renderMascotReaction('content', ansiPalette)).toContain('\x1b[33m');
-    expect(renderMascotReaction('ecstatic', ansiPalette)).toContain('\x1b[32m');
-    expect(renderMascotReaction('happy', ansiPalette)).toContain('\x1b[32m');
+  it('content, happy, and ecstatic are all visually distinct from each other', () => {
+    const content = renderMascotReaction('content');
+    const happy = renderMascotReaction('happy');
+    const ecstatic = renderMascotReaction('ecstatic');
+    expect(content).not.toBe(happy);
+    expect(happy).not.toBe(ecstatic);
+    expect(content).not.toBe(ecstatic);
+  });
+  it('happy and ecstatic both apply a blush accent that content does not have', () => {
+    const content = renderMascotReaction('content');
+    const happy = renderMascotReaction('happy');
+    const ecstatic = renderMascotReaction('ecstatic');
+    // Blush pink (happy) / brighter blush pink (ecstatic) truecolor codes.
+    expect(content).not.toContain('\x1b[38;2;255;145;175m');
+    expect(content).not.toContain('\x1b[38;2;255;105;150m');
+    expect(happy).toContain('\x1b[38;2;255;145;175m');
+    expect(ecstatic).toContain('\x1b[38;2;255;105;150m');
   });
   it('confetti wraps the given mascot block with a particle row above and below, deterministically', () => {
-    const mascotBlock = renderMascotReaction('ecstatic', noColorPalette);
-    const frame = renderConfettiFrame(0, mascotBlock, noColorPalette);
+    const mascotBlock = renderMascotReaction('ecstatic');
+    const frame = renderConfettiFrame(0, mascotBlock);
     const lines = frame.split('\n');
-    expect(lines).toHaveLength(6); // 1 confetti row + 4 mascot lines + 1 confetti row
+    expect(lines).toHaveLength(9); // 1 confetti row + 7 mascot lines + 1 confetti row
     expect(lines[0]).not.toBe(''); // top confetti row has content
     expect(lines[lines.length - 1]).not.toBe('');
     // Deterministic: same offset always produces the same row (no RNG).
-    expect(renderConfettiFrame(0, mascotBlock, noColorPalette)).toBe(frame);
+    expect(renderConfettiFrame(0, mascotBlock)).toBe(frame);
   });
 });
 
 describe('startMascotSpinner', () => {
   it('writes nothing when disabled and returns a working stop()', () => {
     const { writes, stream } = fakeStream();
-    const spin = startMascotSpinner('Analyzing…', { enabled: false, palette: noColorPalette, stream });
+    const spin = startMascotSpinner('Analyzing…', { enabled: false, stream });
     spin.stop();
     expect(writes).toEqual([]);
   });
   it('writes a frame immediately when enabled, containing the status text', () => {
     const { writes, stream } = fakeStream();
-    const spin = startMascotSpinner('Analyzing…', { enabled: true, palette: noColorPalette, stream });
+    const spin = startMascotSpinner('Analyzing…', { enabled: true, stream });
     expect(writes.length).toBeGreaterThan(0);
     expect(writes[0]).toContain('Analyzing…');
     spin.stop();
   });
   it('clears the block on stop (no leftover mascot art)', () => {
     const { writes, stream } = fakeStream();
-    const spin = startMascotSpinner('Analyzing…', { enabled: true, palette: noColorPalette, stream });
+    const spin = startMascotSpinner('Analyzing…', { enabled: true, stream });
     spin.stop();
     const last = writes[writes.length - 1]!;
     expect(last).not.toContain('Analyzing…');

--- a/packages/cli/test/pulse-animation.test.ts
+++ b/packages/cli/test/pulse-animation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { scoreAnimationEnabled, playScoreAnimation } from '../src/pulse-animation.js';
 import { noColorPalette, ansiPalette } from '../src/color.js';
+import { REACTION_MESSAGES } from '../src/speech-bubble.js';
 
 function fakeStream() {
   const writes: string[] = [];
@@ -92,5 +93,23 @@ describe('playScoreAnimation', () => {
     await playScoreAnimation({ score: 82, palette: noColorPalette, stream, frameDelayMs: 0 });
     expect(writes[writes.length - 1]).toContain('82/100');
     expect(writes.join('')).not.toContain('\x1b[38;2;255;62;0m'); // no mascot body art anywhere
+  });
+
+  it('shows a reaction speech bubble matching the final state, on a wide enough terminal', async () => {
+    const { writes, stream } = fakeStream();
+    await playScoreAnimation({ score: 95, palette: ansiPalette, stream, frameDelayMs: 0 }); // happy
+    const allWrites = writes.join('');
+    expect(REACTION_MESSAGES.happy.some((m) => allWrites.includes(m))).toBe(true);
+  });
+
+  it('omits the speech bubble (but keeps the fox) when the terminal fits the mascot but not the bubble', async () => {
+    const { writes, stream } = fakeStream();
+    Object.defineProperty(stream, 'columns', { value: 45 }); // >= 40 (mascot) but < 55 (bubble)
+    await playScoreAnimation({ score: 95, palette: ansiPalette, stream, frameDelayMs: 0 });
+    const allWrites = writes.join('');
+    expect(allWrites).toContain('\x1b[38;2;255;62;0m'); // fox still present
+    for (const pool of Object.values(REACTION_MESSAGES)) {
+      for (const m of pool) expect(allWrites).not.toContain(m);
+    }
   });
 });

--- a/packages/cli/test/pulse-animation.test.ts
+++ b/packages/cli/test/pulse-animation.test.ts
@@ -40,38 +40,34 @@ describe('scoreAnimationEnabled', () => {
 describe('playScoreAnimation', () => {
   it('writes multiple frames ending on the final score', async () => {
     const { writes, stream } = fakeStream();
-    await playScoreAnimation({ score: 82, hasCritical: false, palette: noColorPalette, stream, frameDelayMs: 0 });
+    await playScoreAnimation({ score: 82, palette: noColorPalette, stream, frameDelayMs: 0 });
     expect(writes.length).toBeGreaterThan(1);
     expect(writes[writes.length - 1]).toContain('82/100');
   });
 
   it('colors the final Health score using scoreColor thresholds', async () => {
     const { writes, stream } = fakeStream();
-    await playScoreAnimation({ score: 95, hasCritical: false, palette: ansiPalette, stream, frameDelayMs: 0 });
+    await playScoreAnimation({ score: 95, palette: ansiPalette, stream, frameDelayMs: 0 });
     expect(writes[writes.length - 1]).toContain('\x1b[32m'); // green, score >= 90
   });
 
   it('shows the mascot reaction matching the final state on the last frame', async () => {
+    // log-update only rewrites lines that actually changed between frames, so the last
+    // write's content depends on which rows differ between the anticipating pose and the
+    // reaction pose. A happy/ecstatic score reliably touches that diff because blush is
+    // only added on the reaction frame (never during anticipating) — a score in the
+    // "content" band wouldn't, since its mouth uses the same fixed palette as the
+    // anticipating pose's neutral mouth, just a different shape.
     const { writes, stream } = fakeStream();
-    // content: 70-89, no critical -> yellow face
-    await playScoreAnimation({ score: 75, hasCritical: false, palette: ansiPalette, stream, frameDelayMs: 0 });
+    await playScoreAnimation({ score: 95, palette: ansiPalette, stream, frameDelayMs: 0 }); // happy
     const last = writes[writes.length - 1]!;
-    expect(last).toContain('\x1b[38;2;255;62;0m'); // svelte-orange body present
-    expect(last).toContain('\x1b[33m'); // content's yellow face
-  });
-
-  it('shows the alarmed (red) reaction when a critical finding is present, even at a middling score', async () => {
-    const { writes, stream } = fakeStream();
-    await playScoreAnimation({ score: 75, hasCritical: true, palette: ansiPalette, stream, frameDelayMs: 0 });
-    const last = writes[writes.length - 1]!;
-    expect(last).toContain('\x1b[31m'); // alarmed's red face, not content's yellow
+    expect(last).toContain('\x1b[38;2;255;145;175m'); // happy's blush accent, added only on the reaction frame
   });
 
   it('plays a confetti bonus after a perfect 100, but not for any other score', async () => {
     const perfect = fakeStream();
     await playScoreAnimation({
       score: 100,
-      hasCritical: false,
       palette: ansiPalette,
       stream: perfect.stream,
       frameDelayMs: 0
@@ -83,7 +79,6 @@ describe('playScoreAnimation', () => {
     const high = fakeStream();
     await playScoreAnimation({
       score: 99,
-      hasCritical: false,
       palette: ansiPalette,
       stream: high.stream,
       frameDelayMs: 0
@@ -94,8 +89,8 @@ describe('playScoreAnimation', () => {
   it('omits the mascot entirely on a narrow terminal, still completing the wave/score reveal', async () => {
     const { writes, stream } = fakeStream();
     Object.defineProperty(stream, 'columns', { value: 30 });
-    await playScoreAnimation({ score: 82, hasCritical: false, palette: noColorPalette, stream, frameDelayMs: 0 });
+    await playScoreAnimation({ score: 82, palette: noColorPalette, stream, frameDelayMs: 0 });
     expect(writes[writes.length - 1]).toContain('82/100');
-    expect(writes.join('')).not.toContain('.---.'); // no mascot body art anywhere
+    expect(writes.join('')).not.toContain('\x1b[38;2;255;62;0m'); // no mascot body art anywhere
   });
 });

--- a/packages/cli/test/run.test.ts
+++ b/packages/cli/test/run.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { run } from '../src/index.js';
+import { GREETING_MESSAGES } from '../src/speech-bubble.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const fixtureDir = join(here, 'fixtures', 'basic-project');
@@ -402,12 +403,31 @@ describe('run() --verbose and animation', () => {
       env: CLEAN_ENV,
       stderrIsTTY: true,
       stderrStream,
-      stdoutIsTTY: false // isolate: only exercise the analysis-phase mascot here
+      stdoutIsTTY: false, // isolate: only exercise the analysis-phase mascot here
+      animationFrameDelayMs: 0 // keep the greeting's hold near-instant in tests
     });
     expect(stderrWrites.length).toBeGreaterThan(0);
     // The mascot's orange truecolor escape is a reliable "this is mascot art, not the
     // plain braille spinner" marker — the braille spinner never emits color.
     expect(stderrWrites.join('')).toContain('\x1b[38;2;255;62;0m');
+  });
+
+  it('shows a one-off greeting speech bubble before the idle loop, on a wide interactive terminal', async () => {
+    const cap = capture();
+    const stderrWrites: string[] = [];
+    const stderrStream = { write: (s: string) => stderrWrites.push(s) } as unknown as NodeJS.WriteStream;
+    await run({
+      cwd: fixtureDir,
+      log: cap.log,
+      errorLog: cap.errorLog,
+      env: CLEAN_ENV,
+      stderrIsTTY: true,
+      stderrStream,
+      stdoutIsTTY: false,
+      animationFrameDelayMs: 0
+    });
+    const allWrites = stderrWrites.join('');
+    expect(GREETING_MESSAGES.some((m) => allWrites.includes(m))).toBe(true);
   });
 
   it('falls back to the plain braille spinner when --no-animation is set, even on a wide interactive terminal', async () => {

--- a/packages/cli/test/speech-bubble.test.ts
+++ b/packages/cli/test/speech-bubble.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { renderSpeechBubble, withSpeechBubble, bubbleFitsWidth } from '../src/speech-bubble.js';
+import {
+  renderSpeechBubble,
+  withSpeechBubble,
+  bubbleFitsWidth,
+  pickMessage,
+  renderMascotWithSpeech,
+  GREETING_MESSAGES,
+  REACTION_MESSAGES
+} from '../src/speech-bubble.js';
 import { renderMascotReaction } from '../src/mascot.js';
 
 describe('renderSpeechBubble', () => {
@@ -52,5 +60,43 @@ describe('bubbleFitsWidth', () => {
   });
   it('treats an unknown width (undefined columns) as fitting (defaults to 80)', () => {
     expect(bubbleFitsWidth(undefined)).toBe(true);
+  });
+});
+
+describe('pickMessage', () => {
+  it('picks the first item when random() returns 0', () => {
+    expect(pickMessage(['a', 'b', 'c'], () => 0)).toBe('a');
+  });
+  it('picks the last item when random() returns just under 1', () => {
+    expect(pickMessage(['a', 'b', 'c'], () => 0.999)).toBe('c');
+  });
+  it('defaults to Math.random and always returns a pool member', () => {
+    const pool = ['a', 'b', 'c'];
+    for (let i = 0; i < 20; i++) {
+      expect(pool).toContain(pickMessage(pool));
+    }
+  });
+});
+
+describe('message pools', () => {
+  it('all greeting messages fit a compact bubble (<=26 chars)', () => {
+    for (const m of GREETING_MESSAGES) expect(m.length).toBeLessThanOrEqual(26);
+  });
+  it('all reaction messages fit a compact bubble (<=26 chars)', () => {
+    for (const pool of Object.values(REACTION_MESSAGES)) {
+      for (const m of pool) expect(m.length).toBeLessThanOrEqual(26);
+    }
+  });
+  it('has a reaction pool for every mascot state', () => {
+    expect(Object.keys(REACTION_MESSAGES).sort()).toEqual(['content', 'ecstatic', 'happy']);
+  });
+});
+
+describe('renderMascotWithSpeech', () => {
+  it('composes a mascot pose and a message into a single bubbled block', () => {
+    const block = renderMascotWithSpeech(renderMascotReaction('happy'), 'Nice work!');
+    expect(block.split('\n')).toHaveLength(7);
+    expect(block).toContain('Nice work!');
+    expect(block).toContain('\x1b[38;2;255;62;0m'); // still the fox, orange present
   });
 });

--- a/packages/cli/test/speech-bubble.test.ts
+++ b/packages/cli/test/speech-bubble.test.ts
@@ -5,6 +5,7 @@ import {
   bubbleFitsWidth,
   pickMessage,
   renderMascotWithSpeech,
+  playMascotGreeting,
   GREETING_MESSAGES,
   REACTION_MESSAGES
 } from '../src/speech-bubble.js';
@@ -98,5 +99,29 @@ describe('renderMascotWithSpeech', () => {
     expect(block.split('\n')).toHaveLength(7);
     expect(block).toContain('Nice work!');
     expect(block).toContain('\x1b[38;2;255;62;0m'); // still the fox, orange present
+  });
+});
+
+function fakeStream() {
+  const writes: string[] = [];
+  return { writes, stream: { write: (s: string) => writes.push(s) } as unknown as NodeJS.WriteStream };
+}
+
+describe('playMascotGreeting', () => {
+  it('writes nothing when disabled', async () => {
+    const { writes, stream } = fakeStream();
+    await playMascotGreeting({ enabled: false, stream, holdMs: 0 });
+    expect(writes).toEqual([]);
+  });
+
+  it('writes a frame containing the fox and one of the greeting messages, then clears', async () => {
+    const { writes, stream } = fakeStream();
+    await playMascotGreeting({ enabled: true, stream, holdMs: 0 });
+    expect(writes.length).toBeGreaterThan(0);
+    const allWrites = writes.join('');
+    expect(allWrites).toContain('\x1b[38;2;255;62;0m'); // the fox
+    expect(GREETING_MESSAGES.some((m) => allWrites.includes(m))).toBe(true);
+    const last = writes[writes.length - 1]!;
+    expect(GREETING_MESSAGES.some((m) => last.includes(m))).toBe(false); // cleared on the last write
   });
 });

--- a/packages/cli/test/speech-bubble.test.ts
+++ b/packages/cli/test/speech-bubble.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { renderSpeechBubble, withSpeechBubble, bubbleFitsWidth } from '../src/speech-bubble.js';
+import { renderMascotReaction } from '../src/mascot.js';
+
+describe('renderSpeechBubble', () => {
+  it('returns exactly 3 lines: top border, text, bottom border', () => {
+    const lines = renderSpeechBubble('Hi there!');
+    expect(lines).toHaveLength(3);
+    expect(lines[0]!.startsWith('┌')).toBe(true);
+    expect(lines[0]!.endsWith('┐')).toBe(true);
+    expect(lines[2]!.startsWith('└')).toBe(true);
+    expect(lines[2]!.endsWith('┘')).toBe(true);
+    expect(lines[1]).toBe('│ Hi there! │');
+  });
+
+  it('all 3 lines have equal width regardless of text length', () => {
+    const lines = renderSpeechBubble('Welcome to Svelte Vitals!');
+    const widths = new Set(lines.map((l) => l.length));
+    expect(widths.size).toBe(1);
+  });
+});
+
+describe('withSpeechBubble', () => {
+  it('combines a 7-line mascot block with a 3-line bubble into 7 lines total', () => {
+    const mascot = renderMascotReaction('content');
+    const bubble = renderSpeechBubble('Keep going!');
+    const combined = withSpeechBubble(mascot, bubble).split('\n');
+    expect(combined).toHaveLength(7);
+  });
+
+  it('vertically centers the bubble: blank on the outer rows, bubble content on the middle 3', () => {
+    const mascot = renderMascotReaction('content');
+    const bubble = renderSpeechBubble('Keep going!');
+    const combined = withSpeechBubble(mascot, bubble).split('\n');
+    expect(combined[0]).not.toContain('┌');
+    expect(combined[1]).not.toContain('┌');
+    expect(combined[2]).toContain('┌');
+    expect(combined[3]).toContain('Keep going!');
+    expect(combined[4]).toContain('└');
+    expect(combined[5]).not.toContain('└');
+    expect(combined[6]).not.toContain('└');
+  });
+});
+
+describe('bubbleFitsWidth', () => {
+  it('fits at 55 columns and above', () => {
+    expect(bubbleFitsWidth(55)).toBe(true);
+    expect(bubbleFitsWidth(80)).toBe(true);
+  });
+  it('does not fit below 55 columns', () => {
+    expect(bubbleFitsWidth(54)).toBe(false);
+  });
+  it('treats an unknown width (undefined columns) as fitting (defaults to 80)', () => {
+    expect(bubbleFitsWidth(undefined)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Replace the line-art mascot (merged in #172) with a half-block Unicode pixel-art fox — orange/Svelte-brand palette, per-cell transparent background so it renders correctly on any terminal theme, not just the one recording it was tuned against.
- Simplify `mascotStateFor` from 5 states down to 3 (`ecstatic`/`happy`/`content`) and drop the `hasCritical` override entirely — the mascot now reacts to the numeric score only.
- Updates `packages/cli/README.md`'s mascot description to match (drops the now-false "critical finding always reads as concerned" claim, describes it as a pixel-art fox instead of line art).
- Updates the pending mascot changeset in place (feature hasn't shipped in a release yet) rather than adding a second one.
- Full design rationale: `docs/superpowers/specs/2026-07-11-cli-mascot-pixel-fox-redesign.md`.

## Test plan
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm test` (all packages)
- [x] `pnpm lint`
- [x] Manually verified rendering via `vhs` recordings against multiple terminal background themes (including an unusual bright-green one) to confirm no transparency artifacts
- [ ] Follow-up (separate PR, not in scope here): re-record the docs homepage demo GIF (currently open in #174, still shows the old line-art mascot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZVgzgmaCEmTT9mJ5D9SHH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pixel-art fox mascot to interactive CLI animations, including a one-time startup greeting and a score-reveal reaction line (shown only on sufficiently wide terminals).
* **Updates**
  * Mascot reactions are now based on the numeric score (three moods) and include a confetti flourish for a perfect 100.
  * `--no-animation` disables the mascot effects, reverting to the plain spinner/score animations.
* **Bug Fixes**
  * Improved mascot transparency/color handling to avoid visible artifacts on different terminal backgrounds.
* **Documentation / Tests**
  * Updated CLI documentation and refreshed mascot/speech-bubble coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->