### PR TITLE
feat(action): apply the suppressions file in the action gate

### DIFF
--- a/.changeset/action-apply-suppressions.md
+++ b/.changeset/action-apply-suppressions.md
@@ -1,0 +1,5 @@
+---
+'@svelte-vitals/action': minor
+---
+
+Apply `svelte-vitals-suppressions.json` in the GitHub Action gate, matching the CLI: when the file is present in the repo it's applied automatically (no new input needed), and suppressed/stale-entry counts are logged as job warnings. Previously the action ignored this file entirely, so projects that adopted suppressions locally still had their whole backlog re-surface in Action-based CI.

--- a/docs/src/content/docs/guides/ci.md
+++ b/docs/src/content/docs/guides/ci.md
@@ -34,10 +34,11 @@ first: it writes `svelte-vitals-suppressions.json`, accepting every current find
 Commit that file, then enable whatever gate you want (`--fail-on`, `--min-health`, a pre-commit
 hook, or this workflow) — from then on it only fails on findings introduced afterward, without
 having to fix the backlog up front. See [`--update-suppressions`](/svelte-vitals/guides/cli/#svelte-vitals-suppressionsjson---update-suppressions---no-suppressions)
-in the CLI reference for the full behavior. `@svelte-vitals/action` doesn't read this file directly
-yet (v1 is CLI-only) — its own `diff`/`baseline` scoping below already limits _this_ workflow to a
-PR's own changes; the suppressions file additionally lets you turn on gating outside of PRs (e.g.
-`--fail-on` in a local pre-commit hook) without the same backlog problem.
+in the CLI reference for the full behavior. `@svelte-vitals/action` applies this file
+automatically too, whenever it's present in the repo — no extra input needed to enable it. Its own
+`diff`/`baseline` scoping below already limits _this_ workflow to a PR's own changes; the
+suppressions file additionally lets you turn on gating outside of PRs (e.g. `--fail-on` in a local
+pre-commit hook) without the same backlog problem.
 
 ## What the workflow does
 

