### PR TITLE
ci: cache package dist output across build/test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,16 @@ jobs:
         with:
           path: packages/*/dist
           key: dist-${{ hashFiles('packages/*/src/**', 'pnpm-lock.yaml', 'packages/*/tsup.config.ts') }}
+      # This key doesn't vary with the commit SHA, even though `pnpm build`'s prebuild
+      # step (scripts/gen-action-pin.mjs) embeds `git rev-parse HEAD` into a generated,
+      # gitignored source file — so two commits with identical src/**/lockfile/tsup
+      # config can share a cache entry despite producing a different action-pin. This is
+      # safe today only because nothing downstream reads that stale `dist`'s embedded SHA:
+      # `pnpm build` below is unconditional (always fresh, so the "Verify action dist is
+      # up to date" and `check:publish` steps never see a cache-restored dist), and the
+      # `test` job's own `pnpm test` regenerates action-pin.generated.ts fresh before
+      # vitest runs (no test imports from dist/). If either of those stops being true,
+      # this key needs `github.sha` (or an equivalent) added.
       - name: Build packages
         run: pnpm build
       - name: Verify action dist is up to date
@@ -81,6 +91,10 @@ jobs:
         with:
           path: packages/*/dist
           key: dist-${{ hashFiles('packages/*/src/**', 'pnpm-lock.yaml', 'packages/*/tsup.config.ts') }}
+      # See the matching comment on the `check` job's cache step: this key doesn't
+      # account for scripts/gen-action-pin.mjs's embedded commit SHA, but a stale
+      # cache-restored `dist` here is harmless — `pnpm test` below regenerates
+      # action-pin.generated.ts fresh for every commit, and no test reads from dist/.
       - name: Build packages
         if: steps.dist-cache.outputs.cache-hit != 'true'
         run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Node.js and dependencies
         uses: ./.github/workflows/setup-node
+      - name: Cache package builds
+        id: dist-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: packages/*/dist
+          key: dist-${{ hashFiles('packages/*/src/**', 'pnpm-lock.yaml', 'packages/*/tsup.config.ts') }}
       - name: Build packages
         run: pnpm build
       - name: Verify action dist is up to date
@@ -49,6 +55,7 @@ jobs:
         run: pnpm check:publish
 
   test:
+    needs: check
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -68,7 +75,14 @@ jobs:
         uses: ./.github/workflows/setup-node
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Restore package builds
+        id: dist-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: packages/*/dist
+          key: dist-${{ hashFiles('packages/*/src/**', 'pnpm-lock.yaml', 'packages/*/tsup.config.ts') }}
       - name: Build packages
+        if: steps.dist-cache.outputs.cache-hit != 'true'
         run: pnpm build
       - name: Run tests
         run: pnpm test


### PR DESCRIPTION
## Summary
- `check` and `test` (3-way Node matrix) each ran `pnpm build` independently — 4 redundant full builds per CI run for the same commit.
- Caches `packages/*/dist` keyed on source + lockfile hash; `test` restores it and skips its own build step on a cache hit. `check`'s own build always runs unconditionally, since its "verify action dist is up to date" and `check:publish` steps must validate a fresh build.

## Test plan
- [x] YAML validity confirmed.
- [ ] Real cache-hit/skip behavior and wall-clock improvement can only be confirmed once this actually runs in GitHub Actions — please check the Actions tab after this PR's checks run.

Generated via an `/improve` advisor session, plan `plans/027-ci-build-cache.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)