### PR TITLE
fix(core): stop showing the dynamic-marker footnote in compact mode

### DIFF
--- a/.changeset/fix-dynamic-footer-compact-mode.md
+++ b/.changeset/fix-dynamic-footer-compact-mode.md
@@ -1,0 +1,5 @@
+---
+'@svelte-vitals/core': patch
+---
+
+Console reporter: stop printing the "↯ = set dynamically (verified at runtime)." footnote in compact (default, non-`--verbose`) mode. The `↯` marker itself only ever appears in the verbose `Passed` listing — showing the footnote without it visible anywhere in the output was confusing.

--- a/docs/src/content/docs/guides/getting-started.md
+++ b/docs/src/content/docs/guides/getting-started.md
@@ -43,10 +43,13 @@ To target a sub-directory:
 npx svelte-vitals@latest ./apps/web
 ```
 
-Example output:
+Example output (`--verbose`, to show every passed check individually rather than just a count):
 
 ```text
-Svelte Vitals  ·  SEO (static mode)
+Svelte Vitals  ·  static mode
+
+Health: 79/100
+SEO Score: 79/100   (route avg 96 · capped at 79: critical present)
 
 Critical (1)
 ────────────────────────
@@ -63,7 +66,7 @@ Passed (3)
 ↯ = set dynamically (verified at runtime).
 ```
 
-A `↯` marker means the value is set dynamically (e.g. `<title>{data.title}</title>`). Dynamic titles pass — only genuinely missing or empty metadata is flagged.
+A `↯` marker means the value is set dynamically (e.g. `<title>{data.title}</title>`). Dynamic titles pass — only genuinely missing or empty metadata is flagged. Without `--verbose`, the `Passed` section collapses to a bare count (`Passed (3)`) and this footnote is omitted, since there'd be no `↯` marker on screen for it to explain.
 
 ## Exit codes
 

--- a/docs/src/content/docs/guides/getting-started.md
+++ b/docs/src/content/docs/guides/getting-started.md
@@ -34,16 +34,16 @@ pnpm add -D svelte-vitals
 Run inside the root of any SvelteKit project:
 
 ```bash
-npx svelte-vitals@latest
+npx svelte-vitals@latest --verbose
 ```
 
 To target a sub-directory:
 
 ```bash
-npx svelte-vitals@latest ./apps/web
+npx svelte-vitals@latest ./apps/web --verbose
 ```
 
-Example output (`--verbose`, to show every passed check individually rather than just a count):
+Example output (`--verbose` shows every passed check individually rather than just a count):
 
 ```text
 Svelte Vitals  ·  static mode

--- a/docs/src/content/docs/ja/guides/getting-started.md
+++ b/docs/src/content/docs/ja/guides/getting-started.md
@@ -34,16 +34,16 @@ pnpm add -D svelte-vitals
 任意の SvelteKit プロジェクトのルートで実行してください：
 
 ```bash
-npx svelte-vitals@latest
+npx svelte-vitals@latest --verbose
 ```
 
 サブディレクトリを指定する場合：
 
 ```bash
-npx svelte-vitals@latest ./apps/web
+npx svelte-vitals@latest ./apps/web --verbose
 ```
 
-出力例(`--verbose` — 件数だけでなく、パスした各項目を個別に表示):
+出力例(`--verbose` を付けると、件数だけでなく、パスした各項目を個別に表示):
 
 ```text
 Svelte Vitals  ·  static mode

--- a/docs/src/content/docs/ja/guides/getting-started.md
+++ b/docs/src/content/docs/ja/guides/getting-started.md
@@ -43,10 +43,13 @@ npx svelte-vitals@latest
 npx svelte-vitals@latest ./apps/web
 ```
 
-出力例：
+出力例(`--verbose` — 件数だけでなく、パスした各項目を個別に表示):
 
 ```text
-Svelte Vitals  ·  SEO (static mode)
+Svelte Vitals  ·  static mode
+
+Health: 79/100
+SEO Score: 79/100   (route avg 96 · capped at 79: critical present)
 
 Critical (1)
 ────────────────────────
@@ -63,7 +66,7 @@ Passed (3)
 ↯ = set dynamically (verified at runtime).
 ```
 
