### PR TITLE
fix(cli): center the ecstatic mascot's mouth

### DIFF
--- a/.changeset/fix-ecstatic-mouth-centering.md
+++ b/.changeset/fix-ecstatic-mouth-centering.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': patch
+---
+
+CLI mascot: fix the ecstatic (100/100) face's mouth sitting one column left of center under the eyes.

--- a/.changeset/fix-ecstatic-mouth-centering.md
+++ b/.changeset/fix-ecstatic-mouth-centering.md
@@ -2,4 +2,4 @@
 'svelte-vitals': patch
 ---
 
-CLI mascot: fix the ecstatic (100/100) face's mouth sitting one column left of center under the eyes.
+CLI mascot: fix the ecstatic (100/100) face's mouth being off-center under the eyes — switched to the same 4-column mouth width the happy face already centers correctly (a 5-column mouth can never land exactly on the eyes' midpoint).

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -56976,7 +56976,7 @@ function applyRuleSeverities(results, config) {
   });
 }
 
-// ../cli/dist/chunk-TCZ6OF6J.js
+// ../cli/dist/chunk-EU27FVUM.js
 import { readFile, access as access2 } from "fs/promises";
 import { join } from "path";
 
@@ -57754,7 +57754,7 @@ async function glob(globInput, options) {
   return crawler ? formatPaths(await crawler.withPromise(), relative2) : [];
 }
 
-// ../cli/dist/chunk-TCZ6OF6J.js
+// ../cli/dist/chunk-EU27FVUM.js
 import { readFileSync as readFileSync2 } from "fs";
 import { execFileSync } from "child_process";
 import { execFileSync as execFileSync2 } from "child_process";