--- a/docs/src/content/docs/ja/guides/ci.md
+++ b/docs/src/content/docs/ja/guides/ci.md
@@ -31,7 +31,7 @@ svelte-vitals が生成したワークフローが既にある場合は、`--for
 
 ## 既存プロジェクトへの導入
 
-リポジトリに既に検出結果の蓄積がある場合は、まずローカルで `svelte-vitals --update-suppressions` を実行してください。現在のすべての検出結果を受け入れる `svelte-vitals-suppressions.json` が一度で書き出されます。そのファイルをコミットしてから、好きなゲート(`--fail-on`、`--min-health`、pre-commit フック、あるいはこのワークフロー)を有効にすれば、以降はそれ以後に導入された検出結果だけで失敗するようになり、蓄積分を事前に直す必要はありません。詳しくは CLI リファレンスの [`--update-suppressions`](/svelte-vitals/ja/guides/cli/#svelte-vitals-suppressionsjson---update-suppressions---no-suppressions) を参照してください。`@svelte-vitals/action` はまだこのファイルを直接読み込みません(v1 は CLI のみ対応)— 以下で説明する `diff`/`baseline` によるスコープ絞り込みが、この _ワークフロー_ を既に PR 自体の変更分に限定しています。抑制ファイルはそれに加えて、PR の外(たとえばローカルの pre-commit フックでの `--fail-on`)でも同じ蓄積問題なしにゲートを有効にできるようにするものです。
+リポジトリに既に検出結果の蓄積がある場合は、まずローカルで `svelte-vitals --update-suppressions` を実行してください。現在のすべての検出結果を受け入れる `svelte-vitals-suppressions.json` が一度で書き出されます。そのファイルをコミットしてから、好きなゲート(`--fail-on`、`--min-health`、pre-commit フック、あるいはこのワークフロー)を有効にすれば、以降はそれ以後に導入された検出結果だけで失敗するようになり、蓄積分を事前に直す必要はありません。詳しくは CLI リファレンスの [`--update-suppressions`](/svelte-vitals/ja/guides/cli/#svelte-vitals-suppressionsjson---update-suppressions---no-suppressions) を参照してください。`@svelte-vitals/action` もこのファイルを自動的に適用します — 有効にするための追加の入力は不要です。リポジトリにファイルが存在すれば、以下で説明する `diff`/`baseline` によるスコープ絞り込みが、この _ワークフロー_ を既に PR 自体の変更分に限定しているのに加えて、抑制ファイルによって PR の外(たとえばローカルの pre-commit フックでの `--fail-on`)でも同じ蓄積問題なしにゲートを有効にできるようになります。
 
 ## ワークフローの動作
 

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -58694,6 +58694,7 @@ async function main() {
   const { config, version: version2 } = analysis;
   const results = await applyScope(analysis.results, {
     cwd: path,
+    config,
     diffBase: diff,
     baseline,
     errorLog: (line) => warning(line)

--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -15,6 +15,7 @@ async function main(): Promise<void> {
   const { config, version } = analysis;
   const results = await applyScope(analysis.results, {
     cwd: path,
+    config,
     diffBase: diff,
     baseline,
     errorLog: (line) => core.warning(line)

--- a/packages/cli/src/baseline.ts
+++ b/packages/cli/src/baseline.ts
@@ -21,9 +21,10 @@ export function findingKey(r: Pick<Result, 'id' | 'route' | 'location'>): string
 }
 
 /**
- * `ref` 時点のプロジェクトを一時 git worktree に展開し、そのパス(解析すべき cwd)を返す。
- * 返り値 undefined = git が答えられない(repo 外 / ref 不在 / git 不在)。
- * 呼び出し側は必ず cleanup コールバックを finally で呼ぶこと。
+ * Expands the project as of `ref` into a temporary git worktree and returns its path
+ * (the cwd to analyze). Returns undefined when git can't answer — outside a repo, the
+ * ref doesn't exist, or git isn't installed. Callers must always invoke the cleanup
+ * callback in a `finally` block.
  */
 export function checkoutBaseline(cwd: string, ref: string): { analyzeCwd: string; cleanup: () => void } | undefined {
   let tmp: string | undefined;
@@ -69,7 +70,7 @@ export function checkoutBaseline(cwd: string, ref: string): { analyzeCwd: string
   }
 }
 
-/** 現在の results から、baseline に存在した finding(同一キー)を取り除く。 */
+/** Removes findings from the current `results` that already existed in the baseline (same key). */
 export function filterToNewFindings(results: Result[], baselineResults: Result[]): Result[] {
   const baselineKeys = new Set(baselineResults.map(findingKey));
   return results.filter((r) => !baselineKeys.has(findingKey(r)));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -214,9 +214,8 @@ export interface ApplyScopeOptions {
   /**
    * Resolved config, needed to decide which findings count as "penalized" when
    * applying svelte-vitals-suppressions.json (`isPenalized`). Suppression
-   * application is skipped entirely when omitted — callers that don't pass a
-   * config (e.g. @svelte-vitals/action, which doesn't opt into this yet) keep
-   * their previous behavior unchanged.
+   * application is skipped entirely when omitted, keeping such callers'
+   * behavior unchanged (the CLI and @svelte-vitals/action both pass it).
    */
   config?: Config;
   /** Disable applying svelte-vitals-suppressions.json for this run. */

--- a/packages/cli/src/mascot.ts
+++ b/packages/cli/src/mascot.ts
@@ -50,7 +50,8 @@ const FACE_OPEN_EYES_NEUTRAL_MOUTH = ['╭──────────╮', '�
 const FACE_CLOSED_EYES_NEUTRAL_MOUTH = ['╭──────────╮', '│  ─    ─  │', '│    ──    │', '╰──────────╯'];
 
 // Idle-loop personality flourishes, alongside the blink above. `>`/`<` (not the
-// full-width `＞`/`＜`/`・` originally proposed) — those are East Asian Width
+// full-width FULLWIDTH GREATER-THAN SIGN / FULLWIDTH LESS-THAN SIGN / KATAKANA
+// MIDDLE DOT originally proposed) — those are East Asian Width
 // Fullwidth/Wide, always 2 columns, which would break the fixed 1-column-per-eye
 // layout the same way the pulse-wave heart glyph almost did (see pulse-animation.ts's
 // WAVE_FRAMES doc comment). The one-eye wink reuses `●` for the open eye (not a


### PR DESCRIPTION
## Summary

Implements plan `plans/026-action-suppressions-and-comment-sweep.md` — two small items bundled deliberately, since both touch sources that `@svelte-vitals/action` bundles (one dist rebuild instead of two).

### 1. The action now applies the suppressions file (#196 follow-up)

`applyScope`'s suppression pass runs only when a `config` is provided; the action had one in scope but didn't pass it, so `svelte-vitals-suppressions.json` — whose main use case is exactly the CI gate — had no effect in action-based workflows. This wires it in (one line): the file is now applied automatically, suppressed/stale counts surface via `core.warning` in the job log, and the adoption-ramp docs (en/ja) are updated accordingly. The `ApplyScopeOptions.config` JSDoc that said the action "doesn't opt into this yet" is updated to match.

### 2. Remaining Japanese code comments translated (#196 review follow-up)

The convention is English-only code comments. A CJK sweep found two remaining files: `packages/cli/src/baseline.ts` (two docblocks from #142) and `packages/cli/src/mascot.ts` (one comment quoting full-width glyphs — rewritten to name the Unicode characters so the technical point survives). `grep -rlP '[CJK]' packages/*/src --include='*.ts'` now returns zero hits.

## Verification

- Scoped 4-package build/typecheck, `pnpm --filter svelte-vitals test` (563 tests), `pnpm lint` — all green. The suppression-application behavior itself is already pinned by `run-suppressions.test.ts` (the action's one-liner joins that tested path).
- `packages/action` can't be typechecked/rebuilt in the sandboxed environment (known `tunnel`/.idea install block) — CI's `check` job is the gate, and **a `chore(action): rebuild dist/` commit from a real machine will follow on this branch before merge** (same flow as #196).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub Actions now automatically apply `svelte-vitals-suppressions.json` when present.
  * CI job warnings report suppressed findings and stale suppression entries.

* **Documentation**
  * Updated CI guidance in English and Japanese to explain automatic suppression handling.
  * Clarified suppression behavior and baseline analysis details in developer documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->