### PR TITLE
perf(vite): keep the dev dashboard's parse cache across re-analyses

### DIFF
--- a/.changeset/dev-dashboard-persistent-parse-cache.md
+++ b/.changeset/dev-dashboard-persistent-parse-cache.md
@@ -1,0 +1,6 @@
+---
+'svelte-vitals': patch
+'@svelte-vitals/vite': patch
+---
+
+`analyzeProject` accepts an optional `parseCache` (exported as `ParseCache`) that lets a caller re-analyzing the same project repeatedly reuse read+parse results across calls instead of starting fresh each time. The vite dev dashboard now keeps one `ParseCache` alive for the lifetime of the dev server and invalidates only the entry for the file that actually changed on each debounced re-analysis, so saving an unrelated file no longer re-reads and re-parses every route and layout in the project.

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -56976,7 +56976,7 @@ function applyRuleSeverities(results, config) {
   });
 }
 
-// ../cli/dist/chunk-S4QJ5TSF.js
+// ../cli/dist/chunk-OCLDCX4Y.js
 import { readFile, access as access2 } from "fs/promises";
 import { join } from "path";
 
@@ -57754,7 +57754,7 @@ async function glob(globInput, options) {
   return crawler ? formatPaths(await crawler.withPromise(), relative2) : [];
 }
 
-// ../cli/dist/chunk-S4QJ5TSF.js
+// ../cli/dist/chunk-OCLDCX4Y.js
 import { readFileSync as readFileSync2 } from "fs";
 import { execFileSync } from "child_process";
 import { execFileSync as execFileSync2 } from "child_process";
@@ -58337,9 +58337,8 @@ async function resolveRoute(rt, cwd, pageRel, config, layouts, cache) {
     headings: { route, headings }
   };
 }
