### PR TITLE
fix(cli): let ci upgrade rewrite YAML-anchored uses: lines

### DIFF
--- a/packages/cli/src/ci/upgrade.ts
+++ b/packages/cli/src/ci/upgrade.ts
@@ -9,12 +9,16 @@ export interface UpgradeOutcome {
   from?: string;
 }
 
-// Matches lines like (indentation, and the trailing version comment, are both optional so a
-// user's hand-edited workflow still matches):
+// Matches lines like (indentation, an optional YAML anchor `&name`, and the trailing
+// version comment, are all optional so a user's hand-edited workflow still matches):
 //   - uses: oekazuma/svelte-vitals/packages/action@<ref>
 //   - uses: oekazuma/svelte-vitals/packages/action@<ref> # @svelte-vitals/action@1.2.3
+//   - uses: &vitals_action oekazuma/svelte-vitals/packages/action@<ref> # @svelte-vitals/action@1.2.3
+// An anchor definition's value is shared by every `*name` alias line elsewhere in the
+// file (YAML semantics) — rewriting only the anchor line's ref is sufficient; alias
+// lines need no separate rewrite.
 const ACTION_USES_LINE =
-  /^(?<indent>\s*-\s*uses:\s*oekazuma\/svelte-vitals\/packages\/action@)(?<ref>[^\s#]+)(?<comment>\s*#.*)?$/;
+  /^(?<indent>\s*-\s*uses:\s*(?:&\S+\s+)?oekazuma\/svelte-vitals\/packages\/action@)(?<ref>[^\s#]+)(?<comment>\s*#.*)?$/;
 
 /**
  * Rewrite every `uses: oekazuma/svelte-vitals/packages/action@<ref>` line in `content` to pin

--- a/packages/cli/test/ci/upgrade.test.ts
+++ b/packages/cli/test/ci/upgrade.test.ts
@@ -160,4 +160,46 @@ describe('upgradeActionPin', () => {
 
     expect(outcome).toEqual({ status: 'up-to-date' });
   });
+
+  it('rewrites an anchor-defined uses: line, preserving the anchor name', () => {
+    const content = [
+      'jobs:',
+      '  a:',
+      '    steps:',
+      `      - uses: &vitals_action oekazuma/svelte-vitals/packages/action@${OLD_SHA} # @svelte-vitals/action@1.0.0`,
+      '  b:',
+      '    steps:',
+      '      - uses: *vitals_action'
+    ].join('\n');
+
+    const outcome = upgradeActionPin(content, NEW_SHA, '2.0.0');
+
+    expect(outcome.status).toBe('upgraded');
+    expect(outcome.replaced).toBe(1);
+    expect(outcome.from).toBe('1.0.0');
+    expect(outcome.content).toContain(
+      `      - uses: &vitals_action oekazuma/svelte-vitals/packages/action@${NEW_SHA} # @svelte-vitals/action@2.0.0`
+    );
+    // The alias line itself has no literal ref to rewrite — a YAML parser resolves it
+    // to the anchor's (now-updated) value at parse time, so it's correctly left as-is.
+    expect(outcome.content).toContain('      - uses: *vitals_action');
+  });
+
+  it('rewrites an anchor-defined uses: line with no trailing comment', () => {
+    const content = `      - uses: &vitals_action oekazuma/svelte-vitals/packages/action@${OLD_SHA}`;
+    const outcome = upgradeActionPin(content, NEW_SHA, '2.0.0');
+
+    expect(outcome.status).toBe('upgraded');
+    expect(outcome.from).toBe(OLD_SHA.slice(0, 7));
+    expect(outcome.content).toBe(
+      `      - uses: &vitals_action oekazuma/svelte-vitals/packages/action@${NEW_SHA} # @svelte-vitals/action@2.0.0`
+    );
+  });
+
+  it('reports up-to-date for an anchor-defined line already pinned to the current sha', () => {
+    const content = `      - uses: &vitals_action oekazuma/svelte-vitals/packages/action@${NEW_SHA} # @svelte-vitals/action@2.0.0`;
+    const outcome = upgradeActionPin(content, NEW_SHA, '2.0.0');
+
+    expect(outcome).toEqual({ status: 'up-to-date' });
+  });
 });


### PR DESCRIPTION
## Summary
- `svelte-vitals ci upgrade` couldn't rewrite `uses:` lines that pin the action via a YAML anchor (`&name`), incorrectly reporting "no reference found" even though the workflow correctly references the action.
- Extends the matching regex to recognize an optional anchor between `uses:` and the package path. `*alias` lines need no separate rewrite — they resolve to the anchor's (now-updated) value at YAML-parse time.

## Test plan
- [x] `pnpm --filter svelte-vitals test` — 566/566 passing, including 3 new anchor-handling cases.
- [x] `pnpm --filter svelte-vitals typecheck` — clean.
- [x] `pnpm lint` — clean.

Generated via an `/improve` advisor session, plan `plans/032-ci-upgrade-yaml-anchor-support.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)