### PR TITLE
feat(cli): give the mascot a speech bubble (greeting + reaction)

### DIFF
--- a/.changeset/mascot-speech-bubble.md
+++ b/.changeset/mascot-speech-bubble.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': minor
+---
+
+Give the CLI's pixel-art fox mascot a speech bubble: a random greeting line at startup, and a reaction line matching the Health-score band at the score reveal (on terminals wide enough for both). Falls back to the fox alone on narrower terminals, same as before.

--- a/docs/superpowers/plans/2026-07-11-mascot-speech-bubble.md
+++ b/docs/superpowers/plans/2026-07-11-mascot-speech-bubble.md
@@ -1,0 +1,683 @@
+# Mascot Speech Bubble Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the CLI's pixel-art fox mascot a bordered speech-bubble line of text next to it, at two moments: a random greeting at startup, and a random reaction line (matching the score band) at the Health-score reveal.
+
+**Architecture:** A new, self-contained module `packages/cli/src/speech-bubble.ts` owns bubble rendering, message pools, random selection, and the greeting playback. `mascot.ts` is untouched. `pulse-animation.ts` and `index.ts` each gain a few lines to call into the new module at their existing mascot-rendering points.
+
+**Tech Stack:** No new dependencies — plain Unicode box-drawing characters, the same `log-update` already used by `mascot.ts`/`pulse-animation.ts`.
+
+## Global Constraints
+
+- Speech bubble appears only at (a) CLI startup, before analysis begins, and (b) the Health-score reveal's final/reaction frame. It never appears during the analysis-phase idle loop (`startMascotSpinner` in `mascot.ts` — do not modify this function).
+- New width gate `bubbleFitsWidth`: `MIN_BUBBLE_COLUMNS = 55`, same shape as `mascotFitsWidth`'s existing `MIN_MASCOT_COLUMNS = 40` (defaults `columns ?? 80`). Below 55 columns, render the fox alone (no bubble) — never hide the fox because the bubble doesn't fit.
+- The startup greeting only plays when `bubbleFitsWidth` is also true (not just `mascotFitsWidth`) — a wordless greeting isn't worth a dedicated hold before the idle loop.
+- Messages are English only, each ≤26 characters, matching the existing spinner copy ("Analyzing…") and `README.md` conventions.
+- Message selection is uniformly random per pool via `pickMessage(pool, random = Math.random)` — `random` is only ever overridden in `speech-bubble.test.ts`'s own unit tests; production call sites and other test files never pass it, and instead assert "one of the pool's messages appears" to stay robust against actual randomness.
+- Reaction messages are split per `MascotState` (`ecstatic`/`happy`/`content`, from `mascot.ts` — do not add new states). Greeting messages are one shared pool (score isn't known yet at startup).
+- Greeting hold defaults to 800ms real playback; both the greeting (`playMascotGreeting`'s `holdMs`) and the score reveal (`playScoreAnimation`'s existing `frameDelayMs`) accept a test override that makes playback near-instant, following the pattern already established by `pulse-animation.ts`.
+- Full spec: `docs/superpowers/specs/2026-07-11-mascot-speech-bubble-design.md`.
+
+---
+
+### Task 1: Speech bubble rendering + width gate
+
+**Files:**
+- Create: `packages/cli/src/speech-bubble.ts`
+- Test: `packages/cli/test/speech-bubble.test.ts`
+
+**Interfaces:**
+- Produces: `bubbleFitsWidth(columns: number | undefined): boolean`, `renderSpeechBubble(text: string): string[]`, `withSpeechBubble(mascotBlock: string, bubbleLines: readonly string[]): string`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/cli/test/speech-bubble.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { renderSpeechBubble, withSpeechBubble, bubbleFitsWidth } from '../src/speech-bubble.js';
+import { renderMascotReaction } from '../src/mascot.js';
+
+describe('renderSpeechBubble', () => {
+  it('returns exactly 3 lines: top border, text, bottom border', () => {
+    const lines = renderSpeechBubble('Hi there!');
+    expect(lines).toHaveLength(3);
+    expect(lines[0]!.startsWith('┌')).toBe(true);
+    expect(lines[0]!.endsWith('┐')).toBe(true);
+    expect(lines[2]!.startsWith('└')).toBe(true);
+    expect(lines[2]!.endsWith('┘')).toBe(true);
+    expect(lines[1]).toBe('│ Hi there! │');
+  });
+
+  it('all 3 lines have equal width regardless of text length', () => {
+    const lines = renderSpeechBubble('Welcome to Svelte Vitals!');
+    const widths = new Set(lines.map((l) => l.length));
+    expect(widths.size).toBe(1);
+  });
+});
+
+describe('withSpeechBubble', () => {
+  it('combines a 7-line mascot block with a 3-line bubble into 7 lines total', () => {
+    const mascot = renderMascotReaction('content');
+    const bubble = renderSpeechBubble('Keep going!');
+    const combined = withSpeechBubble(mascot, bubble).split('\n');
+    expect(combined).toHaveLength(7);
+  });
+
+  it('vertically centers the bubble: blank on the outer rows, bubble content on the middle 3', () => {
+    const mascot = renderMascotReaction('content');
+    const bubble = renderSpeechBubble('Keep going!');
+    const combined = withSpeechBubble(mascot, bubble).split('\n');
+    expect(combined[0]).not.toContain('┌');
+    expect(combined[1]).not.toContain('┌');
+    expect(combined[2]).toContain('┌');
+    expect(combined[3]).toContain('Keep going!');
+    expect(combined[4]).toContain('└');
+    expect(combined[5]).not.toContain('└');
+    expect(combined[6]).not.toContain('└');
+  });
+});
+
+describe('bubbleFitsWidth', () => {
+  it('fits at 55 columns and above', () => {
+    expect(bubbleFitsWidth(55)).toBe(true);
+    expect(bubbleFitsWidth(80)).toBe(true);
+  });
+  it('does not fit below 55 columns', () => {
+    expect(bubbleFitsWidth(54)).toBe(false);
+  });
+  it('treats an unknown width (undefined columns) as fitting (defaults to 80)', () => {
+    expect(bubbleFitsWidth(undefined)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/speech-bubble.test.ts`
+Expected: FAIL — `Cannot find module '../src/speech-bubble.js'`
+
+- [ ] **Step 3: Create `packages/cli/src/speech-bubble.ts`**
+
+```ts
+const MIN_BUBBLE_COLUMNS = 55;
+
+/**
+ * Whether the terminal is wide enough for the mascot + speech bubble combination —
+ * a stricter gate than `mascotFitsWidth` (mascot.ts), which only covers the fox
+ * sprite alone. Below this, callers render the mascot without a bubble (or skip a
+ * bubble-only moment like the greeting entirely) rather than hiding the fox itself.
+ */
+export function bubbleFitsWidth(columns: number | undefined): boolean {
+  return (columns ?? 80) >= MIN_BUBBLE_COLUMNS;
+}
+
+/**
+ * Renders `text` inside a Unicode box-drawing border, sized to the text (1-space
+ * padding on each side). Always exactly 3 lines: top border, text line, bottom
+ * border. Plain terminal-default colors — unlike the fox sprite, this is readable
+ * text, not pixel art, so it doesn't need a fixed color identity.
+ */
+export function renderSpeechBubble(text: string): string[] {
+  const border = '─'.repeat(text.length + 2);
+  return [`┌${border}┐`, `│ ${text} │`, `└${border}┘`];
+}
+
+/**
+ * Places `bubbleLines` to the right of `mascotBlock`, vertically centered against
+ * it. `mascotBlock` is a `renderPixelGrid` output (mascot.ts) — its lines already
+ * end in an ANSI reset, so appending plain text after a space is safe (no color
+ * bleed into the bubble).
+ */
+export function withSpeechBubble(mascotBlock: string, bubbleLines: readonly string[]): string {
+  const mascotLines = mascotBlock.split('\n');
+  const bubbleWidth = bubbleLines[0]?.length ?? 0;
+  const blankBubbleLine = ' '.repeat(bubbleWidth);
+  const padTop = Math.floor((mascotLines.length - bubbleLines.length) / 2);
+  const padBottom = mascotLines.length - bubbleLines.length - padTop;
+  const paddedBubble = [
+    ...Array<string>(Math.max(padTop, 0)).fill(blankBubbleLine),
+    ...bubbleLines,
+    ...Array<string>(Math.max(padBottom, 0)).fill(blankBubbleLine)
+  ];
+  return mascotLines.map((line, i) => `${line} ${paddedBubble[i] ?? blankBubbleLine}`).join('\n');
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/speech-bubble.test.ts`
+Expected: PASS (7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/speech-bubble.ts packages/cli/test/speech-bubble.test.ts
+git commit -m "feat(cli): add speech bubble rendering primitives"
+```
+
+---
+
+### Task 2: Message pools, random selection, composition helper
+
+**Files:**
+- Modify: `packages/cli/src/speech-bubble.ts`
+- Modify: `packages/cli/test/speech-bubble.test.ts`
+
+**Interfaces:**
+- Consumes: `withSpeechBubble`, `renderSpeechBubble` (Task 1, same file); `MascotState` (`packages/cli/src/mascot.ts`)
+- Produces: `GREETING_MESSAGES: readonly string[]`, `REACTION_MESSAGES: Record<MascotState, readonly string[]>`, `pickMessage(pool, random?): string`, `renderMascotWithSpeech(mascotBlock: string, message: string): string`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `packages/cli/test/speech-bubble.test.ts`, replace the existing `import { renderSpeechBubble, withSpeechBubble, bubbleFitsWidth } from '../src/speech-bubble.js';` line (do not add a second import from the same path) with:
+
+```ts
+import {
+  renderSpeechBubble,
+  withSpeechBubble,
+  bubbleFitsWidth,
+  pickMessage,
+  renderMascotWithSpeech,
+  GREETING_MESSAGES,
+  REACTION_MESSAGES
+} from '../src/speech-bubble.js';
+```
+
+And append these new `describe` blocks at the end of the file:
+
+```ts
+describe('pickMessage', () => {
+  it('picks the first item when random() returns 0', () => {
+    expect(pickMessage(['a', 'b', 'c'], () => 0)).toBe('a');
+  });
+  it('picks the last item when random() returns just under 1', () => {
+    expect(pickMessage(['a', 'b', 'c'], () => 0.999)).toBe('c');
+  });
+  it('defaults to Math.random and always returns a pool member', () => {
+    const pool = ['a', 'b', 'c'];
+    for (let i = 0; i < 20; i++) {
+      expect(pool).toContain(pickMessage(pool));
+    }
+  });
+});
+
+describe('message pools', () => {
+  it('all greeting messages fit a compact bubble (<=26 chars)', () => {
+    for (const m of GREETING_MESSAGES) expect(m.length).toBeLessThanOrEqual(26);
+  });
+  it('all reaction messages fit a compact bubble (<=26 chars)', () => {
+    for (const pool of Object.values(REACTION_MESSAGES)) {
+      for (const m of pool) expect(m.length).toBeLessThanOrEqual(26);
+    }
+  });
+  it('has a reaction pool for every mascot state', () => {
+    expect(Object.keys(REACTION_MESSAGES).sort()).toEqual(['content', 'ecstatic', 'happy']);
+  });
+});
+
+describe('renderMascotWithSpeech', () => {
+  it('composes a mascot pose and a message into a single bubbled block', () => {
+    const block = renderMascotWithSpeech(renderMascotReaction('happy'), 'Nice work!');
+    expect(block.split('\n')).toHaveLength(7);
+    expect(block).toContain('Nice work!');
+    expect(block).toContain('\x1b[38;2;255;62;0m'); // still the fox, orange present
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/speech-bubble.test.ts`
+Expected: FAIL — `pickMessage`/`renderMascotWithSpeech`/`GREETING_MESSAGES`/`REACTION_MESSAGES` are not exported
+
+- [ ] **Step 3: Add to `packages/cli/src/speech-bubble.ts`**
+
+Add this import at the very top of the file:
+
+```ts
+import type { MascotState } from './mascot.js';
+```
+
+Then append after `withSpeechBubble`:
+
+```ts
+export const GREETING_MESSAGES: readonly string[] = [
+  'Welcome to Svelte Vitals!',
+  "Let's check your project!",
+  'Ready when you are!',
+  "Hi there! Let's dig in."
+];
+
+export const REACTION_MESSAGES: Record<MascotState, readonly string[]> = {
+  ecstatic: ['Perfect score!', 'Flawless!', 'You nailed it!'],
+  happy: ['Nice work!', 'Looking great!', 'Almost perfect!'],
+  content: ['Keep going!', 'Room to grow!', "Let's improve this!"]
+};
+
+/**
+ * Picks one message uniformly at random from `pool`. `random` defaults to
+ * `Math.random` — only overridden by this module's own unit tests below, for
+ * deterministic selection; other call sites and their tests never pass it.
+ */
+export function pickMessage(pool: readonly string[], random: () => number = Math.random): string {
+  return pool[Math.floor(random() * pool.length)]!;
+}
+
+/** Composes a mascot pose with a speech bubble to its right — the shared shape both the startup greeting and the score-reveal reaction use. */
+export function renderMascotWithSpeech(mascotBlock: string, message: string): string {
+  return withSpeechBubble(mascotBlock, renderSpeechBubble(message));
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/speech-bubble.test.ts`
+Expected: PASS (13 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/speech-bubble.ts packages/cli/test/speech-bubble.test.ts
+git commit -m "feat(cli): add speech bubble message pools and random selection"
+```
+
+---
+
+### Task 3: Startup greeting playback
+
+**Files:**
+- Modify: `packages/cli/src/speech-bubble.ts`
+- Modify: `packages/cli/test/speech-bubble.test.ts`
+
+**Interfaces:**
+- Consumes: `renderMascotAnticipating` (`packages/cli/src/mascot.ts`); `renderMascotWithSpeech`, `pickMessage`, `GREETING_MESSAGES` (Task 1/2, same file)
+- Produces: `playMascotGreeting(opts: { enabled: boolean; stream: NodeJS.WriteStream; holdMs?: number }): Promise<void>`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `packages/cli/test/speech-bubble.test.ts`, add `playMascotGreeting` to the existing `../src/speech-bubble.js` import list (do not add a second import from the same path):
+
+```ts
+import {
+  renderSpeechBubble,
+  withSpeechBubble,
+  bubbleFitsWidth,
+  pickMessage,
+  renderMascotWithSpeech,
+  playMascotGreeting,
+  GREETING_MESSAGES,
+  REACTION_MESSAGES
+} from '../src/speech-bubble.js';
+```
+
+Append at the end of the file:
+
+```ts
+function fakeStream() {
+  const writes: string[] = [];
+  return { writes, stream: { write: (s: string) => writes.push(s) } as unknown as NodeJS.WriteStream };
+}
+
+describe('playMascotGreeting', () => {
+  it('writes nothing when disabled', async () => {
+    const { writes, stream } = fakeStream();
+    await playMascotGreeting({ enabled: false, stream, holdMs: 0 });
+    expect(writes).toEqual([]);
+  });
+
+  it('writes a frame containing the fox and one of the greeting messages, then clears', async () => {
+    const { writes, stream } = fakeStream();
+    await playMascotGreeting({ enabled: true, stream, holdMs: 0 });
+    expect(writes.length).toBeGreaterThan(0);
+    const allWrites = writes.join('');
+    expect(allWrites).toContain('\x1b[38;2;255;62;0m'); // the fox
+    expect(GREETING_MESSAGES.some((m) => allWrites.includes(m))).toBe(true);
+    const last = writes[writes.length - 1]!;
+    expect(GREETING_MESSAGES.some((m) => last.includes(m))).toBe(false); // cleared on the last write
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/speech-bubble.test.ts`
+Expected: FAIL — `playMascotGreeting` is not exported
+
+- [ ] **Step 3: Add to `packages/cli/src/speech-bubble.ts`**
+
+Replace the top-of-file import block (from Task 2's `import type { MascotState } from './mascot.js';`) with:
+
+```ts
+import { createLogUpdate } from 'log-update';
+import { renderMascotAnticipating, type MascotState } from './mascot.js';
+```
+
+Then append at the end of the file:
+
+```ts
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const GREETING_HOLD_MS = 800;
+
+/**
+ * Plays a one-shot greeting: the fox's idle-open pose with a random greeting
+ * message in a speech bubble, held for `holdMs`, then cleared — called once
+ * before analysis starts (index.ts), never repeated within a single run. Uses
+ * `log-update` for the same reason mascot.ts's `startMascotSpinner` and
+ * pulse-animation.ts's `playScoreAnimation` do: accurate multi-line redraw/clear.
+ */
+export async function playMascotGreeting(opts: {
+  enabled: boolean;
+  stream: NodeJS.WriteStream;
+  /** Override for tests — real playback uses GREETING_HOLD_MS; 0 completes near-instantly. */
+  holdMs?: number;
+}): Promise<void> {
+  if (!opts.enabled) return;
+  const holdMs = opts.holdMs ?? GREETING_HOLD_MS;
+  const render = createLogUpdate(opts.stream);
+  render(renderMascotWithSpeech(renderMascotAnticipating(), pickMessage(GREETING_MESSAGES)));
+  if (holdMs > 0) await sleep(holdMs);
+  render.clear();
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/speech-bubble.test.ts`
+Expected: PASS (15 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/speech-bubble.ts packages/cli/test/speech-bubble.test.ts
+git commit -m "feat(cli): add mascot startup greeting playback"
+```
+
+---
+
+### Task 4: Score-reveal reaction bubble
+
+**Files:**
+- Modify: `packages/cli/src/pulse-animation.ts`
+- Modify: `packages/cli/test/pulse-animation.test.ts`
+
+**Interfaces:**
+- Consumes: `bubbleFitsWidth`, `pickMessage`, `renderMascotWithSpeech`, `REACTION_MESSAGES` (`packages/cli/src/speech-bubble.ts`, Tasks 1-2)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this import to `packages/cli/test/pulse-animation.test.ts`'s import block:
+
+```ts
+import { REACTION_MESSAGES } from '../src/speech-bubble.js';
+```
+
+Append inside the `describe('playScoreAnimation', ...)` block (after the existing `'omits the mascot entirely on a narrow terminal...'` test):
+
+```ts
+  it('shows a reaction speech bubble matching the final state, on a wide enough terminal', async () => {
+    const { writes, stream } = fakeStream();
+    await playScoreAnimation({ score: 95, palette: ansiPalette, stream, frameDelayMs: 0 }); // happy
+    const allWrites = writes.join('');
+    expect(REACTION_MESSAGES.happy.some((m) => allWrites.includes(m))).toBe(true);
+  });
+
+  it('omits the speech bubble (but keeps the fox) when the terminal fits the mascot but not the bubble', async () => {
+    const { writes, stream } = fakeStream();
+    Object.defineProperty(stream, 'columns', { value: 45 }); // >= 40 (mascot) but < 55 (bubble)
+    await playScoreAnimation({ score: 95, palette: ansiPalette, stream, frameDelayMs: 0 });
+    const allWrites = writes.join('');
+    expect(allWrites).toContain('\x1b[38;2;255;62;0m'); // fox still present
+    for (const pool of Object.values(REACTION_MESSAGES)) {
+      for (const m of pool) expect(allWrites).not.toContain(m);
+    }
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/pulse-animation.test.ts`
+Expected: FAIL — the first new test fails because no reaction message is ever written yet
+
+- [ ] **Step 3: Modify `packages/cli/src/pulse-animation.ts`**
+
+Add this import after the existing `import { ... } from './mascot.js';` block:
+
+```ts
+import { bubbleFitsWidth, pickMessage, renderMascotWithSpeech, REACTION_MESSAGES } from './speech-bubble.js';
+```
+
+Replace the body of `playScoreAnimation` (from `const render = createLogUpdate(opts.stream);` through the confetti loop) with:
+
+```ts
+  const render = createLogUpdate(opts.stream);
+  const showMascot = mascotFitsWidth(opts.stream.columns);
+  const state = mascotStateFor(opts.score);
+  const reactionMessage =
+    showMascot && bubbleFitsWidth(opts.stream.columns) ? pickMessage(REACTION_MESSAGES[state]) : undefined;
+  const finalMascotBlock = reactionMessage
+    ? renderMascotWithSpeech(renderMascotReaction(state), reactionMessage)
+    : renderMascotReaction(state);
+
+  for (let frame = 0; frame < FRAME_COUNT; frame++) {
+    const progress = frame / (FRAME_COUNT - 1);
+    const displayScore = Math.round(opts.score * progress);
+    const isFinalFrame = frame === FRAME_COUNT - 1;
+    const wave = WAVE_FRAMES[frame]!;
+    const scoreText = isFinalFrame
+      ? scoreColor(opts.palette, opts.score)(`${displayScore}/100`)
+      : opts.palette.dim(`${displayScore}/100`);
+    const waveBlock = `  ${wave}\n  Health: ${scoreText}`;
+    const mascotBlock = showMascot
+      ? (isFinalFrame ? finalMascotBlock : renderMascotAnticipating()) + '\n'
+      : '';
+    render(`${mascotBlock}${waveBlock}`);
+    if (!isFinalFrame) await sleep(frameDelayMs);
+  }
+
+  if (holdMs > 0) await sleep(holdMs);
+
+  if (showMascot && state === 'ecstatic') {
+    for (let i = 0; i < CONFETTI_FRAME_COUNT; i++) {
+      const waveBlock = `  ${WAVE_FRAMES[FRAME_COUNT - 1]!}\n  Health: ${scoreColor(opts.palette, opts.score)('100/100')}`;
+      render(`${renderConfettiFrame(i, finalMascotBlock)}\n${waveBlock}`);
+      if (i < CONFETTI_FRAME_COUNT - 1 && confettiDelayMs > 0) await sleep(confettiDelayMs);
+    }
+  }
+```
+
+(The lines above and below this block — the `frameDelayMs`/`holdMs`/`confettiDelayMs` consts at the top, and the trailing `render.done();` — are unchanged.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/pulse-animation.test.ts`
+Expected: PASS (14 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/pulse-animation.ts packages/cli/test/pulse-animation.test.ts
+git commit -m "feat(cli): show a reaction speech bubble at the score reveal"
+```
+
+---
+
+### Task 5: Startup greeting integration
+
+**Files:**
+- Modify: `packages/cli/src/index.ts`
+- Modify: `packages/cli/test/run.test.ts`
+
+**Interfaces:**
+- Consumes: `playMascotGreeting`, `bubbleFitsWidth`, `GREETING_MESSAGES` (`packages/cli/src/speech-bubble.ts`, Tasks 1-3)
+
+- [ ] **Step 1: Write the failing test**
+
+Add this import to `packages/cli/test/run.test.ts`'s top import block:
+
+```ts
+import { GREETING_MESSAGES } from '../src/speech-bubble.js';
+```
+
+Update the existing test `'shows the mascot idle loop on stderr during analysis on a wide interactive terminal'` (in the same `describe` block as the other mascot/spinner tests) — add `animationFrameDelayMs: 0` to its `run()` call so the new greeting's hold doesn't slow the test down:
+
+```ts
+  it('shows the mascot idle loop on stderr during analysis on a wide interactive terminal', async () => {
+    const cap = capture();
+    const stderrWrites: string[] = [];
+    const stderrStream = { write: (s: string) => stderrWrites.push(s) } as unknown as NodeJS.WriteStream;
+    await run({
+      cwd: fixtureDir,
+      log: cap.log,
+      errorLog: cap.errorLog,
+      env: CLEAN_ENV,
+      stderrIsTTY: true,
+      stderrStream,
+      stdoutIsTTY: false, // isolate: only exercise the analysis-phase mascot here
+      animationFrameDelayMs: 0 // keep the greeting's hold near-instant in tests
+    });
+    expect(stderrWrites.length).toBeGreaterThan(0);
+    // The mascot's orange truecolor escape is a reliable "this is mascot art, not the
+    // plain braille spinner" marker — the braille spinner never emits color.
+    expect(stderrWrites.join('')).toContain('\x1b[38;2;255;62;0m');
+  });
+```
+
+Then add a new test immediately after it:
+
+```ts
+  it('shows a one-off greeting speech bubble before the idle loop, on a wide interactive terminal', async () => {
+    const cap = capture();
+    const stderrWrites: string[] = [];
+    const stderrStream = { write: (s: string) => stderrWrites.push(s) } as unknown as NodeJS.WriteStream;
+    await run({
+      cwd: fixtureDir,
+      log: cap.log,
+      errorLog: cap.errorLog,
+      env: CLEAN_ENV,
+      stderrIsTTY: true,
+      stderrStream,
+      stdoutIsTTY: false,
+      animationFrameDelayMs: 0
+    });
+    const allWrites = stderrWrites.join('');
+    expect(GREETING_MESSAGES.some((m) => allWrites.includes(m))).toBe(true);
+  });
+```
+
+- [ ] **Step 2: Run tests to verify the new one fails**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/run.test.ts`
+Expected: FAIL — the new "shows a one-off greeting" test fails (no greeting is played yet); the updated idle-loop test still passes (the added option is inert until Step 3)
+
+- [ ] **Step 3: Modify `packages/cli/src/index.ts`**
+
+Add this import after the existing `import { startMascotSpinner, mascotFitsWidth } from './mascot.js';` line:
+
+```ts
+import { playMascotGreeting, bubbleFitsWidth } from './speech-bubble.js';
+```
+
+Replace:
+
+```ts
+  const useMascotSpinner = spinnerBaseEnabled && !opts.noAnimation && mascotFitsWidth(stderrStream.columns);
+  const spinner = useMascotSpinner
+    ? startMascotSpinner('Analyzing…', { enabled: true, stream: stderrStream })
+    : startSpinner('Analyzing…', { enabled: spinnerBaseEnabled, stream: stderrStream });
+```
+
+with:
+
+```ts
+  const useMascotSpinner = spinnerBaseEnabled && !opts.noAnimation && mascotFitsWidth(stderrStream.columns);
+  if (useMascotSpinner && bubbleFitsWidth(stderrStream.columns)) {
+    // A wordless greeting isn't worth a dedicated hold before the idle loop, so this
+    // only plays when there's room for the speech bubble too — not just the fox alone.
+    await playMascotGreeting({ enabled: true, stream: stderrStream, holdMs: opts.animationFrameDelayMs });
+  }
+  const spinner = useMascotSpinner
+    ? startMascotSpinner('Analyzing…', { enabled: true, stream: stderrStream })
+    : startSpinner('Analyzing…', { enabled: spinnerBaseEnabled, stream: stderrStream });
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/run.test.ts`
+Expected: PASS (all tests in the file)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/index.ts packages/cli/test/run.test.ts
+git commit -m "feat(cli): play a startup greeting speech bubble before analysis"
+```
+
+---
+
+### Task 6: Docs, changeset, and full verification
+
+**Files:**
+- Modify: `packages/cli/README.md`
+- Create: `.changeset/mascot-speech-bubble.md`
+
+**Interfaces:**
+- None (docs/metadata only; no code interfaces produced or consumed)
+
+- [ ] **Step 1: Update `packages/cli/README.md`**
+
+Find the existing mascot paragraph:
+
+```md
+On an interactive terminal, a small pixel-art fox mascot appears alongside both the analysis spinner and the Health-score reveal, reacting to the score (a perfect 100 gets a confetti flourish). `--no-animation` disables it, falling back to the plain spinner and plain score animation.
+```
+
+Replace it with:
+
+```md
+On an interactive terminal, a small pixel-art fox mascot appears alongside both the analysis spinner and the Health-score reveal, reacting to the score (a perfect 100 gets a confetti flourish). On a wide enough terminal it also greets you with a short line in a speech bubble at startup, and again with a matching reaction line at the score reveal. `--no-animation` disables all of it, falling back to the plain spinner and plain score animation.
+```
+
+- [ ] **Step 2: Create the changeset**
+
+Create `.changeset/mascot-speech-bubble.md`:
+
+```md
+---
+'svelte-vitals': minor
+---
+
+Give the CLI's pixel-art fox mascot a speech bubble: a random greeting line at startup, and a reaction line matching the Health-score band at the score reveal (on terminals wide enough for both). Falls back to the fox alone on narrower terminals, same as before.
+```
+
+- [ ] **Step 3: Run full verification**
+
+Run, in order, from the repo root of this worktree:
+
+```bash
+pnpm --filter @svelte-vitals/core build && pnpm --filter svelte-vitals build
+pnpm build
+pnpm typecheck
+pnpm test
+pnpm lint
+```
+
+Expected: all five commands exit 0. If `pnpm lint`'s `prettier --check` flags `speech-bubble.ts` or any modified file, run `pnpm exec prettier --write <file>` and re-run `pnpm lint`.
+
+If `packages/action/dist/index.js` shows as changed in `git status` after `pnpm build` (it bundles the CLI source), that is expected — stage it in the final commit.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cli/README.md .changeset/mascot-speech-bubble.md packages/action/dist/index.js
+git commit -m "docs(cli): document the mascot speech bubble; add changeset"
+```
+
+- [ ] **Step 5: Final check**
+
+Run: `git status --short`
+Expected: clean (nothing uncommitted) except any files intentionally left for the finishing-a-development-branch workflow.

--- a/docs/superpowers/plans/2026-07-11-mascot-speech-bubble.md
+++ b/docs/superpowers/plans/2026-07-11-mascot-speech-bubble.md
@@ -24,10 +24,12 @@
 ### Task 1: Speech bubble rendering + width gate
 
 **Files:**
+
 - Create: `packages/cli/src/speech-bubble.ts`
 - Test: `packages/cli/test/speech-bubble.test.ts`
 
 **Interfaces:**
+
 - Produces: `bubbleFitsWidth(columns: number | undefined): boolean`, `renderSpeechBubble(text: string): string[]`, `withSpeechBubble(mascotBlock: string, bubbleLines: readonly string[]): string`
 
 - [ ] **Step 1: Write the failing tests**
@@ -162,10 +164,12 @@ git commit -m "feat(cli): add speech bubble rendering primitives"
 ### Task 2: Message pools, random selection, composition helper
 
 **Files:**
+
 - Modify: `packages/cli/src/speech-bubble.ts`
 - Modify: `packages/cli/test/speech-bubble.test.ts`
 
 **Interfaces:**
+
 - Consumes: `withSpeechBubble`, `renderSpeechBubble` (Task 1, same file); `MascotState` (`packages/cli/src/mascot.ts`)
 - Produces: `GREETING_MESSAGES: readonly string[]`, `REACTION_MESSAGES: Record<MascotState, readonly string[]>`, `pickMessage(pool, random?): string`, `renderMascotWithSpeech(mascotBlock: string, message: string): string`
 
@@ -288,10 +292,12 @@ git commit -m "feat(cli): add speech bubble message pools and random selection"
 ### Task 3: Startup greeting playback
 
 **Files:**
+
 - Modify: `packages/cli/src/speech-bubble.ts`
 - Modify: `packages/cli/test/speech-bubble.test.ts`
 
 **Interfaces:**
+
 - Consumes: `renderMascotAnticipating` (`packages/cli/src/mascot.ts`); `renderMascotWithSpeech`, `pickMessage`, `GREETING_MESSAGES` (Task 1/2, same file)
 - Produces: `playMascotGreeting(opts: { enabled: boolean; stream: NodeJS.WriteStream; holdMs?: number }): Promise<void>`
 
@@ -402,10 +408,12 @@ git commit -m "feat(cli): add mascot startup greeting playback"
 ### Task 4: Score-reveal reaction bubble
 
 **Files:**
+
 - Modify: `packages/cli/src/pulse-animation.ts`
 - Modify: `packages/cli/test/pulse-animation.test.ts`
 
 **Interfaces:**
+
 - Consumes: `bubbleFitsWidth`, `pickMessage`, `renderMascotWithSpeech`, `REACTION_MESSAGES` (`packages/cli/src/speech-bubble.ts`, Tasks 1-2)
 
 - [ ] **Step 1: Write the failing tests**
@@ -419,23 +427,23 @@ import { REACTION_MESSAGES } from '../src/speech-bubble.js';
 Append inside the `describe('playScoreAnimation', ...)` block (after the existing `'omits the mascot entirely on a narrow terminal...'` test):
 
 ```ts
-  it('shows a reaction speech bubble matching the final state, on a wide enough terminal', async () => {
-    const { writes, stream } = fakeStream();
-    await playScoreAnimation({ score: 95, palette: ansiPalette, stream, frameDelayMs: 0 }); // happy
-    const allWrites = writes.join('');
-    expect(REACTION_MESSAGES.happy.some((m) => allWrites.includes(m))).toBe(true);
-  });
+it('shows a reaction speech bubble matching the final state, on a wide enough terminal', async () => {
+  const { writes, stream } = fakeStream();
+  await playScoreAnimation({ score: 95, palette: ansiPalette, stream, frameDelayMs: 0 }); // happy
+  const allWrites = writes.join('');
+  expect(REACTION_MESSAGES.happy.some((m) => allWrites.includes(m))).toBe(true);
+});
 
-  it('omits the speech bubble (but keeps the fox) when the terminal fits the mascot but not the bubble', async () => {
-    const { writes, stream } = fakeStream();
-    Object.defineProperty(stream, 'columns', { value: 45 }); // >= 40 (mascot) but < 55 (bubble)
-    await playScoreAnimation({ score: 95, palette: ansiPalette, stream, frameDelayMs: 0 });
-    const allWrites = writes.join('');
-    expect(allWrites).toContain('\x1b[38;2;255;62;0m'); // fox still present
-    for (const pool of Object.values(REACTION_MESSAGES)) {
-      for (const m of pool) expect(allWrites).not.toContain(m);
-    }
-  });
+it('omits the speech bubble (but keeps the fox) when the terminal fits the mascot but not the bubble', async () => {
+  const { writes, stream } = fakeStream();
+  Object.defineProperty(stream, 'columns', { value: 45 }); // >= 40 (mascot) but < 55 (bubble)
+  await playScoreAnimation({ score: 95, palette: ansiPalette, stream, frameDelayMs: 0 });
+  const allWrites = writes.join('');
+  expect(allWrites).toContain('\x1b[38;2;255;62;0m'); // fox still present
+  for (const pool of Object.values(REACTION_MESSAGES)) {
+    for (const m of pool) expect(allWrites).not.toContain(m);
+  }
+});
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
@@ -454,40 +462,38 @@ import { bubbleFitsWidth, pickMessage, renderMascotWithSpeech, REACTION_MESSAGES
 Replace the body of `playScoreAnimation` (from `const render = createLogUpdate(opts.stream);` through the confetti loop) with:
 
 ```ts
-  const render = createLogUpdate(opts.stream);
-  const showMascot = mascotFitsWidth(opts.stream.columns);
-  const state = mascotStateFor(opts.score);
-  const reactionMessage =
-    showMascot && bubbleFitsWidth(opts.stream.columns) ? pickMessage(REACTION_MESSAGES[state]) : undefined;
-  const finalMascotBlock = reactionMessage
-    ? renderMascotWithSpeech(renderMascotReaction(state), reactionMessage)
-    : renderMascotReaction(state);
+const render = createLogUpdate(opts.stream);
+const showMascot = mascotFitsWidth(opts.stream.columns);
+const state = mascotStateFor(opts.score);
+const reactionMessage =
+  showMascot && bubbleFitsWidth(opts.stream.columns) ? pickMessage(REACTION_MESSAGES[state]) : undefined;
+const finalMascotBlock = reactionMessage
+  ? renderMascotWithSpeech(renderMascotReaction(state), reactionMessage)
+  : renderMascotReaction(state);
 
-  for (let frame = 0; frame < FRAME_COUNT; frame++) {
-    const progress = frame / (FRAME_COUNT - 1);
-    const displayScore = Math.round(opts.score * progress);
-    const isFinalFrame = frame === FRAME_COUNT - 1;
-    const wave = WAVE_FRAMES[frame]!;
-    const scoreText = isFinalFrame
-      ? scoreColor(opts.palette, opts.score)(`${displayScore}/100`)
-      : opts.palette.dim(`${displayScore}/100`);
-    const waveBlock = `  ${wave}\n  Health: ${scoreText}`;
-    const mascotBlock = showMascot
-      ? (isFinalFrame ? finalMascotBlock : renderMascotAnticipating()) + '\n'
-      : '';
-    render(`${mascotBlock}${waveBlock}`);
-    if (!isFinalFrame) await sleep(frameDelayMs);
+for (let frame = 0; frame < FRAME_COUNT; frame++) {
+  const progress = frame / (FRAME_COUNT - 1);
+  const displayScore = Math.round(opts.score * progress);
+  const isFinalFrame = frame === FRAME_COUNT - 1;
+  const wave = WAVE_FRAMES[frame]!;
+  const scoreText = isFinalFrame
+    ? scoreColor(opts.palette, opts.score)(`${displayScore}/100`)
+    : opts.palette.dim(`${displayScore}/100`);
+  const waveBlock = `  ${wave}\n  Health: ${scoreText}`;
+  const mascotBlock = showMascot ? (isFinalFrame ? finalMascotBlock : renderMascotAnticipating()) + '\n' : '';
+  render(`${mascotBlock}${waveBlock}`);
+  if (!isFinalFrame) await sleep(frameDelayMs);
+}
+
+if (holdMs > 0) await sleep(holdMs);
+
+if (showMascot && state === 'ecstatic') {
+  for (let i = 0; i < CONFETTI_FRAME_COUNT; i++) {
+    const waveBlock = `  ${WAVE_FRAMES[FRAME_COUNT - 1]!}\n  Health: ${scoreColor(opts.palette, opts.score)('100/100')}`;
+    render(`${renderConfettiFrame(i, finalMascotBlock)}\n${waveBlock}`);
+    if (i < CONFETTI_FRAME_COUNT - 1 && confettiDelayMs > 0) await sleep(confettiDelayMs);
   }
-
-  if (holdMs > 0) await sleep(holdMs);
-
-  if (showMascot && state === 'ecstatic') {
-    for (let i = 0; i < CONFETTI_FRAME_COUNT; i++) {
-      const waveBlock = `  ${WAVE_FRAMES[FRAME_COUNT - 1]!}\n  Health: ${scoreColor(opts.palette, opts.score)('100/100')}`;
-      render(`${renderConfettiFrame(i, finalMascotBlock)}\n${waveBlock}`);
-      if (i < CONFETTI_FRAME_COUNT - 1 && confettiDelayMs > 0) await sleep(confettiDelayMs);
-    }
-  }
+}
 ```
 
 (The lines above and below this block — the `frameDelayMs`/`holdMs`/`confettiDelayMs` consts at the top, and the trailing `render.done();` — are unchanged.)
@@ -509,10 +515,12 @@ git commit -m "feat(cli): show a reaction speech bubble at the score reveal"
 ### Task 5: Startup greeting integration
 
 **Files:**
+
 - Modify: `packages/cli/src/index.ts`
 - Modify: `packages/cli/test/run.test.ts`
 
 **Interfaces:**
+
 - Consumes: `playMascotGreeting`, `bubbleFitsWidth`, `GREETING_MESSAGES` (`packages/cli/src/speech-bubble.ts`, Tasks 1-3)
 
 - [ ] **Step 1: Write the failing test**
@@ -526,47 +534,47 @@ import { GREETING_MESSAGES } from '../src/speech-bubble.js';
 Update the existing test `'shows the mascot idle loop on stderr during analysis on a wide interactive terminal'` (in the same `describe` block as the other mascot/spinner tests) — add `animationFrameDelayMs: 0` to its `run()` call so the new greeting's hold doesn't slow the test down:
 
 ```ts
-  it('shows the mascot idle loop on stderr during analysis on a wide interactive terminal', async () => {
-    const cap = capture();
-    const stderrWrites: string[] = [];
-    const stderrStream = { write: (s: string) => stderrWrites.push(s) } as unknown as NodeJS.WriteStream;
-    await run({
-      cwd: fixtureDir,
-      log: cap.log,
-      errorLog: cap.errorLog,
-      env: CLEAN_ENV,
-      stderrIsTTY: true,
-      stderrStream,
-      stdoutIsTTY: false, // isolate: only exercise the analysis-phase mascot here
-      animationFrameDelayMs: 0 // keep the greeting's hold near-instant in tests
-    });
-    expect(stderrWrites.length).toBeGreaterThan(0);
-    // The mascot's orange truecolor escape is a reliable "this is mascot art, not the
-    // plain braille spinner" marker — the braille spinner never emits color.
-    expect(stderrWrites.join('')).toContain('\x1b[38;2;255;62;0m');
+it('shows the mascot idle loop on stderr during analysis on a wide interactive terminal', async () => {
+  const cap = capture();
+  const stderrWrites: string[] = [];
+  const stderrStream = { write: (s: string) => stderrWrites.push(s) } as unknown as NodeJS.WriteStream;
+  await run({
+    cwd: fixtureDir,
+    log: cap.log,
+    errorLog: cap.errorLog,
+    env: CLEAN_ENV,
+    stderrIsTTY: true,
+    stderrStream,
+    stdoutIsTTY: false, // isolate: only exercise the analysis-phase mascot here
+    animationFrameDelayMs: 0 // keep the greeting's hold near-instant in tests
   });
+  expect(stderrWrites.length).toBeGreaterThan(0);
+  // The mascot's orange truecolor escape is a reliable "this is mascot art, not the
+  // plain braille spinner" marker — the braille spinner never emits color.
+  expect(stderrWrites.join('')).toContain('\x1b[38;2;255;62;0m');
+});
 ```
 
 Then add a new test immediately after it:
 
 ```ts
-  it('shows a one-off greeting speech bubble before the idle loop, on a wide interactive terminal', async () => {
-    const cap = capture();
-    const stderrWrites: string[] = [];
-    const stderrStream = { write: (s: string) => stderrWrites.push(s) } as unknown as NodeJS.WriteStream;
-    await run({
-      cwd: fixtureDir,
-      log: cap.log,
-      errorLog: cap.errorLog,
-      env: CLEAN_ENV,
-      stderrIsTTY: true,
-      stderrStream,
-      stdoutIsTTY: false,
-      animationFrameDelayMs: 0
-    });
-    const allWrites = stderrWrites.join('');
-    expect(GREETING_MESSAGES.some((m) => allWrites.includes(m))).toBe(true);
+it('shows a one-off greeting speech bubble before the idle loop, on a wide interactive terminal', async () => {
+  const cap = capture();
+  const stderrWrites: string[] = [];
+  const stderrStream = { write: (s: string) => stderrWrites.push(s) } as unknown as NodeJS.WriteStream;
+  await run({
+    cwd: fixtureDir,
+    log: cap.log,
+    errorLog: cap.errorLog,
+    env: CLEAN_ENV,
+    stderrIsTTY: true,
+    stderrStream,
+    stdoutIsTTY: false,
+    animationFrameDelayMs: 0
   });
+  const allWrites = stderrWrites.join('');
+  expect(GREETING_MESSAGES.some((m) => allWrites.includes(m))).toBe(true);
+});
 ```
 
 - [ ] **Step 2: Run tests to verify the new one fails**
@@ -585,24 +593,24 @@ import { playMascotGreeting, bubbleFitsWidth } from './speech-bubble.js';
 Replace:
 
 ```ts
-  const useMascotSpinner = spinnerBaseEnabled && !opts.noAnimation && mascotFitsWidth(stderrStream.columns);
-  const spinner = useMascotSpinner
-    ? startMascotSpinner('Analyzing…', { enabled: true, stream: stderrStream })
-    : startSpinner('Analyzing…', { enabled: spinnerBaseEnabled, stream: stderrStream });
+const useMascotSpinner = spinnerBaseEnabled && !opts.noAnimation && mascotFitsWidth(stderrStream.columns);
+const spinner = useMascotSpinner
+  ? startMascotSpinner('Analyzing…', { enabled: true, stream: stderrStream })
+  : startSpinner('Analyzing…', { enabled: spinnerBaseEnabled, stream: stderrStream });
 ```
 
 with:
 
 ```ts
-  const useMascotSpinner = spinnerBaseEnabled && !opts.noAnimation && mascotFitsWidth(stderrStream.columns);
-  if (useMascotSpinner && bubbleFitsWidth(stderrStream.columns)) {
-    // A wordless greeting isn't worth a dedicated hold before the idle loop, so this
-    // only plays when there's room for the speech bubble too — not just the fox alone.
-    await playMascotGreeting({ enabled: true, stream: stderrStream, holdMs: opts.animationFrameDelayMs });
-  }
-  const spinner = useMascotSpinner
-    ? startMascotSpinner('Analyzing…', { enabled: true, stream: stderrStream })
-    : startSpinner('Analyzing…', { enabled: spinnerBaseEnabled, stream: stderrStream });
+const useMascotSpinner = spinnerBaseEnabled && !opts.noAnimation && mascotFitsWidth(stderrStream.columns);
+if (useMascotSpinner && bubbleFitsWidth(stderrStream.columns)) {
+  // A wordless greeting isn't worth a dedicated hold before the idle loop, so this
+  // only plays when there's room for the speech bubble too — not just the fox alone.
+  await playMascotGreeting({ enabled: true, stream: stderrStream, holdMs: opts.animationFrameDelayMs });
+}
+const spinner = useMascotSpinner
+  ? startMascotSpinner('Analyzing…', { enabled: true, stream: stderrStream })
+  : startSpinner('Analyzing…', { enabled: spinnerBaseEnabled, stream: stderrStream });
 ```
 
 - [ ] **Step 4: Run tests to verify they pass**
@@ -622,10 +630,12 @@ git commit -m "feat(cli): play a startup greeting speech bubble before analysis"
 ### Task 6: Docs, changeset, and full verification
 
 **Files:**
+
 - Modify: `packages/cli/README.md`
 - Create: `.changeset/mascot-speech-bubble.md`
 
 **Interfaces:**
+
 - None (docs/metadata only; no code interfaces produced or consumed)
 
 - [ ] **Step 1: Update `packages/cli/README.md`**

--- a/docs/superpowers/specs/2026-07-11-mascot-speech-bubble-design.md
+++ b/docs/superpowers/specs/2026-07-11-mascot-speech-bubble-design.md
@@ -1,0 +1,141 @@
+# Design: Mascot speech bubble
+
+**Date:** 2026-07-11
+**Status:** Proposed
+**Packages:** `svelte-vitals` (CLI) only — no `@svelte-vitals/core` changes
+**Depends on:** `docs/superpowers/specs/2026-07-11-cli-mascot-pixel-fox-redesign.md` (unmerged, PR #175) — this branch stacks on `feat/mascot-pixel-fox`.
+
+## Goal
+
+Give the pixel-art fox mascot a short line of speech in a bordered box next
+to it, at two moments: once at CLI startup (a greeting) and once at the
+Health-score reveal (a reaction comment matching the score band). The
+project owner's own framing: "吹き出して喋るようにしてもいいですね！
+Welcome Svelte Vitals！とかいろんなバリエーションで" — a talking speech
+bubble with several message variations.
+
+## Where it appears (and where it doesn't)
+
+Two moments only:
+
+1. **Startup greeting** — shown once, before analysis begins, for a fixed
+   hold duration regardless of how fast analysis actually finishes.
+2. **Score reveal** — shown alongside the existing reaction pose, riding
+   the same hold window `playScoreAnimation` already uses
+   (`REACTION_HOLD_MS`, 500ms in real playback).
+
+Explicitly **not** shown during the analysis-phase idle loop
+(`startMascotSpinner`): the project owner ruled this out directly —
+analysis can finish fast enough that a message would flash by unreadably
+("解析中は早く終わる場合だと読めない文字が一瞬出ることになるからいらないと
+思う"). The idle loop is unchanged by this design.
+
+## Message selection
+
+Random, not fixed or deterministic-by-score — confirmed as the project
+owner's preference over a single fixed line per state. Each display picks
+one message uniformly at random from the relevant pool:
+
+- **Greeting pool** — one shared pool, shown at startup (score isn't known
+  yet, so no state-based split here):
+  ```
+  Welcome to Svelte Vitals!
+  Let's check your project!
+  Ready when you are!
+  Hi there! Let's dig in.
+  ```
+- **Reaction pools** — one pool per `MascotState`, so the message tone
+  matches the fox's expression:
+  - `ecstatic`: `Perfect score!` / `Flawless!` / `You nailed it!`
+  - `happy`: `Nice work!` / `Looking great!` / `Almost perfect!`
+  - `content`: `Keep going!` / `Room to grow!` / `Let's improve this!`
+
+All messages are English (matches the existing spinner copy, `README.md`,
+and the original mascot design's explicit marketing intent — shareable
+screenshots/clips aimed at a global audience, not localized CLI chrome)
+and kept to ≤26 characters so the bubble stays compact.
+
+## Rendering
+
+New file `packages/cli/src/speech-bubble.ts`, kept separate from
+`mascot.ts` (pixel-art rendering) — one clear responsibility each.
+
+```ts
+function renderSpeechBubble(text: string): string[] {
+  // Unicode box-drawing border (┌─┐│└─┘), sized to `text.length + 2`
+  // interior padding. Returns exactly 3 lines: top border, "│ text │",
+  // bottom border.
+}
+
+function withSpeechBubble(mascotBlock: string, bubbleLines: string[]): string {
+  // Zips mascotBlock's lines (always 7, uniform 14-cell visible width —
+  // see mascot.ts's renderPixelGrid) with bubbleLines to their right,
+  // separated by one space. bubbleLines (3 lines) is vertically centered
+  // against the 7 mascot lines: 2 blank-padded lines above, 3 bubble
+  // lines, 2 blank-padded lines below.
+}
+```
+
+Bubble width is dynamic per message (`text.length + 2` interior + 2 border
+columns), not a fixed constant — each display is a static, non-animating
+render, so there's no visual "jump" to avoid between frames the way there
+would be in an animated sequence.
+
+**Width gating.** A new `bubbleFitsWidth(columns): boolean` sits above the
+existing `mascotFitsWidth` (40 columns) — the fox itself doesn't need the
+extra space, but the fox+bubble combination does. Worst case (longest
+message "Welcome to Svelte Vitals!", 26 chars): 14 (fox) + 1 (gap) + 30
+(26 + 2 padding + 2 border) = 45 columns. `MIN_BUBBLE_COLUMNS = 55` gives
+comfortable margin. Below that threshold, the bubble is skipped and the
+fox renders alone (existing behavior, unchanged) — the mascot doesn't
+disappear just because the bubble doesn't fit.
+
+**Randomness injection.** Message pickers accept an optional
+`random?: () => number` (default `Math.random`), so tests can inject a
+fixed value and assert deterministically which message was chosen:
+
+```ts
+function pickMessage(pool: readonly string[], random: () => number = Math.random): string {
+  return pool[Math.floor(random() * pool.length)]!;
+}
+```
+
+## Integration points
+
+- **`mascot.ts`**: no changes — `speech-bubble.ts` composes on top of its
+  existing exports (`renderMascotReaction`, `renderMascotAnticipating`'s
+  idle-open pose reused for the greeting frame).
+- **`pulse-animation.ts`**: on the final frame, if `bubbleFitsWidth`, wrap
+  the reaction block with a randomly-picked message from
+  `REACTION_MESSAGES[state]` via `withSpeechBubble` before rendering. No
+  change to frame timing — rides the existing hold window.
+- **`index.ts`**: new one-shot greeting step before `startMascotSpinner`
+  is called — reuses `spinnerEnabled`'s result and stderr stream (no new
+  gating function). Holds for a fixed duration via `log-update`, then
+  clears, then proceeds to the (unchanged, bubble-free) idle spinner.
+
+## Testing
+
+- `speech-bubble.test.ts` (new): `renderSpeechBubble` border/line-count/
+  content correctness; `withSpeechBubble` line-count and width
+  consistency against a real `renderMascotReaction` output;
+  `bubbleFitsWidth` boundary; `pickMessage` determinism with an injected
+  `random`.
+- `pulse-animation.test.ts`: extend the final-frame assertions to check a
+  reaction message appears in the last write when width allows, and is
+  absent below `MIN_BUBBLE_COLUMNS`.
+- `run.test.ts` / `index.ts`-level test (wherever the existing spinner
+  start-up is exercised): assert the greeting renders once, holds, then
+  clears before the idle loop's first tick.
+
+## Non-goals
+
+- A literal comic-style bubble with a tail pointing at the fox (rejected
+  in favor of the simpler side-by-side box, the project owner's explicit
+  pick).
+- Bubble text during the idle analysis loop (explicitly ruled out — see
+  "Where it appears").
+- Localized (ja) message variants — English only, matching existing CLI
+  copy conventions.
+- Re-recording docs demo GIFs — separate, already-tracked follow-up
+  (PR #174), unaffected by this change.

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -56976,7 +56976,7 @@ function applyRuleSeverities(results, config) {
   });
 }
 
-// ../cli/dist/chunk-YGQV6XN3.js
+// ../cli/dist/chunk-RVZZNMTI.js
 import { readFile, access as access2 } from "fs/promises";
 import { join } from "path";
 
@@ -57754,7 +57754,7 @@ async function glob(globInput, options) {
   return crawler ? formatPaths(await crawler.withPromise(), relative2) : [];
 }
 
-// ../cli/dist/chunk-YGQV6XN3.js
+// ../cli/dist/chunk-RVZZNMTI.js
 import { readFileSync as readFileSync2 } from "fs";
 import { execFileSync } from "child_process";
 import { execFileSync as execFileSync2 } from "child_process";

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -40,7 +40,7 @@ Passed (3)
 
 By default, console output groups failures by rule (top 5 per severity, each with one example location and an "…and N more" count) and collapses the Passed section to a bare count, so large projects don't flood the terminal. Pass `--verbose` to see every finding uncapped and ungrouped, with each passed item listed individually. On an interactive, color-capable terminal the Health score plays a short reveal animation; pass `--no-animation` to disable it.
 
-On an interactive terminal, a small pixel-art fox mascot appears alongside both the analysis spinner and the Health-score reveal, reacting to the score (a perfect 100 gets a confetti flourish). `--no-animation` disables it, falling back to the plain spinner and plain score animation.
+On an interactive terminal, a small pixel-art fox mascot appears alongside both the analysis spinner and the Health-score reveal, reacting to the score (a perfect 100 gets a confetti flourish). On a wide enough terminal it also greets you with a short line in a speech bubble at startup, and again with a matching reaction line at the score reveal. `--no-animation` disables all of it, falling back to the plain spinner and plain score animation.
 
 ### Exit codes
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -34,6 +34,7 @@ import { checkoutBaseline, filterToNewFindings } from './baseline.js';
 import { colorEnabled, paletteFor } from './color.js';
 import { startSpinner } from './spinner.js';
 import { startMascotSpinner, mascotFitsWidth } from './mascot.js';
+import { playMascotGreeting, bubbleFitsWidth } from './speech-bubble.js';
 import { loadConfigFile } from './config-file.js';
 import { playScoreAnimation, scoreAnimationEnabled } from './pulse-animation.js';
 
@@ -279,6 +280,11 @@ export async function run(opts: RunOptions = {}): Promise<number> {
       noColorFlag: opts.noColor
     });
   const useMascotSpinner = spinnerBaseEnabled && !opts.noAnimation && mascotFitsWidth(stderrStream.columns);
+  if (useMascotSpinner && bubbleFitsWidth(stderrStream.columns)) {
+    // A wordless greeting isn't worth a dedicated hold before the idle loop, so this
+    // only plays when there's room for the speech bubble too — not just the fox alone.
+    await playMascotGreeting({ enabled: true, stream: stderrStream, holdMs: opts.animationFrameDelayMs });
+  }
   const spinner = useMascotSpinner
     ? startMascotSpinner('Analyzing…', { enabled: true, stream: stderrStream })
     : startSpinner('Analyzing…', { enabled: spinnerBaseEnabled, stream: stderrStream });

--- a/packages/cli/src/pulse-animation.ts
+++ b/packages/cli/src/pulse-animation.ts
@@ -9,6 +9,7 @@ import {
   renderMascotReaction,
   renderConfettiFrame
 } from './mascot.js';
+import { bubbleFitsWidth, pickMessage, renderMascotWithSpeech, REACTION_MESSAGES } from './speech-bubble.js';
 
 const FRAME_COUNT = 6;
 const FRAME_DELAY_MS = 200;
@@ -57,6 +58,11 @@ export async function playScoreAnimation(opts: ScoreAnimationOptions): Promise<v
   const render = createLogUpdate(opts.stream);
   const showMascot = mascotFitsWidth(opts.stream.columns);
   const state = mascotStateFor(opts.score);
+  const reactionMessage =
+    showMascot && bubbleFitsWidth(opts.stream.columns) ? pickMessage(REACTION_MESSAGES[state]) : undefined;
+  const finalMascotBlock = reactionMessage
+    ? renderMascotWithSpeech(renderMascotReaction(state), reactionMessage)
+    : renderMascotReaction(state);
 
   for (let frame = 0; frame < FRAME_COUNT; frame++) {
     const progress = frame / (FRAME_COUNT - 1);
@@ -67,9 +73,7 @@ export async function playScoreAnimation(opts: ScoreAnimationOptions): Promise<v
       ? scoreColor(opts.palette, opts.score)(`${displayScore}/100`)
       : opts.palette.dim(`${displayScore}/100`);
     const waveBlock = `  ${wave}\n  Health: ${scoreText}`;
-    const mascotBlock = showMascot
-      ? (isFinalFrame ? renderMascotReaction(state) : renderMascotAnticipating()) + '\n'
-      : '';
+    const mascotBlock = showMascot ? (isFinalFrame ? finalMascotBlock : renderMascotAnticipating()) + '\n' : '';
     render(`${mascotBlock}${waveBlock}`);
     if (!isFinalFrame) await sleep(frameDelayMs);
   }
@@ -77,10 +81,9 @@ export async function playScoreAnimation(opts: ScoreAnimationOptions): Promise<v
   if (holdMs > 0) await sleep(holdMs);
 
   if (showMascot && state === 'ecstatic') {
-    const mascotBlock = renderMascotReaction('ecstatic');
     for (let i = 0; i < CONFETTI_FRAME_COUNT; i++) {
       const waveBlock = `  ${WAVE_FRAMES[FRAME_COUNT - 1]!}\n  Health: ${scoreColor(opts.palette, opts.score)('100/100')}`;
-      render(`${renderConfettiFrame(i, mascotBlock)}\n${waveBlock}`);
+      render(`${renderConfettiFrame(i, finalMascotBlock)}\n${waveBlock}`);
       if (i < CONFETTI_FRAME_COUNT - 1 && confettiDelayMs > 0) await sleep(confettiDelayMs);
     }
   }

--- a/packages/cli/src/speech-bubble.ts
+++ b/packages/cli/src/speech-bubble.ts
@@ -1,0 +1,42 @@
+const MIN_BUBBLE_COLUMNS = 55;
+
+/**
+ * Whether the terminal is wide enough for the mascot + speech bubble combination —
+ * a stricter gate than `mascotFitsWidth` (mascot.ts), which only covers the fox
+ * sprite alone. Below this, callers render the mascot without a bubble (or skip a
+ * bubble-only moment like the greeting entirely) rather than hiding the fox itself.
+ */
+export function bubbleFitsWidth(columns: number | undefined): boolean {
+  return (columns ?? 80) >= MIN_BUBBLE_COLUMNS;
+}
+
+/**
+ * Renders `text` inside a Unicode box-drawing border, sized to the text (1-space
+ * padding on each side). Always exactly 3 lines: top border, text line, bottom
+ * border. Plain terminal-default colors — unlike the fox sprite, this is readable
+ * text, not pixel art, so it doesn't need a fixed color identity.
+ */
+export function renderSpeechBubble(text: string): string[] {
+  const border = '─'.repeat(text.length + 2);
+  return [`┌${border}┐`, `│ ${text} │`, `└${border}┘`];
+}
+
+/**
+ * Places `bubbleLines` to the right of `mascotBlock`, vertically centered against
+ * it. `mascotBlock` is a `renderPixelGrid` output (mascot.ts) — its lines already
+ * end in an ANSI reset, so appending plain text after a space is safe (no color
+ * bleed into the bubble).
+ */
+export function withSpeechBubble(mascotBlock: string, bubbleLines: readonly string[]): string {
+  const mascotLines = mascotBlock.split('\n');
+  const bubbleWidth = bubbleLines[0]?.length ?? 0;
+  const blankBubbleLine = ' '.repeat(bubbleWidth);
+  const padTop = Math.floor((mascotLines.length - bubbleLines.length) / 2);
+  const padBottom = mascotLines.length - bubbleLines.length - padTop;
+  const paddedBubble = [
+    ...Array<string>(Math.max(padTop, 0)).fill(blankBubbleLine),
+    ...bubbleLines,
+    ...Array<string>(Math.max(padBottom, 0)).fill(blankBubbleLine)
+  ];
+  return mascotLines.map((line, i) => `${line} ${paddedBubble[i] ?? blankBubbleLine}`).join('\n');
+}

--- a/packages/cli/src/speech-bubble.ts
+++ b/packages/cli/src/speech-bubble.ts
@@ -1,3 +1,5 @@
+import type { MascotState } from './mascot.js';
+
 const MIN_BUBBLE_COLUMNS = 55;
 
 /**
@@ -39,4 +41,31 @@ export function withSpeechBubble(mascotBlock: string, bubbleLines: readonly stri
     ...Array<string>(Math.max(padBottom, 0)).fill(blankBubbleLine)
   ];
   return mascotLines.map((line, i) => `${line} ${paddedBubble[i] ?? blankBubbleLine}`).join('\n');
+}
+
+export const GREETING_MESSAGES: readonly string[] = [
+  'Welcome to Svelte Vitals!',
+  "Let's check your project!",
+  'Ready when you are!',
+  "Hi there! Let's dig in."
+];
+
+export const REACTION_MESSAGES: Record<MascotState, readonly string[]> = {
+  ecstatic: ['Perfect score!', 'Flawless!', 'You nailed it!'],
+  happy: ['Nice work!', 'Looking great!', 'Almost perfect!'],
+  content: ['Keep going!', 'Room to grow!', "Let's improve this!"]
+};
+
+/**
+ * Picks one message uniformly at random from `pool`. `random` defaults to
+ * `Math.random` — only overridden by this module's own unit tests below, for
+ * deterministic selection; other call sites and their tests never pass it.
+ */
+export function pickMessage(pool: readonly string[], random: () => number = Math.random): string {
+  return pool[Math.floor(random() * pool.length)]!;
+}
+
+/** Composes a mascot pose with a speech bubble to its right — the shared shape both the startup greeting and the score-reveal reaction use. */
+export function renderMascotWithSpeech(mascotBlock: string, message: string): string {
+  return withSpeechBubble(mascotBlock, renderSpeechBubble(message));
 }

--- a/packages/cli/src/speech-bubble.ts
+++ b/packages/cli/src/speech-bubble.ts
@@ -1,4 +1,5 @@
-import type { MascotState } from './mascot.js';
+import { createLogUpdate } from 'log-update';
+import { renderMascotAnticipating, type MascotState } from './mascot.js';
 
 const MIN_BUBBLE_COLUMNS = 55;
 
@@ -68,4 +69,31 @@ export function pickMessage(pool: readonly string[], random: () => number = Math
 /** Composes a mascot pose with a speech bubble to its right — the shared shape both the startup greeting and the score-reveal reaction use. */
 export function renderMascotWithSpeech(mascotBlock: string, message: string): string {
   return withSpeechBubble(mascotBlock, renderSpeechBubble(message));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const GREETING_HOLD_MS = 800;
+
+/**
+ * Plays a one-shot greeting: the fox's idle-open pose with a random greeting
+ * message in a speech bubble, held for `holdMs`, then cleared — called once
+ * before analysis starts (index.ts), never repeated within a single run. Uses
+ * `log-update` for the same reason mascot.ts's `startMascotSpinner` and
+ * pulse-animation.ts's `playScoreAnimation` do: accurate multi-line redraw/clear.
+ */
+export async function playMascotGreeting(opts: {
+  enabled: boolean;
+  stream: NodeJS.WriteStream;
+  /** Override for tests — real playback uses GREETING_HOLD_MS; 0 completes near-instantly. */
+  holdMs?: number;
+}): Promise<void> {
+  if (!opts.enabled) return;
+  const holdMs = opts.holdMs ?? GREETING_HOLD_MS;
+  const render = createLogUpdate(opts.stream);
+  render(renderMascotWithSpeech(renderMascotAnticipating(), pickMessage(GREETING_MESSAGES)));
+  if (holdMs > 0) await sleep(holdMs);
+  render.clear();
 }

--- a/packages/cli/test/pulse-animation.test.ts
+++ b/packages/cli/test/pulse-animation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { scoreAnimationEnabled, playScoreAnimation } from '../src/pulse-animation.js';
 import { noColorPalette, ansiPalette } from '../src/color.js';
+import { REACTION_MESSAGES } from '../src/speech-bubble.js';
 
 function fakeStream() {
   const writes: string[] = [];
@@ -92,5 +93,23 @@ describe('playScoreAnimation', () => {
     await playScoreAnimation({ score: 82, palette: noColorPalette, stream, frameDelayMs: 0 });
     expect(writes[writes.length - 1]).toContain('82/100');
     expect(writes.join('')).not.toContain('\x1b[38;2;255;62;0m'); // no mascot body art anywhere
+  });
+
+  it('shows a reaction speech bubble matching the final state, on a wide enough terminal', async () => {
+    const { writes, stream } = fakeStream();
+    await playScoreAnimation({ score: 95, palette: ansiPalette, stream, frameDelayMs: 0 }); // happy
+    const allWrites = writes.join('');
+    expect(REACTION_MESSAGES.happy.some((m) => allWrites.includes(m))).toBe(true);
+  });
+
+  it('omits the speech bubble (but keeps the fox) when the terminal fits the mascot but not the bubble', async () => {
+    const { writes, stream } = fakeStream();
+    Object.defineProperty(stream, 'columns', { value: 45 }); // >= 40 (mascot) but < 55 (bubble)
+    await playScoreAnimation({ score: 95, palette: ansiPalette, stream, frameDelayMs: 0 });
+    const allWrites = writes.join('');
+    expect(allWrites).toContain('\x1b[38;2;255;62;0m'); // fox still present
+    for (const pool of Object.values(REACTION_MESSAGES)) {
+      for (const m of pool) expect(allWrites).not.toContain(m);
+    }
   });
 });

--- a/packages/cli/test/run.test.ts
+++ b/packages/cli/test/run.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { run } from '../src/index.js';
+import { GREETING_MESSAGES } from '../src/speech-bubble.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const fixtureDir = join(here, 'fixtures', 'basic-project');
@@ -402,12 +403,31 @@ describe('run() --verbose and animation', () => {
       env: CLEAN_ENV,
       stderrIsTTY: true,
       stderrStream,
-      stdoutIsTTY: false // isolate: only exercise the analysis-phase mascot here
+      stdoutIsTTY: false, // isolate: only exercise the analysis-phase mascot here
+      animationFrameDelayMs: 0 // keep the greeting's hold near-instant in tests
     });
     expect(stderrWrites.length).toBeGreaterThan(0);
     // The mascot's orange truecolor escape is a reliable "this is mascot art, not the
     // plain braille spinner" marker — the braille spinner never emits color.
     expect(stderrWrites.join('')).toContain('\x1b[38;2;255;62;0m');
+  });
+
+  it('shows a one-off greeting speech bubble before the idle loop, on a wide interactive terminal', async () => {
+    const cap = capture();
+    const stderrWrites: string[] = [];
+    const stderrStream = { write: (s: string) => stderrWrites.push(s) } as unknown as NodeJS.WriteStream;
+    await run({
+      cwd: fixtureDir,
+      log: cap.log,
+      errorLog: cap.errorLog,
+      env: CLEAN_ENV,
+      stderrIsTTY: true,
+      stderrStream,
+      stdoutIsTTY: false,
+      animationFrameDelayMs: 0
+    });
+    const allWrites = stderrWrites.join('');
+    expect(GREETING_MESSAGES.some((m) => allWrites.includes(m))).toBe(true);
   });
 
   it('falls back to the plain braille spinner when --no-animation is set, even on a wide interactive terminal', async () => {

--- a/packages/cli/test/speech-bubble.test.ts
+++ b/packages/cli/test/speech-bubble.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { renderSpeechBubble, withSpeechBubble, bubbleFitsWidth } from '../src/speech-bubble.js';
+import {
+  renderSpeechBubble,
+  withSpeechBubble,
+  bubbleFitsWidth,
+  pickMessage,
+  renderMascotWithSpeech,
+  GREETING_MESSAGES,
+  REACTION_MESSAGES
+} from '../src/speech-bubble.js';
 import { renderMascotReaction } from '../src/mascot.js';
 
 describe('renderSpeechBubble', () => {
@@ -52,5 +60,43 @@ describe('bubbleFitsWidth', () => {
   });
   it('treats an unknown width (undefined columns) as fitting (defaults to 80)', () => {
     expect(bubbleFitsWidth(undefined)).toBe(true);
+  });
+});
+
+describe('pickMessage', () => {
+  it('picks the first item when random() returns 0', () => {
+    expect(pickMessage(['a', 'b', 'c'], () => 0)).toBe('a');
+  });
+  it('picks the last item when random() returns just under 1', () => {
+    expect(pickMessage(['a', 'b', 'c'], () => 0.999)).toBe('c');
+  });
+  it('defaults to Math.random and always returns a pool member', () => {
+    const pool = ['a', 'b', 'c'];
+    for (let i = 0; i < 20; i++) {
+      expect(pool).toContain(pickMessage(pool));
+    }
+  });
+});
+
+describe('message pools', () => {
+  it('all greeting messages fit a compact bubble (<=26 chars)', () => {
+    for (const m of GREETING_MESSAGES) expect(m.length).toBeLessThanOrEqual(26);
+  });
+  it('all reaction messages fit a compact bubble (<=26 chars)', () => {
+    for (const pool of Object.values(REACTION_MESSAGES)) {
+      for (const m of pool) expect(m.length).toBeLessThanOrEqual(26);
+    }
+  });
+  it('has a reaction pool for every mascot state', () => {
+    expect(Object.keys(REACTION_MESSAGES).sort()).toEqual(['content', 'ecstatic', 'happy']);
+  });
+});
+
+describe('renderMascotWithSpeech', () => {
+  it('composes a mascot pose and a message into a single bubbled block', () => {
+    const block = renderMascotWithSpeech(renderMascotReaction('happy'), 'Nice work!');
+    expect(block.split('\n')).toHaveLength(7);
+    expect(block).toContain('Nice work!');
+    expect(block).toContain('\x1b[38;2;255;62;0m'); // still the fox, orange present
   });
 });

--- a/packages/cli/test/speech-bubble.test.ts
+++ b/packages/cli/test/speech-bubble.test.ts
@@ -5,6 +5,7 @@ import {
   bubbleFitsWidth,
   pickMessage,
   renderMascotWithSpeech,
+  playMascotGreeting,
   GREETING_MESSAGES,
   REACTION_MESSAGES
 } from '../src/speech-bubble.js';
@@ -98,5 +99,29 @@ describe('renderMascotWithSpeech', () => {
     expect(block.split('\n')).toHaveLength(7);
     expect(block).toContain('Nice work!');
     expect(block).toContain('\x1b[38;2;255;62;0m'); // still the fox, orange present
+  });
+});
+
+function fakeStream() {
+  const writes: string[] = [];
+  return { writes, stream: { write: (s: string) => writes.push(s) } as unknown as NodeJS.WriteStream };
+}
+
+describe('playMascotGreeting', () => {
+  it('writes nothing when disabled', async () => {
+    const { writes, stream } = fakeStream();
+    await playMascotGreeting({ enabled: false, stream, holdMs: 0 });
+    expect(writes).toEqual([]);
+  });
+
+  it('writes a frame containing the fox and one of the greeting messages, then clears', async () => {
+    const { writes, stream } = fakeStream();
+    await playMascotGreeting({ enabled: true, stream, holdMs: 0 });
+    expect(writes.length).toBeGreaterThan(0);
+    const allWrites = writes.join('');
+    expect(allWrites).toContain('\x1b[38;2;255;62;0m'); // the fox
+    expect(GREETING_MESSAGES.some((m) => allWrites.includes(m))).toBe(true);
+    const last = writes[writes.length - 1]!;
+    expect(GREETING_MESSAGES.some((m) => last.includes(m))).toBe(false); // cleared on the last write
   });
 });

--- a/packages/cli/test/speech-bubble.test.ts
+++ b/packages/cli/test/speech-bubble.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { renderSpeechBubble, withSpeechBubble, bubbleFitsWidth } from '../src/speech-bubble.js';
+import { renderMascotReaction } from '../src/mascot.js';
+
+describe('renderSpeechBubble', () => {
+  it('returns exactly 3 lines: top border, text, bottom border', () => {
+    const lines = renderSpeechBubble('Hi there!');
+    expect(lines).toHaveLength(3);
+    expect(lines[0]!.startsWith('┌')).toBe(true);
+    expect(lines[0]!.endsWith('┐')).toBe(true);
+    expect(lines[2]!.startsWith('└')).toBe(true);
+    expect(lines[2]!.endsWith('┘')).toBe(true);
+    expect(lines[1]).toBe('│ Hi there! │');
+  });
+
+  it('all 3 lines have equal width regardless of text length', () => {
+    const lines = renderSpeechBubble('Welcome to Svelte Vitals!');
+    const widths = new Set(lines.map((l) => l.length));
+    expect(widths.size).toBe(1);
+  });
+});
+
+describe('withSpeechBubble', () => {
+  it('combines a 7-line mascot block with a 3-line bubble into 7 lines total', () => {
+    const mascot = renderMascotReaction('content');
+    const bubble = renderSpeechBubble('Keep going!');
+    const combined = withSpeechBubble(mascot, bubble).split('\n');
+    expect(combined).toHaveLength(7);
+  });
+
+  it('vertically centers the bubble: blank on the outer rows, bubble content on the middle 3', () => {
+    const mascot = renderMascotReaction('content');
+    const bubble = renderSpeechBubble('Keep going!');
+    const combined = withSpeechBubble(mascot, bubble).split('\n');
+    expect(combined[0]).not.toContain('┌');
+    expect(combined[1]).not.toContain('┌');
+    expect(combined[2]).toContain('┌');
+    expect(combined[3]).toContain('Keep going!');
+    expect(combined[4]).toContain('└');
+    expect(combined[5]).not.toContain('└');
+    expect(combined[6]).not.toContain('└');
+  });
+});
+
+describe('bubbleFitsWidth', () => {
+  it('fits at 55 columns and above', () => {
+    expect(bubbleFitsWidth(55)).toBe(true);
+    expect(bubbleFitsWidth(80)).toBe(true);
+  });
+  it('does not fit below 55 columns', () => {
+    expect(bubbleFitsWidth(54)).toBe(false);
+  });
+  it('treats an unknown width (undefined columns) as fitting (defaults to 80)', () => {
+    expect(bubbleFitsWidth(undefined)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Stacked on #175 (the pixel-art fox redesign) — targets `feat/mascot-pixel-fox`, not `main`, so this diff is scoped to just the speech-bubble feature.

- New `packages/cli/src/speech-bubble.ts`: a bordered Unicode speech bubble rendered next to the fox, with its own message pools and random selection. `mascot.ts` is untouched.
- Startup: a random greeting (`"Welcome to Svelte Vitals!"`, etc.) plays once before the "Analyzing…" spinner starts, held ~800ms, then clears.
- Score reveal: a random reaction line matching the Health-score band (ecstatic/happy/content) appears next to the fox's reaction pose, and persists through the confetti bonus on a perfect 100.
- Both are gated by a new `bubbleFitsWidth` (55-column) threshold, stricter than the existing 40-column `mascotFitsWidth` — narrower terminals still show the fox, just without a bubble; the startup greeting is skipped entirely below that width (a wordless greeting isn't worth a dedicated hold).
- `--no-animation` disables all of it, same as before.
- Full design rationale: `docs/superpowers/specs/2026-07-11-mascot-speech-bubble-design.md`. Implementation plan: `docs/superpowers/plans/2026-07-11-mascot-speech-bubble.md`.

Built via subagent-driven development: 6 tasks, each with an isolated implementer + spec/quality review, followed by a whole-branch review (opus) — zero Critical/Important findings at any stage.

**Known tradeoff (flagged by the final review, not a defect):** on a wide interactive terminal, every run now has a fixed ~800ms startup delay for the greeting. There's no way to disable just the greeting without `--no-animation` disabling the whole mascot.

## Test plan
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm test` (all packages, 660 tests)
- [x] `pnpm lint`
- [x] Per-task spec-compliance + code-quality reviews (6/6 approved, no Critical/Important findings)
- [x] Whole-branch review (opus): Ready to merge — Yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZVgzgmaCEmTT9mJ5D9SHH