-async function collectRoutes(rt, cwd, config = defaultConfig) {
+async function collectRoutes(rt, cwd, config = defaultConfig, cache = /* @__PURE__ */ new Map()) {
   const [pages, layouts] = await Promise.all([enumerateRoutePages(rt, cwd), collectLayouts(rt, cwd)]);
-  const cache = /* @__PURE__ */ new Map();
   const facts = await Promise.all(pages.map((page) => resolveRoute(rt, cwd, page, config, layouts, cache)));
   return {
     heads: facts.map((f) => f.head),
@@ -58613,7 +58612,7 @@ async function analyzeProject(opts = {}) {
   });
   await detectProject(rt, cwd);
   const matches = routeMatcher(opts.route);
-  const collected = await collectRoutes(rt, cwd, config);
+  const collected = await collectRoutes(rt, cwd, config, opts.parseCache);
   const heads = collected.heads.filter((h) => matches(h.route));
   const images = collected.images.filter((i) => matches(i.route));
   const headings = collected.headings.filter((h) => matches(h.route));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,6 +24,7 @@ import {
 } from '@svelte-vitals/core';
 import { createNodeRuntime } from './runtime/node.js';
 import { collectRoutes } from './providers/source/routes.js';
+import type { ParseCache } from './providers/source/resolve.js';
 import { collectComponentFacts } from './providers/source/components.js';
 import { detectProject, ProjectError, collectProjectFacts } from './providers/source/project.js';
 import { discoverApps } from './discover-apps.js';
@@ -148,6 +149,16 @@ export interface AnalyzeOptions {
   weights?: Partial<Record<Category, number>>;
   /** Restrict analysis to rules in these categories (applied after rules/ignore selection). */
   categories?: Category[];
+  /**
+   * Reuse this parse cache across multiple `analyzeProject` calls instead of
+   * starting fresh each time — the vite dev dashboard passes a long-lived cache
+   * and invalidates only the changed file's entry between re-analyses, so
+   * unchanged routes/layouts/components are never re-read or re-parsed.
+   * Callers that don't need cross-call reuse (the CLI's `run()`, MCP, the
+   * Action — each analyzes once per process) can omit this; a fresh cache is
+   * created automatically.
+   */
+  parseCache?: ParseCache;
 }
 
 export interface AnalyzeResult {
@@ -189,7 +200,7 @@ export async function analyzeProject(opts: AnalyzeOptions = {}): Promise<Analyze
   await detectProject(rt, cwd); // throws ProjectError if not a SvelteKit project
 
   const matches = routeMatcher(opts.route);
-  const collected = await collectRoutes(rt, cwd, config);
+  const collected = await collectRoutes(rt, cwd, config, opts.parseCache);
   const heads = collected.heads.filter((h) => matches(h.route));
   const images = collected.images.filter((i) => matches(i.route));
   const headings = collected.headings.filter((h) => matches(h.route));
@@ -521,6 +532,7 @@ export async function run(opts: RunOptions = {}): Promise<number> {
 }
 
 export { ProjectError } from './providers/source/project.js';
+export type { ParseCache } from './providers/source/resolve.js';
 export { buildRulesConfig, findUnknownRuleIds, knownRuleIds } from './rules-config.js';
 export { loadConfigFile } from './config-file.js';
 export type { LoadedConfigFile } from './config-file.js';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -153,10 +153,12 @@ export interface AnalyzeOptions {
    * Reuse this parse cache across multiple `analyzeProject` calls instead of
    * starting fresh each time — the vite dev dashboard passes a long-lived cache
    * and invalidates only the changed file's entry between re-analyses, so
-   * unchanged routes/layouts/components are never re-read or re-parsed.
-   * Callers that don't need cross-call reuse (the CLI's `run()`, MCP, the
-   * Action — each analyzes once per process) can omit this; a fresh cache is
-   * created automatically.
+   * unchanged routes/layouts are never re-read or re-parsed. This only covers
+   * the route/layout (head-resolution) parse path via `collectRoutes` —
+   * `collectComponentFacts` (Correctness facts) is unaffected and still scans
+   * every component on each call. Callers that don't need cross-call reuse
+   * (the CLI's `run()`, MCP, the Action — each analyzes once per process) can
+   * omit this; a fresh cache is created automatically.
    */
   parseCache?: ParseCache;
 }

--- a/packages/cli/src/providers/source/routes.ts
+++ b/packages/cli/src/providers/source/routes.ts
@@ -185,14 +185,20 @@ async function resolveRoute(
  * chain exactly once, returning both the mode-independent ResolvedHead[] (design
  * §8) and the per-route ResolvedImages[] for Performance rules from a single
  * parse pass per file.
+ *
+ * `cache` defaults to a fresh, single-call `ParseCache` (existing callers are
+ * unaffected). A caller that re-analyzes the same project repeatedly (the vite
+ * dev dashboard) can pass in a long-lived cache and invalidate only the entries
+ * for files that actually changed between calls, so unchanged routes/layouts
+ * are never re-read or re-parsed.
  */
 export async function collectRoutes(
   rt: Runtime,
   cwd: string,
-  config: Config = defaultConfig
+  config: Config = defaultConfig,
+  cache: ParseCache = new Map()
 ): Promise<{ heads: ResolvedHead[]; images: ResolvedImages[]; headings: ResolvedHeadings[] }> {
   const [pages, layouts] = await Promise.all([enumerateRoutePages(rt, cwd), collectLayouts(rt, cwd)]);
-  const cache: ParseCache = new Map();
   const facts = await Promise.all(pages.map((page) => resolveRoute(rt, cwd, page, config, layouts, cache)));
   return {
     heads: facts.map((f) => f.head),

--- a/packages/vite/src/ui/analysis.ts
+++ b/packages/vite/src/ui/analysis.ts
@@ -1,4 +1,6 @@
+import { relative, sep } from 'node:path';
 import type { Result, RuleSetting, Severity, TreatDynamicAs } from '@svelte-vitals/core';
+import type { ParseCache } from 'svelte-vitals';
 
 /** The subset of `analyzeProject` (from `svelte-vitals`) the runner needs. Injectable for tests. */
 export type AnalyzeFn = (opts: {
@@ -7,6 +9,7 @@ export type AnalyzeFn = (opts: {
   metaComponents?: string[];
   rules?: Record<string, RuleSetting>;
   failOn?: Severity;
+  parseCache?: ParseCache;
 }) => Promise<{ results: Result[] }>;
 
 export interface AnalysisRunnerOptions {
@@ -48,6 +51,7 @@ export interface AnalysisRunner {
 export function createAnalysisRunner(opts: AnalysisRunnerOptions): AnalysisRunner {
   const debounceMs = opts.debounceMs ?? 500;
   let cachedAnalyze: AnalyzeFn | undefined = opts.analyze;
+  const parseCache: ParseCache = new Map();
   let stopped = false;
   let running = false;
   let pending = false;
@@ -72,7 +76,8 @@ export function createAnalysisRunner(opts: AnalysisRunnerOptions): AnalysisRunne
         treatDynamicAs: opts.treatDynamicAs,
         metaComponents: opts.metaComponents,
         rules: opts.rules,
-        failOn: opts.failOn
+        failOn: opts.failOn,
+        parseCache
       });
       if (!stopped) opts.onResults(results);
     } catch (err) {
@@ -92,8 +97,13 @@ export function createAnalysisRunner(opts: AnalysisRunnerOptions): AnalysisRunne
       if (stopped) return;
       void runOnce();
     },
-    notifyChange() {
+    notifyChange(file: string) {
       if (stopped) return;
+      // Invalidate only the changed file's cache entry — the ParseCache is keyed
+      // by project-root-relative POSIX path (as tinyglobby returns it), while the
+      // watcher hands us an absolute, OS-separated path, so normalize to match.
+      const rel = relative(opts.root, file).split(sep).join('/');
+      parseCache.delete(rel);
       if (timer !== undefined) clearTimeout(timer);
       timer = setTimeout(() => {
         timer = undefined;

--- a/packages/vite/test/ui-analysis.test.ts
+++ b/packages/vite/test/ui-analysis.test.ts
@@ -1,9 +1,21 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import * as fsp from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createAnalysisRunner, type AnalyzeFn } from '../src/ui/analysis.js';
+import type { ParseCache } from 'svelte-vitals';
 import type { Result } from '@svelte-vitals/core';
+
+// Wraps the real node:fs/promises#readFile in a spy so the integration test (plan
+// 034) can count reads per file across two `analyzeProject` calls and prove that
+// an unchanged route's parse-cache entry is reused rather than re-read. Every
+// other test in this file uses an injected `analyze` mock and never touches disk,
+// so wrapping (not replacing) the real implementation doesn't change their behavior.
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return { ...actual, readFile: vi.fn(actual.readFile) };
+});
 
 const R = (id: string): Result =>
   ({
@@ -36,7 +48,8 @@ describe('createAnalysisRunner', () => {
       treatDynamicAs: undefined,
       metaComponents: undefined,
       rules: undefined,
-      failOn: undefined
+      failOn: undefined,
+      parseCache: expect.any(Map)
     });
   });
 
@@ -201,4 +214,138 @@ describe('createAnalysisRunner', () => {
     await vi.waitFor(() => expect(analyze).toHaveBeenCalledTimes(2));
     expect(onStatusChange.mock.calls.map((c) => c[0])).toEqual([true, false, true, false]);
   });
+
+  it('passes the same parseCache instance to every analyze() call across re-analyses (plan 034)', async () => {
+    const seenCaches: (ParseCache | undefined)[] = [];
+    const analyze = vi.fn<AnalyzeFn>(async (opts) => {
+      seenCaches.push(opts.parseCache);
+      return { results: [] };
+    });
+    const runner = createAnalysisRunner({
+      root: '/proj',
+      analyze,
+      onResults: vi.fn(),
+      onError: vi.fn(),
+      debounceMs: 10
+    });
+
+    runner.start();
+    await vi.waitFor(() => expect(analyze).toHaveBeenCalledTimes(1));
+    runner.notifyChange('a.svelte');
+    await vi.advanceTimersByTimeAsync(20);
+    await vi.waitFor(() => expect(analyze).toHaveBeenCalledTimes(2));
+
+    expect(seenCaches).toHaveLength(2);
+    expect(seenCaches[0]).toBeInstanceOf(Map);
+    // Reference identity — not just equal contents — is the direct evidence that the
+    // runner reuses one long-lived cache instead of creating a fresh one per run.
+    expect(seenCaches[1]).toBe(seenCaches[0]);
+  });
+
+  it("notifyChange evicts only the changed file's cache entry, leaving unrelated entries intact (plan 034)", async () => {
+    let capturedCache: ParseCache | undefined;
+    const analyze = vi.fn<AnalyzeFn>(async (opts) => {
+      if (!capturedCache) {
+        capturedCache = opts.parseCache;
+        capturedCache?.set('src/routes/a/+page.svelte', Promise.resolve({}) as never);
+        capturedCache?.set('src/routes/b/+page.svelte', Promise.resolve({}) as never);
+      }
+      return { results: [] };
+    });
+    const runner = createAnalysisRunner({
+      root: '/proj',
+      analyze,
+      onResults: vi.fn(),
+      onError: vi.fn(),
+      debounceMs: 10
+    });
+
+    runner.start();
+    await vi.waitFor(() => expect(analyze).toHaveBeenCalledTimes(1));
+    expect(capturedCache?.size).toBe(2);
+
+    // The watcher hands notifyChange an absolute, OS-separated path; only the entry
+    // for that file (normalized to the cache's project-relative POSIX key) should go.
+    runner.notifyChange(join('/proj', 'src', 'routes', 'a', '+page.svelte'));
+    await vi.advanceTimersByTimeAsync(20);
+    await vi.waitFor(() => expect(analyze).toHaveBeenCalledTimes(2));
+
+    expect(capturedCache?.has('src/routes/a/+page.svelte')).toBe(false);
+    expect(capturedCache?.has('src/routes/b/+page.svelte')).toBe(true);
+  });
+});
+
+describe('createAnalysisRunner integration: real analyzeProject reuses the parse cache (plan 034)', () => {
+  it('does not re-parse an unrelated, unchanged route file on the second analysis after notifyChange', async () => {
+    vi.useRealTimers();
+    const root = mkdtempSync(join(tmpdir(), 'svelte-vitals-ui-analysis-cache-'));
+    try {
+      writeFileSync(join(root, 'svelte.config.js'), 'export default {};\n');
+      mkdirSync(join(root, 'src/routes/a'), { recursive: true });
+      mkdirSync(join(root, 'src/routes/b'), { recursive: true });
+      const pageA = join(root, 'src/routes/a/+page.svelte');
+      const pageB = join(root, 'src/routes/b/+page.svelte');
+      writeFileSync(pageA, '<svelte:head><title>Page A</title></svelte:head>\n<h1>A</h1>\n');
+      writeFileSync(pageB, '<svelte:head><title>Page B</title></svelte:head>\n<h1>B</h1>\n');
+
+      const { analyzeProject } = await import('svelte-vitals');
+      let calls = 0;
+      let resolveRun1!: () => void;
+      let resolveRun2!: () => void;
+      const run1 = new Promise<void>((r) => (resolveRun1 = r));
+      const run2 = new Promise<void>((r) => (resolveRun2 = r));
+      const onResults = vi.fn(() => {
+        calls++;
+        if (calls === 1) resolveRun1();
+        if (calls === 2) resolveRun2();
+      });
+      const onError = vi.fn((err: unknown) => {
+        // Surface analysis failures loudly instead of hanging on the `run1`/`run2` awaits.
+        calls++;
+        resolveRun1();
+        resolveRun2();
+        throw err instanceof Error ? err : new Error(String(err));
+      });
+      const runner = createAnalysisRunner({
+        root,
+        analyze: (o) => analyzeProject(o),
+        onResults,
+        onError,
+        debounceMs: 10
+      });
+
+      const readFileMock = vi.mocked(fsp.readFile);
+      readFileMock.mockClear();
+      const readsOf = (p: string) => readFileMock.mock.calls.filter(([callPath]) => String(callPath) === p).length;
+
+      runner.start();
+      await run1;
+      const pageAReadsRun1 = readsOf(pageA);
+      const pageBReadsRun1 = readsOf(pageB);
+      // Both files are read twice on the first run: once by the independent, always-fresh
+      // component scan (collectComponentFacts — out of this plan's scope) and once by the
+      // route parse cache's initial (cold) miss.
+      expect(pageAReadsRun1).toBe(2);
+      expect(pageBReadsRun1).toBe(2);
+
+      readFileMock.mockClear();
+      writeFileSync(pageA, '<svelte:head><title>Page A v2</title></svelte:head>\n<h1>A</h1>\n');
+      runner.notifyChange(pageA);
+      await run2;
+
+      const pageAReadsRun2 = readsOf(pageA);
+      const pageBReadsRun2 = readsOf(pageB);
+      // The changed file's cache entry was invalidated, so it's read twice again (same
+      // as the cold run). The unrelated, unchanged file's cache entry is still warm, so
+      // it's read only once — by the independent component scan; the route parse cache
+      // reused its cached, already-parsed result instead of re-reading the file. This is
+      // the plan's core evidence: unchanged files are not re-parsed on a debounced re-analysis.
+      expect(pageAReadsRun2).toBe(2);
+      expect(pageBReadsRun2).toBe(1);
+
+      runner.stop();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 15000);
 });


### PR DESCRIPTION
## Summary
- The dev dashboard re-parsed every route/layout file on every debounced re-analysis, even when only one unrelated file changed.
- `collectRoutes`/`analyzeProject` now accept an optional external `ParseCache`; the vite dev dashboard keeps one long-lived cache across its session and invalidates only the changed file's entry on each save.
- Verified with a real integration test measuring actual file-read counts: an unrelated route is read once (cache hit) on the second analysis instead of twice (cold).

## Test plan
- [x] `pnpm --filter svelte-vitals test` — 563/563 passing.
- [x] `pnpm --filter @svelte-vitals/vite test` — 136/136 passing, including the read-count integration test.
- [x] Changesets added (`svelte-vitals` + `@svelte-vitals/vite`, patch).

Generated via an `/improve` advisor session, plan `plans/034-dev-dashboard-persistent-parse-cache.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)