### PR TITLE
feat(mcp): apply diff/baseline scoping and suppressions in the analyze tool

### DIFF
--- a/.changeset/mcp-apply-scope.md
+++ b/.changeset/mcp-apply-scope.md
@@ -1,0 +1,5 @@
+---
+'@svelte-vitals/mcp': minor
+---
+
+The `analyze` tool now supports `diff`/`baseline` scoping and `svelte-vitals-suppressions.json`, matching the CLI and GitHub Action. Previously the MCP server ignored these entirely, so agents calling `analyze` on a project that scopes its PR gate to changed files or has accepted legacy findings via suppressions would see the full, unscoped backlog resurface.

--- a/docs/src/content/docs/guides/mcp.md
+++ b/docs/src/content/docs/guides/mcp.md
@@ -22,6 +22,9 @@ Run static-mode analysis on a SvelteKit project.
 | `path`           | `string?`                            | Path to the SvelteKit project (defaults to cwd)                                                                                                |
 | `metaComponents` | `string[]?`                          | Component names that emit head metadata                                                                                                        |
 | `route`          | `string?`                            | Only analyze routes matching this glob                                                                                                         |
+| `diff`           | `string?`                            | Scope findings to files changed vs this git ref (e.g. `"origin/main"`); mirrors the CLI `--diff` flag                                          |
+| `baseline`       | `string?`                            | Report only findings not already present at this git ref (e.g. `"origin/main"`); mirrors the CLI `--baseline` flag                             |
+| `noSuppressions` | `boolean?`                           | Ignore `svelte-vitals-suppressions.json` for this call; mirrors the CLI `--no-suppressions` flag                                               |
 | `treatDynamicAs` | `'pass' \| 'warn' \| 'fail'?`        | How to handle dynamic metadata values                                                                                                          |
 | `rules`          | `string[]?`                          | Rule IDs to enable (all others disabled)                                                                                                       |
 | `ignore`         | `string[]?`                          | Rule IDs to disable                                                                                                                            |

--- a/docs/src/content/docs/ja/guides/mcp.md
+++ b/docs/src/content/docs/ja/guides/mcp.md
@@ -22,6 +22,9 @@ SvelteKit プロジェクトの静的モード分析を実行します。
 | `path`           | `string?`                            | SvelteKit プロジェクトへのパス（デフォルトは cwd）                                                                                                              |
 | `metaComponents` | `string[]?`                          | ヘッドメタデータを出力するコンポーネント名                                                                                                                      |
 | `route`          | `string?`                            | この glob に一致するルートのみを分析                                                                                                                            |
+| `diff`           | `string?`                            | この git 参照（例：`"origin/main"`）と比較して変更されたファイルに検出結果を絞り込む。CLI の `--diff` フラグに相当                                              |
+| `baseline`       | `string?`                            | この git 参照（例：`"origin/main"`）の時点でまだ存在しなかった検出結果のみを報告する。CLI の `--baseline` フラグに相当                                          |
+| `noSuppressions` | `boolean?`                           | この呼び出しでは `svelte-vitals-suppressions.json` を無視する。CLI の `--no-suppressions` フラグに相当                                                          |
 | `treatDynamicAs` | `'pass' \| 'warn' \| 'fail'?`        | 動的メタデータ値の扱い方                                                                                                                                        |
 | `rules`          | `string[]?`                          | 有効にするルール ID（他はすべて無効）                                                                                                                           |
 | `ignore`         | `string[]?`                          | 無効にするルール ID                                                                                                                                             |

--- a/packages/mcp/src/tools/analyze.ts
+++ b/packages/mcp/src/tools/analyze.ts
@@ -1,5 +1,12 @@
 import { z } from 'zod';
