### PR TITLE
feat(cli): suppressions file — accept existing findings, gate only new ones

### DIFF
--- a/.changeset/suppressions-file.md
+++ b/.changeset/suppressions-file.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': minor
+---
+
+Add a `svelte-vitals-suppressions.json` file: `--update-suppressions` records every currently-penalized finding once (a persistent adoption ramp, unlike the transient `--baseline <ref>` git-ref comparison), and the file is then applied automatically on every run — after `--diff`/`--staged` and `--baseline` — so gating (`--fail-on`, `--min-health`) can be turned on for an existing project without first fixing its whole backlog. `--no-suppressions` disables it for one run.

--- a/docs/src/content/docs/guides/ci.md
+++ b/docs/src/content/docs/guides/ci.md
@@ -27,6 +27,18 @@ Re-running `ci install` without `--force` is a no-op if the file already exists 
 safe to run again after upgrading svelte-vitals). If you already have a workflow from an older
 svelte-vitals version, re-run with `--force` to migrate to the current, shorter template.
 
+## Adopting on an existing project
+
+If the repo already has a backlog of findings, run `svelte-vitals --update-suppressions` locally
+first: it writes `svelte-vitals-suppressions.json`, accepting every current finding in one shot.
+Commit that file, then enable whatever gate you want (`--fail-on`, `--min-health`, a pre-commit
+hook, or this workflow) — from then on it only fails on findings introduced afterward, without
+having to fix the backlog up front. See [`--update-suppressions`](/svelte-vitals/guides/cli/#svelte-vitals-suppressionsjson---update-suppressions---no-suppressions)
+in the CLI reference for the full behavior. `@svelte-vitals/action` doesn't read this file directly
+yet (v1 is CLI-only) — its own `diff`/`baseline` scoping below already limits _this_ workflow to a
+PR's own changes; the suppressions file additionally lets you turn on gating outside of PRs (e.g.
+`--fail-on` in a local pre-commit hook) without the same backlog problem.
+
 ## What the workflow does
 
 On every `pull_request` event, the generated workflow:

--- a/docs/src/content/docs/guides/cli.md
+++ b/docs/src/content/docs/guides/cli.md
@@ -131,6 +131,36 @@ svelte-vitals --diff origin/main --baseline origin/main --fail-on warning   # re
 
 > Findings are matched without their line number, so a second violation of the same rule added lower in a file you already had one violation in won't surface as "new".
 
