### PR TITLE
feat(cli): add `ci upgrade` to refresh the pinned action in an existing workflow

### DIFF
--- a/.changeset/ci-upgrade-action-pin.md
+++ b/.changeset/ci-upgrade-action-pin.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': minor
+---
+
+Add `svelte-vitals ci upgrade`: rewrites only the pinned `@svelte-vitals/action` reference line(s) in an existing generated workflow to the pin bundled with the CLI, leaving everything else (other pins like `actions/checkout`, custom triggers/steps) untouched. Use `ci install --force` if you want to regenerate the whole file instead.

--- a/docs/src/content/docs/guides/ci.md
+++ b/docs/src/content/docs/guides/ci.md
@@ -151,3 +151,33 @@ See the [CLI reference](/svelte-vitals/guides/cli/) for `--diff`, `--baseline`, 
 flags if you'd rather run svelte-vitals directly instead of through the action, and the
 [Reporters guide](/svelte-vitals/guides/reporters/) for the output formats the action's summary
 and comment build on.
+
+## Upgrading the pinned action
+
+`@svelte-vitals/action` is pinned by commit SHA for supply-chain safety, so the pin in your
+workflow goes stale as new releases ship. Regenerating the whole file with `ci install --force`
+works, but it throws away any customizations you've made to the workflow (extra triggers, added
+steps, etc).
+
+`svelte-vitals ci upgrade` is the surgical alternative: it rewrites **only** the
+`uses: oekazuma/svelte-vitals/packages/action@<sha>` line(s) in your existing workflow to the pin
+bundled with the CLI you're running — everything else in the file (other `uses:` pins like
+`actions/checkout`, your triggers, extra steps) is left untouched.
+
+```bash
+npx svelte-vitals@latest ci upgrade              # rewrite the pin in place
+npx svelte-vitals@latest ci upgrade --dry-run    # preview the before/after without writing
+```
+
+The pin `ci upgrade` writes comes from the CLI build itself, not a network lookup — run it with
+`@latest` (as above) to pick up the most recent one. Possible outcomes:
+
+- **Upgraded** — the reference line(s) didn't match the bundled pin; they're rewritten and the
+  old version (read from the line's `# @svelte-vitals/action@X.Y.Z` comment) is reported.
+- **Already up to date** — every reference already matches the bundled pin; nothing is written.
+- **No workflow found** / **no action reference found** — exits with an error telling you to run
+  `ci install` first; `ci upgrade` never creates a workflow from scratch.
+
+If you use Renovate (or another tool) to bump the pin directly, `ci upgrade` won't conflict with
+it — both keep the same line in the same `uses: ... @<sha> # @svelte-vitals/action@<version>`
+shape.

--- a/docs/src/content/docs/ja/guides/ci.md
+++ b/docs/src/content/docs/ja/guides/ci.md
@@ -158,3 +158,34 @@ Action を経由せず svelte-vitals を直接実行したい場合の `--diff`�
 対応フラグについては[CLI リファレンス](/svelte-vitals/ja/guides/cli/)を、Action のサマリーと
 コメントが基づいている出力フォーマットについては
 [レポーターガイド](/svelte-vitals/ja/guides/reporters/)を参照してください。
+
+## ピン留めされた Action の更新
+
+`@svelte-vitals/action` はサプライチェーンの安全性のためコミット SHA でピン留めされているため、
+新しいリリースが出るたびにワークフロー内のピンは古くなります。ファイル全体を
+`ci install --force` で再生成することもできますが、それではワークフローに加えた
+カスタマイズ(追加のトリガーやステップなど)が失われてしまいます。
+
+`svelte-vitals ci upgrade` はより外科的な代替手段です — 既存のワークフロー内の
+`uses: oekazuma/svelte-vitals/packages/action@<sha>` の行**だけ**を、実行している CLI に
+同梱されたピンへ書き換えます。それ以外の内容(`actions/checkout` など他の `uses:` ピン、
+独自のトリガー、追加ステップ)はそのまま残ります。
+
+```bash
+npx svelte-vitals@latest ci upgrade              # その場でピンを書き換える
+npx svelte-vitals@latest ci upgrade --dry-run    # 書き込まずに変更前後をプレビュー
+```
+
+`ci upgrade` が書き込むピンはネットワーク経由の取得ではなく CLI のビルドに焼き込まれた値です
+— 最新のピンを得るには(上記のように)`@latest` を付けて実行してください。想定される結果：
+
+- **アップグレードされた場合** — 参照行が同梱ピンと一致していなかったため書き換えられ、
+  行のコメント(`# @svelte-vitals/action@X.Y.Z`)から読み取った旧バージョンが表示されます。
+- **既に最新の場合** — すべての参照が既に同梱ピンと一致しており、何も書き込まれません。
+- **ワークフローが見つからない / action の参照が見つからない場合** — `ci install` を
+  先に実行するよう促すエラーで終了します。`ci upgrade` はワークフローをゼロから
+  作成することはありません。
+
+Renovate など別のツールで直接ピンを更新している場合でも、`ci upgrade` と競合することは
+ありません — どちらも同じ `uses: ... @<sha> # @svelte-vitals/action@<version>` という形式の
+同じ行を保ちます。

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -13,6 +13,7 @@ Usage:
   svelte-vitals [path] [options]
   svelte-vitals install          Set up the MCP server, Vite integration, or agent skills/rules
   svelte-vitals ci install       Add a GitHub Actions PR gate (annotations + summary comment)
+  svelte-vitals ci upgrade       Refresh the pinned @svelte-vitals/action in an existing workflow
 
 Options:
   --meta-components <names>   Comma-separated component names that emit head metadata

--- a/packages/cli/src/ci/cli.ts
+++ b/packages/cli/src/ci/cli.ts
@@ -3,19 +3,26 @@ import mri from 'mri';
 import type { InstallIO } from '../install/index.js';
 import { realIO } from '../install/cli.js';
 import { WORKFLOW_PATH, buildWorkflowYaml, planWorkflowWrite } from './workflow.js';
+import { upgradeActionPin } from './upgrade.js';
 import { ACTION_SHA, ACTION_VERSION } from './action-pin.generated.js';
 
 const CI_HELP = `svelte-vitals ci — scaffold CI integration
 
 Usage:
   svelte-vitals ci install [options]
+  svelte-vitals ci upgrade [--dry-run]
 
 Adds a GitHub Actions workflow (${WORKFLOW_PATH}) that calls the \`@svelte-vitals/action\`
 GitHub Action on pull requests: inline annotations, a job summary, and a sticky PR
 comment with the findings.
 
+\`ci upgrade\` rewrites only the pinned \`@svelte-vitals/action\` reference in an existing
+workflow to the pin bundled with this CLI, leaving the rest of the file (and any other
+pins, like actions/checkout) untouched. To pick up the latest pin, run
+\`npx svelte-vitals@latest ci upgrade\`.
+
 Options:
-  --force       Overwrite an existing workflow file
+  --force       Overwrite an existing workflow file (install only)
   --dry-run     Print the plan and exit without writing
   -h, --help    Show this help`;
 
@@ -26,6 +33,9 @@ export async function runCiCli(args: string[], io: InstallIO = realIO()): Promis
   if (sub === '--help' || sub === '-h') {
     io.log(CI_HELP);
     return 0;
+  }
+  if (sub === 'upgrade') {
+    return runCiUpgrade(args.slice(1), io);
   }
   if (sub !== 'install') {
     io.log(CI_HELP);
@@ -68,5 +78,56 @@ export async function runCiCli(args: string[], io: InstallIO = realIO()): Promis
   }
 
   io.log('Done. Commit the workflow file and open a PR to see it in action.');
+  return 0;
+}
+
+/**
+ * `ci upgrade` — rewrite only the pinned `@svelte-vitals/action` reference line(s) in an
+ * existing workflow to the pin bundled with this CLI build. Never touches other lines (other
+ * `uses:` pins, custom triggers/steps a user added) — see upgrade.ts for the replacement logic.
+ */
+async function runCiUpgrade(args: string[], io: InstallIO): Promise<number> {
+  const argv = mri(args, {
+    boolean: ['dry-run', 'help'],
+    alias: { h: 'help' }
+  });
+  if (argv.help) {
+    io.log(CI_HELP);
+    return 0;
+  }
+
+  const path = join(io.cwd, WORKFLOW_PATH);
+  const existing = io.readFile(path);
+  if (existing === undefined) {
+    io.errorLog(`svelte-vitals: no ${WORKFLOW_PATH} found — run \`svelte-vitals ci install\` first.`);
+    return 2;
+  }
+
+  const outcome = upgradeActionPin(existing, ACTION_SHA, ACTION_VERSION);
+
+  if (outcome.status === 'no-reference') {
+    io.errorLog(`svelte-vitals: no @svelte-vitals/action reference found in ${WORKFLOW_PATH}.`);
+    return 2;
+  }
+
+  if (outcome.status === 'up-to-date') {
+    io.log(`= already up to date (@svelte-vitals/action@${ACTION_VERSION}).`);
+    return 0;
+  }
+
+  if (argv['dry-run']) {
+    io.log(`Would upgrade @svelte-vitals/action: ${outcome.from} → ${ACTION_VERSION} (${outcome.replaced} line(s)).`);
+    io.log('Dry run — no files written.');
+    return 0;
+  }
+
+  try {
+    io.writeFile(path, outcome.content ?? existing);
+  } catch (err) {
+    io.errorLog(`svelte-vitals: failed to write ${WORKFLOW_PATH}: ${err instanceof Error ? err.message : String(err)}`);
+    return 2;
+  }
+
+  io.log(`✓ upgraded @svelte-vitals/action: ${outcome.from} → ${ACTION_VERSION} (${outcome.replaced} line(s)).`);
   return 0;
 }

