### PR TITLE
ci: run independent post-build checks in parallel (GitHub Actions parallel:)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,13 @@ jobs:
         uses: ./.github/workflows/setup-node
       - name: Build packages
         run: pnpm build
-      - name: Verify action dist is up to date
-        run: git diff --exit-code -- packages/action/dist
-      - name: Typecheck
-        run: pnpm typecheck
-      - name: Validate publishable packages
-        run: pnpm check:publish
+      - parallel:
+          - name: Verify action dist is up to date
+            run: git diff --exit-code -- packages/action/dist
+          - name: Typecheck
+            run: pnpm typecheck
+          - name: Validate publishable packages
+            run: pnpm check:publish
 
   test:
     runs-on: ubuntu-latest
@@ -80,7 +81,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Node.js and dependencies
         uses: ./.github/workflows/setup-node
-      - name: Check docs
-        run: pnpm --filter docs check
-      - name: Build docs
-        run: pnpm --filter docs build
+      - parallel:
+          - name: Check docs
+            run: pnpm --filter docs check
+          - name: Build docs
+            run: pnpm --filter docs build


### PR DESCRIPTION
## Summary
- Uses GitHub Actions' new step-level `parallel:` keyword (GA 2026-06-25) to run independent post-build steps concurrently within the same job (shared runner/setup, unlike job-level parallelism).
- `check` job: `Verify action dist is up to date` / `Typecheck` / `Validate publishable packages` now run in parallel — all three only read the already-built `dist/`, none depends on another's output.
- `docs` job: `Check docs` (`astro check`) / `Build docs` (`astro build`) run in parallel — both read the same source, neither depends on the other's output.
- **Not applied** to the `test` job's `pnpm test` (5 packages of CPU-bound vitest runs risk contending for the runner's limited cores rather than genuinely parallelizing) or to `lint` (prettier+eslint are one npm script; splitting would diverge from local `pnpm lint`). See the plan's Non-goals for the full reasoning.

## Base branch
- Stacked on `advisor/027-ci-build-cache` (dist caching) since both touch the `check` job — this PR's diff is only the `parallel:` wrapping on top of that change. Merge #212 first, then this one (or merge this one via its current base and it will resolve automatically once #212 lands).

## Test plan
- [x] YAML validity confirmed.
- [ ] Real parallel execution / wall-clock reduction can only be confirmed once this runs in GitHub Actions — please check the Actions tab after this PR's checks run.

Generated via an `/improve` advisor session, plan `plans/040-ci-step-level-parallelism.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)