--- a/packages/cli/src/mascot.ts
+++ b/packages/cli/src/mascot.ts
@@ -68,11 +68,13 @@ const FACE_CONTENT = ['╭──────────╮', '│  ●    ●  
 // mouth "shape language" on top of the neutral/content one.
 const FACE_HAPPY = ['╭──────────╮', '│  ●    ●  │', '│   ╰──╯   │', '╰──────────╯'];
 
-// Same 4-char mouth as happy (cols 3-6, exactly centered on the eyes' 4.5 midpoint) —
-// a 5-char mouth was tried first but can only ever sit one column off-center either
-// way (its own span's center always lands on an integer, never the eyes' x.5
-// midpoint), which read as skewed regardless of which side it favored. Mood is
-// differentiated by the eyes alone here (^ vs ●), not mouth width.
+// Same 4-char mouth as happy. Indexing the literal string itself (position 0 = the
+// leading │): the eyes sit at positions 3 and 8 (midpoint 5.5) and this mouth spans
+// 4-7 (midpoint 5.5) — exactly centered. A 5-char mouth was tried first but can only
+// ever sit one position off-center either way (an odd-width span's own center always
+// lands on an integer, never the eyes' x.5 midpoint), which read as skewed regardless
+// of which side it favored. Mood is differentiated by the eyes alone here (^ vs ●),
+// not mouth width.
 const FACE_ECSTATIC = ['╭──────────╮', '│  ^    ^  │', '│   ╰──╯   │', '╰──────────╯'];
 
 const REACTION_FACES: Record<MascotState, readonly string[]> = {

--- a/packages/cli/src/mascot.ts
+++ b/packages/cli/src/mascot.ts
@@ -62,16 +62,18 @@ const FACE_WINK_ONE = ['╭──────────╮', '│  ●    <  �
 
 const FACE_CONTENT = ['╭──────────╮', '│  ●    ●  │', '│    ◡◡    │', '╰──────────╯'];
 
-// happy/ecstatic use a rounded bracket (╰──╯/╰───╯) rather than repeating ◡ — four or
-// five small arcs in a row read as a wavy scallop, not one smile. The bracket also
-// echoes the face's own rounded corners (╭╮╰╯), self-similar rather than introducing a
-// third mouth "shape language" on top of the neutral/content one.
+// happy/ecstatic use a rounded bracket (╰──╯) rather than repeating ◡ — four or five
+// small arcs in a row read as a wavy scallop, not one smile. The bracket also echoes
+// the face's own rounded corners (╭╮╰╯), self-similar rather than introducing a third
+// mouth "shape language" on top of the neutral/content one.
 const FACE_HAPPY = ['╭──────────╮', '│  ●    ●  │', '│   ╰──╯   │', '╰──────────╯'];
 
-// The 5-char mouth can't sit exactly on the eyes' center (2,7 → midpoint 4.5) the way
-// the 4-char happy mouth does — one column off either way. Centered right (cols 3-7)
-// reads correctly; centered left (cols 2-6, the original placement) read as skewed.
-const FACE_ECSTATIC = ['╭──────────╮', '│  ^    ^  │', '│   ╰───╯  │', '╰──────────╯'];
+// Same 4-char mouth as happy (cols 3-6, exactly centered on the eyes' 4.5 midpoint) —
+// a 5-char mouth was tried first but can only ever sit one column off-center either
+// way (its own span's center always lands on an integer, never the eyes' x.5
+// midpoint), which read as skewed regardless of which side it favored. Mood is
+// differentiated by the eyes alone here (^ vs ●), not mouth width.
+const FACE_ECSTATIC = ['╭──────────╮', '│  ^    ^  │', '│   ╰──╯   │', '╰──────────╯'];
 
 const REACTION_FACES: Record<MascotState, readonly string[]> = {
   content: FACE_CONTENT,

--- a/packages/cli/src/mascot.ts
+++ b/packages/cli/src/mascot.ts
@@ -68,7 +68,10 @@ const FACE_CONTENT = ['╭──────────╮', '│  ●    ●  
 // third mouth "shape language" on top of the neutral/content one.
 const FACE_HAPPY = ['╭──────────╮', '│  ●    ●  │', '│   ╰──╯   │', '╰──────────╯'];
 
-const FACE_ECSTATIC = ['╭──────────╮', '│  ^    ^  │', '│  ╰───╯   │', '╰──────────╯'];
+// The 5-char mouth can't sit exactly on the eyes' center (2,7 → midpoint 4.5) the way
+// the 4-char happy mouth does — one column off either way. Centered right (cols 3-7)
+// reads correctly; centered left (cols 2-6, the original placement) read as skewed.
+const FACE_ECSTATIC = ['╭──────────╮', '│  ^    ^  │', '│   ╰───╯  │', '╰──────────╯'];
 
 const REACTION_FACES: Record<MascotState, readonly string[]> = {
   content: FACE_CONTENT,


### PR DESCRIPTION
## Summary
- Fixes a visual bug reported at 100/100 (ecstatic mascot): the mouth sat off-center under the `^ ^` eyes.
- A 5-column mouth (`╰───╯`) was tried first, shifted between the two possible placements (columns 2-6, then 3-7) — but an odd-width mouth's own span always centers on an integer, and the eyes' midpoint is `x.5`, so neither placement could ever be exactly centered; one read as skewed left, the other skewed right.
- Switched `FACE_ECSTATIC` to the same 4-column mouth (`╰──╯`) `FACE_HAPPY` already uses, which centers exactly (an even-width span can land on the eyes' `.5` midpoint). Ecstatic is now differentiated from happy purely by the eyes (`^` vs `●`), not mouth width.
- Also rebuilds `packages/action/dist/` (bundles the changed CLI chunk) and adds a patch changeset.

## Test plan
- [x] `pnpm --filter svelte-vitals test` — 508/508 pass (no test hardcoded the old string)
- [x] `pnpm --filter svelte-vitals typecheck` — clean
- [x] `pnpm lint` — clean
- [x] Visually verified via vhs recording + frame extraction (confirmed with the user after an initial attempt was still off-center)
- [x] `pnpm build` — confirms `packages/action/dist` is in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZVgzgmaCEmTT9mJ5D9SHH