--- a/packages/cli/src/ci/upgrade.ts
+++ b/packages/cli/src/ci/upgrade.ts
@@ -1,0 +1,52 @@
+export interface UpgradeOutcome {
+  status: 'upgraded' | 'up-to-date' | 'no-reference';
+  /** status='upgraded' only: the full file content with the pin(s) replaced. */
+  content?: string;
+  /** status='upgraded' only: how many `uses:` lines were rewritten. */
+  replaced?: number;
+  /** status='upgraded' only: the previous version (from the line's comment) or, absent a
+   *  comment, the previous SHA's first 7 characters. */
+  from?: string;
+}
+
+// Matches lines like (indentation, and the trailing version comment, are both optional so a
+// user's hand-edited workflow still matches):
+//   - uses: oekazuma/svelte-vitals/packages/action@<ref>
+//   - uses: oekazuma/svelte-vitals/packages/action@<ref> # @svelte-vitals/action@1.2.3
+const ACTION_USES_LINE =
+  /^(?<indent>\s*-\s*uses:\s*oekazuma\/svelte-vitals\/packages\/action@)(?<ref>[^\s#]+)(?<comment>\s*#.*)?$/;
+
+/**
+ * Rewrite every `uses: oekazuma/svelte-vitals/packages/action@<ref>` line in `content` to pin
+ * `sha`, with a same-line `# @svelte-vitals/action@<version>` comment — leaving every other line
+ * (including other `uses:` pins, like `actions/checkout`) untouched.
+ */
+export function upgradeActionPin(content: string, sha: string, version: string): UpgradeOutcome {
+  const lines = content.split('\n');
+  let replaced = 0;
+  let from: string | undefined;
+
+  const next = lines.map((line) => {
+    const match = ACTION_USES_LINE.exec(line);
+    if (!match || !match.groups) return line;
+
+    const { indent, ref } = match.groups;
+    if (indent === undefined || ref === undefined) return line;
+    if (ref === sha) return line; // already pinned to the current sha
+
+    if (from === undefined) {
+      const commentMatch = /#\s*@svelte-vitals\/action@(\S+)/.exec(match.groups.comment ?? '');
+      from = commentMatch ? commentMatch[1] : ref.slice(0, 7);
+    }
+
+    replaced += 1;
+    return `${indent}${sha} # @svelte-vitals/action@${version}`;
+  });
+
+  if (replaced === 0) {
+    const hasAnyReference = lines.some((line) => ACTION_USES_LINE.test(line));
+    return { status: hasAnyReference ? 'up-to-date' : 'no-reference' };
+  }
+
+  return { status: 'upgraded', content: next.join('\n'), replaced, from };
+}

--- a/packages/cli/src/ci/upgrade.ts
+++ b/packages/cli/src/ci/upgrade.ts
@@ -27,7 +27,12 @@ export function upgradeActionPin(content: string, sha: string, version: string):
   let from: string | undefined;
 
   const next = lines.map((line) => {
-    const match = ACTION_USES_LINE.exec(line);
+    // Splitting a CRLF file on '\n' leaves a trailing '\r' on every line — strip it before
+    // matching (the regex is anchored with `$`) and re-append it to a rewritten line so the
+    // file's line endings are preserved.
+    const eol = line.endsWith('\r') ? '\r' : '';
+    const bare = eol ? line.slice(0, -1) : line;
+    const match = ACTION_USES_LINE.exec(bare);
     if (!match || !match.groups) return line;
 
     const { indent, ref } = match.groups;
@@ -40,11 +45,11 @@ export function upgradeActionPin(content: string, sha: string, version: string):
     }
 
     replaced += 1;
-    return `${indent}${sha} # @svelte-vitals/action@${version}`;
+    return `${indent}${sha} # @svelte-vitals/action@${version}${eol}`;
   });
 
   if (replaced === 0) {
-    const hasAnyReference = lines.some((line) => ACTION_USES_LINE.test(line));
+    const hasAnyReference = lines.some((line) => ACTION_USES_LINE.test(line.endsWith('\r') ? line.slice(0, -1) : line));
     return { status: hasAnyReference ? 'up-to-date' : 'no-reference' };
   }
 

--- a/packages/cli/test/ci/cli.test.ts
+++ b/packages/cli/test/ci/cli.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { runCiCli } from '../../src/ci/cli.js';
-import { WORKFLOW_PATH } from '../../src/ci/workflow.js';
+import { WORKFLOW_PATH, buildWorkflowYaml } from '../../src/ci/workflow.js';
+import { ACTION_SHA, ACTION_VERSION } from '../../src/ci/action-pin.generated.js';
 import type { InstallIO } from '../../src/install/index.js';
 
 function fakeIO(over: { files?: Record<string, string>; failWritePath?: string } = {}): {
@@ -90,6 +91,63 @@ describe('runCiCli', () => {
   it('returns exit 2 and logs an error when writing fails', async () => {
     const { io, err } = fakeIO({ failWritePath: PATH });
     expect(await runCiCli(['install'], io)).toBe(2);
+    expect(err.join('\n')).toContain('failed to write');
+  });
+});
+
+describe('runCiCli upgrade', () => {
+  const OLD_SHA = '1'.repeat(40);
+  const oldWorkflow = buildWorkflowYaml({ actionSha: OLD_SHA, actionVersion: '0.1.0' });
+
+  it('with no workflow file, exits 2 with an install hint', async () => {
+    const { io, err } = fakeIO();
+    expect(await runCiCli(['upgrade'], io)).toBe(2);
+    expect(err.join('\n')).toContain('run `svelte-vitals ci install` first');
+  });
+
+  it('with a workflow that has no action reference, exits 2', async () => {
+    const { io, err } = fakeIO({ files: { [PATH]: 'name: no-action-here\n' } });
+    expect(await runCiCli(['upgrade'], io)).toBe(2);
+    expect(err.join('\n')).toContain('no @svelte-vitals/action reference found');
+  });
+
+  it('when already pinned to the current sha, reports up to date and writes nothing', async () => {
+    const current = buildWorkflowYaml({ actionSha: ACTION_SHA, actionVersion: ACTION_VERSION });
+    const { io, writes, out } = fakeIO({ files: { [PATH]: current } });
+    expect(await runCiCli(['upgrade'], io)).toBe(0);
+    expect(writes).toEqual({});
+    expect(out.join('\n')).toContain('already up to date');
+  });
+
+  it('upgrades a stale pin, rewriting only the action line', async () => {
+    const { io, writes, out } = fakeIO({ files: { [PATH]: oldWorkflow } });
+    expect(await runCiCli(['upgrade'], io)).toBe(0);
+    expect(writes[PATH]).toContain(
+      `uses: oekazuma/svelte-vitals/packages/action@${ACTION_SHA} # @svelte-vitals/action@${ACTION_VERSION}`
+    );
+    // The other pinned action (actions/checkout) is untouched.
+    expect(writes[PATH]).toContain('uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0');
+    expect(out.join('\n')).toContain('upgraded @svelte-vitals/action');
+  });
+
+  it('--dry-run previews the upgrade and writes nothing', async () => {
+    const { io, writes, out } = fakeIO({ files: { [PATH]: oldWorkflow } });
+    expect(await runCiCli(['upgrade', '--dry-run'], io)).toBe(0);
+    expect(writes).toEqual({});
+    expect(out.join('\n')).toContain('Dry run — no files written.');
+    expect(out.join('\n')).toContain('Would upgrade');
+  });
+
+  it('`ci upgrade --help` prints help and exits 0 without writing', async () => {
+    const { io, out, writes } = fakeIO({ files: { [PATH]: oldWorkflow } });
+    expect(await runCiCli(['upgrade', '--help'], io)).toBe(0);
+    expect(out.join('\n')).toContain('svelte-vitals ci upgrade');
+    expect(writes).toEqual({});
+  });
+
+  it('returns exit 2 and logs an error when writing fails', async () => {
+    const { io, err } = fakeIO({ files: { [PATH]: oldWorkflow }, failWritePath: PATH });
+    expect(await runCiCli(['upgrade'], io)).toBe(2);
     expect(err.join('\n')).toContain('failed to write');
   });
 });

--- a/packages/cli/test/ci/upgrade.test.ts
+++ b/packages/cli/test/ci/upgrade.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { upgradeActionPin } from '../../src/ci/upgrade.js';
+
+const OLD_SHA = 'a'.repeat(40);
+const NEW_SHA = 'b'.repeat(40);
+
+describe('upgradeActionPin', () => {
+  it('replaces a pin with a same-line version comment', () => {
+    const content = [
+      'jobs:',
+      '  svelte-vitals:',
+      '    steps:',
+      `      - uses: oekazuma/svelte-vitals/packages/action@${OLD_SHA} # @svelte-vitals/action@1.0.0`,
+      '        with:',
+      '          diff: origin/main'
+    ].join('\n');
+
+    const outcome = upgradeActionPin(content, NEW_SHA, '2.0.0');
+
+    expect(outcome.status).toBe('upgraded');
+    expect(outcome.replaced).toBe(1);
+    expect(outcome.from).toBe('1.0.0');
+    expect(outcome.content).toContain(
+      `      - uses: oekazuma/svelte-vitals/packages/action@${NEW_SHA} # @svelte-vitals/action@2.0.0`
+    );
+    // Every other line is untouched.
+    expect(outcome.content).toContain('        with:');
+    expect(outcome.content).toContain('          diff: origin/main');
+  });
+
+  it('replaces a pin with no trailing comment, deriving `from` from the sha prefix', () => {
+    const content = `      - uses: oekazuma/svelte-vitals/packages/action@${OLD_SHA}`;
+    const outcome = upgradeActionPin(content, NEW_SHA, '2.0.0');
+
+    expect(outcome.status).toBe('upgraded');
+    expect(outcome.from).toBe(OLD_SHA.slice(0, 7));
+    expect(outcome.content).toBe(
+      `      - uses: oekazuma/svelte-vitals/packages/action@${NEW_SHA} # @svelte-vitals/action@2.0.0`
+    );
+  });
+
+  it('is tolerant of different indentation (user-edited workflow)', () => {
+    const content = `- uses: oekazuma/svelte-vitals/packages/action@${OLD_SHA} # @svelte-vitals/action@1.0.0`;
+    const outcome = upgradeActionPin(content, NEW_SHA, '2.0.0');
+
+    expect(outcome.status).toBe('upgraded');
+    expect(outcome.content).toBe(
+      `- uses: oekazuma/svelte-vitals/packages/action@${NEW_SHA} # @svelte-vitals/action@2.0.0`
+    );
+  });
+
+  it('replaces every matching line for matrix-style workflows', () => {
+    const content = [
+      `      - uses: oekazuma/svelte-vitals/packages/action@${OLD_SHA} # @svelte-vitals/action@1.0.0`,
+      'some unrelated line',
+      `      - uses: oekazuma/svelte-vitals/packages/action@${OLD_SHA} # @svelte-vitals/action@1.0.0`
+    ].join('\n');
+
+    const outcome = upgradeActionPin(content, NEW_SHA, '2.0.0');
+
+    expect(outcome.status).toBe('upgraded');
+    expect(outcome.replaced).toBe(2);
+    expect(outcome.content?.split('\n').filter((l) => l.includes(NEW_SHA))).toHaveLength(2);
+    expect(outcome.content).toContain('some unrelated line');
+  });
+
+  it('does not touch other `uses:` pins (e.g. actions/checkout)', () => {
+    const content = [
+      `      - uses: actions/checkout@${OLD_SHA} # v7.0.0`,
+      `      - uses: oekazuma/svelte-vitals/packages/action@${OLD_SHA} # @svelte-vitals/action@1.0.0`
+    ].join('\n');
+
+    const outcome = upgradeActionPin(content, NEW_SHA, '2.0.0');
+
+    expect(outcome.status).toBe('upgraded');
+    expect(outcome.replaced).toBe(1);
+    expect(outcome.content).toContain(`- uses: actions/checkout@${OLD_SHA} # v7.0.0`);
+  });
+
+  it('preserves user customizations elsewhere in the file', () => {
+    const content = [
+      'on:',
+      '  pull_request:',
+      '  workflow_dispatch: # custom trigger the user added',
+      'jobs:',
+      '  svelte-vitals:',
+      '    steps:',
+      `      - uses: oekazuma/svelte-vitals/packages/action@${OLD_SHA} # @svelte-vitals/action@1.0.0`,
+      '      - name: custom follow-up step',
+      '        run: echo done'
+    ].join('\n');
+
+    const outcome = upgradeActionPin(content, NEW_SHA, '2.0.0');
+
+    expect(outcome.status).toBe('upgraded');
+    expect(outcome.content).toContain('workflow_dispatch: # custom trigger the user added');
+    expect(outcome.content).toContain('custom follow-up step');
+    expect(outcome.content).toContain('run: echo done');
+  });
+
+  it('reports up-to-date when the pin already matches', () => {
+    const content = `      - uses: oekazuma/svelte-vitals/packages/action@${NEW_SHA} # @svelte-vitals/action@2.0.0`;
+    const outcome = upgradeActionPin(content, NEW_SHA, '2.0.0');
+
+    expect(outcome).toEqual({ status: 'up-to-date' });
+  });
+
+  it('reports no-reference when the workflow has no action reference at all', () => {
+    const content = ['on:', '  pull_request:', 'jobs:', '  build:', '    steps:', '      - run: echo hi'].join('\n');
+    const outcome = upgradeActionPin(content, NEW_SHA, '2.0.0');
+
+    expect(outcome).toEqual({ status: 'no-reference' });
+  });
+});

--- a/packages/cli/test/ci/upgrade.test.ts
+++ b/packages/cli/test/ci/upgrade.test.ts
@@ -111,4 +111,53 @@ describe('upgradeActionPin', () => {
 
     expect(outcome).toEqual({ status: 'no-reference' });
   });
+
+  it('upgrades a CRLF workflow (with a version comment) and preserves \\r\\n on every line', () => {
+    const content = [
+      'jobs:',
+      '  svelte-vitals:',
+      '    steps:',
+      `      - uses: oekazuma/svelte-vitals/packages/action@${OLD_SHA} # @svelte-vitals/action@1.0.0`,
+      '        with:',
+      '          diff: origin/main',
+      ''
+    ].join('\r\n');
+
+    const outcome = upgradeActionPin(content, NEW_SHA, '2.0.0');
+
+    expect(outcome.status).toBe('upgraded');
+    expect(outcome.replaced).toBe(1);
+    expect(outcome.from).toBe('1.0.0');
+    expect(outcome.content).toContain(
+      `      - uses: oekazuma/svelte-vitals/packages/action@${NEW_SHA} # @svelte-vitals/action@2.0.0\r\n`
+    );
+    // No mixed line endings: stripping every '\r\n' pair must leave no bare '\n' behind.
+    expect(outcome.content?.replace(/\r\n/g, '')).not.toContain('\n');
+  });
+
+  it('upgrades a CRLF workflow with no trailing comment, keeping the line CRLF-terminated', () => {
+    const content = [`      - uses: oekazuma/svelte-vitals/packages/action@${OLD_SHA}`, 'next line'].join('\r\n');
+
+    const outcome = upgradeActionPin(content, NEW_SHA, '2.0.0');
+
+    expect(outcome.status).toBe('upgraded');
+    expect(outcome.from).toBe(OLD_SHA.slice(0, 7));
+    expect(outcome.content).toBe(
+      [
+        `      - uses: oekazuma/svelte-vitals/packages/action@${NEW_SHA} # @svelte-vitals/action@2.0.0`,
+        'next line'
+      ].join('\r\n')
+    );
+  });
+
+  it('reports up-to-date (not no-reference) for a CRLF workflow already pinned to the current sha', () => {
+    const content = [
+      `      - uses: oekazuma/svelte-vitals/packages/action@${NEW_SHA} # @svelte-vitals/action@2.0.0`,
+      ''
+    ].join('\r\n');
+
+    const outcome = upgradeActionPin(content, NEW_SHA, '2.0.0');
+
+    expect(outcome).toEqual({ status: 'up-to-date' });
+  });
 });


