### PR TITLE
docs: fix stale reporter count, pnpm version, and bring docs/demo into the workspace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ This is a pnpm-workspaces monorepo (TypeScript / ESM).
 ## Requirements
 
 - Node.js `24.16.0` (see `devEngines` in [`package.json`](./package.json))
-- pnpm `11.9.0` (see `packageManager` in [`package.json`](./package.json))
+- pnpm `11.11.0` (see `packageManager` in [`package.json`](./package.json))
 
 ## Setup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@ This is a pnpm-workspaces monorepo (TypeScript / ESM).
 
 ## Requirements
 
-- Node.js `24.16.0` (see `devEngines` in [`package.json`](./package.json))
-- pnpm `11.11.0` (see `packageManager` in [`package.json`](./package.json))
+- Node.js — see `devEngines` in [`package.json`](./package.json)
+- pnpm — see `packageManager` in [`package.json`](./package.json)
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Five categories — **SEO**, **Performance**, **Correctness**, **Security**, **A
 
 ## Features
 
-- **Multiple reporters** — `console`, `json`, `agent` (a Markdown remediation document an AI agent can act on directly), `sarif`, and `github`. The `agent` reporter auto-selects inside AI-agent harnesses (e.g. Claude Code); `github` auto-selects under GitHub Actions. → [Reporters](https://oekazuma.github.io/svelte-vitals/guides/reporters/)
+- **Multiple reporters** — `console`, `json`, `agent` (a Markdown remediation document an AI agent can act on directly), `sarif`, `github`, `md` (a plain Markdown report), and `html` (a self-contained, shareable report). The `agent` reporter auto-selects inside AI-agent harnesses (e.g. Claude Code); `github` auto-selects under GitHub Actions. → [Reporters](https://oekazuma.github.io/svelte-vitals/guides/reporters/)
 - **GitHub integration** — zero-config inline PR annotations, plus SARIF upload for persistent code-scanning alerts in the Security tab. → [Reporters](https://oekazuma.github.io/svelte-vitals/guides/reporters/)
 - **Live dashboard** — a searchable, filterable dashboard at `/__svelte-vitals/` during `vite dev`, on by default: whole-project coverage from startup, refined to real rendered values as you browse. → [Live dashboard](https://oekazuma.github.io/svelte-vitals/guides/dev-dashboard/)
 - **Plugin mode** (`@svelte-vitals/vite`) — build-time analysis of the prerendered `<head>`; library-agnostic and exact. → [Plugin mode](https://oekazuma.github.io/svelte-vitals/guides/plugin-mode/)

--- a/docs/demo/package.json
+++ b/docs/demo/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@sveltejs/kit": "^2.69.2",
-    "svelte": "^5.56.4"
+    "@sveltejs/kit": "catalog:",
+    "svelte": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,15 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
 
+  docs/demo:
+    devDependencies:
+      '@sveltejs/kit':
+        specifier: 'catalog:'
+        version: 2.69.2(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4(@typescript-eslint/types@8.63.0))(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.63.0))(typescript@6.0.3)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(yaml@2.9.0))
+      svelte:
+        specifier: 'catalog:'
+        version: 5.56.4(@typescript-eslint/types@8.63.0)
+
   packages/action:
     dependencies:
       '@actions/core':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - 'docs/'
+  - 'docs/demo'
   - 'packages/*'
 
 minimumReleaseAge: 4320


### PR DESCRIPTION
## Summary
- README undercounted reporters (5 listed, 7 actually exist — missing `md`/`html`).
- CONTRIBUTING.md's pnpm version was 2 releases stale.
- `docs/demo` was outside the pnpm workspace glob and hardcoded dependency versions instead of using `catalog:`.

## Test plan
- [x] `pnpm -r list --depth -1` — `svelte-vitals-demo` now listed.
- [x] `pnpm install` — lockfile updated cleanly.
- [x] Full build/typecheck/test/lint unaffected (core/cli/vite/mcp packages verified individually, plus repo-wide lint).

Note: touches `pnpm-workspace.yaml`'s `packages:` list. PR #209 (open concurrently) touches the same file's `catalog:` block — different, non-adjacent regions, should merge cleanly in either order.

Generated via an `/improve` advisor session, plan `plans/030-docs-and-workspace-quick-fixes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)