-import { analyzeProject, buildRulesConfig, findUnknownRuleIds, knownRuleIds, ProjectError } from 'svelte-vitals';
+import {
+  analyzeProject,
+  applyScope,
+  buildRulesConfig,
+  findUnknownRuleIds,
+  knownRuleIds,
+  ProjectError
+} from 'svelte-vitals';
 import { buildJsonReport } from '@svelte-vitals/core';
 
 export interface McpToolResult {
@@ -21,6 +28,24 @@ const analyzeInputSchema = z.object({
       'Component names that resolve SEO tags into <head> (e.g. ["Seo"]); their presence suppresses missing-tag findings for the head they own. Mirrors the CLI --meta-components flag.'
     ),
   route: z.string().optional().describe('Glob to restrict which routes are analyzed, e.g. "blog/**".'),
+  diff: z
+    .string()
+    .optional()
+    .describe(
+      'Scope findings to files changed vs this git ref (e.g. "origin/main"). Mirrors the CLI --diff flag; omit for no diff scoping.'
+    ),
+  baseline: z
+    .string()
+    .optional()
+    .describe(
+      'Report only findings not already present at this git ref (e.g. "origin/main"). Mirrors the CLI --baseline flag.'
+    ),
+  noSuppressions: z
+    .boolean()
+    .optional()
+    .describe(
+      'Ignore svelte-vitals-suppressions.json for this call, reporting every finding even if previously accepted. Mirrors the CLI --no-suppressions flag.'
+    ),
   treatDynamicAs: z
     .enum(['pass', 'warn', 'fail'])
     .optional()
@@ -83,6 +108,9 @@ export async function handleAnalyze(args: AnalyzeArgs): Promise<McpToolResult> {
   const rules = Object.keys(rulesConfig).length > 0 ? rulesConfig : undefined;
 
   try {
+    // analyzeProject falls back to process.cwd() internally when args.path is
+    // undefined; applyScope's `cwd` is required, so mirror that default here.
+    const cwd = args.path ?? process.cwd();
     const { results, config, version } = await analyzeProject({
       cwd: args.path,
       metaComponents: args.metaComponents,
@@ -93,7 +121,14 @@ export async function handleAnalyze(args: AnalyzeArgs): Promise<McpToolResult> {
       weights: args.weights,
       categories: args.categories
     });
-    const report = buildJsonReport(results, config, { version });
+    const scoped = await applyScope(results, {
+      cwd,
+      config,
+      diffBase: args.diff,
+      baseline: args.baseline,
+      noSuppressions: args.noSuppressions
+    });
+    const report = buildJsonReport(scoped, config, { version });
     return {
       content: [{ type: 'text', text: JSON.stringify(report, null, 2) }],
       structuredContent: report

--- a/packages/mcp/test/analyze-tool.test.ts
+++ b/packages/mcp/test/analyze-tool.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { cpSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
@@ -11,7 +14,34 @@ const here = dirname(fileURLToPath(import.meta.url));
 const fixtureDir = join(here, '..', '..', 'cli', 'test', 'fixtures', 'basic-project');
 const configFileFixtureDir = join(here, '..', '..', 'cli', 'test', 'fixtures', 'config-file-project');
 
+// diff/baseline scoping goes through applyScope's real git integration
+// (packages/cli/src/changed-files.ts / baseline.ts), which the CLI's own tests stub
+// out via vi.mock on internal modules that aren't part of svelte-vitals' public API —
+// not reusable from this package. So these tests spin up a minimal real git repo
+// instead, following run-suppressions.test.ts's temp-directory-copy pattern for the
+// (mock-free) suppressions case.
+const dirs: string[] = [];
+function git(args: string[], cwd: string): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+}
+function makeGitProjectCopy(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'svelte-vitals-mcp-scope-'));
+  dirs.push(dir);
+  cpSync(fixtureDir, dir, { recursive: true });
+  git(['init'], dir);
+  git(['add', '-A'], dir);
+  git(['commit', '-m', 'init', '--no-gpg-sign'], dir);
+  return dir;
+}
+
 describe('analyze tool', () => {
+  afterEach(() => {
+    while (dirs.length > 0) {
+      const dir = dirs.pop();
+      if (dir) rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('returns a structured JSON report for a project path', async () => {
     const res = await handleAnalyze({ path: fixtureDir });
     expect(res.isError).toBeFalsy();
@@ -178,5 +208,66 @@ describe('analyze tool', () => {
       await client.close();
       await server.close();
     }
+  });
+
+  it('scopes findings to files changed vs a git ref via diff', async () => {
+    const dir = makeGitProjectCopy();
+
+    // Unscoped: the fixture's usual findings (e.g. /widget's SEO001) are present.
+    const unscoped = await handleAnalyze({ path: dir });
+    expect(unscoped.isError).toBeFalsy();
+    const unscopedReport = unscoped.structuredContent as { routes: Array<{ issues: Array<{ id: string }> }> };
+    expect(unscopedReport.routes.flatMap((r) => r.issues.map((i) => i.id))).toContain('SEO001');
+
+    // The repo was just committed with no further changes, so diffing against HEAD
+    // finds no changed (or untracked) files — every finding is filtered out.
+    const scoped = await handleAnalyze({ path: dir, diff: 'HEAD' });
+    expect(scoped.isError).toBeFalsy();
+    const scopedReport = scoped.structuredContent as { routes: Array<{ issues: Array<{ id: string }> }> };
+    expect(scopedReport.routes.flatMap((r) => r.issues.map((i) => i.id))).not.toContain('SEO001');
+  });
+
+  it('drops findings already present at the baseline ref via baseline', async () => {
+    const dir = makeGitProjectCopy();
+
+    // Unscoped: the fixture's usual findings are present.
+    const unscoped = await handleAnalyze({ path: dir });
+    expect(unscoped.isError).toBeFalsy();
+    const unscopedReport = unscoped.structuredContent as { routes: Array<{ issues: Array<{ id: string }> }> };
+    expect(unscopedReport.routes.flatMap((r) => r.issues.map((i) => i.id))).toContain('SEO001');
+
+    // The baseline ref (HEAD) is identical to the current project, so every current
+    // finding is "already present" there and gets filtered out as not-new.
+    const scoped = await handleAnalyze({ path: dir, baseline: 'HEAD' });
+    expect(scoped.isError).toBeFalsy();
+    const scopedReport = scoped.structuredContent as { routes: Array<{ issues: Array<{ id: string }> }> };
+    expect(scopedReport.routes.flatMap((r) => r.issues.map((i) => i.id))).not.toContain('SEO001');
+  });
+
+  it('ignores svelte-vitals-suppressions.json when noSuppressions is set', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'svelte-vitals-mcp-suppressions-'));
+    dirs.push(dir);
+    cpSync(fixtureDir, dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'svelte-vitals-suppressions.json'),
+      JSON.stringify({
+        version: 1,
+        suppressions: [{ id: 'SEO001', route: '/widget', location: 'src/routes/widget/+page.svelte' }]
+      })
+    );
+
+    type Report = { routes: Array<{ route: string; issues: Array<{ id: string }> }> };
+    const widgetIssues = (report: Report) =>
+      report.routes.find((r) => r.route === '/widget')?.issues.map((i) => i.id) ?? [];
+
+    // Default: the accepted finding (widget's SEO001) is suppressed and does not surface.
+    const suppressed = await handleAnalyze({ path: dir });
+    expect(suppressed.isError).toBeFalsy();
+    expect(widgetIssues(suppressed.structuredContent as Report)).not.toContain('SEO001');
+
+    // noSuppressions: true bypasses the file, so the finding reappears.
+    const unsuppressed = await handleAnalyze({ path: dir, noSuppressions: true });
+    expect(unsuppressed.isError).toBeFalsy();
+    expect(widgetIssues(unsuppressed.structuredContent as Report)).toContain('SEO001');
   });
 });

--- a/packages/mcp/test/analyze-tool.test.ts
+++ b/packages/mcp/test/analyze-tool.test.ts
@@ -30,7 +30,22 @@ function makeGitProjectCopy(): string {
   cpSync(fixtureDir, dir, { recursive: true });
   git(['init'], dir);
   git(['add', '-A'], dir);
-  git(['commit', '-m', 'init', '--no-gpg-sign'], dir);
+  // CI runners have no global git user configured, so `commit` fails with "Author
+  // identity unknown" unless we supply one explicitly (local machines usually have
+  // ~/.gitconfig set, which is why this only failed in CI).
+  git(
+    [
+      '-c',
+      'user.name=svelte-vitals-test',
+      '-c',
+      'user.email=test@svelte-vitals.invalid',
+      'commit',
+      '-m',
+      'init',
+      '--no-gpg-sign'
+    ],
+    dir
+  );
   return dir;
 }
 


### PR DESCRIPTION
## Summary
- The MCP `analyze` tool never applied `--diff`/`--baseline` scoping or `svelte-vitals-suppressions.json`, unlike the CLI and GitHub Action — an agent using MCP saw noisier results than the same project via CLI/Action.
- Adds `diff`/`baseline`/`noSuppressions` input fields and wires `applyScope` before building the report, mirroring the Action's existing usage.

## Test plan
- [x] `pnpm --filter @svelte-vitals/mcp test` — 20/20 passing, including 3 new cases (diff scoping, baseline scoping, suppressions bypass).
- [x] docs (en/ja) updated.
- [x] Changeset added (`@svelte-vitals/mcp` minor).

Generated via an `/improve` advisor session, plan `plans/033-mcp-applyscope-wiring.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The MCP `analyze` tool now supports scoping results with `diff` and `baseline` references.
  * Added an option to ignore suppression rules for individual analyses.
  * Results now align with CLI and GitHub Action scoping behavior.

* **Documentation**
  * Documented the new `diff`, `baseline`, and `noSuppressions` options in English and Japanese MCP guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->