### PR DESCRIPTION
## Summary

Implements plan `plans/024-ci-upgrade.md` — `svelte-vitals ci upgrade`, the surgical counterpart to `ci install --force`.

The generated workflow pins `@svelte-vitals/action` by SHA (supply-chain safety), so every action release makes existing workflows stale. Until now the only refresh path was `ci install --force`, which regenerates the whole file and wipes user customizations. `ci upgrade` rewrites **only** the `uses: oekazuma/svelte-vitals/packages/action@<ref>` line(s):

- Tolerant matching (any indentation, with or without the version comment) so hand-edited workflows still upgrade; multiple matching lines (matrix setups) are all rewritten.
- Everything else is preserved — other `uses:` pins (`actions/checkout` stays Renovate/user territory), custom triggers, custom steps.
- Clear outcomes: `upgraded X → Y (N line(s))` / `already up to date` (exit 0) / no workflow → "run `ci install` first" / no action reference (both exit 2). `--dry-run` previews without writing.
- The pin source is the value baked into the CLI at build time (`action-pin.generated`), not the network — refreshing means `npx svelte-vitals@latest ci upgrade` (documented).

## Verification

- `pnpm --filter svelte-vitals test` (523 tests; 15 new across the pin-rewrite unit tests and CLI paths), scoped 4-package typecheck, `pnpm lint` — all green
- Live e2e with the built binary: `ci install` → hand-edit the pin to a fake old value + add a custom trigger/step → `ci upgrade --dry-run` previews without writing → `ci upgrade` restores only the pin line (customizations intact) → re-run reports `already up to date`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