-`↯` マーカーは値が動的に設定されていること（例：`<title>{data.title}</title>`）を意味します。動的なタイトルはパスします — 本当に欠けているか空のメタデータのみがフラグされます。
+`↯` マーカーは値が動的に設定されていること(例:`<title>{data.title}</title>`)を意味します。動的なタイトルはパスします — 本当に欠けているか空のメタデータのみがフラグされます。`--verbose` を付けない場合、`Passed` セクションは件数のみ(`Passed (3)`)に折りたたまれ、この脚注も表示されません — 画面上に説明対象の `↯` マーカーが無いためです。
 
 ## 終了コード
 

--- a/packages/core/src/reporter/console.ts
+++ b/packages/core/src/reporter/console.ts
@@ -174,7 +174,9 @@ export function formatConsoleReport(results: Result[], config: Config, options: 
   }
 
   if (options.byRoute) lines.push(...byRouteTree(p, results, config, options.verbose ?? false));
-  if (summary.dynamic > 0) lines.push(p.dim('↯ = set dynamically (verified at runtime).'));
+  // The ↯ marker itself only ever prints in the verbose Passed listing above — showing
+  // this footnote in compact mode would explain a symbol the user can't see anywhere.
+  if (options.verbose && summary.dynamic > 0) lines.push(p.dim('↯ = set dynamically (verified at runtime).'));
 
   return lines.join('\n').replace(/\n+$/, '\n');
 }

--- a/packages/core/test/console-report.test.ts
+++ b/packages/core/test/console-report.test.ts
@@ -261,6 +261,24 @@ describe('formatConsoleReport', () => {
     expect(out).toContain('✓ SEO003  Has <title>');
   });
 
+  it('omits the "↯ = set dynamically" footnote in compact mode, since the ↯ marker itself only prints under verbose:true', () => {
+    const dynamicPass: Result[] = [
+      {
+        id: 'SEO001',
+        severity: 'critical',
+        detection: { presence: 'own', value: 'dynamic' },
+        route: '/a',
+        message: '<title>'
+      }
+    ];
+    const compact = formatConsoleReport(dynamicPass, config);
+    expect(compact).not.toContain('↯');
+
+    const verbose = formatConsoleReport(dynamicPass, config, { verbose: true });
+    expect(verbose).toContain('↯ dynamic');
+    expect(verbose).toContain('↯ = set dynamically (verified at runtime).');
+  });
+
   it('omitHeader:true skips the brand/Health lines but still prints category score lines', () => {
     const out = formatConsoleReport(results, config, { omitHeader: true });
     expect(out).not.toContain('Svelte Vitals');


### PR DESCRIPTION
## Summary
- Fixes a bug reported from real-world usage: in compact (default) mode, the `↯ = set dynamically (verified at runtime).` footnote could print even though the `↯` marker it explains never appears anywhere in compact output (that marker only prints in the verbose `Passed` listing, per `packages/core/src/reporter/console.ts:168`). The footnote was gated only on `summary.dynamic > 0`, independent of `--verbose`.
- Gates the footnote on `options.verbose` too, so it only ever appears alongside the marker it explains.
- Also refreshes `docs/guides/getting-started.md` (en+ja)'s example output, which showed this same combination as if it were the default — regenerated against a real CLI run (`--verbose --rules SEO001` against a small fixture) rather than hand-edited, which also fixed two other stale details in the same block: the header read "SEO (static mode)" instead of the actual "static mode", and the `Health:`/`SEO Score:` lines were missing entirely.

## Test plan
- [x] New test: compact mode with a dynamic pass omits `↯` entirely; verbose mode shows both the marker and the footnote
- [x] `pnpm --filter @svelte-vitals/core test` — 398/398 pass
- [x] `pnpm --filter svelte-vitals build && test` — 508/508 pass (CLI consumes this reporter)
- [x] `pnpm --filter docs build` — 121 pages, no errors
- [x] `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZVgzgmaCEmTT9mJ5D9SHH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Compact console reports no longer display the dynamic-value footnote.
  - Verbose reports continue to show dynamic markers and their explanatory footnote.

- **Documentation**
  - Updated English and Japanese getting-started guides with revised verbose output examples.
  - Clarified the differences between compact and verbose report formats, including dynamic-value explanations and the collapsed “Passed” section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->