+### `svelte-vitals-suppressions.json` / `--update-suppressions` / `--no-suppressions`
+
+Adopting svelte-vitals on an existing project usually means there's a backlog of findings you can't fix before turning on gating. `--baseline <ref>` covers the **transient** case — comparing a PR against its base — but there's also a **persistent** ramp: record today's findings once, accept them, and gate only on anything new from then on.
+
+```bash
+svelte-vitals --update-suppressions   # write svelte-vitals-suppressions.json, accepting every current finding
+git add svelte-vitals-suppressions.json && git commit -m "chore: accept existing svelte-vitals findings"
+svelte-vitals --fail-on warning       # now gates only on findings introduced after that commit
+```
+
+`--update-suppressions` analyzes the whole project (any `--diff`/`--staged`/`--baseline` scoping is ignored — the file is meant to capture the whole project's state, not a diff), writes every currently-penalized finding to `svelte-vitals-suppressions.json` in the analyzed directory (passing findings are never written), prints a summary to stderr, and exits `0` without printing a report.
+
+Once the file exists, it's applied **automatically** on every run — after `--diff`/`--staged` and `--baseline` — removing any penalized finding whose rule id, route, and location match an entry, and printing how many were suppressed:
+
+```
+svelte-vitals: 12 finding(s) suppressed by svelte-vitals-suppressions.json.
+```
+
+Fix an accepted finding and its entry becomes **stale** (matches nothing); svelte-vitals reports the stale count on stderr as a reminder to prune, but never fails the run because of it:
+
+```
+svelte-vitals: 3 finding(s) suppressed by svelte-vitals-suppressions.json (1 stale entry — re-run --update-suppressions to prune).
+```
+
+Use `--no-suppressions` to ignore the file for one run (e.g. to see the project's true current state). A malformed `svelte-vitals-suppressions.json` (not valid JSON, wrong `version`, or an entry missing `id`) is a hard error (exit `2`) rather than being silently ignored — a typo'd file must not silently un-gate CI.
+
+**Key difference from `--baseline <ref>`:** `--baseline` re-derives "what's pre-existing" by re-analyzing a git ref on every run — nothing to commit, but it only ever compares against one ref. The suppressions file is a committed, persistent record you build once (or update deliberately) and that keeps applying regardless of which ref you're on.
+
+> Entries match without a line number, same as `--baseline` — a second violation of an accepted rule lower in the same file won't surface as new. This file only affects the CLI in v1; it isn't yet read by `@svelte-vitals/vite`, `@svelte-vitals/mcp`, or the GitHub Action.
+
 ### `--by-route`
 
 Print a per-route score breakdown in the console output.

--- a/docs/src/content/docs/ja/guides/ci.md
+++ b/docs/src/content/docs/ja/guides/ci.md
@@ -29,6 +29,10 @@ npx svelte-vitals@latest ci install --force     # 既存のワークフローフ
 svelte-vitals が生成したワークフローが既にある場合は、`--force` で再実行すると現行の
 短いテンプレートに移行できます。
 
+## 既存プロジェクトへの導入
+
+リポジトリに既に検出結果の蓄積がある場合は、まずローカルで `svelte-vitals --update-suppressions` を実行してください。現在のすべての検出結果を受け入れる `svelte-vitals-suppressions.json` が一度で書き出されます。そのファイルをコミットしてから、好きなゲート(`--fail-on`、`--min-health`、pre-commit フック、あるいはこのワークフロー)を有効にすれば、以降はそれ以後に導入された検出結果だけで失敗するようになり、蓄積分を事前に直す必要はありません。詳しくは CLI リファレンスの [`--update-suppressions`](/svelte-vitals/ja/guides/cli/#svelte-vitals-suppressionsjson---update-suppressions---no-suppressions) を参照してください。`@svelte-vitals/action` はまだこのファイルを直接読み込みません(v1 は CLI のみ対応)— 以下で説明する `diff`/`baseline` によるスコープ絞り込みが、この _ワークフロー_ を既に PR 自体の変更分に限定しています。抑制ファイルはそれに加えて、PR の外(たとえばローカルの pre-commit フックでの `--fail-on`)でも同じ蓄積問題なしにゲートを有効にできるようにするものです。
+
 ## ワークフローの動作
 
 `pull_request` イベントが発生するたびに、生成されるワークフローは以下を行います：

--- a/docs/src/content/docs/ja/guides/cli.md
+++ b/docs/src/content/docs/ja/guides/cli.md
@@ -131,6 +131,36 @@ svelte-vitals --diff origin/main --baseline origin/main --fail-on warning   # �
 
 > 検出結果は行番号を含めずに照合されるため、既に 1 件違反があるファイルの下の方に同じルールの 2 件目の違反を追加しても「新規」としては表示されません。
 
+### `svelte-vitals-suppressions.json` / `--update-suppressions` / `--no-suppressions`
+
+既存プロジェクトに svelte-vitals を導入する場合、たいてい修正しきれない検出結果の蓄積があり、ゲートを有効にする前にすべて直すことはできません。`--baseline <ref>` は **一時的な**ケース(PR とそのベースの比較)をカバーしますが、それとは別に **恒久的な**ランプもあります — 今日の検出結果を一度だけ記録して受け入れ、以降は新規のものだけをゲート対象にする、というものです。
+
+```bash
+svelte-vitals --update-suppressions   # svelte-vitals-suppressions.json を書き出し、現在のすべての検出結果を受け入れる
+git add svelte-vitals-suppressions.json && git commit -m "chore: accept existing svelte-vitals findings"
+svelte-vitals --fail-on warning       # 以降はこのコミット以後に導入された検出結果だけをゲート対象にする
+```
+
+`--update-suppressions` はプロジェクト全体を解析し(`--diff`/`--staged`/`--baseline` によるスコープ絞り込みは無視されます — このファイルは差分ではなくプロジェクト全体の状態を記録するためのものです)、現在ペナルティ対象になっているすべての検出結果を解析対象ディレクトリの `svelte-vitals-suppressions.json` に書き込み(パスしている検出結果は書き込まれません)、stderr にサマリーを表示して、レポートを出力せずに終了コード `0` で終了します。
+
+ファイルが存在すると、以降の実行では**自動的に**(`--diff`/`--staged` と `--baseline` の後に)適用され、ルール ID・route・location がエントリと一致するペナルティ対象の検出結果を取り除いたうえで、抑制した件数を表示します:
+
+```
+svelte-vitals: 12 finding(s) suppressed by svelte-vitals-suppressions.json.
+```
+
+受け入れ済みの検出結果を修正すると、そのエントリは**stale(未使用)**になります(何にも一致しなくなります)。svelte-vitals は stale の件数を stderr に表示してプルーニングを促しますが、それだけで実行を失敗させることはありません:
+
+```
+svelte-vitals: 3 finding(s) suppressed by svelte-vitals-suppressions.json (1 stale entry — re-run --update-suppressions to prune).
+```
+
+`--no-suppressions` を使うと、その回の実行だけファイルを無視できます(例えばプロジェクトの本当の現状を確認したいとき)。壊れた `svelte-vitals-suppressions.json`(JSON として不正、`version` が一致しない、エントリに `id` がない、など)は黙って無視されるのではなく、致命的エラー(終了コード `2`)になります — タイプミスのあるファイルが CI のゲートを黙って無効化してしまうことを防ぐためです。
+
+**`--baseline <ref>` との違い:** `--baseline` は実行のたびに git の ref を再解析して「何が既存か」を導出します — コミットは不要ですが、常に 1 つの ref としか比較できません。抑制ファイルは、一度だけ(または意図的に)構築してコミットする永続的な記録で、どの ref 上にいても適用され続けます。
+
+> `--baseline` と同様、エントリは行番号なしで照合されます — 受け入れ済みのルールの 2 件目の違反が同じファイルの下の方に追加されても「新規」としては表示されません。このファイルは v1 では CLI にのみ影響します。まだ `@svelte-vitals/vite`、`@svelte-vitals/mcp`、GitHub Action からは読み込まれません。
+
 ### `--by-route`
 
 コンソール出力にルートごとのスコア内訳を表示します。

--- a/docs/superpowers/specs/2026-07-13-suppressions-file-design.md
+++ b/docs/superpowers/specs/2026-07-13-suppressions-file-design.md
@@ -1,0 +1,64 @@
+# Suppressions file: accept existing findings, gate only new ones
+
+**Date:** 2026-07-13
+**Status:** Accepted (design delegated to the advisor by the maintainer, 2026-07-13; implementation plan: `plans/023-suppressions-file.md`)
+**Packages:** `svelte-vitals` (CLI only)
+
+## Goal
+
+Adopting svelte-vitals on an existing project is blocked by accumulated
+findings: you cannot turn on `--fail-on` gating without first fixing
+everything. `--baseline <ref>` (PR #142) covers the _transient_ case (compare a
+PR against its base), but there is no _persistent_ ramp — "record today's
+findings, accept them, and fail only on new ones". This design adds a
+suppressions file (direction note DIR-03).
+
+**Naming:** the file mechanism is called **suppressions**, not "baseline" —
+`--baseline <ref>` already means the git-ref comparison, and overloading the
+word was flagged as a hazard in plan 014's maintenance notes. Precedent:
+ESLint's bulk suppressions.
+
+## Decisions
+
+1. **File:** `svelte-vitals-suppressions.json` in the analyzed directory (same
+   placement rule as `svelte-vitals.config.*`; no upward search). Applied
+   **automatically** when present, with a stderr notice
+   (`N finding(s) suppressed by svelte-vitals-suppressions.json`).
+   `--no-suppressions` disables application for one run.
+2. **Creating/updating:** `--update-suppressions` runs the analysis, writes
+   ALL currently penalized findings to the file (full rewrite — stale entries
+   are pruned), prints a summary to stderr, and exits 0. Reporter output and
+   exit gating are skipped in this mode. Scoping flags (`--diff`/`--staged`/
+   `--baseline`) are ignored while updating — the file records the whole
+   project.
+3. **Entry identity:** same key as `--baseline`'s `findingKey`
+   (`id` + `route` + `location`, **no line number** — line drift must not
+   resurface accepted findings; the known trade-off is that a second violation
+   of the same rule in the same file is masked).
+4. **Format:** `{ "version": 1, "suppressions": [{ "id", "route"?, "location"? }] }`,
+   entries sorted by (id, route, location) for stable diffs. Unknown keys are
+   ignored (forward compatibility); a malformed file is a hard error (exit 2)
+   — silently ignoring a typo'd suppressions file would un-gate CI.
+5. **Application order:** `--diff`/`--staged` → `--baseline <ref>` →
+   suppressions (last). Only penalized findings are removed; passing seeds are
+   untouched. Suppressed findings leave `results` entirely, so scores/Health
+   rise accordingly — intended: the ramp's purpose is to make dashboards and
+   gates reflect _new_ debt only.
+6. **Stale entries:** application reports a stale count on stderr (with a hint
+   to re-run `--update-suppressions`) but never fails the run.
+
+## Non-goals
+
+- A config-file key or custom path (fixed filename in v1).
+- MCP / vite / action integration (CLI only in v1).
+- Line-scoped suppression or merging with the inline
+  `svelte-vitals-disable-next-line` directive — separate mechanisms.
+
+## Test plan
+
+Unit: load (missing/malformed/version), write (penalized-only, sorted, prune),
+apply (removal, passing seeds untouched, stale count). Run-level: auto-apply →
+exit 0, `--no-suppressions` restores failure, `--update-suppressions` writes
+and exits 0, malformed file exits 2, ordering with `--diff`/`--baseline`.
+The full adoption-ramp sequence (update → all suppressed → new finding fails)
+is pinned end-to-end.

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -56976,7 +56976,7 @@ function applyRuleSeverities(results, config) {
   });
 }
 
-// ../cli/dist/chunk-EU27FVUM.js
+// ../cli/dist/chunk-S4QJ5TSF.js
 import { readFile, access as access2 } from "fs/promises";
 import { join } from "path";
 
@@ -57754,15 +57754,17 @@ async function glob(globInput, options) {
   return crawler ? formatPaths(await crawler.withPromise(), relative2) : [];
 }
 
-// ../cli/dist/chunk-EU27FVUM.js
+// ../cli/dist/chunk-S4QJ5TSF.js
 import { readFileSync as readFileSync2 } from "fs";
 import { execFileSync } from "child_process";
 import { execFileSync as execFileSync2 } from "child_process";
 import { mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join as join3 } from "path";
-import { existsSync as existsSync2 } from "fs";
+import { readFileSync as readFileSync22, writeFileSync } from "fs";
 import { join as join4 } from "path";
+import { existsSync as existsSync2 } from "fs";
+import { join as join5 } from "path";
 import { pathToFileURL } from "url";
 function createNodeRuntime() {
   return {
@@ -58417,6 +58419,66 @@ function filterToNewFindings(results, baselineResults) {
   const baselineKeys = new Set(baselineResults.map(findingKey));
   return results.filter((r) => !baselineKeys.has(findingKey(r)));
 }
+var SUPPRESSIONS_FILE = "svelte-vitals-suppressions.json";
+function isPlainObject3(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function loadSuppressions(cwd) {
+  const path = join4(cwd, SUPPRESSIONS_FILE);
+  let raw;
+  try {
+    raw = readFileSync22(path, "utf8");
+  } catch {
+    return void 0;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `invalid ${SUPPRESSIONS_FILE}: not valid JSON (${err instanceof Error ? err.message : String(err)}).`,
+      { cause: err }
+    );
+  }
+  if (!isPlainObject3(parsed)) {
+    throw new Error(`invalid ${SUPPRESSIONS_FILE}: expected a top-level JSON object.`);
+  }
+  if (parsed.version !== 1) {
+    throw new Error(`invalid ${SUPPRESSIONS_FILE}: expected "version": 1, got ${JSON.stringify(parsed.version)}.`);
+  }
+  if (!Array.isArray(parsed.suppressions)) {
+    throw new Error(`invalid ${SUPPRESSIONS_FILE}: "suppressions" must be an array.`);
+  }
+  const entries = [];
+  parsed.suppressions.forEach((entry, i) => {
+    if (!isPlainObject3(entry) || typeof entry.id !== "string") {
+      throw new Error(`invalid ${SUPPRESSIONS_FILE}: suppressions[${i}] must be an object with a string "id".`);
+    }
+    entries.push({
+      id: entry.id,
+      ...typeof entry.route === "string" ? { route: entry.route } : {},
+      ...typeof entry.location === "string" ? { location: entry.location } : {}
+    });
+  });
+  return entries;
+}
+function applySuppressions(results, entries, config) {
+  const keys = new Set(entries.map((e2) => findingKey(e2)));
+  const usedKeys = /* @__PURE__ */ new Set();
+  const kept = [];
+  let suppressed = 0;
+  for (const r of results) {
+    const key2 = findingKey(r);
+    if (keys.has(key2) && isPenalized(r.detection, config.treatDynamicAs)) {
+      suppressed++;
+      usedKeys.add(key2);
+      continue;
+    }
+    kept.push(r);
+  }
+  const stale = [...keys].filter((k) => !usedKeys.has(k)).length;
+  return { results: kept, suppressed, stale };
+}
 var wrap = (open3, close2 = 0) => (s) => `\x1B[${open3}m${s}\x1B[${close2}m`;
 var ansiPalette = {
   bold: wrap(1, 22),
@@ -58438,7 +58500,7 @@ var CATEGORIES = ["seo", "performance", "correctness", "security", "architecture
 var TREAT_DYNAMIC_AS_VALUES = ["pass", "warn", "fail"];
 var FAIL_ON_VALUES = ["critical", "warning", "info"];
 var KNOWN_TOP_LEVEL_KEYS = /* @__PURE__ */ new Set(["treatDynamicAs", "metaComponents", "rules", "failOn", "weights"]);
-function isPlainObject3(value) {
+function isPlainObject22(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 function isMissingExtensionLoaderError(err) {
@@ -58476,7 +58538,7 @@ function validateConfigFile(raw, path) {
     }
   }
   if (raw.rules !== void 0) {
-    if (!isPlainObject3(raw.rules)) {
+    if (!isPlainObject22(raw.rules)) {
       throw new Error(`${path}: rules must be an object of rule-id \u2192 setting.`);
     }
     const rules = raw.rules;
@@ -58489,7 +58551,7 @@ function validateConfigFile(raw, path) {
     config.rules = rules;
   }
   if (raw.weights !== void 0) {
-    if (!isPlainObject3(raw.weights)) {
+    if (!isPlainObject22(raw.weights)) {
       throw new Error(`${path}: weights must be an object of category \u2192 number.`);
     }
     const weights = {};
@@ -58508,7 +58570,7 @@ function validateConfigFile(raw, path) {
   return { config, warnings: warnings2 };
 }
 async function loadConfigFile(cwd) {
-  const found = CONFIG_FILENAMES.map((name) => join4(cwd, name)).find((path) => existsSync2(path));
+  const found = CONFIG_FILENAMES.map((name) => join5(cwd, name)).find((path) => existsSync2(path));
   if (!found) return void 0;
   let mod;
   try {
@@ -58522,7 +58584,7 @@ async function loadConfigFile(cwd) {
     }
     throw err;
   }
-  if (!isPlainObject3(mod.default)) {
+  if (!isPlainObject22(mod.default)) {
     throw new Error(
       `${found} must have a default export that is a plain object (e.g. \`export default defineConfig({...})\` or a plain object literal).`
     );
@@ -58592,6 +58654,18 @@ async function applyScope(results, opts) {
         errorLog(`svelte-vitals: baseline analysis of '${opts.baseline}' failed; reporting all findings.`);
       } finally {
         checkout.cleanup();
+      }
+    }
+  }
+  if (!opts.noSuppressions && opts.config) {
+    const entries = loadSuppressions(opts.cwd);
+    if (entries !== void 0) {
+      const { results: afterSuppressions, suppressed, stale } = applySuppressions(scoped, entries, opts.config);
+      scoped = afterSuppressions;
+      if (suppressed > 0 || stale > 0) {
+        errorLog(
+          `svelte-vitals: ${suppressed} finding(s) suppressed by ${SUPPRESSIONS_FILE}` + (stale > 0 ? ` (${stale} stale entr${stale === 1 ? "y" : "ies"} \u2014 re-run --update-suppressions to prune)` : "") + "."
+        );
       }
     }
   }

--- a/packages/cli/src/baseline.ts
+++ b/packages/cli/src/baseline.ts
@@ -8,8 +8,13 @@ function git(args: string[], cwd: string): string {
   return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
 }
 
-/** finding の同一性キー。line は含めない — 無関係な行ズレで「新規」誤検出しないため。 */
-export function findingKey(r: Result): string {
+/**
+ * finding の同一性キー。line は含めない — 無関係な行ズレで「新規」誤検出しないため。
+ * `Pick` で受けるのは、suppressions.ts(packages/cli/src/suppressions.ts)が
+ * `SuppressionEntry`(`id`/`route`/`location` のみを持つ、完全な `Result` ではない値)
+ * にも同じキー関数を使い回せるようにするため — 複製しない。
+ */
+export function findingKey(r: Pick<Result, 'id' | 'route' | 'location'>): string {
   return `${r.id}::${r.route ?? ''}::${r.location ?? ''}`;
 }
 

--- a/packages/cli/src/baseline.ts
+++ b/packages/cli/src/baseline.ts
@@ -9,10 +9,12 @@ function git(args: string[], cwd: string): string {
 }
 
 /**
- * finding の同一性キー。line は含めない — 無関係な行ズレで「新規」誤検出しないため。
- * `Pick` で受けるのは、suppressions.ts(packages/cli/src/suppressions.ts)が
- * `SuppressionEntry`(`id`/`route`/`location` のみを持つ、完全な `Result` ではない値)
- * にも同じキー関数を使い回せるようにするため — 複製しない。
+ * Identity key for a finding. `line` is deliberately excluded — unrelated line
+ * drift must not make an existing finding look "new". The parameter is a `Pick`
+ * so that suppressions.ts (packages/cli/src/suppressions.ts) can reuse this
+ * exact key function on `SuppressionEntry` values (which carry only
+ * `id`/`route`/`location`, not a full `Result`) instead of duplicating the
+ * key template.
  */
 export function findingKey(r: Pick<Result, 'id' | 'route' | 'location'>): string {
   return `${r.id}::${r.route ?? ''}::${r.location ?? ''}`;

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -21,6 +21,8 @@ Options:
   --diff [ref]                Report only findings in files changed vs ref (default HEAD; e.g. --diff main)
   --staged                    Report only findings in files staged for commit (pre-commit gate)
   --baseline <ref>            Report only findings not present at ref (compare against e.g. origin/main)
+  --update-suppressions       Write svelte-vitals-suppressions.json accepting all current findings (introduce gates on legacy projects)
+  --no-suppressions           Ignore svelte-vitals-suppressions.json for this run
   --by-route                  Show per-route score breakdown in console output
   --reporter <fmt>            console | json | agent | sarif | github | html | md (auto: agent under AI-agent envs, github under GitHub Actions)
   --out-file <path>           Output path for --reporter html (default: svelte-vitals-report.html; '-' for stdout)
@@ -70,7 +72,7 @@ async function main(): Promise<void> {
 
   const argv = mri(process.argv.slice(2), {
     alias: { h: 'help', v: 'version' },
-    boolean: ['by-route', 'staged', 'score', 'verbose'],
+    boolean: ['by-route', 'staged', 'score', 'verbose', 'update-suppressions'],
     string: [
       'meta-components',
       'treat-dynamic-as',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -31,6 +31,7 @@ import { readPackageVersion, readCoreVersion } from './version.js';
 import { resolveReporter, isAutoDetectedAgent, isAutoDetectedGithub, type ReporterName } from './reporter-resolve.js';
 import { getChangedFiles, filterToChangedFiles } from './changed-files.js';
 import { checkoutBaseline, filterToNewFindings } from './baseline.js';
+import { loadSuppressions, writeSuppressions, applySuppressions, SUPPRESSIONS_FILE } from './suppressions.js';
 import { colorEnabled, paletteFor } from './color.js';
 import { startSpinner } from './spinner.js';
 import { startMascotSpinner, mascotFitsWidth } from './mascot.js';
@@ -70,6 +71,10 @@ export interface RunOptions {
   staged?: boolean;
   /** Report only findings not present when analyzing this git ref (e.g. the PR base). */
   baseline?: string;
+  /** Disable applying svelte-vitals-suppressions.json for this run. */
+  noSuppressions?: boolean;
+  /** Analyze, then (re)write svelte-vitals-suppressions.json with all currently penalized findings and exit 0. */
+  updateSuppressions?: boolean;
   /** Disable ANSI color in console output. */
   noColor?: boolean;
   /** Override stdout TTY detection (tests). */
@@ -206,15 +211,27 @@ export interface ApplyScopeOptions {
   staged?: boolean;
   diffBase?: string;
   baseline?: string;
+  /**
+   * Resolved config, needed to decide which findings count as "penalized" when
+   * applying svelte-vitals-suppressions.json (`isPenalized`). Suppression
+   * application is skipped entirely when omitted — callers that don't pass a
+   * config (e.g. @svelte-vitals/action, which doesn't opt into this yet) keep
+   * their previous behavior unchanged.
+   */
+  config?: Config;
+  /** Disable applying svelte-vitals-suppressions.json for this run. */
+  noSuppressions?: boolean;
   errorLog?: (line: string) => void;
   analyzeOpts?: AnalyzeOptions;
 }
 
 /**
  * Narrow `results` to what a PR gate cares about: `--staged`/`--diff` restrict to
- * changed files, `--baseline` drops findings that already existed at that ref. Shared
- * by `run()` and `@svelte-vitals/action` (issue #154) so the git-diff/baseline
- * orchestration lives in exactly one place.
+ * changed files, `--baseline` drops findings that already existed at that ref,
+ * and (last) svelte-vitals-suppressions.json drops findings that were explicitly
+ * accepted via `--update-suppressions`. Shared by `run()` and
+ * `@svelte-vitals/action` (issue #154) so the git-diff/baseline orchestration
+ * lives in exactly one place.
  */
 export async function applyScope(results: Result[], opts: ApplyScopeOptions): Promise<Result[]> {
   const errorLog = opts.errorLog ?? ((line: string) => console.error(line));
@@ -247,6 +264,23 @@ export async function applyScope(results: Result[], opts: ApplyScopeOptions): Pr
         errorLog(`svelte-vitals: baseline analysis of '${opts.baseline}' failed; reporting all findings.`);
       } finally {
         checkout.cleanup();
+      }
+    }
+  }
+
+  if (!opts.noSuppressions && opts.config) {
+    const entries = loadSuppressions(opts.cwd);
+    if (entries !== undefined) {
+      const { results: afterSuppressions, suppressed, stale } = applySuppressions(scoped, entries, opts.config);
+      scoped = afterSuppressions;
+      if (suppressed > 0 || stale > 0) {
+        errorLog(
+          `svelte-vitals: ${suppressed} finding(s) suppressed by ${SUPPRESSIONS_FILE}` +
+            (stale > 0
+              ? ` (${stale} stale entr${stale === 1 ? 'y' : 'ies'} — re-run --update-suppressions to prune)`
+              : '') +
+            '.'
+        );
       }
     }
   }
@@ -371,11 +405,23 @@ export async function run(opts: RunOptions = {}): Promise<number> {
 
   try {
     const { config, version } = analysis;
+
+    if (opts.updateSuppressions) {
+      // Scoping flags (--diff/--staged/--baseline) are deliberately ignored here —
+      // the suppressions file is meant to record the whole project's current state,
+      // not a diff (design doc 2026-07-13-suppressions-file-design.md, decision 2).
+      const count = writeSuppressions(cwd, analysis.results, config);
+      errorLog(`svelte-vitals: wrote ${count} suppression(s) to ${SUPPRESSIONS_FILE}.`);
+      return 0;
+    }
+
     const results = await applyScope(analysis.results, {
       cwd,
+      config,
       staged: opts.staged,
       diffBase: opts.diffBase,
       baseline: opts.baseline,
+      noSuppressions: opts.noSuppressions,
       errorLog,
       analyzeOpts: {
         metaComponents: opts.metaComponents,

--- a/packages/cli/src/resolve-args.ts
+++ b/packages/cli/src/resolve-args.ts
@@ -218,6 +218,13 @@ export function resolveArgs(argv: mri.Argv): ResolvedArgs {
   // default.
   const noColor = argv.color === false;
   const noAnimation = argv.animation === false;
+  // Same mri auto-negation as --no-color/--no-animation above: `--no-suppressions`
+  // surfaces as `argv.suppressions === false`, never as an `argv['no-suppressions']` key.
+  const noSuppressions = argv.suppressions === false;
+  const updateSuppressions = Boolean(argv['update-suppressions']);
+  if (updateSuppressions && noSuppressions) {
+    errors.push('svelte-vitals: --update-suppressions and --no-suppressions cannot be used together.');
+  }
 
   // `buildRulesConfig` returns `{}` when neither --rules nor --ignore was passed;
   // normalize that to `undefined` so it doesn't clobber a config file's `rules`
@@ -250,7 +257,9 @@ export function resolveArgs(argv: mri.Argv): ResolvedArgs {
       ...(noAnimation ? { noAnimation } : {}),
       ...(diffBase !== undefined ? { diffBase } : {}),
       ...(staged ? { staged } : {}),
-      ...(baselineRef !== undefined ? { baseline: baselineRef } : {})
+      ...(baselineRef !== undefined ? { baseline: baselineRef } : {}),
+      ...(noSuppressions ? { noSuppressions } : {}),
+      ...(updateSuppressions ? { updateSuppressions } : {})
     },
     warnings,
     errors

--- a/packages/cli/src/suppressions.ts
+++ b/packages/cli/src/suppressions.ts
@@ -1,0 +1,150 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Config, Result } from '@svelte-vitals/core';
+import { isPenalized } from '@svelte-vitals/core';
+import { findingKey } from './baseline.js';
+
+/**
+ * Persistent adoption ramp (design doc 2026-07-13-suppressions-file-design.md):
+ * accept every currently-penalized finding once (`--update-suppressions`), then
+ * gate only on findings that appear afterward. Unlike `--baseline <ref>` (a
+ * transient git-ref comparison), this file is committed and applied on every run.
+ */
+export const SUPPRESSIONS_FILE = 'svelte-vitals-suppressions.json';
+
+export interface SuppressionEntry {
+  id: string;
+  route?: string;
+  location?: string;
+}
+
+/** Whether `value` is a plain object (not null, not an array) — usable with property access. */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Reads `svelte-vitals-suppressions.json` from `cwd`. Returns `undefined` when
+ * the file doesn't exist. Throws when the file exists but is not valid JSON, its
+ * top-level shape isn't `{ version: 1, suppressions: [...] }`, or an entry is
+ * missing a string `id` — a silently-ignored typo would un-gate CI, so malformed
+ * files are a hard error (mapped to exit 2 by the caller). Unknown keys (both
+ * top-level and per-entry) are ignored for forward compatibility.
+ */
+export function loadSuppressions(cwd: string): SuppressionEntry[] | undefined {
+  const path = join(cwd, SUPPRESSIONS_FILE);
+
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch {
+    return undefined;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `invalid ${SUPPRESSIONS_FILE}: not valid JSON (${err instanceof Error ? err.message : String(err)}).`,
+      { cause: err }
+    );
+  }
+
+  if (!isPlainObject(parsed)) {
+    throw new Error(`invalid ${SUPPRESSIONS_FILE}: expected a top-level JSON object.`);
+  }
+  if (parsed.version !== 1) {
+    throw new Error(`invalid ${SUPPRESSIONS_FILE}: expected "version": 1, got ${JSON.stringify(parsed.version)}.`);
+  }
+  if (!Array.isArray(parsed.suppressions)) {
+    throw new Error(`invalid ${SUPPRESSIONS_FILE}: "suppressions" must be an array.`);
+  }
+
+  const entries: SuppressionEntry[] = [];
+  parsed.suppressions.forEach((entry: unknown, i: number) => {
+    if (!isPlainObject(entry) || typeof entry.id !== 'string') {
+      throw new Error(`invalid ${SUPPRESSIONS_FILE}: suppressions[${i}] must be an object with a string "id".`);
+    }
+    entries.push({
+      id: entry.id,
+      ...(typeof entry.route === 'string' ? { route: entry.route } : {}),
+      ...(typeof entry.location === 'string' ? { location: entry.location } : {})
+    });
+  });
+
+  return entries;
+}
+
+function toEntry(r: Result): SuppressionEntry {
+  return {
+    id: r.id,
+    ...(r.route !== undefined ? { route: r.route } : {}),
+    ...(r.location !== undefined ? { location: r.location } : {})
+  };
+}
+
+function compareEntries(a: SuppressionEntry, b: SuppressionEntry): number {
+  if (a.id !== b.id) return a.id < b.id ? -1 : 1;
+  const ar = a.route ?? '';
+  const br = b.route ?? '';
+  if (ar !== br) return ar < br ? -1 : 1;
+  const al = a.location ?? '';
+  const bl = b.location ?? '';
+  if (al !== bl) return al < bl ? -1 : 1;
+  return 0;
+}
+
+/**
+ * Full rewrite of `svelte-vitals-suppressions.json`: records every currently
+ * penalized finding in `results` (passing seeds are never written) and prunes
+ * anything not present anymore. Entries are de-duplicated and sorted by
+ * (id, route, location) for stable diffs. Returns the number of entries written.
+ */
+export function writeSuppressions(cwd: string, results: Result[], config: Config): number {
+  const seen = new Set<string>();
+  const entries: SuppressionEntry[] = [];
+  for (const r of results) {
+    if (!isPenalized(r.detection, config.treatDynamicAs)) continue;
+    const entry = toEntry(r);
+    const key = findingKey(entry);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    entries.push(entry);
+  }
+  entries.sort(compareEntries);
+
+  const path = join(cwd, SUPPRESSIONS_FILE);
+  writeFileSync(path, JSON.stringify({ version: 1, suppressions: entries }, null, 2) + '\n');
+  return entries.length;
+}
+
+/**
+ * Removes penalized findings whose key matches a suppression entry. Passing
+ * seeds are never removed even if their key happens to match. Reports how many
+ * findings were suppressed and how many entries in `entries` matched nothing
+ * (stale — most likely fixed since the file was last written).
+ */
+export function applySuppressions(
+  results: Result[],
+  entries: SuppressionEntry[],
+  config: Config
+): { results: Result[]; suppressed: number; stale: number } {
+  const keys = new Set(entries.map((e) => findingKey(e)));
+  const usedKeys = new Set<string>();
+  const kept: Result[] = [];
+  let suppressed = 0;
+
+  for (const r of results) {
+    const key = findingKey(r);
+    if (keys.has(key) && isPenalized(r.detection, config.treatDynamicAs)) {
+      suppressed++;
+      usedKeys.add(key);
+      continue;
+    }
+    kept.push(r);
+  }
+
+  const stale = [...keys].filter((k) => !usedKeys.has(k)).length;
+  return { results: kept, suppressed, stale };
+}

--- a/packages/cli/test/resolve-args.test.ts
+++ b/packages/cli/test/resolve-args.test.ts
@@ -6,7 +6,7 @@ import { resolveArgs } from '../src/resolve-args.js';
 function resolve(...args: string[]) {
   const argv = mri(args, {
     alias: { h: 'help', v: 'version' },
-    boolean: ['by-route', 'staged', 'score', 'verbose'],
+    boolean: ['by-route', 'staged', 'score', 'verbose', 'update-suppressions'],
     string: [
       'meta-components',
       'treat-dynamic-as',
@@ -90,6 +90,32 @@ describe('resolveArgs', () => {
     const { options, errors } = resolve('--baseline');
     expect(options).toBeNull();
     expect(errors.some((e) => e.includes('--baseline requires a git ref'))).toBe(true);
+  });
+
+  it('maps --update-suppressions to options.updateSuppressions', () => {
+    const { options, errors } = resolve('--update-suppressions');
+    expect(options?.updateSuppressions).toBe(true);
+    expect(errors).toEqual([]);
+  });
+
+  it('maps --no-suppressions to options.noSuppressions', () => {
+    const { options, errors } = resolve('--no-suppressions');
+    expect(options?.noSuppressions).toBe(true);
+    expect(errors).toEqual([]);
+  });
+
+  it('omits updateSuppressions/noSuppressions when neither flag is passed', () => {
+    const { options } = resolve('--reporter', 'json');
+    expect(options?.updateSuppressions).toBeUndefined();
+    expect(options?.noSuppressions).toBeUndefined();
+  });
+
+  it('reports --update-suppressions with --no-suppressions as a fatal error (no options)', () => {
+    const { options, errors } = resolve('--update-suppressions', '--no-suppressions');
+    expect(options).toBeNull();
+    expect(errors.some((e) => e.includes('--update-suppressions and --no-suppressions cannot be used together'))).toBe(
+      true
+    );
   });
 
   it('leaves rules undefined when neither --rules nor --ignore is passed', () => {

--- a/packages/cli/test/run-suppressions.test.ts
+++ b/packages/cli/test/run-suppressions.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+// Mock the diff layer so the ordering test doesn't need a real git repo, following
+// run-diff.test.ts's / run-baseline.test.ts's pattern for the analogous layers.
+vi.mock('../src/changed-files.js', async (orig) => {
+  const actual = await orig<typeof import('../src/changed-files.js')>();
+  return { ...actual, getChangedFiles: vi.fn() };
+});
+
+import { run } from '../src/index.js';
+import { getChangedFiles } from '../src/changed-files.js';
+import { SUPPRESSIONS_FILE } from '../src/suppressions.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixtureDir = join(here, 'fixtures', 'basic-project');
+const CLEAN_ENV: NodeJS.ProcessEnv = {};
+const mockGet = vi.mocked(getChangedFiles);
+
+function capture() {
+  const out: string[] = [];
+  const err: string[] = [];
+  return { out, err, log: (l: string) => out.push(l), errorLog: (l: string) => err.push(l) };
+}
+
+// --update-suppressions writes into cwd, so every test in this file runs against a
+// throwaway copy of the fixture rather than the checked-in fixtures/basic-project.
+const dirs: string[] = [];
+function makeProjectCopy(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'svelte-vitals-suppressions-run-'));
+  dirs.push(dir);
+  cpSync(fixtureDir, dir, { recursive: true });
+  return dir;
+}
+
+describe('run() svelte-vitals-suppressions.json', () => {
+  beforeEach(() => mockGet.mockReset());
+  afterEach(() => {
+    while (dirs.length > 0) {
+      const dir = dirs.pop();
+      if (dir) rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('auto-applies the file when present: suppressed findings disappear and stderr reports the count', async () => {
+    const dir = makeProjectCopy();
+    writeFileSync(
+      join(dir, SUPPRESSIONS_FILE),
+      JSON.stringify({
+        version: 1,
+        suppressions: [
+          { id: 'SEO001', route: '/none', location: 'src/routes/none/+page.svelte' },
+          { id: 'SEO001', route: '/widget', location: 'src/routes/widget/+page.svelte' }
+        ]
+      })
+    );
+    const cap = capture();
+    await run({ cwd: dir, log: cap.log, errorLog: cap.errorLog, env: CLEAN_ENV });
+    expect(cap.out.join('\n')).not.toContain('SEO001');
+    expect(cap.err.join('\n')).toContain(`2 finding(s) suppressed by ${SUPPRESSIONS_FILE}`);
+  });
+
+  it('--no-suppressions ignores the file for the run', async () => {
+    const dir = makeProjectCopy();
+    writeFileSync(
+      join(dir, SUPPRESSIONS_FILE),
+      JSON.stringify({
+        version: 1,
+        suppressions: [{ id: 'SEO001', route: '/none', location: 'src/routes/none/+page.svelte' }]
+      })
+    );
+    const cap = capture();
+    await run({ cwd: dir, noSuppressions: true, log: cap.log, errorLog: cap.errorLog, env: CLEAN_ENV });
+    expect(cap.out.join('\n')).toContain('SEO001');
+    expect(cap.err.join('\n')).not.toContain('suppressed by');
+  });
+
+  it('--update-suppressions writes the file, exits 0, and skips reporter output', async () => {
+    const dir = makeProjectCopy();
+    const cap = capture();
+    const code = await run({
+      cwd: dir,
+      updateSuppressions: true,
+      log: cap.log,
+      errorLog: cap.errorLog,
+      env: CLEAN_ENV
+    });
+    expect(code).toBe(0);
+    expect(cap.out).toEqual([]); // reporter output is skipped in update mode
+    expect(cap.err.some((l) => l.includes(`wrote`) && l.includes(SUPPRESSIONS_FILE))).toBe(true);
+
+    const written = JSON.parse(readFileSync(join(dir, SUPPRESSIONS_FILE), 'utf8'));
+    expect(written.version).toBe(1);
+    expect(written.suppressions.length).toBeGreaterThan(0);
+    expect(written.suppressions.some((e: { id: string }) => e.id === 'SEO001')).toBe(true);
+  });
+
+  it('adoption-ramp sequence: update accepts everything, a re-run suppresses it all, and a subsequently-un-suppressed finding still fails', async () => {
+    const dir = makeProjectCopy();
+
+    // 1. Record the current state.
+    const updateCap = capture();
+    const updateCode = await run({
+      cwd: dir,
+      updateSuppressions: true,
+      log: updateCap.log,
+      errorLog: updateCap.errorLog,
+      env: CLEAN_ENV
+    });
+    expect(updateCode).toBe(0);
+
+    // 2. Re-running normally now suppresses every previously-recorded finding.
+    const allSuppressedCap = capture();
+    const allSuppressedCode = await run({
+      cwd: dir,
+      log: allSuppressedCap.log,
+      errorLog: allSuppressedCap.errorLog,
+      env: CLEAN_ENV
+    });
+    expect(allSuppressedCode).toBe(0);
+    expect(allSuppressedCap.out.join('\n')).not.toContain('SEO001');
+
+    // 3. Simulate a new/un-suppressed finding by dropping one accepted entry from the
+    //    file — the corresponding finding is "new" relative to the suppressions file
+    //    and must surface (and fail the gate) again.
+    const written = JSON.parse(readFileSync(join(dir, SUPPRESSIONS_FILE), 'utf8')) as {
+      version: 1;
+      suppressions: { id: string; route?: string; location?: string }[];
+    };
+    const withoutOneEntry = {
+      version: 1,
+      suppressions: written.suppressions.filter((e) => !(e.id === 'SEO001' && e.route === '/none'))
+    };
+    writeFileSync(join(dir, SUPPRESSIONS_FILE), JSON.stringify(withoutOneEntry));
+
+    const newFindingCap = capture();
+    const newFindingCode = await run({
+      cwd: dir,
+      log: newFindingCap.log,
+      errorLog: newFindingCap.errorLog,
+      env: CLEAN_ENV
+    });
+    expect(newFindingCap.out.join('\n')).toContain('SEO001');
+    expect(newFindingCode).toBe(1);
+  });
+
+  it('reports a stale-entry count on stderr without failing the run', async () => {
+    const dir = makeProjectCopy();
+    writeFileSync(
+      join(dir, SUPPRESSIONS_FILE),
+      JSON.stringify({
+        version: 1,
+        suppressions: [
+          { id: 'SEO001', route: '/none', location: 'src/routes/none/+page.svelte' },
+          { id: 'SEO999', route: '/does-not-exist' } // never matches -> stale
+        ]
+      })
+    );
+    const cap = capture();
+    await run({ cwd: dir, log: cap.log, errorLog: cap.errorLog, env: CLEAN_ENV });
+    expect(cap.err.join('\n')).toContain('1 stale entry');
+    expect(cap.err.join('\n')).toContain('--update-suppressions');
+  });
+
+  it('a malformed suppressions file is a fatal error (exit 2)', async () => {
+    const dir = makeProjectCopy();
+    writeFileSync(join(dir, SUPPRESSIONS_FILE), '{not json');
+    const cap = capture();
+    const code = await run({ cwd: dir, log: cap.log, errorLog: cap.errorLog, env: CLEAN_ENV });
+    expect(code).toBe(2);
+    expect(cap.err.join('\n')).toContain(`svelte-vitals: invalid ${SUPPRESSIONS_FILE}`);
+  });
+
+  it('applies after --diff: diff narrows first, suppressions removes what remains', async () => {
+    const dir = makeProjectCopy();
+    // The "none" route's file has several penalized findings (SEO001, SEO003, ...);
+    // only SEO001 is accepted here, so it must be gone from the output while a
+    // sibling finding on the same (diff-narrowed) file still surfaces.
+    writeFileSync(
+      join(dir, SUPPRESSIONS_FILE),
+      JSON.stringify({
+        version: 1,
+        suppressions: [{ id: 'SEO001', route: '/none', location: 'src/routes/none/+page.svelte' }]
+      })
+    );
+    mockGet.mockReturnValue(new Set(['src/routes/none/+page.svelte']));
+    const cap = capture();
+    // SEO001 is 'critical' (suppressed here) but SEO003 is only 'warning' — force
+    // --fail-on warning so the still-unsuppressed SEO003 keeps the gate failing,
+    // proving suppressions removed exactly SEO001 and nothing more.
+    const code = await run({
+      cwd: dir,
+      diffBase: 'main',
+      failOn: 'warning',
+      log: cap.log,
+      errorLog: cap.errorLog,
+      env: CLEAN_ENV
+    });
+    expect(mockGet).toHaveBeenCalledWith(dir, { base: 'main' });
+    expect(cap.err.join('\n')).toContain(`1 finding(s) suppressed by ${SUPPRESSIONS_FILE}`);
+    expect(cap.out.join('\n')).not.toContain('SEO001');
+    expect(cap.out.join('\n')).toContain('SEO003'); // same diff-narrowed file, not suppressed -> still fails the gate
+    expect(code).toBe(1);
+  });
+});

--- a/packages/cli/test/suppressions.test.ts
+++ b/packages/cli/test/suppressions.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Config, Result } from '@svelte-vitals/core';
+import { defineConfig } from '@svelte-vitals/core';
+import { loadSuppressions, writeSuppressions, applySuppressions, SUPPRESSIONS_FILE } from '../src/suppressions.js';
+
+const r = (over: Partial<Result>): Result => ({
+  id: 'X',
+  severity: 'warning',
+  detection: { presence: 'none', value: 'absent' }, // penalized by default (isPenalized: presence 'none')
+  message: 'm',
+  ...over
+});
+
+const passing = (over: Partial<Result>): Result => ({
+  id: 'X',
+  severity: 'warning',
+  detection: { presence: 'own', value: 'static' }, // not penalized
+  message: 'm',
+  ...over
+});
+
+const config: Config = defineConfig({});
+
+const dirs: string[] = [];
+function makeDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'svelte-vitals-suppressions-'));
+  dirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  while (dirs.length > 0) {
+    const dir = dirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('loadSuppressions', () => {
+  it('returns undefined when the file does not exist', () => {
+    expect(loadSuppressions(makeDir())).toBeUndefined();
+  });
+
+  it('throws on invalid JSON', () => {
+    const dir = makeDir();
+    writeFileSync(join(dir, SUPPRESSIONS_FILE), '{not json');
+    expect(() => loadSuppressions(dir)).toThrow(/not valid JSON/);
+  });
+
+  it('throws when the top level is not an object', () => {
+    const dir = makeDir();
+    writeFileSync(join(dir, SUPPRESSIONS_FILE), '[]');
+    expect(() => loadSuppressions(dir)).toThrow(/expected a top-level JSON object/);
+  });
+
+  it('throws on a version mismatch', () => {
+    const dir = makeDir();
+    writeFileSync(join(dir, SUPPRESSIONS_FILE), JSON.stringify({ version: 2, suppressions: [] }));
+    expect(() => loadSuppressions(dir)).toThrow(/expected "version": 1/);
+  });
+
+  it('throws when suppressions is not an array', () => {
+    const dir = makeDir();
+    writeFileSync(join(dir, SUPPRESSIONS_FILE), JSON.stringify({ version: 1, suppressions: {} }));
+    expect(() => loadSuppressions(dir)).toThrow(/"suppressions" must be an array/);
+  });
+
+  it('throws when an entry is missing a string id', () => {
+    const dir = makeDir();
+    writeFileSync(join(dir, SUPPRESSIONS_FILE), JSON.stringify({ version: 1, suppressions: [{ route: '/blog' }] }));
+    expect(() => loadSuppressions(dir)).toThrow(/must be an object with a string "id"/);
+  });
+
+  it('parses valid entries and ignores unknown keys (forward compat)', () => {
+    const dir = makeDir();
+    writeFileSync(
+      join(dir, SUPPRESSIONS_FILE),
+      JSON.stringify({
+        version: 1,
+        extra: 'ignored',
+        suppressions: [{ id: 'SEO001', route: '/blog', location: 'a.svelte', future: 'ignored' }]
+      })
+    );
+    expect(loadSuppressions(dir)).toEqual([{ id: 'SEO001', route: '/blog', location: 'a.svelte' }]);
+  });
+});
+
+describe('writeSuppressions', () => {
+  it('writes only penalized findings, sorted and de-duplicated', () => {
+    const dir = makeDir();
+    const results: Result[] = [
+      r({ id: 'SEO002', route: '/blog' }),
+      r({ id: 'SEO001', route: '/a' }),
+      r({ id: 'SEO001', route: '/a' }), // duplicate key, should collapse
+      passing({ id: 'SEO003', route: '/pass' }) // passing seed, must not be written
+    ];
+    const count = writeSuppressions(dir, results, config);
+    expect(count).toBe(2);
+
+    const written = JSON.parse(readFileSync(join(dir, SUPPRESSIONS_FILE), 'utf8'));
+    expect(written).toEqual({
+      version: 1,
+      suppressions: [
+        { id: 'SEO001', route: '/a' },
+        { id: 'SEO002', route: '/blog' }
+      ]
+    });
+  });
+
+  it('prunes stale entries on a full rewrite (no merge with the previous file)', () => {
+    const dir = makeDir();
+    writeSuppressions(dir, [r({ id: 'OLD', route: '/gone' })], config);
+    writeSuppressions(dir, [r({ id: 'NEW', route: '/here' })], config);
+    const written = JSON.parse(readFileSync(join(dir, SUPPRESSIONS_FILE), 'utf8'));
+    expect(written.suppressions).toEqual([{ id: 'NEW', route: '/here' }]);
+  });
+
+  it('writes an empty suppressions array when nothing is penalized', () => {
+    const dir = makeDir();
+    const count = writeSuppressions(dir, [passing({ id: 'SEO003' })], config);
+    expect(count).toBe(0);
+    const written = JSON.parse(readFileSync(join(dir, SUPPRESSIONS_FILE), 'utf8'));
+    expect(written).toEqual({ version: 1, suppressions: [] });
+  });
+});
+
+describe('applySuppressions', () => {
+  it('removes penalized findings matching an entry', () => {
+    const results: Result[] = [r({ id: 'SEO001', route: '/blog' }), r({ id: 'SEO002', route: '/other' })];
+    const { results: kept, suppressed, stale } = applySuppressions(results, [{ id: 'SEO001', route: '/blog' }], config);
+    expect(kept.map((x) => x.id)).toEqual(['SEO002']);
+    expect(suppressed).toBe(1);
+    expect(stale).toBe(0);
+  });
+
+  it('never removes a passing seed even if its key matches an entry', () => {
+    const results: Result[] = [passing({ id: 'SEO001', route: '/blog' })];
+    const { results: kept, suppressed } = applySuppressions(results, [{ id: 'SEO001', route: '/blog' }], config);
+    expect(kept).toEqual(results);
+    expect(suppressed).toBe(0);
+  });
+
+  it('counts entries that matched nothing as stale', () => {
+    const results: Result[] = [r({ id: 'SEO001', route: '/blog' })];
+    const {
+      results: kept,
+      suppressed,
+      stale
+    } = applySuppressions(
+      results,
+      [
+        { id: 'SEO001', route: '/blog' },
+        { id: 'SEO999', route: '/gone' }
+      ],
+      config
+    );
+    expect(kept).toEqual([]);
+    expect(suppressed).toBe(1);
+    expect(stale).toBe(1);
+  });
+
+  it('is a no-op with an empty entry list', () => {
+    const results: Result[] = [r({ id: 'SEO001', route: '/blog' })];
+    const { results: kept, suppressed, stale } = applySuppressions(results, [], config);
+    expect(kept).toEqual(results);
+    expect(suppressed).toBe(0);
+    expect(stale).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Implements plan `plans/023-suppressions-file.md` (design doc included: `docs/superpowers/specs/2026-07-13-suppressions-file-design.md`) — the adoption ramp recorded as direction note DIR-03.

Adopting svelte-vitals on an existing project is blocked by accumulated findings: you can't turn on `--fail-on` gating without fixing everything first. `--baseline <ref>` (#142) covers the *transient* case (PR vs. its base); this adds the *persistent* one:

```bash
npx svelte-vitals --update-suppressions   # record & accept today's findings (writes svelte-vitals-suppressions.json)
git add svelte-vitals-suppressions.json   # commit the ramp
npx svelte-vitals --fail-on warning       # from now on, only NEW findings gate
```

- The file is applied automatically when present (stderr notice with the suppressed count); `--no-suppressions` bypasses it for one run.
- `--update-suppressions` does a full rewrite (stale entries pruned) and exits 0; scoping flags are ignored while updating.
- Entry identity reuses `--baseline`'s `findingKey` (`id` + `route` + `location`, no line number — line drift can't resurface accepted findings).
- Format: `{ "version": 1, "suppressions": [...] }`, sorted for stable diffs; unknown keys ignored (forward compat); a **malformed file is a hard exit-2 error** — a silently-ignored typo would un-gate CI.
- Application order: `--diff`/`--staged` → `--baseline` → suppressions (last). Passing seeds are never written or removed.
- **Naming**: deliberately "suppressions", not "baseline" — `--baseline <ref>` already means the git-ref comparison (hazard flagged in plan 014's maintenance notes; precedent: ESLint bulk suppressions).

## Reviewed deviations (both approved)

- `findingKey`'s parameter widened to `Pick<Result, 'id' | 'route' | 'location'>` (behavior-preserving) so `SuppressionEntry` can use the exact same key function instead of duplicating the template.
- `ApplyScopeOptions.config` is optional and suppression application no-ops without it — so `@svelte-vitals/action`'s existing `applyScope` call keeps its behavior. **Known v1 limitation**: the Action does not yet honor the suppressions file; passing its config through is a small follow-up worth doing so the ramp works in Action-based CI too.

## Verification

- Scoped typecheck (4 changed packages), `pnpm --filter svelte-vitals test` (533 tests, 58 files), `pnpm lint` — all green. (Root `pnpm typecheck` can't run in the sandbox because `packages/action`'s deps can't install there — environment-only; CI is the root-chain gate.)
- Live adoption-ramp exercised with the built CLI on a fixture: `--update-suppressions` wrote 78 entries (exit 0) → re-run suppressed all 78, Health 100, exit 0; the update → suppress-all → new-finding-fails sequence is also pinned end-to-end in `run-suppressions.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent suppression files for existing findings.
  * Added `--update-suppressions` to create or refresh suppressions.
  * Added `--no-suppressions` to disable suppression handling for a single run.
  * Suppressed findings are excluded from results and quality gates.

* **Documentation**
  * Added CLI and CI guidance for adopting suppressions in existing projects.
  * Documented stale and invalid suppression-file behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->