### PR TITLE
docs: check in advisor plans 027-040 and their outcome status

### DIFF
--- a/plans/027-ci-build-cache.md
+++ b/plans/027-ci-build-cache.md
@@ -1,0 +1,243 @@
+# Plan 027: CI の `pnpm build` 重複実行を dist キャッシュで排除する
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat 3341587..HEAD -- .github/workflows/ci.yml`
+> 差分があれば下記「Current state」の抜粋と実ファイルを突き合わせ、不一致なら STOP。
+
+## Status
+
+- **Priority**: P1
+- **Effort**: S
+- **Risk**: LOW(CI ワークフローの追加ステップのみ。キャッシュミス時は素のフルビルドにフォールバックするため、キャッシュが壊れても最悪ケースは「今と同じ」)
+- **Depends on**: none
+- **Category**: perf / dx
+- **Planned at**: commit `3341587`, 2026-07-13
+
+## Why this matters
+
+`.github/workflows/ci.yml` は4つのジョブ(`lint`/`check`/`test`/`docs`)を実行するが、
+`check` ジョブが `pnpm build`(`pnpm -r build`、5パッケージ全部)を実行したあと、
+`test` ジョブの Node 3-way マトリクス(`22.13.0`/`24.16.0`/`26`)がそれぞれ独立に
+**もう一度** `pnpm build` を実行している。つまり同一コミットに対して、テストを走らせる前
+提としてのビルドが CI 実行1回あたり **計4回**(check 1 + test matrix 3)行われる。
+`actions/setup-node` の `cache: pnpm` は pnpm store(ダウンロード済み依存)だけをキャッ
+シュし、`tsup` のビルド出力(`packages/*/dist`)はキャッシュされない。
+
+ビルド入力(各パッケージの `src/`)はテストを走らせる Node バージョンに依存しないので、
+この重複は完全に無駄な計算であり、パッケージ数が増えるほど CI 時間に対して線形に効いてくる。
+`packages/*/dist` を lockfile + ソースのハッシュでキャッシュし、`test` ジョブがそれを
+再利用できるようにすれば、実質的なビルド回数を4回から1回に減らせる。
+
+## Current state
+
+- `.github/workflows/ci.yml` — `check` ジョブ:
+
+```yaml
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Setup Node.js and dependencies
+        uses: ./.github/workflows/setup-node
+      - name: Build packages
+        run: pnpm build
+      - name: Verify action dist is up to date
+        run: git diff --exit-code -- packages/action/dist
+      - name: Typecheck
+        run: pnpm typecheck
+      - name: Validate publishable packages
+        run: pnpm check:publish
+```
+
+- 同ファイル、`test` ジョブ(3-way node matrix):
+
+```yaml
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        node-version: ['22.13.0', '24.16.0', '26']
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Setup Node.js and dependencies
+        uses: ./.github/workflows/setup-node
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Build packages
+        run: pnpm build
+      - name: Run tests
+        run: pnpm test
+```
+
+- `.github/workflows/setup-node/action.yml` — `actions/setup-node@...` の `cache: 'pnpm'`
+  は pnpm のダウンロード store のみをキャッシュする(38-42行目)。`packages/*/dist` を
+  キャッシュする仕組みは現状どこにもない。
+- 各パッケージの `build` スクリプトは全て `tsup`(`packages/cli` のみビルド前に
+  `node scripts/gen-action-pin.mjs` を実行 — キャッシュキーに影響しないメタデータ生成
+  なので無視してよい)。
+- **重要な制約**: `check` ジョブには `Verify action dist is up to date`
+  (`git diff --exit-code -- packages/action/dist`)というステップがある。`packages/action/dist`
+  は Git にコミットされた成果物であり、`tsup` の再ビルド結果と一致している必要がある —
+  つまり `check` ジョブの `pnpm build` の**出力そのもの**(特に `packages/action/dist`)は
+  「ビルドキャッシュから復元した dist」であってもこの diff チェックと矛盾してはならない
+  (ソースが変わっていなければ tsup の出力は決定的であるべきなので、通常は問題にならない
+  はずだが、Step 2 でキャッシュキーにこのファイルの扱いを明記する)。
+
+## Commands you will need
+
+| Purpose                     | Command                                              | Expected on success |
+| ---------------------------- | ----------------------------------------------------- | -------------------- |
+| ワークフロー構文の妥当性(ローカルでの簡易チェック) | `cd .github/workflows && python3 -c "import yaml,sys; yaml.safe_load(open('ci.yml'))"` (or any YAML linter available) | エラーなし |
+| ビルド確認(参考、CI相当) | `pnpm build`                                         | exit 0               |
+| テスト確認(参考、CI相当) | `pnpm test`                                          | all pass             |
+
+このプランは CI ワークフロー YAML のみを変更するため、ローカルで実行して検証できる
+コマンドは限られる。**最終検証は実際に CI 上で行う**(PR を開いて Actions の実行結果を
+見る)ことが前提 — Step 3 の Done criteria 参照。
+
+## Scope
+
+**In scope**(変更してよいファイル):
+
+- `.github/workflows/ci.yml`
+
+**Out of scope**(関連して見えても触らない):
+
+- `.github/workflows/setup-node/action.yml` — pnpm store のキャッシュは引き続きこの
+  action に任せる。dist キャッシュは `ci.yml` 側に追加のステップとして足す。
+- `packages/*/tsup.config.ts` — ビルド設定自体は変更しない。
+- `docs` ジョブ — `pnpm --filter docs build` は対象外(docs は他パッケージの dist に
+  依存しないため、このプランのスコープに含めない)。
+
+## Git workflow
+
+- Branch: `advisor/027-ci-build-cache`
+- コミット: `ci: cache package dist output across build/test jobs`(1コミットでよい)
+- コミットメッセージは英語(既存 changelog/commit 規約に合わせる)。
+- push / PR 作成はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: `check` ジョブに dist キャッシュの保存ステップを追加する
+
+`check` ジョブの `Build packages` ステップの**前**に `actions/cache` ステップを追加し、
+`packages/*/dist` をソース + lockfile のハッシュでキーにして保存/復元する。
+
+```yaml
+      - name: Cache package builds
+        id: dist-cache
+        uses: actions/cache@<pin-latest-major-actions/cache-with-sha> # vX.X.X
+        with:
+          path: packages/*/dist
+          key: dist-${{ hashFiles('packages/*/src/**', 'pnpm-lock.yaml', 'packages/*/tsup.config.ts') }}
+```
+
+`actions/cache` はこのリポジトリで既出の action ではないため、`actions/checkout` や
+`actions/setup-node` と同じ流儀(コメントでバージョンを明記した SHA ピン)で追加する
+こと。SHA は `gh api repos/actions/cache/tags` などで最新の安定版タグを確認して解決す
+る(推測でハードコードしない)。
+
+`check` ジョブの `Build packages` ステップは変更しない(キャッシュがヒットしても、
+`tsup` 自体は増分ビルドの判断をしないため、キャッシュから復元した dist がある状態で
+`pnpm build` を実行してもソースが同じなら同じ出力になるはずだが、**確実性のため
+`pnpm build` の実行自体は毎回そのまま行う**——このステップの目的は `test` ジョブが
+`check` の成果物を再利用できるようにすることであり、`check` 自身の実行時間短縮は
+狙わない。理由: `check` ジョブは `Verify action dist is up to date` の diff チェックと
+`check:publish` の両方が生の再ビルド結果に依存しており、キャッシュ復元だけで済ませる
+と "ビルドされていないのに気づかない" リスクが生まれるため)。
+
+**Verify**: YAML として妥当であること(`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` がエラーなく終了)。
+
+### Step 2: `test` ジョブがキャッシュを復元し、ヒット時は `pnpm build` をスキップする
+
+`test` ジョブの `Build packages` ステップの前に同じキーで `actions/cache` の復元ステッ
+プを追加し、キャッシュがヒットした場合は `Build packages` ステップを `if:` でスキップ
+する。
+
+```yaml
+      - name: Restore package builds
+        id: dist-cache
+        uses: actions/cache@<same-pin-as-step-1>
+        with:
+          path: packages/*/dist
+          key: dist-${{ hashFiles('packages/*/src/**', 'pnpm-lock.yaml', 'packages/*/tsup.config.ts') }}
+      - name: Build packages
+        if: steps.dist-cache.outputs.cache-hit != 'true'
+        run: pnpm build
+```
+
+同じキー文字列を `check` と `test` の両方のステップで使うこと(コピペで揃える — キー
+がずれると `test` 側が常にキャッシュミスして意味がなくなる)。`test` の3並列マトリクス
+はそれぞれ独立した runner なので、`check` ジョブが先に走ってキャッシュを書き込んでいる
+必要がある。GitHub Actions の同一ワークフロー内でジョブ間の暗黙の実行順は保証されない
+ため、`test` ジョブに `needs: check` を追加して `check` の完了(≒ キャッシュ書き込み完
+了)を待つようにする。**これは新しい依存関係の追加であり、`test` の開始が `check` の
+完了を待つぶん、`lint`/`check`/`test` 全体の合計時間ではなく「開始から全ジョブ完了ま
+での時間」が変わりうる — Step 3 で実測して確認すること。**
+
+**Verify**: YAML として妥当であること(Step 1 と同じ確認コマンド)。
+
+### Step 3: CI 上で実測して確認する
+
+このプランの変更はワークフロー YAML のみで、ローカルの `pnpm build`/`pnpm test` 実行
+では効果を確認できない。ドラフト PR を開き、GitHub Actions の実行結果を見て確認する:
+
+1. 1回目の実行(キャッシュなし): `check` ジョブでキャッシュが `Cache saved` になること、
+   `test` ジョブの3レッグとも `Build packages` ステップが実行されること(キャッシュ未
+   ヒットなので通常通りビルドする)。
+2. 同じコミットで re-run(または空コミットで再プッシュ): `check`/`test` とも
+   `Cache restored` になり、`test` の3レッグで `Build packages` ステップが `skipped`
+   と表示されること。
+3. `check` ジョブの `Verify action dist is up to date` ステップが引き続き green である
+   こと(キャッシュ経由でも `packages/action/dist` の内容が変わらないことの確認)。
+
+**Verify**: 上記1〜3が GitHub Actions の実行ログで確認できること。
+
+## Test plan
+
+このプランは CI ワークフローの変更であり、vitest によるテストは追加しない。検証は
+Step 3 の CI 実測が全てであり、それが唯一の「テスト」に相当する。
+
+## Done criteria
+
+- [ ] `.github/workflows/ci.yml` の YAML が妥当(パース可能)
+- [ ] `check`/`test` 両ジョブが同一のキャッシュキーで `packages/*/dist` を保存/復元する
+- [ ] `test` ジョブに `needs: check` が追加されている
+- [ ] ドラフト PR 上での実測で、2回目の実行時に `test` の `Build packages` が3レッグと
+      も skip されることを確認済み
+- [ ] `check` ジョブの `Verify action dist is up to date` ステップが引き続き green
+- [ ] `plans/README.md` の該当行を更新済み
+
+## STOP conditions
+
+- `actions/cache` の最新安定版タグ/SHA が確認できない(ネットワークアクセスが使えない
+  等)場合、推測でピンを埋めずに STOP して報告する。
+- `test` に `needs: check` を追加した結果、CI の合計待ち時間(壁時計)が明らかに悪化す
+  る(現状 `lint`/`check`/`test`/`docs` は並列実行されており、`test` が `check` を待つ
+  ようになると `lint` 単体より早く終わっていたケースが遅くなる可能性がある)——実測して
+  明らかな悪化が見えたら、`needs` を使わない代替案(例: `test` 側もキャッシュミス時は
+  常にフルビルドする、`check` を待たない)を検討し、その判断を Maintenance notes に記
+  録してから完了とする。
+- `check` ジョブの `Verify action dist is up to date` がキャッシュ復元後に red になる
+  (= キャッシュから復元した dist が実際のビルド結果と食い違う)場合、原因を調査せずに
+  キャッシュ機構を無効化する変更で誤魔化さず、STOP して報告する。
+
+## Maintenance notes
+
+- 新しいパッケージが `packages/` に追加された場合、`packages/*/dist` の glob は自動的
+  に含む(キー変更不要)。ただし新パッケージが `tsup` 以外のビルドツールを使う場合は
+  キャッシュ対象パスを見直す必要がある。
+- `docs` ジョブは今回のスコープ外だが、将来 docs ビルドが他パッケージの dist(型定義な
+  ど)を必要とするようになった場合、同じキャッシュキーを再利用できる。
+- レビュアーは「`needs: check` によって CI の合計待ち時間が悪化していないか」を実測ログ
+  で確認すること — これがこのプランの主なリスクである。

--- a/plans/027-ci-build-cache.md
+++ b/plans/027-ci-build-cache.md
@@ -39,44 +39,44 @@
 - `.github/workflows/ci.yml` — `check` ジョブ:
 
 ```yaml
-  check:
-    runs-on: ubuntu-latest
-    timeout-minutes: 8
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Setup Node.js and dependencies
-        uses: ./.github/workflows/setup-node
-      - name: Build packages
-        run: pnpm build
-      - name: Verify action dist is up to date
-        run: git diff --exit-code -- packages/action/dist
-      - name: Typecheck
-        run: pnpm typecheck
-      - name: Validate publishable packages
-        run: pnpm check:publish
+check:
+  runs-on: ubuntu-latest
+  timeout-minutes: 8
+  steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - name: Setup Node.js and dependencies
+      uses: ./.github/workflows/setup-node
+    - name: Build packages
+      run: pnpm build
+    - name: Verify action dist is up to date
+      run: git diff --exit-code -- packages/action/dist
+    - name: Typecheck
+      run: pnpm typecheck
+    - name: Validate publishable packages
+      run: pnpm check:publish
 ```
 
 - 同ファイル、`test` ジョブ(3-way node matrix):
 
 ```yaml
-  test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    strategy:
-      matrix:
-        node-version: ['22.13.0', '24.16.0', '26']
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-      - name: Setup Node.js and dependencies
-        uses: ./.github/workflows/setup-node
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: Build packages
-        run: pnpm build
-      - name: Run tests
-        run: pnpm test
+test:
+  runs-on: ubuntu-latest
+  timeout-minutes: 15
+  strategy:
+    matrix:
+      node-version: ['22.13.0', '24.16.0', '26']
+  steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
+    - name: Setup Node.js and dependencies
+      uses: ./.github/workflows/setup-node
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Build packages
+      run: pnpm build
+    - name: Run tests
+      run: pnpm test
 ```
 
 - `.github/workflows/setup-node/action.yml` — `actions/setup-node@...` の `cache: 'pnpm'`
@@ -95,11 +95,11 @@
 
 ## Commands you will need
 
-| Purpose                     | Command                                              | Expected on success |
-| ---------------------------- | ----------------------------------------------------- | -------------------- |
-| ワークフロー構文の妥当性(ローカルでの簡易チェック) | `cd .github/workflows && python3 -c "import yaml,sys; yaml.safe_load(open('ci.yml'))"` (or any YAML linter available) | エラーなし |
-| ビルド確認(参考、CI相当) | `pnpm build`                                         | exit 0               |
-| テスト確認(参考、CI相当) | `pnpm test`                                          | all pass             |
+| Purpose                                            | Command                                                                                                               | Expected on success |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| ワークフロー構文の妥当性(ローカルでの簡易チェック) | `cd .github/workflows && python3 -c "import yaml,sys; yaml.safe_load(open('ci.yml'))"` (or any YAML linter available) | エラーなし          |
+| ビルド確認(参考、CI相当)                           | `pnpm build`                                                                                                          | exit 0              |
+| テスト確認(参考、CI相当)                           | `pnpm test`                                                                                                           | all pass            |
 
 このプランは CI ワークフロー YAML のみを変更するため、ローカルで実行して検証できる
 コマンドは限られる。**最終検証は実際に CI 上で行う**(PR を開いて Actions の実行結果を
@@ -134,12 +134,12 @@
 `packages/*/dist` をソース + lockfile のハッシュでキーにして保存/復元する。
 
 ```yaml
-      - name: Cache package builds
-        id: dist-cache
-        uses: actions/cache@<pin-latest-major-actions/cache-with-sha> # vX.X.X
-        with:
-          path: packages/*/dist
-          key: dist-${{ hashFiles('packages/*/src/**', 'pnpm-lock.yaml', 'packages/*/tsup.config.ts') }}
+- name: Cache package builds
+  id: dist-cache
+  uses: actions/cache@<pin-latest-major-actions/cache-with-sha> # vX.X.X
+  with:
+    path: packages/*/dist
+    key: dist-${{ hashFiles('packages/*/src/**', 'pnpm-lock.yaml', 'packages/*/tsup.config.ts') }}
 ```
 
 `actions/cache` はこのリポジトリで既出の action ではないため、`actions/checkout` や
@@ -165,15 +165,15 @@
 する。
 
 ```yaml
-      - name: Restore package builds
-        id: dist-cache
-        uses: actions/cache@<same-pin-as-step-1>
-        with:
-          path: packages/*/dist
-          key: dist-${{ hashFiles('packages/*/src/**', 'pnpm-lock.yaml', 'packages/*/tsup.config.ts') }}
-      - name: Build packages
-        if: steps.dist-cache.outputs.cache-hit != 'true'
-        run: pnpm build
+- name: Restore package builds
+  id: dist-cache
+  uses: actions/cache@<same-pin-as-step-1>
+  with:
+    path: packages/*/dist
+    key: dist-${{ hashFiles('packages/*/src/**', 'pnpm-lock.yaml', 'packages/*/tsup.config.ts') }}
+- name: Build packages
+  if: steps.dist-cache.outputs.cache-hit != 'true'
+  run: pnpm build
 ```
 
 同じキー文字列を `check` と `test` の両方のステップで使うこと(コピペで揃える — キー

--- a/plans/028-perf009-line-tracking.md
+++ b/plans/028-perf009-line-tracking.md
@@ -1,0 +1,354 @@
+# Plan 028: PERF009(heavy import)の finding に正しい行番号を持たせる
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat 3341587..HEAD -- packages/core/src/component.ts packages/core/src/component-parse.ts packages/core/src/component-collect.ts packages/core/src/rules/perf/perf009-heavy-import.ts packages/core/src/rules/component-rule.ts`
+> 差分があれば下記「Current state」の抜粋と実ファイルを突き合わせ、不一致なら STOP。
+
+## Status
+
+- **Priority**: P1
+- **Effort**: S
+- **Risk**: LOW(`ComponentFacts` に新規フィールドを追加するだけの加法的変更。既存の
+  `imports: string[]` フィールドは変更しない)
+- **Depends on**: none
+- **Category**: bug
+- **Planned at**: commit `3341587`, 2026-07-13
+
+## Why this matters
+
+`PERF009`(重い依存パッケージの import を検出するルール)は、常に `line: 0` を報告する。
+`packages/core/src/rules/component-rule.ts:58` の suppression チェックは
+`b.line > 0 && isSuppressed(c, opts.id, b.line)` という条件で、`line` が正の数でなけれ
+ば抑制ディレクティブを一切見にいかない。つまり `// svelte-vitals-disable-next-line
+PERF009` をコンポーネントに書いても、**PERF009 だけは絶対に抑制できない** —
+ユーザーから見ると、抑制ディレクティブがパースエラーもなく黙って無視される。
+
+同じ「Bundle 系」ルールである PERF010(namespace import)は既に import ごとの正しい行
+番号(`namespaceImports: { source: string; line: number }[]`)を持っており、抑制も正常
+に機能する。PERF009 だけが `imports: string[]`(行情報なし)という別の弱いデータソース
+を使っているのが原因。
+
+## Current state
+
+- **`ComponentFacts`** 型定義 — `packages/core/src/component.ts:53-56`:
+
+```ts
+  /** Module specifiers of every `import` in the instance + module scripts (Bundle PERF009). */
+  imports: string[];
+  /** Value `import * as X from '<bare pkg>'` namespace imports (type-only excluded) — Bundle PERF010. */
+  namespaceImports: { source: string; line: number }[];
+```
+
+- **収集ロジック** — `packages/core/src/component-parse.ts:504-509`(行番号を捨てている
+  張本人):
+
+```ts
+/** Module specifiers of every `import` in an ESTree program (Bundle PERF009). */
+function collectImportSources(program: Node, acc: string[]): void {
+  walkEstree(program, (n) => {
+    if (n.type === 'ImportDeclaration' && typeof n.source?.value === 'string') acc.push(n.source.value);
+  });
+}
+```
+
+対して `collectNamespaceImports`(517-526行目)は同じ `walkEstree` パターンで
+`lineOf(source, n.start)` を使って行を記録している — このプランはそれと同じ仕組みを
+import 収集全体に広げる。
+
+- **呼び出し元** — `packages/core/src/component-parse.ts:575-581`(module/instance の
+  両方のスクリプトで `imports`/`namespaceImports` を集める)と、戻り値オブジェクト
+  626-637行目(`imports, namespaceImports, ...` をそのまま返す)。
+- **`emptyComponentFacts`** — `packages/core/src/component-collect.ts:11-24` はコメント
+  で「add new `ComponentFacts` fields HERE so TypeScript catches every call site」と明記
+  している、新フィールド追加時に必ず更新すべき箇所。
+- **PERF009 ルール本体** — `packages/core/src/rules/perf/perf009-heavy-import.ts`(全文):
+
+```ts
+import { componentRule } from '../component-rule.js';
+
+const HEAVY_PACKAGES: Record<string, string> = {
+  lodash: 'import a submodule (lodash/debounce) or use lodash-es for tree-shaking',
+  moment: 'use a lighter date library (date-fns or dayjs) — moment is large and not tree-shakeable'
+};
+
+export const perf009HeavyImport = componentRule({
+  id: 'PERF009',
+  title: 'Heavy dependency import',
+  category: 'performance',
+  severity: 'info',
+  label: 'No heavy imports',
+  recommendation: 'Import a submodule or switch to a lighter, tree-shakeable alternative.',
+  rationale:
+    'Importing a large, non-tree-shakeable package pulls its whole weight into the bundle even when only a fraction is used, slowing load.',
+  applies: (c) => c.imports.length > 0,
+  bad: (c) => {
+    const seen = new Set<string>();
+    const out: { line: number; message: string }[] = [];
+    for (const src of c.imports) {
+      if (!Object.hasOwn(HEAVY_PACKAGES, src) || seen.has(src)) continue;
+      seen.add(src);
+      out.push({ line: 0, message: `Heavy import "${src}" — ${HEAVY_PACKAGES[src]}` });
+    }
+    return out;
+  }
+});
+```
+
+- **既存テスト** — `packages/core/test/bundle-rules.test.ts:12-20` のヘルパー:
+
+```ts
+const comp = (imports: string[]): ComponentFacts => ({
+  ...
+  imports,
+  ...
+});
+```
+
+このヘルパーが PERF009/PERF010 両方のテストで使われている(47行目・91行目付近)。
+- **抑制の仕組み** — `packages/core/src/rules/component-rule.ts:35-37`(`isSuppressed`)
+  と 58行目(`bad.filter((b) => !(b.line > 0 && isSuppressed(...)))`)。今回のフィックス
+  はこの2箇所を変更しない — PERF009 が正しい `line` を渡すようになれば、既存の抑制ロジ
+  ックがそのまま機能するようになる。
+
+## Design decision
+
+`ComponentFacts.imports: string[]` は **変更しない**(型を変えると `applies: (c) =>
+c.imports.length > 0` 以外の潜在的な外部消費者がいた場合に壊れる可能性があり、
+`ComponentFacts` は `packages/core/src/index.ts` から公開エクスポートされている公開
+API 型のため、不要な破壊的変更を避ける)。代わりに、`namespaceImports` と同じ形の
+**新しいフィールド `importSpans: { source: string; line: number }[]`** を追加し、
+PERF009 はそちらを見るように変更する。これは加法的変更であり、`imports` を消費する
+既存コード(PERF009 の `applies` チェックのみ)はそのまま動く。
+
+## Commands you will need
+
+| Purpose   | Command                                        | Expected on success |
+| --------- | ----------------------------------------------- | -------------------- |
+| Build     | `pnpm --filter @svelte-vitals/core build`      | exit 0                |
+| Typecheck | `pnpm --filter @svelte-vitals/core typecheck`  | exit 0                |
+| Tests     | `pnpm --filter @svelte-vitals/core test`       | all pass              |
+| Lint      | `pnpm lint`                                     | exit 0                |
+| 全体確認  | `pnpm build && pnpm typecheck && pnpm test`    | exit 0 / all pass     |
+
+## Scope
+
+**In scope**:
+
+- `packages/core/src/component.ts`(`ComponentFacts` に `importSpans` を追加)
+- `packages/core/src/component-parse.ts`(`collectImportSources` を行番号付きに拡張、
+  `parseComponentFacts` の戻り値の型と実装に `importSpans` を追加)
+- `packages/core/src/component-collect.ts`(`emptyComponentFacts` に `importSpans: []`
+  を追加)
+- `packages/core/src/rules/perf/perf009-heavy-import.ts`(`c.imports` ではなく
+  `c.importSpans` を走査するよう変更)
+- `packages/core/test/bundle-rules.test.ts`(PERF009 のテストを行番号ありで書き直す)
+- `.changeset/`
+
+**Out of scope**:
+
+- `ComponentFacts.imports` の型変更・削除 — 既存のまま維持する。
+- `PERF010`(`namespaceImports`)のロジック — 参考にするだけで変更しない。
+- `packages/core/test/component-rule.test.ts`、`security-rules.test.ts`、
+  `correctness-rules.test.ts`、`architecture-rules.test.ts`、
+  `component-collect.test.ts` — これらは全て `imports: []`(空配列)を使っているだけな
+  ので型互換性は保たれるが、**`importSpans` フィールドが必須(non-optional)になる場合
+  はこれらのフィクスチャにも `importSpans: []` を足す必要がある** — Step 1 で `?` を付
+  けるかどうかを決める際にこの点を考慮すること(推奨: 必須にして忘れを防ぐ。TypeScript
+  のコンパイルエラーがどのファイルを直すべきか教えてくれる)。
+
+## Git workflow
+
+- Branch: `advisor/028-perf009-line-tracking`
+- コミット: 1つでよい。`fix(core): give PERF009 findings a real line number` のような
+  conventional commit(英語)。
+- push / PR 作成はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: `ComponentFacts` に `importSpans` を追加する
+
+`packages/core/src/component.ts` の `imports: string[];` の直後に以下を追加(必須フィ
+ールドにする — `?` を付けない):
+
+```ts
+  /** Module specifiers of every `import`, each with its source line (Bundle PERF009). */
+  importSpans: { source: string; line: number }[];
+```
+
+**Verify**: `pnpm --filter @svelte-vitals/core typecheck` → この時点ではまだ他のファイ
+ルが未更新なのでコンパイルエラーになるはず(次のステップで解消)。エラーメッセージが
+`component-collect.ts`・`component-parse.ts` の返り値の型不一致を指していることを確認
+してから次に進む。
+
+### Step 2: `collectImportSources` を行番号付きに拡張する
+
+`packages/core/src/component-parse.ts` の `collectImportSources` を、`collectNamespaceImports`
+と同じパターンで書き換える:
+
+```ts
+/** Module specifiers of every `import`, each with its source line (Bundle PERF009). */
+function collectImportSources(program: Node, source: string, acc: { source: string; line: number }[]): void {
+  walkEstree(program, (n) => {
+    if (n.type === 'ImportDeclaration' && typeof n.source?.value === 'string') {
+      acc.push({ source: n.source.value, line: lineOf(source, n.start) });
+    }
+  });
+}
+```
+
+呼び出し元(575〜581行目付近、`ast.module?.content` と `ast.instance?.content` の2箇所)
+を新しいシグネチャに合わせて更新する:
+
+```ts
+  const imports: string[] = [];
+  const importSpans: { source: string; line: number }[] = [];
+  const namespaceImports: { source: string; line: number }[] = [];
+  if (ast.module?.content) {
+    collectImportSources(ast.module.content, source, importSpans);
+    collectNamespaceImports(ast.module.content, source, namespaceImports);
+  }
+  ...
+  if (program) {
+    collectImportSources(program, source, importSpans);
+    collectNamespaceImports(program, source, namespaceImports);
+    ...
+  }
+```
+
+`imports: string[]` は既存の公開フィールドとして残す必要があるため、`importSpans` から
+導出する(二重の AST 走査を避ける):
+
+```ts
+  const imports = importSpans.map((s) => s.source);
+```
+
+(この1行を、`imports`/`namespaceImports` を集め終えた直後、戻り値オブジェクトを組み立
+てる前に追加する。`imports` のローカル変数宣言 `const imports: string[] = [];` は削除
+してこの導出行に置き換える。)
+
+`parseComponentFacts` の戻り値の型注釈(553-565行目付近)に `importSpans: { source:
+string; line: number }[];` を追加し、関数末尾の返り値オブジェクト(626行目付近)に
+`importSpans` を追加する。
+
+**Verify**: `pnpm --filter @svelte-vitals/core typecheck` → `component-collect.ts` の
+不一致のみが残っているはず。
+
+### Step 3: `emptyComponentFacts` を更新する
+
+`packages/core/src/component-collect.ts` の `emptyComponentFacts` に
+`importSpans: [],` を追加する(コメント自身が「新フィールドはここに追加せよ」と指示し
+ている場所)。
+
+**Verify**: `pnpm --filter @svelte-vitals/core typecheck` → exit 0(このパッケージ内は
+解消されるはず)。
+
+### Step 4: PERF009 ルールを `importSpans` を使うように変更する
+
+`packages/core/src/rules/perf/perf009-heavy-import.ts` の `applies`/`bad` を変更する:
+
+```ts
+  applies: (c) => c.importSpans.length > 0,
+  bad: (c) => {
+    // `Object.hasOwn` (not `in`) so inherited keys like `toString` never match;
+    // dedupe so the same package imported in both scripts isn't double-penalized.
+    const seen = new Set<string>();
+    const out: { line: number; message: string }[] = [];
+    for (const { source: src, line } of c.importSpans) {
+      if (!Object.hasOwn(HEAVY_PACKAGES, src) || seen.has(src)) continue;
+      seen.add(src);
+      out.push({ line, message: `Heavy import "${src}" — ${HEAVY_PACKAGES[src]}` });
+    }
+    return out;
+  }
+```
+
+(同じ specifier が module スクリプトと instance スクリプトの両方に出現した場合、
+`importSpans` には2エントリ入りうるが `seen` の dedup は既存どおり最初に出現した行を
+採用する — 挙動は今までの「最初に見つかった行」という暗黙の優先順位と変わらない。)
+
+**Verify**: `pnpm --filter @svelte-vitals/core typecheck && pnpm --filter @svelte-vitals/core build`
+→ exit 0(パッケージ全体のコンパイルが通ること)。
+
+### Step 5: テストを更新する
+
+`packages/core/test/bundle-rules.test.ts` の `comp` ヘルパー(`imports: string[]` を受
+け取る)を、`importSpans` も設定するように変更する。最小の変更方法: ヘルパーの引数を
+`imports: string[]` のまま維持し、内部で `importSpans: imports.map((source, i) => ({
+source, line: i + 1 }))` のように仮の行番号を生成してもよいが、**PERF009 が正しい行番
+号を報告することを検証するのがこのプランの目的**なので、既存の PERF009 関連テスト
+(`'emits nothing for a component with no imports'` など、47行目周辺)を実際の意味の
+ある行番号(例: `line: 5`)を持つケースに書き換え、`result.line` がその行番号と一致す
+ることをアサートする新しいテストケースを追加すること。既存の PERF010 テスト(91行目
+「passes a component with no namespace imports」)は `namespaceImports` を直接使うヘ
+ルパー引数なので変更不要。
+
+追加すべきテストケース(新規):
+- `lodash` を import しているコンポーネントで PERF009 の finding が `line: 0` ではな
+  く実際の import 文の行番号を持つこと。
+- 同じ重い import に対して `// svelte-vitals-disable-next-line PERF009` を直前行に置
+  いたとき、finding が抑制される(結果に出ない)こと — これがこのバグの本質的な回帰
+  テストであり、`component-rule.test.ts` の既存の suppression テスト(`isSuppressed`
+  を経由するもの)と同じパターンで書く。
+
+**Verify**: `pnpm --filter @svelte-vitals/core test` → all pass、新規テストが green。
+
+### Step 6: 全体検証 + changeset
+
+**Verify**: `pnpm build && pnpm typecheck && pnpm test && pnpm lint` → 全て exit 0 /
+all pass(core を消費する cli/vite/mcp/action もビルド・型チェックが通ることを確認)。
+
+changeset を追加(`@svelte-vitals/core`: patch — 公開型への加法的フィールド追加 + バ
+グ修正、既存フィールドの破壊的変更はないため patch が妥当。ただし本リポジトリの他の
+プランは「振る舞いが変わる公開挙動の変更」を minor にしている例もあるため、
+`ComponentFacts` という公開型にフィールドが増える点を踏まえ **minor** を選んでもよい
+— 判断に迷ったら `@svelte-vitals/core` の既存 CHANGELOG.md で類似の「型に新フィールド
+追加」の過去の扱いを確認し、それに合わせること)。changeset 本文は英語で、「PERF009
+findings now report the correct source line, so `svelte-vitals-disable-next-line
+PERF009` suppression directives work」の趣旨を書く。
+
+## Test plan
+
+- 新規: PERF009 が実際の import 行番号を報告するテスト(`packages/core/test/bundle-rules.test.ts`)。
+- 新規: PERF009 の finding が `svelte-vitals-disable-next-line PERF009` で抑制される
+  回帰テスト(同ファイル、または `component-rule.test.ts` の既存パターンに倣う)。
+- 既存: `bundle-rules.test.ts` の他のケース(PERF010、"no imports"、非対象パッケージ)
+  は変更後も green であること。
+- 検証: `pnpm --filter @svelte-vitals/core test` → all pass、new tests included。
+
+## Done criteria
+
+- [ ] `pnpm build && pnpm typecheck && pnpm test && pnpm lint` が全て exit 0 / all pass
+- [ ] `packages/core/src/rules/perf/perf009-heavy-import.ts` の finding が `line: 0` を
+      ハードコードしていない(`grep -n "line: 0" packages/core/src/rules/perf/perf009-heavy-import.ts` が0件)
+- [ ] 新規テストで「実際の行番号」と「抑制ディレクティブが効くこと」の両方を確認済み
+- [ ] `ComponentFacts.imports`(既存フィールド)の型・振る舞いが変わっていない
+      (`git diff` で `imports: string[]` の宣言行が変更されていないことを確認)
+- [ ] changeset が `.changeset/` に存在する
+- [ ] `plans/README.md` の該当行を更新済み
+
+## STOP conditions
+
+- `walkEstree`/`lineOf` の呼び出し規約が想定と異なる(例: `lineOf` が `n.start` 以外の
+  引数を要求する)場合、`collectNamespaceImports` の実装を再度読み直し、それでも解決し
+  なければ STOP。
+- `ComponentFacts` を消費する外部パッケージ(vite/mcp/action)のいずれかが `imports`
+  フィールドの**要素の型**(単なる string であること)に依存したコードを持っている
+  ことが分かった場合(grep で確認)、`importSpans` 追加だけでは解決できない可能性があ
+  るため STOP して報告する。
+- テストの追加・修正で 2 回失敗した場合。
+
+## Maintenance notes
+
+- 将来 `imports: string[]` を廃止して `importSpans` に統一したくなった場合、消費者が
+  PERF009 の `applies`/`bad` だけであることを確認済みなので置き換えは低リスクだが、
+  それは別プランのスコープ(公開型の破壊的変更は pre-1.0 の「無警告での削除可」ポリシ
+  ーに従うにしても、独立した意思決定として扱う)。
+- 新しい Bundle 系ルール(PERF009/PERF010 以外)を追加する場合、行番号を持つ
+  `importSpans`/`namespaceImports` のどちらかを再利用すべきで、行番号なしの `imports`
+  を新規ルールの主データソースにしないこと。

--- a/plans/028-perf009-line-tracking.md
+++ b/plans/028-perf009-line-tracking.md
@@ -111,6 +111,7 @@ const comp = (imports: string[]): ComponentFacts => ({
 ```
 
 このヘルパーが PERF009/PERF010 両方のテストで使われている(47行目・91行目付近)。
+
 - **抑制の仕組み** — `packages/core/src/rules/component-rule.ts:35-37`(`isSuppressed`)
   と 58行目(`bad.filter((b) => !(b.line > 0 && isSuppressed(...)))`)。今回のフィックス
   はこの2箇所を変更しない — PERF009 が正しい `line` を渡すようになれば、既存の抑制ロジ
@@ -128,13 +129,13 @@ PERF009 はそちらを見るように変更する。これは加法的変更で
 
 ## Commands you will need
 
-| Purpose   | Command                                        | Expected on success |
-| --------- | ----------------------------------------------- | -------------------- |
-| Build     | `pnpm --filter @svelte-vitals/core build`      | exit 0                |
-| Typecheck | `pnpm --filter @svelte-vitals/core typecheck`  | exit 0                |
-| Tests     | `pnpm --filter @svelte-vitals/core test`       | all pass              |
-| Lint      | `pnpm lint`                                     | exit 0                |
-| 全体確認  | `pnpm build && pnpm typecheck && pnpm test`    | exit 0 / all pass     |
+| Purpose   | Command                                       | Expected on success |
+| --------- | --------------------------------------------- | ------------------- |
+| Build     | `pnpm --filter @svelte-vitals/core build`     | exit 0              |
+| Typecheck | `pnpm --filter @svelte-vitals/core typecheck` | exit 0              |
+| Tests     | `pnpm --filter @svelte-vitals/core test`      | all pass            |
+| Lint      | `pnpm lint`                                   | exit 0              |
+| 全体確認  | `pnpm build && pnpm typecheck && pnpm test`   | exit 0 / all pass   |
 
 ## Scope
 
@@ -177,8 +178,12 @@ PERF009 はそちらを見るように変更する。これは加法的変更で
 ールドにする — `?` を付けない):
 
 ```ts
-  /** Module specifiers of every `import`, each with its source line (Bundle PERF009). */
-  importSpans: { source: string; line: number }[];
+/** Module specifiers of every `import`, each with its source line (Bundle PERF009). */
+importSpans: {
+  source: string;
+  line: number;
+}
+[];
 ```
 
 **Verify**: `pnpm --filter @svelte-vitals/core typecheck` → この時点ではまだ他のファイ
@@ -225,7 +230,7 @@ function collectImportSources(program: Node, source: string, acc: { source: stri
 導出する(二重の AST 走査を避ける):
 
 ```ts
-  const imports = importSpans.map((s) => s.source);
+const imports = importSpans.map((s) => s.source);
 ```
 
 (この1行を、`imports`/`namespaceImports` を集め終えた直後、戻り値オブジェクトを組み立
@@ -289,6 +294,7 @@ source, line: i + 1 }))` のように仮の行番号を生成してもよいが�
 ルパー引数なので変更不要。
 
 追加すべきテストケース(新規):
+
 - `lodash` を import しているコンポーネントで PERF009 の finding が `line: 0` ではな
   く実際の import 文の行番号を持つこと。
 - 同じ重い import に対して `// svelte-vitals-disable-next-line PERF009` を直前行に置

--- a/plans/029-action-main-test-coverage.md
+++ b/plans/029-action-main-test-coverage.md
@@ -1,0 +1,287 @@
+# Plan 029: `@svelte-vitals/action` の `main()` にテストを追加する
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat 3341587..HEAD -- packages/action/src/index.ts`
+> 差分があれば下記「Current state」の抜粋と実ファイルを突き合わせ、不一致なら STOP。
+
+## Status
+
+- **Priority**: P1
+- **Effort**: M
+- **Risk**: LOW(テスト追加のみ。プロダクションコードは変更しない)
+- **Depends on**: none
+- **Category**: tests
+- **Planned at**: commit `3341587`, 2026-07-13
+
+## Why this matters
+
+`packages/action/src/index.ts` の `main()` は `@svelte-vitals/action` の全ロジック
+(analyze → applyScope → GitHub annotations → job summary → sticky PR コメントの
+作成/更新 → fork PR のスキップ判定 → 失敗ゲート)を1関数にまとめたもので、**このリポ
+ジトリが生成する GitHub Actions ワークフローの実体そのもの** — 全ユーザーの PR マージ
+判定がここを通る。
+
+`packages/action/test/` には `fork.test.ts` と `sticky-comment.test.ts` の2ファイルし
+かなく、どちらも `main()` が呼び出す**純粋な補助関数**(`isForkPR`/`planStickyComment`)
+だけをテストしている。`main()` 自体 — octokit 呼び出し、fork スキップの分岐、コメント
+の作成/更新の分岐、エラー握りつぶし、最終的な `setFailed` ゲート — は一切実行されない
+まま今日に至る。`git log --oneline -- packages/action/src/index.ts` を見ると、直近でも
+`3aad0e2`(suppressions 用に `config` を渡す変更)のように振る舞いに関わる変更が
+テストなしでマージされている。
+
+## Current state
+
+`packages/action/src/index.ts`(全文、86行):
+
+```ts
+import * as core from '@actions/core';
+import * as github from '@actions/github';
+import { analyzeProject, applyScope } from 'svelte-vitals';
+import { formatGithubReport, formatMarkdownReport, summarize, hasFailureAtOrAbove } from '@svelte-vitals/core';
+import { isForkPR } from './fork.js';
+import { planStickyComment, STICKY_COMMENT_MARKER } from './sticky-comment.js';
+
+async function main(): Promise<void> {
+  const path = core.getInput('path') || '.';
+  const diff = core.getInput('diff') || undefined;
+  const baseline = core.getInput('baseline') || undefined;
+  const token = core.getInput('github-token') || process.env.GITHUB_TOKEN || '';
+
+  const analysis = await analyzeProject({ cwd: path });
+  const { config, version } = analysis;
+  const results = await applyScope(analysis.results, {
+    cwd: path,
+    config,
+    diffBase: diff,
+    baseline,
+    errorLog: (line) => core.warning(line)
+  });
+
+  const annotations = formatGithubReport(results, config);
+  if (annotations) core.info(annotations);
+
+  const markdown = formatMarkdownReport(results, config, { version });
+  await core.summary.addRaw(markdown).write();
+
+  const ctx = github.context;
+  const pr = ctx.payload.pull_request;
+  if (pr && token) {
+    const headFullName = (pr as { head?: { repo?: { full_name?: string } } }).head?.repo?.full_name;
+    const fork = isForkPR({
+      eventName: ctx.eventName,
+      repoFullName: `${ctx.repo.owner}/${ctx.repo.repo}`,
+      headRepoFullName: headFullName
+    });
+    if (!fork) {
+      try {
+        const octokit = github.getOctokit(token);
+        const body = `${STICKY_COMMENT_MARKER}\n${markdown}`;
+        const { data: comments } = await octokit.rest.issues.listComments({
+          owner: ctx.repo.owner,
+          repo: ctx.repo.repo,
+          issue_number: pr.number,
+          per_page: 100
+        });
+        const plan = planStickyComment(comments.map((c) => ({ id: c.id, body: c.body })));
+        if (plan.op === 'update') {
+          await octokit.rest.issues.updateComment({ owner: ctx.repo.owner, repo: ctx.repo.repo, comment_id: plan.id, body });
+        } else {
+          await octokit.rest.issues.createComment({ owner: ctx.repo.owner, repo: ctx.repo.repo, issue_number: pr.number, body });
+        }
+      } catch (err) {
+        core.warning(`svelte-vitals: failed to post/update the PR comment: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+  }
+
+  const summary = summarize(results, config);
+  if (hasFailureAtOrAbove(summary, config.failOn)) {
+    core.setFailed('svelte-vitals found blocking issues (see annotations above).');
+  }
+}
+
+main().catch((err) => {
+  core.setFailed(err instanceof Error ? err.message : String(err));
+});
+```
+
+- `main` は `export` されていない — テストから直接呼ぶには **`export`を追加する必要
+  がある**(唯一のプロダクションコード変更。振る舞いは変えない)。
+- `packages/action/test/fork.test.ts`(全文、既存パターンの参考): `isForkPR` を直接
+  import してテストするだけの素朴な `describe`/`it`。
+- **モックの参考パターン** — `packages/vite/test/plugin-error.test.ts:1-14` が
+  `vi.mock('../src/analyze.js', () => ({ analyze: vi.fn(async () => { throw ... }) }))`
+  を `import { svelteVitals } from '../src/index.js'` より前に書くパターンを使ってい
+  る。今回も同じ形で `@actions/core`・`@actions/github`・`svelte-vitals`・
+  `@svelte-vitals/core` をモックする。
+- **`action.yml`** の入力: `path`(default `.`)、`diff`、`baseline`、`github-token`
+  (default `${{ github.token }}`)— テストで `core.getInput` のモックが返す値の対応
+  関係を把握しておくこと。
+
+## Commands you will need
+
+| Purpose   | Command                                          | Expected on success |
+| --------- | -------------------------------------------------- | -------------------- |
+| Typecheck | `pnpm --filter @svelte-vitals/action typecheck`   | exit 0 (ローカルで動く場合。下記 NOTES 参照) |
+| Tests     | `pnpm --filter @svelte-vitals/action test`        | all pass              |
+| Build     | `pnpm --filter @svelte-vitals/action build`       | exit 0 (同上)        |
+| Lint      | `pnpm lint`                                        | exit 0                |
+
+**重要**: `packages/action` の依存(`@actions/core`/`@actions/github`)がサンドボック
+ス環境にインストールできないことが過去のプラン(023/026)で確認されている
+(`tunnel` パッケージの展開がブロックされるケースがある)。ローカルで `pnpm install`
+が通らない場合は、**typecheck/build/test はローカル実行不能** — その旨を Maintenance
+notes に明記し、CI の `check`/`test` ジョブでの検証に委ねる。まず
+`pnpm --filter @svelte-vitals/action install`(または相当するコマンド)を試し、失敗
+したら握りつぶさず正直に記録すること。
+
+## Scope
+
+**In scope**:
+
+- `packages/action/src/index.ts`(`main` に `export` を追加する1行のみ。ロジックは
+  一切変更しない)
+- `packages/action/test/index.test.ts`(新規作成)
+
+**Out of scope**:
+
+- `main()` 内部のロジック変更・リファクタリング(このプランはテスト追加のみ)。
+- `packages/action/dist/`(このプランはソースの `export` 追加のみで dist に影響する
+  実害はないが、`main` に `export` を付けても tsup のビルド出力のトップレベル副作用
+  は変わらないはず — ただし念のため Step 3 で dist の diff を確認すること)。
+- `fork.ts`/`sticky-comment.ts` 自体(既にテスト済み、変更しない)。
+
+## Git workflow
+
+- Branch: `advisor/029-action-main-test-coverage`
+- コミット: `test(action): cover main()'s PR-comment, fork-skip, and failure-gate branches`
+  (英語、1コミットでよい)。
+- push / PR 作成はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: `main` を export する
+
+`packages/action/src/index.ts` の `async function main(): Promise<void> {` を
+`export async function main(): Promise<void> {` に変更する。ファイル末尾の
+`main().catch((err) => { core.setFailed(...); });` はそのまま(トップレベル実行の
+副作用は維持する — これは `action.yml` の `main: 'dist/index.js'` が期待する実行時の
+エントリポイントなので消してはいけない)。
+
+**Verify**: この変更単体では振る舞いは変わらない。次のステップでテストから import
+できることを確認する。
+
+### Step 2: `packages/action/test/index.test.ts` を新規作成する
+
+`packages/vite/test/plugin-error.test.ts` と同じ「`vi.mock` を先に書いてから対象
+モジュールを import する」パターンで、以下のモックを用意する:
+
+- `@actions/core` — `getInput`(呼び出し引数に応じて `path`/`diff`/`baseline`/
+  `github-token` を返す)、`info`、`warning`、`setFailed`、`summary.addRaw().write()`
+  をすべて `vi.fn()` でモックする(`summary` はチェーン可能なオブジェクトが必要 —
+  `{ addRaw: vi.fn(() => ({ write: vi.fn(async () => {}) })) }` のような形)。
+- `@actions/github` — `context`(`eventName`/`repo.owner`/`repo.repo`/
+  `payload.pull_request` をテストケースごとに差し替えられるようにする)と
+  `getOctokit`(`rest.issues.listComments`/`updateComment`/`createComment` を
+  `vi.fn()` でモックした octokit ライクなオブジェクトを返す)。
+- `svelte-vitals` — `analyzeProject`(固定の `{ results: [...], config: {...},
+  version: '0.0.0-test' }` を返す)と `applyScope`(受け取った `results` をそのまま
+  返す、またはテストケースに応じて critical な finding を混ぜる)。
+- `@svelte-vitals/core` — `formatGithubReport`・`formatMarkdownReport`・`summarize`・
+  `hasFailureAtOrAbove` を、テストが分岐を制御できる程度の単純な `vi.fn()` にする
+  (例: `hasFailureAtOrAbove` はテストごとに `true`/`false` を返すよう
+  `mockReturnValueOnce` で切り替える)。
+
+テストケース(すべて `main()` を直接呼び出し、各モックへの呼び出しをアサートする):
+
+1. **同一リポジトリの PR、コメントなし** — `github.context.payload.pull_request` が
+   設定され、`headRepoFullName === repoFullName`、`listComments` が空配列を返す →
+   `octokit.rest.issues.createComment` が呼ばれ、`updateComment` は呼ばれないこと。
+2. **同一リポジトリの PR、既存の sticky コメントあり** — `listComments` が
+   `STICKY_COMMENT_MARKER` で始まる `body` を持つコメントを返す →
+   `updateComment` が呼ばれ、`createComment` は呼ばれないこと。
+3. **fork PR** — `isForkPR` が true になる `eventName`/`headRepoFullName` の組み合わ
+   せ → `getOctokit` が一切呼ばれない(コメント関連の呼び出しがすべてスキップされる)
+   こと。既存の annotations/summary 処理(`core.info`/`core.summary.addRaw`)は
+   fork でも実行されることも併せて確認する。
+4. **PR イベントではない(push など)** — `github.context.payload.pull_request` が
+   `undefined` → コメント関連の分岐全体がスキップされ、`getOctokit` が呼ばれないこと。
+5. **octokit がエラーを投げる**(例: `listComments` が reject する)→ `main()` 自体
+   は reject せず完了し、`core.warning` が「failed to post/update the PR comment」
+   を含むメッセージで呼ばれること。この失敗が `core.setFailed` を引き起こさないこと
+   (コメント投稿の失敗は build を失敗させてはいけない、というコード中のコメントの
+   契約)も確認する。
+6. **`hasFailureAtOrAbove` が true を返す** → `core.setFailed` が
+   `'svelte-vitals found blocking issues (see annotations above).'` で呼ばれること。
+7. **`hasFailureAtOrAbove` が false を返す** → `core.setFailed` が一度も呼ばれない
+   こと。
+
+**Verify**: `pnpm --filter @svelte-vitals/action test`(ローカルで依存インストールが
+可能な場合)→ all pass、7ケース以上 green。依存インストールが不能な場合は Step 4 で
+その旨を記録した上で、CI での検証に委ねる。
+
+### Step 3: 波及確認
+
+`export` の追加が `packages/action/dist/` のビルド結果に予期しない差分を生まないか
+確認する(依存インストール・ビルドが可能な環境であれば):
+
+```
+pnpm --filter @svelte-vitals/action build
+git diff --stat -- packages/action/dist
+```
+
+差分が出た場合、意味のある変更(例: `main` が named export として出力されるようになる
+こと自体は許容される正しい変化)であることを確認し、Maintenance notes に記録する。
+
+### Step 4: 全体検証
+
+**Verify**: `pnpm lint` → exit 0。`pnpm --filter @svelte-vitals/action typecheck`
+（可能なら）→ exit 0。ローカルで `packages/action` の依存インストールができない場合
+は、その事実と試したコマンド・エラーメッセージを Maintenance notes に記録し、
+「CI の `check`/`test` ジョブでの検証が必要」と明記する。
+
+## Test plan
+
+- 新規: `packages/action/test/index.test.ts` — 上記7ケース(同一リポジトリ PR の
+  新規/更新コメント、fork PR のスキップ、非 PR イベント、octokit 失敗時の非致命的
+  警告、成功/失敗ゲートの両分岐)。
+- 既存: `fork.test.ts`・`sticky-comment.test.ts` は無変更のまま green であること。
+- 検証: `pnpm --filter @svelte-vitals/action test` → all pass、新規7ケース以上を
+  含む。
+
+## Done criteria
+
+- [ ] `packages/action/src/index.ts` の `main` が `export` されている
+- [ ] `packages/action/test/index.test.ts` が新規作成され、上記7ケースをすべてカバー
+- [ ] `pnpm --filter @svelte-vitals/action test` が all pass(ローカルで実行可能な場
+      合)、または CI での実行結果で確認済み
+- [ ] `pnpm lint` が exit 0
+- [ ] `main()` 内部のロジックが1文字も変わっていない(`git diff -- packages/action/src/index.ts`
+      で `export` の追加のみであることを確認)
+- [ ] `plans/README.md` の該当行を更新済み
+
+## STOP conditions
+
+- `packages/action` の依存インストールがサンドボックスで不能(過去のプラン023/026と
+  同様の症状)で、かつテストをローカルで一度も実行して確認できない場合、書いたテスト
+  コードをレビュー可能な形で残しつつ、「CI 実行が必須の検証ゲート」であることを明記
+  して報告する — 見えないまま「動作確認済み」と主張しない。
+- モックの型(`@actions/core`/`@actions/github` の型定義)が想定と異なりテストの
+  コンパイルが通らない場合、型を無理に `any` で回避せず、実際の型定義ファイル
+  (`node_modules/@actions/*/lib/*.d.ts` など、インストールできていれば)を確認して
+  から対応する。2回試して解決しなければ STOP。
+
+## Maintenance notes
+
+- 今後 `main()` に新しい分岐(例: 別の入力オプション追加)を加える PR のレビュアーは、
+  このテストファイルに対応するケースが追加されているかを確認すること — このプランの
+  存在意義は「`main()` の変更には必ずテストが伴う」という規範を作ることにある。
+- サンドボックスで `packages/action` の依存インストールができなかった場合、その制約
+  は変わらず残るため、次にこのパッケージを触るプランも同じ制約(CI 依存の検証)を
+  引き継ぐ。

--- a/plans/029-action-main-test-coverage.md
+++ b/plans/029-action-main-test-coverage.md
@@ -90,12 +90,24 @@ async function main(): Promise<void> {
         });
         const plan = planStickyComment(comments.map((c) => ({ id: c.id, body: c.body })));
         if (plan.op === 'update') {
-          await octokit.rest.issues.updateComment({ owner: ctx.repo.owner, repo: ctx.repo.repo, comment_id: plan.id, body });
+          await octokit.rest.issues.updateComment({
+            owner: ctx.repo.owner,
+            repo: ctx.repo.repo,
+            comment_id: plan.id,
+            body
+          });
         } else {
-          await octokit.rest.issues.createComment({ owner: ctx.repo.owner, repo: ctx.repo.repo, issue_number: pr.number, body });
+          await octokit.rest.issues.createComment({
+            owner: ctx.repo.owner,
+            repo: ctx.repo.repo,
+            issue_number: pr.number,
+            body
+          });
         }
       } catch (err) {
-        core.warning(`svelte-vitals: failed to post/update the PR comment: ${err instanceof Error ? err.message : String(err)}`);
+        core.warning(
+          `svelte-vitals: failed to post/update the PR comment: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
     }
   }
@@ -126,12 +138,12 @@ main().catch((err) => {
 
 ## Commands you will need
 
-| Purpose   | Command                                          | Expected on success |
-| --------- | -------------------------------------------------- | -------------------- |
-| Typecheck | `pnpm --filter @svelte-vitals/action typecheck`   | exit 0 (ローカルで動く場合。下記 NOTES 参照) |
-| Tests     | `pnpm --filter @svelte-vitals/action test`        | all pass              |
-| Build     | `pnpm --filter @svelte-vitals/action build`       | exit 0 (同上)        |
-| Lint      | `pnpm lint`                                        | exit 0                |
+| Purpose   | Command                                         | Expected on success                          |
+| --------- | ----------------------------------------------- | -------------------------------------------- |
+| Typecheck | `pnpm --filter @svelte-vitals/action typecheck` | exit 0 (ローカルで動く場合。下記 NOTES 参照) |
+| Tests     | `pnpm --filter @svelte-vitals/action test`      | all pass                                     |
+| Build     | `pnpm --filter @svelte-vitals/action build`     | exit 0 (同上)                                |
+| Lint      | `pnpm lint`                                     | exit 0                                       |
 
 **重要**: `packages/action` の依存(`@actions/core`/`@actions/github`)がサンドボック
 ス環境にインストールできないことが過去のプラン(023/026)で確認されている
@@ -191,7 +203,7 @@ notes に明記し、CI の `check`/`test` ジョブでの検証に委ねる。�
   `getOctokit`(`rest.issues.listComments`/`updateComment`/`createComment` を
   `vi.fn()` でモックした octokit ライクなオブジェクトを返す)。
 - `svelte-vitals` — `analyzeProject`(固定の `{ results: [...], config: {...},
-  version: '0.0.0-test' }` を返す)と `applyScope`(受け取った `results` をそのまま
+version: '0.0.0-test' }` を返す)と `applyScope`(受け取った `results` をそのまま
   返す、またはテストケースに応じて critical な finding を混ぜる)。
 - `@svelte-vitals/core` — `formatGithubReport`・`formatMarkdownReport`・`summarize`・
   `hasFailureAtOrAbove` を、テストが分岐を制御できる程度の単純な `vi.fn()` にする

--- a/plans/030-docs-and-workspace-quick-fixes.md
+++ b/plans/030-docs-and-workspace-quick-fixes.md
@@ -95,12 +95,12 @@ packages:
 
 ## Commands you will need
 
-| Purpose                  | Command                                | Expected on success |
-| ------------------------- | ---------------------------------------- | -------------------- |
-| ワークスペース確認        | `pnpm -r list --depth -1`               | `docs/demo` が一覧に出る |
-| lockfile 整合性確認       | `pnpm install`                          | exit 0、lockfile 更新が妥当であること |
-| 全体ビルド/テスト         | `pnpm build && pnpm typecheck && pnpm test` | exit 0 / all pass |
-| lint                       | `pnpm lint`                              | exit 0                |
+| Purpose             | Command                                     | Expected on success                   |
+| ------------------- | ------------------------------------------- | ------------------------------------- |
+| ワークスペース確認  | `pnpm -r list --depth -1`                   | `docs/demo` が一覧に出る              |
+| lockfile 整合性確認 | `pnpm install`                              | exit 0、lockfile 更新が妥当であること |
+| 全体ビルド/テスト   | `pnpm build && pnpm typecheck && pnpm test` | exit 0 / all pass                     |
+| lint                | `pnpm lint`                                 | exit 0                                |
 
 ## Scope
 
@@ -155,8 +155,8 @@ packages:
 `corepack use` to match it automatically」)にしてもよいが、必須ではない。数字を
 更新するだけでも Done criteria は満たす。
 
-**Verify**: `grep "pnpm \`11.11.0\`" CONTRIBUTING.md` がヒットすること
-(実際の `package.json` の値と手動で突き合わせる — ハードコードするなら正しい値を)。
+**Verify**: `grep "pnpm \`11.11.0\`" CONTRIBUTING.md`がヒットすること
+(実際の`package.json` の値と手動で突き合わせる — ハードコードするなら正しい値を)。
 
 ### Step 3: `docs/demo` を pnpm workspace に含める
 

--- a/plans/030-docs-and-workspace-quick-fixes.md
+++ b/plans/030-docs-and-workspace-quick-fixes.md
@@ -1,0 +1,231 @@
+# Plan 030: ドキュメント/ワークスペースの陳腐化した記載を修正する(3件まとめ)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat 3341587..HEAD -- README.md CONTRIBUTING.md pnpm-workspace.yaml docs/demo/package.json`
+> 差分があれば下記「Current state」の抜粋と実ファイルを突き合わせ、不一致なら STOP。
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: LOW(ドキュメント文言 + ワークスペース設定のみ、実行コードへの変更なし)
+- **Depends on**: none
+- **Category**: docs / dx
+- **Planned at**: commit `3341587`, 2026-07-13
+
+## Why this matters
+
+監査で見つかった3件の独立した「陳腐化」を、いずれも1行〜数行のトリビアルな修正である
+ため1本のプランにまとめる:
+
+1. **README.md が reporter を5種と誤記**(実際は7種)。`html`/`md` という差別化機能
+   (CI に貼れる自己完結 HTML レポート、PR コメント向け Markdown レポート)が
+   README の Features 一覧から欠落しており、プロジェクトを評価する最初の入口で
+   実力を過小に見せている。
+2. **CONTRIBUTING.md の pnpm バージョン記載が2リリース分陳腐化**。
+   `package.json` の `packageManager` を見よと自ら指示しているのに、その隣に古い数字
+   を書いている。
+3. **`docs/demo/package.json` が pnpm workspace の対象外**かつ `catalog:` を使わず
+   バージョンをハードコードしている。catalog のバージョンアップがこの demo にだけ
+   反映されず、気づかれないまま陳腐化するリスクがある。
+
+## Current state
+
+### 1. README.md の reporter 一覧
+
+`README.md:36`:
+
+```md
+- **Multiple reporters** — `console`, `json`, `agent` (a Markdown remediation document an AI agent can act on directly), `sarif`, and `github`. The `agent` reporter auto-selects inside AI-agent harnesses (e.g. Claude Code); `github` auto-selects under GitHub Actions. → [Reporters](https://oekazuma.github.io/svelte-vitals/guides/reporters/)
+```
+
+実際の reporter は7種(`packages/cli/src/reporter-resolve.ts` の `ReporterName` 型、
+`docs/src/content/docs/guides/reporters.md` が明記): `console`, `json`, `agent`,
+`sarif`, `github`, `md`, `html`。
+
+### 2. CONTRIBUTING.md の pnpm バージョン
+
+`CONTRIBUTING.md:8`:
+
+```md
+- pnpm `11.9.0` (see `packageManager` in [`package.json`](./package.json))
+```
+
+`package.json:38`:
+
+```json
+  "packageManager": "pnpm@11.11.0",
+```
+
+### 3. `docs/demo` のワークスペース所属 + catalog
+
+`pnpm-workspace.yaml:1-3`:
+
+```yaml
+packages:
+  - 'docs/'
+  - 'packages/*'
+```
+
+`docs/demo/package.json`(全文):
+
+```json
+{
+  "name": "svelte-vitals-demo",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@sveltejs/kit": "^2.69.2",
+    "svelte": "^5.56.4"
+  }
+}
+```
+
+`pnpm-workspace.yaml` の `catalog:` ブロックには既に同じバージョンが定義済み:
+`@sveltejs/kit: ^2.69.2`、`svelte: ^5.56.4`。`docs/'` という glob は `docs/` 直下に
+`package.json` を持つパッケージ(= docs サイト自身)にはマッチするが、
+`docs/demo`(ネストしたサブディレクトリ)にはマッチしない
+(`pnpm -r list --depth -1` で `docs/demo` が一覧に出ないことを確認済み)。
+
+## Commands you will need
+
+| Purpose                  | Command                                | Expected on success |
+| ------------------------- | ---------------------------------------- | -------------------- |
+| ワークスペース確認        | `pnpm -r list --depth -1`               | `docs/demo` が一覧に出る |
+| lockfile 整合性確認       | `pnpm install`                          | exit 0、lockfile 更新が妥当であること |
+| 全体ビルド/テスト         | `pnpm build && pnpm typecheck && pnpm test` | exit 0 / all pass |
+| lint                       | `pnpm lint`                              | exit 0                |
+
+## Scope
+
+**In scope**:
+
+- `README.md`(reporter 一覧の1行)
+- `CONTRIBUTING.md`(pnpm バージョンの1行)
+- `pnpm-workspace.yaml`(`packages` glob に `docs/demo` を追加)
+- `docs/demo/package.json`(ハードコードされた2つのバージョンを `catalog:` に置換)
+
+**Out of scope**:
+
+- README のその他の記述(reporter 以外の Features 項目は変更不要)。
+- `docs/demo` 配下のソースコード(デモの中身自体は触らない — ワークスペース設定と
+  依存バージョンの参照方法のみ)。
+- `docs/` サイト本体(Astro Starlight)の設定。
+
+## Git workflow
+
+- Branch: `advisor/030-docs-and-workspace-quick-fixes`
+- コミットは論理的に分けてよい(例: `docs: list all seven reporters in the README` /
+  `docs: fix the stale pnpm version in CONTRIBUTING.md` /
+  `chore: bring docs/demo into the pnpm workspace and use the catalog`)。
+- push / PR 作成はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: README.md の reporter 一覧を修正する
+
+`README.md:36` の該当行を、7種すべてを列挙する形に書き換える。既存の
+`agent`/`github` の auto-select についての一文は維持し、`md`/`html` についても
+簡潔な一言(何のためのフォーマットか)を加える。例(文面は既存のトーンに合わせて
+調整してよい):
+
+```md
+- **Multiple reporters** — `console`, `json`, `agent` (a Markdown remediation document an AI agent can act on directly), `sarif`, `github`, `md` (a plain Markdown report), and `html` (a self-contained, shareable report). The `agent` reporter auto-selects inside AI-agent harnesses (e.g. Claude Code); `github` auto-selects under GitHub Actions. → [Reporters](https://oekazuma.github.io/svelte-vitals/guides/reporters/)
+```
+
+**Verify**: `grep -c '`console`, `json`, `agent`' README.md` が1件、かつ `grep -c '`md`' README.md`
+と `grep -c '`html`'` README.md` がともに1件以上であること(目視でも確認)。
+
+### Step 2: CONTRIBUTING.md の pnpm バージョンを修正する
+
+`CONTRIBUTING.md:8` を `package.json` の現在値に合わせる:
+
+```md
+- pnpm `11.11.0` (see `packageManager` in [`package.json`](./package.json))
+```
+
+将来また陳腐化しないよう、固定の数字ではなく `packageManager` を見よという指示を
+より強調した文面(例: 「the exact version pinned in `packageManager` — run
+`corepack use` to match it automatically」)にしてもよいが、必須ではない。数字を
+更新するだけでも Done criteria は満たす。
+
+**Verify**: `grep "pnpm \`11.11.0\`" CONTRIBUTING.md` がヒットすること
+(実際の `package.json` の値と手動で突き合わせる — ハードコードするなら正しい値を)。
+
+### Step 3: `docs/demo` を pnpm workspace に含める
+
+`pnpm-workspace.yaml` の `packages` リストに `docs/demo` を追加する:
+
+```yaml
+packages:
+  - 'docs/'
+  - 'docs/demo'
+  - 'packages/*'
+```
+
+**Verify**: `pnpm -r list --depth -1` の出力に `svelte-vitals-demo` が含まれること。
+
+### Step 4: `docs/demo/package.json` のバージョンを catalog 参照に変更する
+
+```json
+{
+  "name": "svelte-vitals-demo",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@sveltejs/kit": "catalog:",
+    "svelte": "catalog:"
+  }
+}
+```
+
+**Verify**: `pnpm install` を実行し、exit 0 であること。`pnpm-lock.yaml` に
+`docs/demo` の importer エントリが追加され、`@sveltejs/kit`/`svelte` が catalog の
+バージョンで解決されていることを確認する。
+
+### Step 5: 全体検証
+
+**Verify**: `pnpm build && pnpm typecheck && pnpm test && pnpm lint` → 全て exit 0 /
+all pass(`docs/demo` がワークスペースに入ったことで他パッケージのビルド/テストに
+悪影響が出ないことを確認する。`docs/demo` 自体には `build`/`typecheck`/`test`
+スクリプトがないため、`pnpm -r` はこのパッケージをスキップするはずだが、念のため
+警告やエラーが出ないことを確認する)。
+
+## Test plan
+
+このプランは設定/ドキュメントの修正であり、vitest の新規テストは追加しない。
+検証は Step 1〜5 の各コマンドの実行結果がすべてである。
+
+## Done criteria
+
+- [ ] README.md が7種類のreporterを正しく列挙している
+- [ ] CONTRIBUTING.md の pnpm バージョンが `package.json` の `packageManager` と一致
+- [ ] `pnpm -r list --depth -1` に `svelte-vitals-demo` が含まれる
+- [ ] `docs/demo/package.json` が `catalog:` を使っている(ハードコードされた
+      semver 文字列が残っていない)
+- [ ] `pnpm install` が exit 0(lockfile が正しく更新されている)
+- [ ] `pnpm build && pnpm typecheck && pnpm test && pnpm lint` が全て exit 0 / all pass
+- [ ] `plans/README.md` の該当行を更新済み
+
+## STOP conditions
+
+- `docs/demo` をワークスペースに追加したことで `pnpm install` が既存の依存解決を
+  壊す(想定外の peer 依存衝突など)場合、原因を調査して報告する — 無理に
+  `--no-strict-peer-dependencies` 等で握りつぶさない。
+- `docs/demo` に実は既存の何らかの CI/ビルドプロセスが依存している(ワークスペース
+  外であることを前提にした特別な扱いがある)ことが分かった場合、その依存関係を
+  確認してから進める。
+
+## Maintenance notes
+
+- 今後 catalog のバージョンをバンプする Renovate PR は、自動的に `docs/demo` にも
+  反映されるようになる(このプランの主眼)。
+- README の reporter 一覧に新しい reporter が追加された場合、このプランが直した
+  「6種類目・7種類目が抜ける」問題が再発しないよう、reporter を追加するプランでは
+  README も併せて更新することを徹底する。

--- a/plans/031-watcher-to-analysis-e2e-test.md
+++ b/plans/031-watcher-to-analysis-e2e-test.md
@@ -1,0 +1,258 @@
+# Plan 031: watcher → 再解析の結線を end-to-end でテストする
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat 3341587..HEAD -- packages/vite/src/plugin.ts packages/vite/test/ui-plugin.test.ts`
+> 差分があれば下記「Current state」の抜粋と実ファイルを突き合わせ、不一致なら STOP。
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: LOW(テスト追加のみ)
+- **Depends on**: none(Plan 034 と同じファイル `packages/vite/src/ui/analysis.ts`
+  周辺を扱うため、Plan 034 を先に実施する場合はこのプランのテストが Plan 034 の変更
+  後の `notifyChange` シグネチャに合わせて自然と検証できる形になる — ただし本プラン
+  単体でも現状の実装に対して意味のあるテストとして成立するため、実行順序は必須では
+  ない)
+- **Category**: tests
+- **Planned at**: commit `3341587`, 2026-07-13
+
+## Why this matters
+
+Vite プラグインは `configureServer` の中で `server.watcher?.on('all', (_event, file)
+=> { if (isRelevant(file, uiRoot)) runner.notifyChange(file); })` という形で、
+ファイル変更 → ライブダッシュボードの再解析という結線を作っている。この2つの部品
+(`isRelevant`・`runner.notifyChange`)はそれぞれ単体テストがあるが、**それらを繋ぐ
+このコールバック自体**を実際に呼び出して検証しているテストは存在しない。
+
+`packages/vite/test/ui-plugin.test.ts` の既存テスト「configureServer registers a
+watcher listener for source-change re-analysis」は `watcher.on` が `'all'` という
+イベント名で呼ばれたことしか確認しておらず、渡されたコールバック自体を実行していない。
+つまり、コールバックの中身(`isRelevant` の呼び出し引数の順序、`runner` への配線)に
+リグレッションが入っても、このテストは red にならない — ライブ再解析が実質的に
+死んでいても気づける仕組みがない。
+
+## Current state
+
+`packages/vite/src/plugin.ts:118-146`(`configureServer` の該当部分):
+
+```ts
+    configureServer(server: ViteDevServer) {
+      process.env.SVELTE_VITALS_UI = '1';
+      const config = defineConfig({ ... });
+      const store = createStore();
+      const uiRoot = options.cwd ?? server.config.root;
+
+      const runner = createAnalysisRunner({
+        root: uiRoot,
+        treatDynamicAs: options.treatDynamicAs,
+        metaComponents: options.metaComponents,
+        rules: options.rules,
+        failOn: options.failOn,
+        onResults: (results) => store.setStatic(results),
+        onError: (err) => console.warn('[svelte-vitals] dev analysis failed:', err),
+        onStatusChange: (analyzing) => store.setAnalyzing(analyzing)
+      });
+      runner.start();
+      server.watcher?.on('all', (_event, file) => {
+        if (isRelevant(file, uiRoot)) runner.notifyChange(file);
+      });
+      ...
+```
+
+`createAnalysisRunner` は `packages/vite/src/ui/analysis.ts` からの import で、
+`configureServer` の中でクロージャとして生成されるため、**外部から `runner` を
+直接差し替える口(依存性注入の口)が現状ない** — テストで `notifyChange` が呼ばれた
+ことを確認するには工夫が要る。
+
+`packages/vite/test/ui-plugin.test.ts:45-57`(既存の該当テスト、全文):
+
+```ts
+  it('configureServer registers a watcher listener for source-change re-analysis', () => {
+    const plugins = svelteVitals({ ui: true }) as Plugin[];
+    const ui = plugins.find((p) => p.name === 'svelte-vitals:ui')!;
+    const watcherEvents: string[] = [];
+    const server = {
+      config: { root: '/tmp/does-not-exist-svelte-vitals-ui-plugin-test' },
+      watcher: { on: (event: string) => watcherEvents.push(event) },
+      middlewares: { use: () => {} }
+    } as unknown as ViteDevServer;
+    const hook = typeof ui.configureServer === 'function' ? ui.configureServer : ui.configureServer!.handler;
+    (hook as (s: ViteDevServer) => void).call({}, server);
+    expect(watcherEvents).toContain('all');
+  });
+```
+
+このテストのモック `server.watcher.on` はイベント名を配列に push するだけで、渡され
+たコールバック関数自体を保持していない。
+
+- `isRelevant`(`packages/vite/src/plugin.ts:29-36`)は export 済みで、既にそれ単体の
+  テストが `ui-plugin.test.ts` 内の別の describe ブロック(このファイルの他の部分、
+  今回読んでいない範囲にある可能性がある — 実装前に確認すること)にあるかもしれない。
+  存在すれば重複させず、なければこのプランで軽く触れてよい(メインは結線のテスト)。
+- `createAnalysisRunner`(`packages/vite/src/ui/analysis.ts`)は `AnalyzeFn` を
+  `opts.analyze` として注入可能(テスト用に設計済み、`analysis.ts:20-25` の JSDoc
+  参照)。ただし `configureServer` はこの `analyze` オプションを渡していない
+  (`createAnalysisRunner({ root: uiRoot, ..., onResults, onError, onStatusChange })`
+  — `analyze` フィールドなし)。テストで実際の解析を走らせたくない場合、この点を
+  踏まえて何を検証するか設計する(下記 Step 2 参照)。
+
+## Commands you will need
+
+| Purpose   | Command                                       | Expected on success |
+| --------- | ----------------------------------------------- | -------------------- |
+| Tests     | `pnpm --filter @svelte-vitals/vite test`      | all pass              |
+| Typecheck | `pnpm --filter @svelte-vitals/vite typecheck` | exit 0                |
+| Lint      | `pnpm lint`                                     | exit 0                |
+
+## Scope
+
+**In scope**:
+
+- `packages/vite/test/ui-plugin.test.ts`(既存テストの拡張、または新規 `it` ブロック
+  の追加)
+
+**Out of scope**:
+
+- `packages/vite/src/plugin.ts`・`packages/vite/src/ui/analysis.ts` のプロダクション
+  コード変更(このプランはテストのみ。ただし後述 STOP 条件を参照 — テストを書く上で
+  「呼び出しを観測するための最小限のフック」が本当に必要だと判明した場合は例外的に
+  検討してよいが、まずはテスト側の工夫で解決を試みること)。
+
+## Git workflow
+
+- Branch: `advisor/031-watcher-to-analysis-e2e-test`
+- コミット: `test(vite): exercise the watcher callback that triggers dev-dashboard re-analysis`
+  (英語、1コミット)。
+- push / PR 作成はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: watcher コールバックを捕捉する
+
+既存テストのモック `server.watcher.on` を、イベント名だけでなくコールバック関数自体
+も保持するように変更する(または新しい `it` ブロックでこれを行う):
+
+```ts
+  it('the watcher callback triggers re-analysis for a relevant file and skips an irrelevant one', () => {
+    const plugins = svelteVitals({ ui: true }) as Plugin[];
+    const ui = plugins.find((p) => p.name === 'svelte-vitals:ui')!;
+    let watcherCallback: ((event: string, file: string) => void) | undefined;
+    const server = {
+      config: { root: '/tmp/does-not-exist-svelte-vitals-ui-plugin-test' },
+      watcher: {
+        on: (_event: string, cb: (event: string, file: string) => void) => {
+          watcherCallback = cb;
+        }
+      },
+      middlewares: { use: () => {} }
+    } as unknown as ViteDevServer;
+    const hook = typeof ui.configureServer === 'function' ? ui.configureServer : ui.configureServer!.handler;
+    (hook as (s: ViteDevServer) => void).call({}, server);
+    expect(watcherCallback).toBeDefined();
+    // ... 続きは Step 2
+  });
+```
+
+### Step 2: `runner.notifyChange` が呼ばれた/呼ばれないことを観測する
+
+`configureServer` は `runner`(`createAnalysisRunner` の戻り値)をクロージャの中に
+閉じ込めており、外部から差し替えたりスパイを仕込んだりする口がない。これを解決する
+2つのアプローチのうち、**まずアプローチ A を試すこと**:
+
+**アプローチ A(推奨・プロダクションコード変更なし)**: `createAnalysisRunner` を
+`vi.mock('../src/ui/analysis.js', ...)` でモックし、モックした
+`createAnalysisRunner` が返すオブジェクトの `notifyChange` を `vi.fn()` にして、
+それが呼ばれる/呼ばれないことを直接アサートする。`packages/vite/test/plugin-error.test.ts`
+の「`vi.mock` を対象モジュールの import より前に書く」パターンをそのまま踏襲する:
+
+```ts
+const mockNotifyChange = vi.fn();
+vi.mock('../src/ui/analysis.js', () => ({
+  createAnalysisRunner: () => ({
+    start: vi.fn(),
+    notifyChange: mockNotifyChange,
+    stop: vi.fn()
+  })
+}));
+
+import { svelteVitals } from '../src/index.js';
+// ... isRelevant も必要なら '../src/plugin.js' から import
+```
+
+このモックを使い、Step 1 で捕捉した `watcherCallback` を実際に呼び出す:
+
+```ts
+    watcherCallback!('change', '/tmp/does-not-exist-svelte-vitals-ui-plugin-test/src/routes/+page.svelte');
+    expect(mockNotifyChange).toHaveBeenCalledWith(
+      '/tmp/does-not-exist-svelte-vitals-ui-plugin-test/src/routes/+page.svelte'
+    );
+
+    mockNotifyChange.mockClear();
+    watcherCallback!('change', '/tmp/does-not-exist-svelte-vitals-ui-plugin-test/node_modules/foo/index.js');
+    expect(mockNotifyChange).not.toHaveBeenCalled();
+```
+
+(2つ目のケースは `node_modules` 配下なので `isRelevant` が false を返すはずのパス —
+`packages/vite/src/plugin.ts:33` の `IGNORED_SEGMENTS` チェックに一致する。)
+
+この `vi.mock` はファイル冒頭(トップレベル)に置く必要があるため、既存の
+`ui-plugin.test.ts` の他のテスト(`createAnalysisRunner` の実装に依存しない
+テスト、例えば printUrls 関連)に影響しないか確認すること — 影響する場合は
+このテストケースを新しい別ファイル(例: `ui-plugin-watcher.test.ts`)に切り出す
+判断をしてよい(1ファイル内で `vi.mock` はモジュール全体に効くため)。
+
+**アプローチ B(A が技術的に無理だった場合のみ)**: `svelteVitals` に非公開の
+テスト用フックを足す(例: `configureServer` が生成した `runner` を
+`server.__svelteVitalsRunner` のような形でテスト時だけ公開する)。これは
+プロダクションコードの変更を伴うため、まず A を試し、A で書けないことが判明した
+場合にのみ検討し、その判断理由を Maintenance notes に残すこと。
+
+**Verify**: `pnpm --filter @svelte-vitals/vite test` → 新規テストが green、既存の
+`ui-plugin.test.ts` の他のテストも引き続き green。
+
+### Step 3: 全体検証
+
+**Verify**: `pnpm --filter @svelte-vitals/vite typecheck && pnpm lint` → 両方 exit 0。
+
+## Test plan
+
+- 新規: watcher コールバックが `isRelevant` を通して「関連ファイルなら
+  `notifyChange` を呼ぶ・無関係なファイルなら呼ばない」ことを実行時に確認するテスト
+  (`ui-plugin.test.ts` または切り出した新ファイル)。
+- 既存の `ui-plugin.test.ts` の全テストが変更後も green であること。
+- 検証: `pnpm --filter @svelte-vitals/vite test` → all pass。
+
+## Done criteria
+
+- [ ] watcher コールバックを実際に呼び出し、関連ファイル/無関係ファイルそれぞれで
+      `notifyChange` の呼び出し有無を検証するテストが存在する
+- [ ] `pnpm --filter @svelte-vitals/vite test` が all pass
+- [ ] `pnpm --filter @svelte-vitals/vite typecheck` が exit 0
+- [ ] `pnpm lint` が exit 0
+- [ ] プロダクションコード(`plugin.ts`/`analysis.ts`)に変更がない、またはアプローチ
+      B を採った場合はその理由が Maintenance notes に記録されている
+- [ ] `plans/README.md` の該当行を更新済み
+
+## STOP conditions
+
+- アプローチ A(`vi.mock('../src/ui/analysis.js', ...)`)が `svelteVitals` の他の
+  内部利用箇所(`plugin.ts` 以外からも `createAnalysisRunner` が import されている
+  等)と衝突してテストが書けないことが判明した場合、アプローチ B に進む前に一度
+  状況を整理して報告する。
+- 検証コマンドが修正1回を挟んで2回失敗した場合。
+
+## Maintenance notes
+
+- 今後 `configureServer` の watcher 配線を変更する場合(例: イベント名を `'all'`
+  以外にする、`isRelevant` の判定基準を変える)は、このテストが最初に red になる
+  はず — レビュアーはその変化が意図したものかを確認すること。
+- Plan 034(dev dashboard の部分再解析)を実施する場合、`notifyChange` のシグネチャ
+  や挙動が変わる可能性があるため、このプランのテストがその変更後も意味を保つか
+  (`notifyChange` が呼ばれること自体の検証は変わらず有効なはず)を確認すること。

--- a/plans/031-watcher-to-analysis-e2e-test.md
+++ b/plans/031-watcher-to-analysis-e2e-test.md
@@ -74,19 +74,19 @@ watcher listener for source-change re-analysis」は `watcher.on` が `'all'` �
 `packages/vite/test/ui-plugin.test.ts:45-57`(既存の該当テスト、全文):
 
 ```ts
-  it('configureServer registers a watcher listener for source-change re-analysis', () => {
-    const plugins = svelteVitals({ ui: true }) as Plugin[];
-    const ui = plugins.find((p) => p.name === 'svelte-vitals:ui')!;
-    const watcherEvents: string[] = [];
-    const server = {
-      config: { root: '/tmp/does-not-exist-svelte-vitals-ui-plugin-test' },
-      watcher: { on: (event: string) => watcherEvents.push(event) },
-      middlewares: { use: () => {} }
-    } as unknown as ViteDevServer;
-    const hook = typeof ui.configureServer === 'function' ? ui.configureServer : ui.configureServer!.handler;
-    (hook as (s: ViteDevServer) => void).call({}, server);
-    expect(watcherEvents).toContain('all');
-  });
+it('configureServer registers a watcher listener for source-change re-analysis', () => {
+  const plugins = svelteVitals({ ui: true }) as Plugin[];
+  const ui = plugins.find((p) => p.name === 'svelte-vitals:ui')!;
+  const watcherEvents: string[] = [];
+  const server = {
+    config: { root: '/tmp/does-not-exist-svelte-vitals-ui-plugin-test' },
+    watcher: { on: (event: string) => watcherEvents.push(event) },
+    middlewares: { use: () => {} }
+  } as unknown as ViteDevServer;
+  const hook = typeof ui.configureServer === 'function' ? ui.configureServer : ui.configureServer!.handler;
+  (hook as (s: ViteDevServer) => void).call({}, server);
+  expect(watcherEvents).toContain('all');
+});
 ```
 
 このテストのモック `server.watcher.on` はイベント名を配列に push するだけで、渡され
@@ -106,10 +106,10 @@ watcher listener for source-change re-analysis」は `watcher.on` が `'all'` �
 ## Commands you will need
 
 | Purpose   | Command                                       | Expected on success |
-| --------- | ----------------------------------------------- | -------------------- |
-| Tests     | `pnpm --filter @svelte-vitals/vite test`      | all pass              |
-| Typecheck | `pnpm --filter @svelte-vitals/vite typecheck` | exit 0                |
-| Lint      | `pnpm lint`                                     | exit 0                |
+| --------- | --------------------------------------------- | ------------------- |
+| Tests     | `pnpm --filter @svelte-vitals/vite test`      | all pass            |
+| Typecheck | `pnpm --filter @svelte-vitals/vite typecheck` | exit 0              |
+| Lint      | `pnpm lint`                                   | exit 0              |
 
 ## Scope
 
@@ -140,24 +140,24 @@ watcher listener for source-change re-analysis」は `watcher.on` が `'all'` �
 も保持するように変更する(または新しい `it` ブロックでこれを行う):
 
 ```ts
-  it('the watcher callback triggers re-analysis for a relevant file and skips an irrelevant one', () => {
-    const plugins = svelteVitals({ ui: true }) as Plugin[];
-    const ui = plugins.find((p) => p.name === 'svelte-vitals:ui')!;
-    let watcherCallback: ((event: string, file: string) => void) | undefined;
-    const server = {
-      config: { root: '/tmp/does-not-exist-svelte-vitals-ui-plugin-test' },
-      watcher: {
-        on: (_event: string, cb: (event: string, file: string) => void) => {
-          watcherCallback = cb;
-        }
-      },
-      middlewares: { use: () => {} }
-    } as unknown as ViteDevServer;
-    const hook = typeof ui.configureServer === 'function' ? ui.configureServer : ui.configureServer!.handler;
-    (hook as (s: ViteDevServer) => void).call({}, server);
-    expect(watcherCallback).toBeDefined();
-    // ... 続きは Step 2
-  });
+it('the watcher callback triggers re-analysis for a relevant file and skips an irrelevant one', () => {
+  const plugins = svelteVitals({ ui: true }) as Plugin[];
+  const ui = plugins.find((p) => p.name === 'svelte-vitals:ui')!;
+  let watcherCallback: ((event: string, file: string) => void) | undefined;
+  const server = {
+    config: { root: '/tmp/does-not-exist-svelte-vitals-ui-plugin-test' },
+    watcher: {
+      on: (_event: string, cb: (event: string, file: string) => void) => {
+        watcherCallback = cb;
+      }
+    },
+    middlewares: { use: () => {} }
+  } as unknown as ViteDevServer;
+  const hook = typeof ui.configureServer === 'function' ? ui.configureServer : ui.configureServer!.handler;
+  (hook as (s: ViteDevServer) => void).call({}, server);
+  expect(watcherCallback).toBeDefined();
+  // ... 続きは Step 2
+});
 ```
 
 ### Step 2: `runner.notifyChange` が呼ばれた/呼ばれないことを観測する
@@ -189,14 +189,14 @@ import { svelteVitals } from '../src/index.js';
 このモックを使い、Step 1 で捕捉した `watcherCallback` を実際に呼び出す:
 
 ```ts
-    watcherCallback!('change', '/tmp/does-not-exist-svelte-vitals-ui-plugin-test/src/routes/+page.svelte');
-    expect(mockNotifyChange).toHaveBeenCalledWith(
-      '/tmp/does-not-exist-svelte-vitals-ui-plugin-test/src/routes/+page.svelte'
-    );
+watcherCallback!('change', '/tmp/does-not-exist-svelte-vitals-ui-plugin-test/src/routes/+page.svelte');
+expect(mockNotifyChange).toHaveBeenCalledWith(
+  '/tmp/does-not-exist-svelte-vitals-ui-plugin-test/src/routes/+page.svelte'
+);
 
-    mockNotifyChange.mockClear();
-    watcherCallback!('change', '/tmp/does-not-exist-svelte-vitals-ui-plugin-test/node_modules/foo/index.js');
-    expect(mockNotifyChange).not.toHaveBeenCalled();
+mockNotifyChange.mockClear();
+watcherCallback!('change', '/tmp/does-not-exist-svelte-vitals-ui-plugin-test/node_modules/foo/index.js');
+expect(mockNotifyChange).not.toHaveBeenCalled();
 ```
 
 (2つ目のケースは `node_modules` 配下なので `isRelevant` が false を返すはずのパス —

--- a/plans/032-ci-upgrade-yaml-anchor-support.md
+++ b/plans/032-ci-upgrade-yaml-anchor-support.md
@@ -56,7 +56,7 @@ const ACTION_USES_LINE =
 このパターンでは以下の行にマッチしない:
 
 ```yaml
-      - uses: &vitals_action oekazuma/svelte-vitals/packages/action@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # @svelte-vitals/action@1.0.0
+- uses: &vitals_action oekazuma/svelte-vitals/packages/action@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # @svelte-vitals/action@1.0.0
 ```
 
 `upgradeActionPin` の全文は既に把握済み(24-57行目)—
@@ -67,19 +67,19 @@ comment` で再構築する。`indent` グループが `uses:` からパッケ�
 `packages/cli/src/ci/cli.ts:108-111`(このバグが表面化する箇所):
 
 ```ts
-  if (outcome.status === 'no-reference') {
-    io.errorLog(`svelte-vitals: no @svelte-vitals/action reference found in ${WORKFLOW_PATH}.`);
-    return 2;
-  }
+if (outcome.status === 'no-reference') {
+  io.errorLog(`svelte-vitals: no @svelte-vitals/action reference found in ${WORKFLOW_PATH}.`);
+  return 2;
+}
 ```
 
 ## Commands you will need
 
-| Purpose   | Command                                              | Expected on success |
-| --------- | ------------------------------------------------------ | -------------------- |
-| Tests     | `pnpm --filter svelte-vitals test`                    | all pass              |
-| Typecheck | `pnpm --filter svelte-vitals typecheck`               | exit 0                |
-| Lint      | `pnpm lint`                                             | exit 0                |
+| Purpose   | Command                                 | Expected on success |
+| --------- | --------------------------------------- | ------------------- |
+| Tests     | `pnpm --filter svelte-vitals test`      | all pass            |
+| Typecheck | `pnpm --filter svelte-vitals typecheck` | exit 0              |
+| Lint      | `pnpm lint`                             | exit 0              |
 
 ## Scope
 
@@ -137,47 +137,47 @@ const ACTION_USES_LINE =
 末尾、`describe('upgradeActionPin', ...)` ブロック内):
 
 ```ts
-  it('rewrites an anchor-defined uses: line, preserving the anchor name', () => {
-    const content = [
-      'jobs:',
-      '  a:',
-      '    steps:',
-      `      - uses: &vitals_action oekazuma/svelte-vitals/packages/action@${OLD_SHA} # @svelte-vitals/action@1.0.0`,
-      '  b:',
-      '    steps:',
-      '      - uses: *vitals_action'
-    ].join('\n');
+it('rewrites an anchor-defined uses: line, preserving the anchor name', () => {
+  const content = [
+    'jobs:',
+    '  a:',
+    '    steps:',
+    `      - uses: &vitals_action oekazuma/svelte-vitals/packages/action@${OLD_SHA} # @svelte-vitals/action@1.0.0`,
+    '  b:',
+    '    steps:',
+    '      - uses: *vitals_action'
+  ].join('\n');
 
-    const outcome = upgradeActionPin(content, NEW_SHA, '2.0.0');
+  const outcome = upgradeActionPin(content, NEW_SHA, '2.0.0');
 
-    expect(outcome.status).toBe('upgraded');
-    expect(outcome.replaced).toBe(1);
-    expect(outcome.from).toBe('1.0.0');
-    expect(outcome.content).toContain(
-      `      - uses: &vitals_action oekazuma/svelte-vitals/packages/action@${NEW_SHA} # @svelte-vitals/action@2.0.0`
-    );
-    // The alias line itself has no literal ref to rewrite — a YAML parser resolves it
-    // to the anchor's (now-updated) value at parse time, so it's correctly left as-is.
-    expect(outcome.content).toContain('      - uses: *vitals_action');
-  });
+  expect(outcome.status).toBe('upgraded');
+  expect(outcome.replaced).toBe(1);
+  expect(outcome.from).toBe('1.0.0');
+  expect(outcome.content).toContain(
+    `      - uses: &vitals_action oekazuma/svelte-vitals/packages/action@${NEW_SHA} # @svelte-vitals/action@2.0.0`
+  );
+  // The alias line itself has no literal ref to rewrite — a YAML parser resolves it
+  // to the anchor's (now-updated) value at parse time, so it's correctly left as-is.
+  expect(outcome.content).toContain('      - uses: *vitals_action');
+});
 
-  it('rewrites an anchor-defined uses: line with no trailing comment', () => {
-    const content = `      - uses: &vitals_action oekazuma/svelte-vitals/packages/action@${OLD_SHA}`;
-    const outcome = upgradeActionPin(content, NEW_SHA, '2.0.0');
+it('rewrites an anchor-defined uses: line with no trailing comment', () => {
+  const content = `      - uses: &vitals_action oekazuma/svelte-vitals/packages/action@${OLD_SHA}`;
+  const outcome = upgradeActionPin(content, NEW_SHA, '2.0.0');
 
-    expect(outcome.status).toBe('upgraded');
-    expect(outcome.from).toBe(OLD_SHA.slice(0, 7));
-    expect(outcome.content).toBe(
-      `      - uses: &vitals_action oekazuma/svelte-vitals/packages/action@${NEW_SHA} # @svelte-vitals/action@2.0.0`
-    );
-  });
+  expect(outcome.status).toBe('upgraded');
+  expect(outcome.from).toBe(OLD_SHA.slice(0, 7));
+  expect(outcome.content).toBe(
+    `      - uses: &vitals_action oekazuma/svelte-vitals/packages/action@${NEW_SHA} # @svelte-vitals/action@2.0.0`
+  );
+});
 
-  it('reports up-to-date for an anchor-defined line already pinned to the current sha', () => {
-    const content = `      - uses: &vitals_action oekazuma/svelte-vitals/packages/action@${NEW_SHA} # @svelte-vitals/action@2.0.0`;
-    const outcome = upgradeActionPin(content, NEW_SHA, '2.0.0');
+it('reports up-to-date for an anchor-defined line already pinned to the current sha', () => {
+  const content = `      - uses: &vitals_action oekazuma/svelte-vitals/packages/action@${NEW_SHA} # @svelte-vitals/action@2.0.0`;
+  const outcome = upgradeActionPin(content, NEW_SHA, '2.0.0');
 
-    expect(outcome).toEqual({ status: 'up-to-date' });
-  });
+  expect(outcome).toEqual({ status: 'up-to-date' });
+});
 ```
 
 **Verify**: `pnpm --filter svelte-vitals test` → all pass、既存の全ケース(CRLF・

--- a/plans/032-ci-upgrade-yaml-anchor-support.md
+++ b/plans/032-ci-upgrade-yaml-anchor-support.md
@@ -1,0 +1,224 @@
+# Plan 032: `ci upgrade` が YAML アンカー付き `uses:` 行を扱えるようにする
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat 3341587..HEAD -- packages/cli/src/ci/upgrade.ts packages/cli/test/ci/upgrade.test.ts`
+> 差分があれば下記「Current state」の抜粋と実ファイルを突き合わせ、不一致なら STOP。
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: LOW(正規表現1箇所の拡張 + テスト追加。既存のマッチ対象は変わらず、
+  マッチ範囲が広がるだけ)
+- **Depends on**: none
+- **Category**: bug / tests
+- **Planned at**: commit `3341587`, 2026-07-13
+
+## Why this matters
+
+`svelte-vitals ci upgrade` は生成済みワークフローの `uses: oekazuma/svelte-vitals/packages/action@<ref>`
+行だけを外科的に書き換える。現在の正規表現 `ACTION_USES_LINE` は `uses:\s*` の直後に
+リテラルのパッケージパスが**そのまま**続くことを前提にしており、YAML のアンカー構文
+(`uses: &vitals_action oekazuma/svelte-vitals/packages/action@<ref>`)を使って複数
+ジョブで同じピンを共有しているワークフローでは、この行にマッチしない。
+
+実際に確認した挙動: このアンカー付き行が唯一の `@svelte-vitals/action` 参照だった
+場合、`replaced === 0` になったあと `hasAnyReference` の判定も同じ正規表現を使うため
+false になり、`upgradeActionPin` は `{ status: 'no-reference' }` を返す —
+`packages/cli/src/ci/cli.ts:108-111` はこれを「ワークフローに参照が存在しない」という
+エラーメッセージ(`svelte-vitals: no @svelte-vitals/action reference found in
+...`、exit 2)として扱う。ユーザーは実際にはアンカーで正しく参照しているにも関わらず、
+`ci upgrade` が使えないという誤った診断を受け取る。
+
+修正方針: YAML のアンカー(`&name`)はキーの値ノード全体に付けられるものであり、
+同じアンカーを参照する `*name` エイリアス行は、実行時に YAML パーサーがアンカー側の
+値をそのまま展開する。つまり **アンカー定義行の値だけを書き換えれば、それを参照する
+すべての `*name` エイリアス行も自動的に新しい値になる**(このツールはテキスト単位の
+書き換えであり、エイリアス行自体のテキストを書き換える必要はない)。したがって、
+このプランの修正は「アンカー定義行にもマッチするよう正規表現を拡張する」だけで、
+アンカーを使ったワークフロー全体が正しく更新される。
+
+## Current state
+
+`packages/cli/src/ci/upgrade.ts:16-17`(現在の正規表現、全文中の該当部分):
+
+```ts
+const ACTION_USES_LINE =
+  /^(?<indent>\s*-\s*uses:\s*oekazuma\/svelte-vitals\/packages\/action@)(?<ref>[^\s#]+)(?<comment>\s*#.*)?$/;
+```
+
+このパターンでは以下の行にマッチしない:
+
+```yaml
+      - uses: &vitals_action oekazuma/svelte-vitals/packages/action@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # @svelte-vitals/action@1.0.0
+```
+
+`upgradeActionPin` の全文は既に把握済み(24-57行目)—
+`lines.map(...)` で各行に対して正規表現をテストし、マッチした行だけ `indent + sha +
+comment` で再構築する。`indent` グループが `uses:` からパッケージパス直前までを丸ごと
+キャプチャしているため、このグループの定義を広げるだけで再構築ロジック自体は変更不要。
+
+`packages/cli/src/ci/cli.ts:108-111`(このバグが表面化する箇所):
+
+```ts
+  if (outcome.status === 'no-reference') {
+    io.errorLog(`svelte-vitals: no @svelte-vitals/action reference found in ${WORKFLOW_PATH}.`);
+    return 2;
+  }
+```
+
+## Commands you will need
+
+| Purpose   | Command                                              | Expected on success |
+| --------- | ------------------------------------------------------ | -------------------- |
+| Tests     | `pnpm --filter svelte-vitals test`                    | all pass              |
+| Typecheck | `pnpm --filter svelte-vitals typecheck`               | exit 0                |
+| Lint      | `pnpm lint`                                             | exit 0                |
+
+## Scope
+
+**In scope**:
+
+- `packages/cli/src/ci/upgrade.ts`(`ACTION_USES_LINE` 正規表現の拡張のみ)
+- `packages/cli/test/ci/upgrade.test.ts`(新規テストケース追加)
+
+**Out of scope**:
+
+- `*alias` のみでアンカー定義自体が別ファイル/別箇所になく解決できないような壊れた
+  YAML の扱い(そもそも invalid な YAML であり、このツールの責務外)。
+- `packages/cli/src/ci/workflow.ts`(生成されるワークフローのテンプレート自体は
+  アンカーを使わない — このプランは「ユーザーが手で YAML アンカーに書き換えた
+  ワークフロー」を後から `ci upgrade` するケースへの対応)。
+- `ACTION_USES_LINE` 以外の正規表現・ロジック。
+
+## Git workflow
+
+- Branch: `advisor/032-ci-upgrade-yaml-anchor-support`
+- コミット: `fix(cli): let ci upgrade rewrite YAML-anchored uses: lines`(英語、
+  1コミットでよい)。
+- push / PR 作成はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: 正規表現を拡張する
+
+`packages/cli/src/ci/upgrade.ts` の `ACTION_USES_LINE` を、`uses:\s*` とリテラル
+パッケージパスの間に任意の `&anchor-name\s+` を許容するよう変更する:
+
+```ts
+// Matches lines like (indentation, an optional YAML anchor `&name`, and the trailing
+// version comment, are all optional so a user's hand-edited workflow still matches):
+//   - uses: oekazuma/svelte-vitals/packages/action@<ref>
+//   - uses: oekazuma/svelte-vitals/packages/action@<ref> # @svelte-vitals/action@1.2.3
+//   - uses: &vitals_action oekazuma/svelte-vitals/packages/action@<ref> # @svelte-vitals/action@1.2.3
+// An anchor definition's value is shared by every `*name` alias line elsewhere in the
+// file (YAML semantics) — rewriting only the anchor line's ref is sufficient; alias
+// lines need no separate rewrite.
+const ACTION_USES_LINE =
+  /^(?<indent>\s*-\s*uses:\s*(?:&\S+\s+)?oekazuma\/svelte-vitals\/packages\/action@)(?<ref>[^\s#]+)(?<comment>\s*#.*)?$/;
+```
+
+`indent` グループが `&anchor-name ` を含めて丸ごとキャプチャするため、
+`upgradeActionPin` 内の再構築ロジック(`${indent}${sha} # @svelte-vitals/action@${version}${eol}`)
+は変更不要 — アンカー名がそのまま保持される。
+
+**Verify**: `pnpm --filter svelte-vitals typecheck` → exit 0(正規表現の変更のみで
+型に影響はないはずだが、念のため確認)。
+
+### Step 2: テストを追加する
+
+`packages/cli/test/ci/upgrade.test.ts` に以下のケースを追加する(既存のテストの
+末尾、`describe('upgradeActionPin', ...)` ブロック内):
+
+```ts
+  it('rewrites an anchor-defined uses: line, preserving the anchor name', () => {
+    const content = [
+      'jobs:',
+      '  a:',
+      '    steps:',
+      `      - uses: &vitals_action oekazuma/svelte-vitals/packages/action@${OLD_SHA} # @svelte-vitals/action@1.0.0`,
+      '  b:',
+      '    steps:',
+      '      - uses: *vitals_action'
+    ].join('\n');
+
+    const outcome = upgradeActionPin(content, NEW_SHA, '2.0.0');
+
+    expect(outcome.status).toBe('upgraded');
+    expect(outcome.replaced).toBe(1);
+    expect(outcome.from).toBe('1.0.0');
+    expect(outcome.content).toContain(
+      `      - uses: &vitals_action oekazuma/svelte-vitals/packages/action@${NEW_SHA} # @svelte-vitals/action@2.0.0`
+    );
+    // The alias line itself has no literal ref to rewrite — a YAML parser resolves it
+    // to the anchor's (now-updated) value at parse time, so it's correctly left as-is.
+    expect(outcome.content).toContain('      - uses: *vitals_action');
+  });
+
+  it('rewrites an anchor-defined uses: line with no trailing comment', () => {
+    const content = `      - uses: &vitals_action oekazuma/svelte-vitals/packages/action@${OLD_SHA}`;
+    const outcome = upgradeActionPin(content, NEW_SHA, '2.0.0');
+
+    expect(outcome.status).toBe('upgraded');
+    expect(outcome.from).toBe(OLD_SHA.slice(0, 7));
+    expect(outcome.content).toBe(
+      `      - uses: &vitals_action oekazuma/svelte-vitals/packages/action@${NEW_SHA} # @svelte-vitals/action@2.0.0`
+    );
+  });
+
+  it('reports up-to-date for an anchor-defined line already pinned to the current sha', () => {
+    const content = `      - uses: &vitals_action oekazuma/svelte-vitals/packages/action@${NEW_SHA} # @svelte-vitals/action@2.0.0`;
+    const outcome = upgradeActionPin(content, NEW_SHA, '2.0.0');
+
+    expect(outcome).toEqual({ status: 'up-to-date' });
+  });
+```
+
+**Verify**: `pnpm --filter svelte-vitals test` → all pass、既存の全ケース(CRLF・
+matrix・actions/checkout 非干渉など)も引き続き green であること。
+
+### Step 3: 全体検証
+
+**Verify**: `pnpm --filter svelte-vitals typecheck && pnpm --filter svelte-vitals test && pnpm lint`
+→ 全て exit 0 / all pass。
+
+## Test plan
+
+- 新規: アンカー定義行の書き換え(コメントあり/なし)、`*alias` 行が触れられず
+  残ること、既に最新 SHA にピンされたアンカー行での `up-to-date` 判定 —
+  上記3ケース。
+- 既存: `upgrade.test.ts` の全12ケース(CRLF・matrix・actions/checkout 非干渉含む)
+  が変更後も green であること。
+- 検証: `pnpm --filter svelte-vitals test` → all pass。
+
+## Done criteria
+
+- [ ] `ACTION_USES_LINE` がアンカー付き `uses:` 行にマッチする
+- [ ] 新規3テストケースが green
+- [ ] 既存の `upgrade.test.ts` 全ケースが変更後も green
+- [ ] `pnpm --filter svelte-vitals typecheck` が exit 0
+- [ ] `pnpm lint` が exit 0
+- [ ] `plans/README.md` の該当行を更新済み
+
+## STOP conditions
+
+- 正規表現の変更によって既存テスト(特に `actions/checkout` の行を誤ってマッチしない
+  ことを確認するテスト)が壊れた場合、`(?:&\S+\s+)?` の非捕捉グループの範囲を見直し、
+  それでも解決しなければ STOP。
+- テスト追加後、検証コマンドが修正1回を挟んで2回失敗した場合。
+
+## Maintenance notes
+
+- 今後 `ACTION_USES_LINE` をさらに拡張する場合(例: 複数行にまたがる YAML flow
+  styleなど)は、まず実際にそのような手書きワークフローが issue や PR で報告されて
+  から対応する — 今回のアンカー対応は「YAML の一般的な機能」という広く使われる
+  パターンへの対応であり、それ以上の speculative な拡張はスコープ外。
+- `packages/cli/src/ci/workflow.ts`(生成テンプレート側)は引き続きアンカーを使わない
+  シンプルな形を維持してよい — アンカーはユーザーが自分のワークフローを手で最適化
+  した結果として現れるものであり、生成側で導入する必要はない。

--- a/plans/033-mcp-applyscope-wiring.md
+++ b/plans/033-mcp-applyscope-wiring.md
@@ -86,15 +86,15 @@ diff/baseline/suppressions に相当するフィールドがない。
 **参考実装 — `packages/action/src/index.ts:14-22`**(このプランが模倣する配線):
 
 ```ts
-  const analysis = await analyzeProject({ cwd: path });
-  const { config, version } = analysis;
-  const results = await applyScope(analysis.results, {
-    cwd: path,
-    config,
-    diffBase: diff,
-    baseline,
-    errorLog: (line) => core.warning(line)
-  });
+const analysis = await analyzeProject({ cwd: path });
+const { config, version } = analysis;
+const results = await applyScope(analysis.results, {
+  cwd: path,
+  config,
+  diffBase: diff,
+  baseline,
+  errorLog: (line) => core.warning(line)
+});
 ```
 
 **`applyScope` のシグネチャ** — `packages/cli/src/index.ts:209-288`
@@ -112,7 +112,7 @@ export interface ApplyScopeOptions {
   analyzeOpts?: AnalyzeOptions;
 }
 
-export async function applyScope(results: Result[], opts: ApplyScopeOptions): Promise<Result[]>
+export async function applyScope(results: Result[], opts: ApplyScopeOptions): Promise<Result[]>;
 ```
 
 `config` を渡さない呼び出しは suppressions の適用を完全にスキップする
@@ -127,12 +127,12 @@ when omitted, keeping such callers' behavior unchanged")。
 
 ## Commands you will need
 
-| Purpose   | Command                                    | Expected on success |
-| --------- | --------------------------------------------- | -------------------- |
-| Tests     | `pnpm --filter @svelte-vitals/mcp test`      | all pass              |
-| Typecheck | `pnpm --filter @svelte-vitals/mcp typecheck` | exit 0                |
-| Build     | `pnpm --filter @svelte-vitals/mcp build`     | exit 0                |
-| Lint      | `pnpm lint`                                    | exit 0                |
+| Purpose   | Command                                      | Expected on success |
+| --------- | -------------------------------------------- | ------------------- |
+| Tests     | `pnpm --filter @svelte-vitals/mcp test`      | all pass            |
+| Typecheck | `pnpm --filter @svelte-vitals/mcp typecheck` | exit 0              |
+| Build     | `pnpm --filter @svelte-vitals/mcp build`     | exit 0              |
+| Lint      | `pnpm lint`                                  | exit 0              |
 
 ## Scope
 
@@ -202,7 +202,14 @@ optional なので型エラーにはならない)。
 渡す:
 
 ```ts
-import { analyzeProject, applyScope, buildRulesConfig, findUnknownRuleIds, knownRuleIds, ProjectError } from 'svelte-vitals';
+import {
+  analyzeProject,
+  applyScope,
+  buildRulesConfig,
+  findUnknownRuleIds,
+  knownRuleIds,
+  ProjectError
+} from 'svelte-vitals';
 ```
 
 `handleAnalyze` の try ブロック内(既存の `analyzeProject` 呼び出しの直後)を以下の
@@ -238,6 +245,7 @@ import { analyzeProject, applyScope, buildRulesConfig, findUnknownRuleIds, known
 ```
 
 注意点:
+
 - `applyScope` は `cwd: string`(必須)を要求する。`analyzeProject` には
   `cwd: args.path`(`string | undefined`)を渡しているが、`analyzeProject` 内部で
   `opts.cwd ?? process.cwd()` としてデフォルト値を補っている(`packages/cli/src/index.ts:173`)
@@ -251,7 +259,7 @@ import { analyzeProject, applyScope, buildRulesConfig, findUnknownRuleIds, known
   こと(stdio トランスポートは stdout を JSON-RPC メッセージ専用に使うため、
   `console.error`(stderr)は安全なはずだが、既存コードで `errorLog` を渡す/渡さない
   の判断基準があるか `packages/action/src/index.ts` の `errorLog: (line) =>
-  core.warning(line)` のような明示的な指定パターンと比較して判断する)。
+core.warning(line)` のような明示的な指定パターンと比較して判断する)。
   デフォルトで問題なければ `errorLog` は省略してよい。
 
 **Verify**: `pnpm --filter @svelte-vitals/mcp typecheck && pnpm --filter @svelte-vitals/mcp build`

--- a/plans/033-mcp-applyscope-wiring.md
+++ b/plans/033-mcp-applyscope-wiring.md
@@ -1,0 +1,338 @@
+# Plan 033: MCP `analyze` tool に `applyScope`(diff/baseline/suppressions)を配線する
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat 3341587..HEAD -- packages/mcp/src/tools/analyze.ts packages/action/src/index.ts packages/cli/src/index.ts`
+> 差分があれば下記「Current state」の抜粋と実ファイルを突き合わせ、不一致なら STOP。
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: LOW(既存の公開関数 `applyScope` を追加で呼び出すだけの加法的変更。
+  新しい引数はすべて optional)
+- **Depends on**: none
+- **Category**: direction / dx
+- **Planned at**: commit `3341587`, 2026-07-13
+
+## Why this matters
+
+`applyScope`(`packages/cli/src/index.ts` からエクスポート、`svelte-vitals` パッケージ
+の公開 API)は、`--diff`/`--staged`/`--baseline` によるスコープ絞り込みと
+`svelte-vitals-suppressions.json` の適用という「PR ゲートが本当に気にする所見だけに
+絞る」ロジックを一箇所に集約したもので、CLI の `run()` と `@svelte-vitals/action` の
+両方が既に使っている(`packages/action/src/index.ts` の docblock 自身が
+"Shared by `run()` and `@svelte-vitals/action` (issue #154)" と明記)。
+
+ところが `packages/mcp/src/tools/analyze.ts` はこれを一切呼んでいない
+(`grep -rn "applyScope\|loadSuppressions" packages/mcp/src` は0件)—
+`analyzeProject` の結果をそのまま JSON レポートとして返すだけ。
+
+これは実用上の非対称を生む: `svelte-vitals-suppressions.json` を導入して
+「レガシーな所見を受け入れ、新規のものだけをゲートする」運用を始めたプロジェクトで
+も、CLI や Action 経由では所見一覧がクリーンに見える一方、**MCP の `analyze` ツール
+を使う AI エージェントだけは**、既に受け入れ済みの所見が全部再浮上した状態を見る。
+MCP はこのプロジェクトの「AI エージェント統合」という中核方針そのものであり、
+まさにこの経路でノイズの多い所見を agent に見せてしまうのは避けたい。
+
+## Current state
+
+`packages/mcp/src/tools/analyze.ts`(全文、69-105行目の `handleAnalyze`):
+
+```ts
+export async function handleAnalyze(args: AnalyzeArgs): Promise<McpToolResult> {
+  const allow = (args.rules ?? []).map((id) => id.toUpperCase());
+  const ignore = (args.ignore ?? []).map((id) => id.toUpperCase());
+  const unknown = findUnknownRuleIds([...allow, ...ignore]);
+  if (unknown.length > 0) {
+    return textError(`Unknown rule id(s): ${unknown.join(', ')}. Known rule ids: ${knownRuleIds().join(', ')}.`);
+  }
+
+  const rulesConfig = buildRulesConfig(allow, ignore);
+  const rules = Object.keys(rulesConfig).length > 0 ? rulesConfig : undefined;
+
+  try {
+    const { results, config, version } = await analyzeProject({
+      cwd: args.path,
+      metaComponents: args.metaComponents,
+      treatDynamicAs: args.treatDynamicAs,
+      route: args.route,
+      failOn: args.failOn,
+      rules,
+      weights: args.weights,
+      categories: args.categories
+    });
+    const report = buildJsonReport(results, config, { version });
+    return {
+      content: [{ type: 'text', text: JSON.stringify(report, null, 2) }],
+      structuredContent: report
+    };
+  } catch (err) {
+    if (err instanceof ProjectError) return textError(err.message);
+    return textError(`svelte-vitals: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+```
+
+`analyzeInputSchema`(1-58行目)は `path`/`metaComponents`/`route`/
+`treatDynamicAs`/`rules`/`ignore`/`categories`/`failOn`/`weights` を持つが、
+diff/baseline/suppressions に相当するフィールドがない。
+
+**参考実装 — `packages/action/src/index.ts:14-22`**(このプランが模倣する配線):
+
+```ts
+  const analysis = await analyzeProject({ cwd: path });
+  const { config, version } = analysis;
+  const results = await applyScope(analysis.results, {
+    cwd: path,
+    config,
+    diffBase: diff,
+    baseline,
+    errorLog: (line) => core.warning(line)
+  });
+```
+
+**`applyScope` のシグネチャ** — `packages/cli/src/index.ts:209-288`
+(`ApplyScopeOptions` 型と実装、既に全文読了済み):
+
+```ts
+export interface ApplyScopeOptions {
+  cwd: string;
+  staged?: boolean;
+  diffBase?: string;
+  baseline?: string;
+  config?: Config;
+  noSuppressions?: boolean;
+  errorLog?: (line: string) => void;
+  analyzeOpts?: AnalyzeOptions;
+}
+
+export async function applyScope(results: Result[], opts: ApplyScopeOptions): Promise<Result[]>
+```
+
+`config` を渡さない呼び出しは suppressions の適用を完全にスキップする
+(`ApplyScopeOptions.config` の JSDoc: "Suppression application is skipped entirely
+when omitted, keeping such callers' behavior unchanged")。
+
+**CLI 側のフラグ名の対応** — `packages/cli/src/resolve-args.ts:159-171,221-226`
+(このプランの MCP スキーマのフィールド名は CLI のフラグ名に極力揃える):
+`--diff [ref]`(省略時 `'HEAD'`)、`--staged`、`--baseline <ref>`(省略不可)、
+`--no-suppressions`(mri の auto-negation で `argv.suppressions === false` として
+現れる)。
+
+## Commands you will need
+
+| Purpose   | Command                                    | Expected on success |
+| --------- | --------------------------------------------- | -------------------- |
+| Tests     | `pnpm --filter @svelte-vitals/mcp test`      | all pass              |
+| Typecheck | `pnpm --filter @svelte-vitals/mcp typecheck` | exit 0                |
+| Build     | `pnpm --filter @svelte-vitals/mcp build`     | exit 0                |
+| Lint      | `pnpm lint`                                    | exit 0                |
+
+## Scope
+
+**In scope**:
+
+- `packages/mcp/src/tools/analyze.ts`(`analyzeInputSchema` に diff/baseline/
+  noSuppressions フィールドを追加し、`handleAnalyze` から `applyScope` を呼ぶ)
+- `packages/mcp/test/analyze-tool.test.ts`(新規テストケース)
+- `docs/src/content/docs/guides/mcp.md` + `ja/guides/mcp.md`(`analyze` ツールの
+  引数一覧に新フィールドを追記 — 既存のドキュメントが引数を列挙している場合)
+
+**Out of scope**:
+
+- `--staged` 相当の入力(MCP はエージェントのツール呼び出しであり、git のステージン
+  グ領域という概念は agent 呼び出し元のコンテキストと相性が悪い可能性がある —
+  `diff`/`baseline`/`noSuppressions` の3つに絞る。将来 `staged` の需要が出れば別
+  プランで追加)。
+- `applyScope` 自体のロジック変更。
+- `packages/mcp/src/tools/explain-rule.ts`(無関係)。
+
+## Git workflow
+
+- Branch: `advisor/033-mcp-applyscope-wiring`
+- コミット: `feat(mcp): apply diff/baseline scoping and suppressions in the analyze tool`
+  (英語、1コミットでよい)。
+- push / PR 作成はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: 入力スキーマにフィールドを追加する
+
+`packages/mcp/src/tools/analyze.ts` の `analyzeInputSchema` に、既存のフィールドと
+同じスタイル(`.optional().describe(...)`)で追加する:
+
+```ts
+  diff: z
+    .string()
+    .optional()
+    .describe(
+      'Scope findings to files changed vs this git ref (e.g. "origin/main"). Mirrors the CLI --diff flag; omit for no diff scoping.'
+    ),
+  baseline: z
+    .string()
+    .optional()
+    .describe(
+      'Report only findings not already present at this git ref (e.g. "origin/main"). Mirrors the CLI --baseline flag.'
+    ),
+  noSuppressions: z
+    .boolean()
+    .optional()
+    .describe(
+      'Ignore svelte-vitals-suppressions.json for this call, reporting every finding even if previously accepted. Mirrors the CLI --no-suppressions flag.'
+    )
+```
+
+(挿入位置は既存フィールドの並びの中で自然な場所でよい — 例えば `route` の後、
+`treatDynamicAs` の前。)
+
+**Verify**: `pnpm --filter @svelte-vitals/mcp typecheck` → この時点ではまだ
+`handleAnalyze` が新フィールドを使っていないためコンパイルは通るはず(未使用でも
+optional なので型エラーにはならない)。
+
+### Step 2: `handleAnalyze` から `applyScope` を呼ぶ
+
+`svelte-vitals` からの import に `applyScope` を追加し(1行目)、
+`analyzeProject` の呼び出し結果を `applyScope` に通してから `buildJsonReport` に
+渡す:
+
+```ts
+import { analyzeProject, applyScope, buildRulesConfig, findUnknownRuleIds, knownRuleIds, ProjectError } from 'svelte-vitals';
+```
+
+`handleAnalyze` の try ブロック内(既存の `analyzeProject` 呼び出しの直後)を以下の
+ように変更する:
+
+```ts
+  try {
+    const cwd = args.path ?? process.cwd();
+    const { results, config, version } = await analyzeProject({
+      cwd: args.path,
+      metaComponents: args.metaComponents,
+      treatDynamicAs: args.treatDynamicAs,
+      route: args.route,
+      failOn: args.failOn,
+      rules,
+      weights: args.weights,
+      categories: args.categories
+    });
+    const scoped = await applyScope(results, {
+      cwd,
+      config,
+      diffBase: args.diff,
+      baseline: args.baseline,
+      noSuppressions: args.noSuppressions
+    });
+    const report = buildJsonReport(scoped, config, { version });
+    return {
+      content: [{ type: 'text', text: JSON.stringify(report, null, 2) }],
+      structuredContent: report
+    };
+  } catch (err) {
+    ...
+```
+
+注意点:
+- `applyScope` は `cwd: string`(必須)を要求する。`analyzeProject` には
+  `cwd: args.path`(`string | undefined`)を渡しているが、`analyzeProject` 内部で
+  `opts.cwd ?? process.cwd()` としてデフォルト値を補っている(`packages/cli/src/index.ts:173`)
+  ——`applyScope` にはこの補完がないため、`handleAnalyze` 側で同じデフォルト
+  (`args.path ?? process.cwd()`)を明示的に計算して渡す必要がある(上記コード例の
+  `const cwd = args.path ?? process.cwd();` がそれ)。
+- `applyScope` の `errorLog` を省略した場合のデフォルトは `console.error` へのフォー
+  ルバック(`packages/cli/src/index.ts:236`)。MCP サーバーの stdout/stderr の扱いに
+  ついて `packages/mcp/src/server.ts` の他のエラーハンドリング方針を確認し、
+  `console.error` への出力が MCP の stdio トランスポートを汚さないか一度確認する
+  こと(stdio トランスポートは stdout を JSON-RPC メッセージ専用に使うため、
+  `console.error`(stderr)は安全なはずだが、既存コードで `errorLog` を渡す/渡さない
+  の判断基準があるか `packages/action/src/index.ts` の `errorLog: (line) =>
+  core.warning(line)` のような明示的な指定パターンと比較して判断する)。
+  デフォルトで問題なければ `errorLog` は省略してよい。
+
+**Verify**: `pnpm --filter @svelte-vitals/mcp typecheck && pnpm --filter @svelte-vitals/mcp build`
+→ exit 0。
+
+### Step 3: テストを追加する
+
+`packages/mcp/test/analyze-tool.test.ts` は `packages/cli/test/fixtures/basic-project`
+と `config-file-project` を再利用しているパターン(9-12行目)。同様に、CLI の
+suppressions/diff/baseline テスト(`packages/cli/test/run-suppressions.test.ts`・
+`run-diff.test.ts`・`run-baseline.test.ts`)がどのようなフィクスチャ/一時ディレクトリ
+セットアップを使っているか読み、同じパターンで以下を検証する新しい `it` ブロックを
+`describe('analyze tool', ...)` に追加する:
+
+1. **`diff` を渡すと変更ファイルにスコープされる** — git リポジトリのフィクスチャ
+   (一時ディレクトリを作り `git init` してコミットするか、既存の diff テストの
+   セットアップヘルパーを再利用)で、`args.diff` を渡した場合と渡さない場合で
+   `report.routes`/所見件数が異なることを確認。
+2. **`baseline` を渡すと既存所見が除外される** — 同様に baseline 用のセットアップを
+   再利用し、`args.baseline` 指定時に新規所見のみが返ることを確認。
+3. **`noSuppressions: true` で suppressions ファイルが無視される** —
+   `svelte-vitals-suppressions.json` を持つフィクスチャ(`run-suppressions.test.ts`
+   のセットアップパターンを参考に一時ディレクトリへ書き出す)に対し、
+   `noSuppressions` なしでは抑制された所見が結果に出ず、`noSuppressions: true` では
+   出ることを確認。
+
+git 操作を伴うテストのセットアップが複雑になる場合、CLI 側の該当テストファイルが
+既に持っているヘルパー関数(一時 git リポジトリの作成など)を import して再利用でき
+るか確認すること — 車輪の再発明を避ける。
+
+**Verify**: `pnpm --filter @svelte-vitals/mcp test` → all pass、新規3ケース以上
+green、既存ケースも green。
+
+### Step 4: docs を更新する
+
+`docs/src/content/docs/guides/mcp.md` と `ja/guides/mcp.md` を開き、`analyze` ツール
+の引数一覧セクションに `diff`/`baseline`/`noSuppressions` を追記する(既存の
+`metaComponents`/`categories`/`weights` などの記述と同じ文体・フォーマットで)。
+実際のドキュメント構成は開いて確認してから、その構成に自然に合流させること。
+
+**Verify**: 目視で en/ja 両方に同じ内容が反映されていることを確認。
+
+### Step 5: 全体検証
+
+**Verify**: `pnpm build && pnpm typecheck && pnpm test && pnpm lint` → 全て exit 0 /
+all pass。changeset を追加(`@svelte-vitals/mcp`: minor — 新しいツール引数の追加、
+英語で「the `analyze` tool now supports `diff`/`baseline` scoping and
+`svelte-vitals-suppressions.json`, matching the CLI and GitHub Action」の趣旨)。
+
+## Test plan
+
+- 新規: `diff`/`baseline`/`noSuppressions` それぞれが `analyze` ツールの結果に
+  正しく反映されることを確認する3ケース(`packages/mcp/test/analyze-tool.test.ts`)。
+- 既存: 同ファイルの全既存ケースが変更後も green。
+- 検証: `pnpm --filter @svelte-vitals/mcp test` → all pass。
+
+## Done criteria
+
+- [ ] `analyzeInputSchema` に `diff`/`baseline`/`noSuppressions` が追加されている
+- [ ] `handleAnalyze` が `applyScope` を呼び、結果をそれに通してからレポートを構築
+      している
+- [ ] 新規3テストケースが green、既存ケースも green
+- [ ] `pnpm --filter @svelte-vitals/mcp typecheck && build` が exit 0
+- [ ] docs(en/ja)が更新されている
+- [ ] changeset が存在する
+- [ ] `plans/README.md` の該当行を更新済み
+
+## STOP conditions
+
+- CLI の diff/baseline/suppressions テストのセットアップヘルパーが再利用できない
+  形で書かれている(密結合したモジュール内部関数など)場合、無理に import せず、
+  MCP 側で最小限の同等のセットアップを自前で書く判断をしてよいが、その場合は
+  Maintenance notes に「重複したセットアップコードがある」旨を記録する。
+- `applyScope` の `cwd` 必須引数の扱いで `analyzeProject` の実際の解決順序
+  (`opts.cwd ?? process.cwd()`)と食い違うことが判明した場合、一度立ち止まって
+  `packages/cli/src/index.ts` の該当箇所を再読し、それでも整合しなければ STOP。
+
+## Maintenance notes
+
+- 今後 CLI に diff/baseline/suppressions 関連の新しいフラグが追加された場合、MCP の
+  `analyzeInputSchema` にも同じ内容を追加することを検討する(このプランが確立した
+  「MCP は CLI/Action と同じスコープ機能を持つ」という対称性を維持するため)。
+- `--staged` 相当は意図的にスコープ外とした — MCP 経由での需要が観測されたら追加を
+  検討する。

--- a/plans/034-dev-dashboard-persistent-parse-cache.md
+++ b/plans/034-dev-dashboard-persistent-parse-cache.md
@@ -138,17 +138,17 @@ export type AnalyzeFn = (opts: {
 
 - **`plugin.ts` の呼び出し元**(既に読了済み) — `runner.notifyChange(file)` は
   `server.watcher.on('all', (_event, file) => { if (isRelevant(file, uiRoot))
-  runner.notifyChange(file); })` から、Vite の watcher が渡す**絶対パス**で呼ばれる。
+runner.notifyChange(file); })` から、Vite の watcher が渡す**絶対パス**で呼ばれる。
   `uiRoot`(= `options.cwd ?? server.config.root`)がプロジェクトルート。
 
 ## Commands you will need
 
-| Purpose   | Command                                                        | Expected on success |
-| --------- | ----------------------------------------------------------------- | -------------------- |
-| Tests     | `pnpm --filter @svelte-vitals/core test --filter svelte-vitals test --filter @svelte-vitals/vite test`(または各パッケージ個別に) | all pass |
-| Typecheck | `pnpm typecheck`                                                 | exit 0                |
-| Build     | `pnpm build`                                                     | exit 0                |
-| Lint      | `pnpm lint`                                                       | exit 0                |
+| Purpose   | Command                                                                                                                          | Expected on success |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| Tests     | `pnpm --filter @svelte-vitals/core test --filter svelte-vitals test --filter @svelte-vitals/vite test`(または各パッケージ個別に) | all pass            |
+| Typecheck | `pnpm typecheck`                                                                                                                 | exit 0              |
+| Build     | `pnpm build`                                                                                                                     | exit 0              |
+| Lint      | `pnpm lint`                                                                                                                      | exit 0              |
 
 ## Scope
 
@@ -246,7 +246,7 @@ export interface AnalyzeOptions {
 `analyzeProject` 実装内の `collectRoutes` 呼び出し(192行目)を更新:
 
 ```ts
-  const collected = await collectRoutes(rt, cwd, config, opts.parseCache);
+const collected = await collectRoutes(rt, cwd, config, opts.parseCache);
 ```
 
 ファイル冒頭の import に `ParseCache` 型を追加(`collectRoutes` と同じ
@@ -298,14 +298,14 @@ export function createAnalysisRunner(opts: AnalysisRunnerOptions): AnalysisRunne
 `runOnce` の `analyze(...)` 呼び出しに `parseCache` を渡す:
 
 ```ts
-      const { results } = await analyze({
-        cwd: opts.root,
-        treatDynamicAs: opts.treatDynamicAs,
-        metaComponents: opts.metaComponents,
-        rules: opts.rules,
-        failOn: opts.failOn,
-        parseCache
-      });
+const { results } = await analyze({
+  cwd: opts.root,
+  treatDynamicAs: opts.treatDynamicAs,
+  metaComponents: opts.metaComponents,
+  rules: opts.rules,
+  failOn: opts.failOn,
+  parseCache
+});
 ```
 
 `getAnalyze()`(production 実装、`svelte-vitals` を dynamic import する箇所)は
@@ -357,7 +357,7 @@ import { relative, sep } from 'node:path';
    `toBe`(参照同一性)でアサートする — これが「キャッシュが使い回されている」
    ことの直接証拠。
 2. `parseCache` に事前に(テストが)ダミーのエントリ(`cache.set('src/routes/+page.svelte',
-   Promise.resolve(...))` 相当 — モックの `AnalyzeFn` が受け取った `parseCache`
+Promise.resolve(...))` 相当 — モックの `AnalyzeFn` が受け取った `parseCache`
    引数に対して行う)を入れておき、`notifyChange(absolutePathToThatFile)` を
    呼んだ後、そのキーが削除されていること、かつ**無関係な別のキーは残っている**
    ことをアサートする。

--- a/plans/034-dev-dashboard-persistent-parse-cache.md
+++ b/plans/034-dev-dashboard-persistent-parse-cache.md
@@ -1,0 +1,439 @@
+# Plan 034: dev dashboard の再解析で変更していないファイルの再パースを避ける
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat 3341587..HEAD -- packages/cli/src/index.ts packages/cli/src/providers/source/routes.ts packages/cli/src/providers/source/resolve.ts packages/vite/src/ui/analysis.ts packages/vite/src/plugin.ts`
+> 差分があれば下記「Current state」の抜粋と実ファイルを突き合わせ、不一致なら STOP。
+
+## Status
+
+- **Priority**: P3
+- **Effort**: M
+- **Risk**: MED(パスの正規化がずれるとキャッシュ無効化が効かず「保存しても
+  ダッシュボードに反映されない」という静かな不具合になりうる — Step 4 のテストで
+  必ず実測すること)
+- **Depends on**: Plan 031(watcher→再解析の結線テストがあると、このプランの変更
+  後もその配線が壊れていないことを既存テストで確認しやすい。ただし独立に実施可能)
+- **Category**: perf
+- **Planned at**: commit `3341587`, 2026-07-13
+
+## Why this matters
+
+Vite dev dashboard は `svelteVitals({ ui: true })` を使うと、`vite dev` 中の関連ソース
+ファイル変更のたびに **プロジェクト全体を再解析**する。`packages/vite/src/ui/analysis.ts`
+の `notifyChange(file: string)` は `file` 引数を受け取るが、実装(`notifyChange()`)は
+その値を一切使わず、常に `runOnce()`(= 無条件のフル `analyzeProject` 呼び出し)を
+デバウンス後に実行するだけ。加えて、CLI 側の `collectRoutes`
+(`packages/cli/src/providers/source/routes.ts:189-196`)はルート/レイアウトの読込+
+パース結果をキャッシュする `ParseCache`(`Map<string, Promise<ParsedFile>>`)を持って
+いるが、これは `collectRoutes` の呼び出しごとに `new Map()` で作り直される「1回の
+解析内でのみ有効な」キャッシュ — デバウンスされた再解析のたびに空から作り直される
+ため、変更していないファイルも毎回ディスクから読み直され再パースされる。
+
+200ルートあるプロジェクトで無関係なコンポーネントを1つ保存するだけで、保存のたびに
+プロジェクト全体のルート/レイアウトファイルが re-glob + re-read + re-parse される —
+「ライブ」ダッシュボードが謳う軽快さと矛盾する。
+
+## Design
+
+`ParseCache` は「ファイルパスをキーにした読込+パース結果の Promise キャッシュ」なので、
+**そのファイルの内容が変わっていなければ再利用してよい**。これを2つの変更で実現する:
+
+1. `collectRoutes`(および呼び出し元の `analyzeProject`)が、外部から渡された
+   永続 `ParseCache` を使えるようにする(渡されなければ従来どおり新規作成 — 既存の
+   CLI/MCP/Action の呼び出しは無変更で動く)。
+2. Vite の dev dashboard(`packages/vite/src/ui/analysis.ts`)が dev サーバーの
+   セッションを通じて**1つの `ParseCache` インスタンスを保持し続け**、
+   `notifyChange(file)` が呼ばれるたびに、変更されたファイル**そのものだけ**の
+   キャッシュエントリを削除してから再解析を走らせる。
+
+これにより、変更されていないファイルは引き続きキャッシュから即座に返り、変更された
+ファイルだけが再読込+再パースされる。ルート解決(`resolveRoute`)自体は毎回全ルート
+に対して実行される(どのルートが影響を受けるかを個別に判定するような、より複雑で
+リスクの高い最適化はこのプランのスコープ外 — Plan 036 の設計スパイクに譲る)ため、
+「レイアウト変更が子ルートに波及しない」という正しさの懸念は生じない: 各ルートの
+解決は常にそのルートの layout chain を辿って `resolveFileTags` を呼び直すので、
+変更されたレイアウトファイルは(キャッシュが無効化されているため)新しい内容で
+読み直され、それを含むすべてのルートに正しく反映される。**節約されるのは「変わって
+いないファイルの無駄な読込+パース」だけであり、ルール判定や合成ロジックは一切変えない**。
+
+## Current state
+
+- **`ParseCache` 型** — `packages/cli/src/providers/source/resolve.ts:16`:
+
+```ts
+export type ParseCache = Map<string, Promise<ParsedFile>>;
+```
+
+キーは「project-root-relative path」(JSDoc: "keyed by project-root-relative path
+(as normalized by chainFiles / resolveComponentPath)")。実際の値は
+`packages/cli/src/runtime/node.ts:24-26` の `glob(pattern, cwd) { return
+tinyglob(pattern, { cwd, dot: false }); }` が返す形式 — `tinyglobby` は OS に関わらず
+**POSIX 形式(`/` 区切り)の cwd 相対パス**を返す(例: `src/routes/+page.svelte`)。
+
+- **`collectRoutes`** — `packages/cli/src/providers/source/routes.ts:189-201`
+  (既に全文読了済み):
+
+```ts
+export async function collectRoutes(
+  rt: Runtime,
+  cwd: string,
+  config: Config = defaultConfig
+): Promise<{ heads: ResolvedHead[]; images: ResolvedImages[]; headings: ResolvedHeadings[] }> {
+  const [pages, layouts] = await Promise.all([enumerateRoutePages(rt, cwd), collectLayouts(rt, cwd)]);
+  const cache: ParseCache = new Map();
+  const facts = await Promise.all(pages.map((page) => resolveRoute(rt, cwd, page, config, layouts, cache)));
+  return {
+    heads: facts.map((f) => f.head),
+    images: facts.map((f) => f.images),
+    headings: facts.map((f) => f.headings)
+  };
+}
+```
+
+- **`analyzeProject`** — `packages/cli/src/index.ts:139-206`(`AnalyzeOptions` と
+  実装、既に全文読了済み)。`collectRoutes(rt, cwd, config)` の呼び出しは172-207行目
+  の中、192行目。
+- **`AnalysisRunner`** — `packages/vite/src/ui/analysis.ts`(全文、既に読了済み)。
+  `notifyChange(file: string)` の実装(95-104行目)は `file` を無視する:
+
+```ts
+    notifyChange() {
+      if (stopped) return;
+      if (timer !== undefined) clearTimeout(timer);
+      timer = setTimeout(() => {
+        timer = undefined;
+        if (stopped) return;
+        if (running) pending = true;
+        else void runOnce();
+      }, debounceMs);
+    },
+```
+
+`AnalyzeFn` 型(4-10行目)と、production 実装が `svelte-vitals` を dynamic import
+する `getAnalyze()`(56-62行目):
+
+```ts
+export type AnalyzeFn = (opts: {
+  cwd: string;
+  treatDynamicAs?: TreatDynamicAs;
+  metaComponents?: string[];
+  rules?: Record<string, RuleSetting>;
+  failOn?: Severity;
+}) => Promise<{ results: Result[] }>;
+...
+  async function getAnalyze(): Promise<AnalyzeFn> {
+    if (cachedAnalyze) return cachedAnalyze;
+    const mod = await import('svelte-vitals');
+    const fn: AnalyzeFn = (o) => mod.analyzeProject(o);
+    cachedAnalyze = fn;
+    return fn;
+  }
+```
+
+- **`plugin.ts` の呼び出し元**(既に読了済み) — `runner.notifyChange(file)` は
+  `server.watcher.on('all', (_event, file) => { if (isRelevant(file, uiRoot))
+  runner.notifyChange(file); })` から、Vite の watcher が渡す**絶対パス**で呼ばれる。
+  `uiRoot`(= `options.cwd ?? server.config.root`)がプロジェクトルート。
+
+## Commands you will need
+
+| Purpose   | Command                                                        | Expected on success |
+| --------- | ----------------------------------------------------------------- | -------------------- |
+| Tests     | `pnpm --filter @svelte-vitals/core test --filter svelte-vitals test --filter @svelte-vitals/vite test`(または各パッケージ個別に) | all pass |
+| Typecheck | `pnpm typecheck`                                                 | exit 0                |
+| Build     | `pnpm build`                                                     | exit 0                |
+| Lint      | `pnpm lint`                                                       | exit 0                |
+
+## Scope
+
+**In scope**:
+
+- `packages/cli/src/providers/source/routes.ts`(`collectRoutes` が外部キャッシュを
+  受け取れるようにする)
+- `packages/cli/src/index.ts`(`AnalyzeOptions` に `parseCache` を追加、`ParseCache`
+  型を re-export、`collectRoutes` 呼び出しにキャッシュを渡す)
+- `packages/cli/src/providers/source/resolve.ts`(`ParseCache` 型は変更不要 —
+  export 済みであることを確認するのみ)
+- `packages/vite/src/ui/analysis.ts`(`AnalyzeFn`/`AnalysisRunner` にキャッシュ管理
+  を追加)
+- `packages/vite/src/plugin.ts`(必要なら `uiRoot` を使ったファイルパス正規化を
+  `analysis.ts` に渡す配線を追加)
+- 上記に対応するテストファイル
+
+**Out of scope**:
+
+- ルート単位で「どのルートが変更ファイルの影響を受けるか」を判定して、影響のない
+  ルートのルール再実行そのものをスキップする最適化(Plan 036 の設計スパイクの領域 —
+  正しさのリスクが本プランより大きいため分離)。
+- `packages/vite/src/analyze.ts`(build-mode の prerendered HTML 解析)— dev
+  dashboard とは別の解析パスであり、このプランのスコープ外。
+- `analyzeProject` を呼ぶ CLI の `run()`・MCP・Action 側の変更 — `parseCache` は
+  optional なので、これらは何も変更せず今までどおり動く。
+
+## Git workflow
+
+- Branch: `advisor/034-dev-dashboard-persistent-parse-cache`
+- コミット: 論理的に分けてよい(例: `feat(cli): let collectRoutes/analyzeProject reuse an external parse cache` /
+  `perf(vite): keep the dev dashboard's parse cache across re-analyses`)。
+- push / PR 作成はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: `collectRoutes` が外部キャッシュを受け取れるようにする
+
+`packages/cli/src/providers/source/routes.ts` の `collectRoutes` のシグネチャに
+第4引数(optional)を追加する:
+
+```ts
+export async function collectRoutes(
+  rt: Runtime,
+  cwd: string,
+  config: Config = defaultConfig,
+  cache: ParseCache = new Map()
+): Promise<{ heads: ResolvedHead[]; images: ResolvedImages[]; headings: ResolvedHeadings[] }> {
+  const [pages, layouts] = await Promise.all([enumerateRoutePages(rt, cwd), collectLayouts(rt, cwd)]);
+  const facts = await Promise.all(pages.map((page) => resolveRoute(rt, cwd, page, config, layouts, cache)));
+  return {
+    heads: facts.map((f) => f.head),
+    images: facts.map((f) => f.images),
+    headings: facts.map((f) => f.headings)
+  };
+}
+```
+
+(ローカル変数 `const cache: ParseCache = new Map();` を削除し、デフォルト引数に
+置き換えるだけ — 呼び出し元がキャッシュを渡さなければ従来と全く同じ挙動。)
+
+`collectRoutes` の他の呼び出し元(`packages/cli/src/index.ts` 以外に存在するか
+`grep -rn "collectRoutes(" packages/cli/src` で確認すること — もしあれば同様に
+無変更で動くことを確認する)。
+
+**Verify**: `pnpm --filter svelte-vitals typecheck` → exit 0。
+
+### Step 2: `analyzeProject` が `parseCache` オプションを受け取り、`ParseCache` 型を公開する
+
+`packages/cli/src/index.ts` の `AnalyzeOptions`(139-151行目)に追加:
+
+```ts
+export interface AnalyzeOptions {
+  cwd?: string;
+  metaComponents?: string[];
+  treatDynamicAs?: 'pass' | 'warn' | 'fail';
+  route?: string;
+  failOn?: Severity;
+  rules?: Record<string, RuleSetting>;
+  weights?: Partial<Record<Category, number>>;
+  categories?: Category[];
+  /**
+   * Reuse this parse cache across multiple `analyzeProject` calls instead of
+   * starting fresh each time — the vite dev dashboard passes a long-lived cache
+   * and invalidates only the changed file's entry between re-analyses, so
+   * unchanged routes/layouts/components are never re-read or re-parsed.
+   * Callers that don't need cross-call reuse (the CLI's `run()`, MCP, the
+   * Action — each analyzes once per process) can omit this; a fresh cache is
+   * created automatically.
+   */
+  parseCache?: ParseCache;
+}
+```
+
+`analyzeProject` 実装内の `collectRoutes` 呼び出し(192行目)を更新:
+
+```ts
+  const collected = await collectRoutes(rt, cwd, config, opts.parseCache);
+```
+
+ファイル冒頭の import に `ParseCache` 型を追加(`collectRoutes` と同じ
+`./providers/source/routes.js` から、または `ParseCache` の定義元
+`./providers/source/resolve.js` から — 実際にどちらから re-export されているか
+確認して整合させる)。ファイル末尾(523行目以降、他の re-export の並び)に
+`ParseCache` 型を公開する一行を追加する:
+
+```ts
+export type { ParseCache } from './providers/source/resolve.js';
+```
+
+**Verify**: `pnpm --filter svelte-vitals typecheck && pnpm --filter svelte-vitals test`
+→ exit 0 / all pass(既存の `analyzeProject`/`collectRoutes` 関連テストが無変更で
+green であることを確認 — このステップは完全に後方互換の追加のはず)。
+
+### Step 3: vite dev dashboard がキャッシュを保持し、変更ファイルだけ無効化する
+
+`packages/vite/src/ui/analysis.ts` を変更する。`AnalyzeFn` の型に `parseCache` を
+追加し(vite パッケージは `@svelte-vitals/core` から型を import しているため、
+`ParseCache` 型を新たに import する必要がある — `svelte-vitals` パッケージから
+`import type { ParseCache } from 'svelte-vitals';` のように、Step 2 で公開した型を
+使う):
+
+```ts
+import type { ParseCache } from 'svelte-vitals';
+
+export type AnalyzeFn = (opts: {
+  cwd: string;
+  treatDynamicAs?: TreatDynamicAs;
+  metaComponents?: string[];
+  rules?: Record<string, RuleSetting>;
+  failOn?: Severity;
+  parseCache?: ParseCache;
+}) => Promise<{ results: Result[] }>;
+```
+
+`createAnalysisRunner` 内で、ランナーの生存期間を通じて1つの `ParseCache` を保持する:
+
+```ts
+export function createAnalysisRunner(opts: AnalysisRunnerOptions): AnalysisRunner {
+  const debounceMs = opts.debounceMs ?? 500;
+  let cachedAnalyze: AnalyzeFn | undefined = opts.analyze;
+  const parseCache: ParseCache = new Map();
+  let stopped = false;
+  ...
+```
+
+`runOnce` の `analyze(...)` 呼び出しに `parseCache` を渡す:
+
+```ts
+      const { results } = await analyze({
+        cwd: opts.root,
+        treatDynamicAs: opts.treatDynamicAs,
+        metaComponents: opts.metaComponents,
+        rules: opts.rules,
+        failOn: opts.failOn,
+        parseCache
+      });
+```
+
+`getAnalyze()`(production 実装、`svelte-vitals` を dynamic import する箇所)は
+`(o) => mod.analyzeProject(o)` のまま変更不要 — `o` に含まれる `parseCache` は
+そのまま `analyzeProject` に渡る。
+
+`notifyChange(file: string)` を、渡された絶対パスをプロジェクト相対の POSIX パスに
+正規化してから、そのキーだけを `parseCache` から削除するように変更する:
+
+```ts
+import { relative, sep } from 'node:path';
+...
+    notifyChange(file: string) {
+      if (stopped) return;
+      const rel = relative(opts.root, file).split(sep).join('/');
+      parseCache.delete(rel);
+      if (timer !== undefined) clearTimeout(timer);
+      timer = setTimeout(() => {
+        timer = undefined;
+        if (stopped) return;
+        if (running) pending = true;
+        else void runOnce();
+      }, debounceMs);
+    },
+```
+
+**重要な正規化の注意**: `ParseCache` のキーは `tinyglobby` が返す cwd 相対 POSIX
+パス(例: `src/routes/+page.svelte`、先頭に `./` は付かない)。`node:path` の
+`relative(opts.root, file)` は OS のパス区切り文字を使う(macOS/Linux では既に `/`
+だが、Windows では `\` になる)ため、`.split(sep).join('/')` で POSIX 形式に正規化
+する必要がある。この正規化が実際のキャッシュキーと一致することを、Step 4 の
+テストで**実際にキャッシュヒット/ミスを観測して**確認すること — 一致しない場合、
+このプランの効果はゼロになる(かつ気づかれにくい)ため、必ず実測すること。
+
+**Verify**: `pnpm --filter @svelte-vitals/vite typecheck` → exit 0(この時点ではまだ
+テストを書いていないので実効果は未確認)。
+
+### Step 4: 効果を実測するテストを書く
+
+`packages/vite/test/ui/analysis.test.ts`(既存ファイルがあれば追記、なければ新規
+作成 — `packages/vite/test/` の既存ファイル一覧を確認して命名規則を合わせる)に、
+以下を検証するテストを追加する:
+
+1. `opts.analyze` にモックの `AnalyzeFn` を注入し(`AnalysisRunnerOptions.analyze`
+   は既にテスト用に注入可能な設計 — JSDoc 参照)、呼び出しごとに渡された
+   `parseCache`(の参照)を記録する。`start()` → `notifyChange(fileA)` →
+   デバウンス待ち、という流れで2回 `analyze` が呼ばれたとき、**両方の呼び出しに
+   同一の `parseCache` インスタンス(オブジェクト参照)が渡されること**を
+   `toBe`(参照同一性)でアサートする — これが「キャッシュが使い回されている」
+   ことの直接証拠。
+2. `parseCache` に事前に(テストが)ダミーのエントリ(`cache.set('src/routes/+page.svelte',
+   Promise.resolve(...))` 相当 — モックの `AnalyzeFn` が受け取った `parseCache`
+   引数に対して行う)を入れておき、`notifyChange(absolutePathToThatFile)` を
+   呼んだ後、そのキーが削除されていること、かつ**無関係な別のキーは残っている**
+   ことをアサートする。
+3. 実際のパス正規化(`relative` + POSIX 変換)が実プロジェクト構造でも動くことを、
+   `packages/cli` の実 `analyzeProject`/`collectRoutes` を使った統合的なテスト
+   (一時ディレクトリに複数ルートを持つ SvelteKit プロジェクトを作り、
+   `createAnalysisRunner` を実際の `analyze: (o) => cliAnalyzeProject(o)` で
+   `start()` → 1ファイルだけ変更して `notifyChange()` → 2回目の解析後、
+   注入した `Runtime`(または `readFile` の呼び出し回数を数えるラッパー)経由で
+   「変更していないファイルは2回目に読み直されていない」ことを確認する)で1本
+   書く。これがこのプランの核心的な回帰テストであり、正規化のミスマッチがあれば
+   ここで確実に失敗する。
+
+**Verify**: `pnpm --filter @svelte-vitals/vite test` → all pass、新規テストが
+すべて green(特に3番目の統合テストが、変更していないファイルの読込回数が
+2回目でゼロであることを実測できていること)。
+
+### Step 5: 全体検証 + changeset
+
+**Verify**: `pnpm build && pnpm typecheck && pnpm test && pnpm lint` → 全て
+exit 0 / all pass。
+
+changeset を追加: `@svelte-vitals/vite`(patch または minor — 内部最適化だが
+`AnalyzeFn` 型のシグネチャに `parseCache` が増える公開的な変更もあるため、
+判断に迷ったら該当パッケージの CHANGELOG.md の類似変更の扱いに合わせる)、
+`svelte-vitals`(patch — `AnalyzeOptions.parseCache` の追加、`ParseCache` 型の
+公開エクスポート)。
+
+## Test plan
+
+- 新規: `createAnalysisRunner` が複数回の解析呼び出しに同一の `parseCache` インスタ
+  ンスを渡し続けることの単体テスト。
+- 新規: `notifyChange` が変更されたファイルのキャッシュキーだけを削除し、無関係な
+  キーは残すことの単体テスト。
+- 新規: 実プロジェクト構造を使った統合テストで、変更していないファイルの読込回数が
+  2回目の解析でゼロであることを実測する回帰テスト(このプランの核心的な証拠)。
+- 既存: `packages/vite/test/ui-plugin.test.ts`、`packages/cli/test` の
+  `collectRoutes`/`analyzeProject` 関連テストが変更後も green。
+- 検証: `pnpm --filter @svelte-vitals/vite test` と
+  `pnpm --filter svelte-vitals test` → 両方 all pass。
+
+## Done criteria
+
+- [ ] `collectRoutes` が optional な外部 `ParseCache` を受け取れる(渡さない場合の
+      挙動は無変更)
+- [ ] `analyzeProject` の `AnalyzeOptions` に `parseCache` が追加され、`ParseCache`
+      型が `svelte-vitals` パッケージから公開されている
+- [ ] `createAnalysisRunner` が長生きする `ParseCache` を保持し、`notifyChange` が
+      変更されたファイルのキーだけを削除する
+- [ ] 統合テストで「変更していないファイルは2回目の解析で読み直されない」ことが
+      実測されている
+- [ ] `pnpm build && pnpm typecheck && pnpm test && pnpm lint` が全て exit 0 / all pass
+- [ ] changeset が存在する
+- [ ] `plans/README.md` の該当行を更新済み
+
+## STOP conditions
+
+- Step 4 の統合テストで、正規化した相対パスが実際の `ParseCache` のキー形式と
+  一致せず、無効化が効かない(= 変更したファイルも古い内容のまま返り続ける)ことが
+  判明した場合、パスの正規化ロジックを見直し、それでも一致しなければ STOP して
+  報告する(この場合、静かに「効果がないが害もない」状態でマージするのではなく、
+  正しく直すか計画を練り直す判断が必要)。
+- Windows 環境でのパス区切り文字の扱いについて、CI のテスト環境(Linux)だけでは
+  検証できない懸念がある場合、その旨を Maintenance notes に明記する(このリポジトリ
+  の CI は ubuntu-latest のみで実行されるため、Windows 固有の不具合が CI で検出
+  されない可能性がある)。
+- 検証コマンドが修正1回を挟んで2回失敗した場合。
+
+## Maintenance notes
+
+- 将来「変更ファイルの影響を受けないルートはルール再実行自体をスキップする」という
+  より踏み込んだ最適化を検討する場合(Plan 036 と関連)、このプランが導入した
+  `parseCache` の仕組みの上に構築できる — レイアウトチェーンの依存関係は
+  `chainFiles` が既に計算しているため、「どのルートがどのファイルに依存するか」の
+  逆引きマップを作れば実現できる。
+- `parseCache` を無限に保持し続けると、長時間の `vite dev` セッションでファイルが
+  削除/リネームされた場合に古いエントリが残り続ける(メモリリークにはならないが、
+  無意味なエントリが蓄積する)。実用上問題になるまでは対応不要だが、気になる場合は
+  `runner.stop()` 時にキャッシュもクリアする、または定期的な GC を検討する。

--- a/plans/035-dashboard-sse-staleness-guard-test.md
+++ b/plans/035-dashboard-sse-staleness-guard-test.md
@@ -31,13 +31,18 @@
 ガードを持つ:
 
 ```js
-  function fetchSnapshot() {
-    fetch('/__svelte-vitals/data.json').then(function (r) { return r.json(); }).then(function (data) {
+function fetchSnapshot() {
+  fetch('/__svelte-vitals/data.json')
+    .then(function (r) {
+      return r.json();
+    })
+    .then(function (data) {
       if (state.snapshot && data.sequence <= state.snapshot.sequence) return;
       state.snapshot = data;
       renderAll();
-    }).catch(function () {});
-  }
+    })
+    .catch(function () {});
+}
 ```
 
 これは「複数回の再解析がほぼ同時に走ったとき、古いレスポンスが後から届いて新しい
@@ -96,12 +101,12 @@
 
 ## Commands you will need
 
-| Purpose   | Command                                    | Expected on success |
-| --------- | --------------------------------------------- | -------------------- |
-| Install   | `pnpm install`(jsdom 追加後)                | exit 0                |
-| Tests     | `pnpm --filter @svelte-vitals/vite test`     | all pass              |
-| Typecheck | `pnpm --filter @svelte-vitals/vite typecheck`| exit 0                |
-| Lint      | `pnpm lint`                                    | exit 0                |
+| Purpose   | Command                                       | Expected on success |
+| --------- | --------------------------------------------- | ------------------- |
+| Install   | `pnpm install`(jsdom 追加後)                  | exit 0              |
+| Tests     | `pnpm --filter @svelte-vitals/vite test`      | all pass            |
+| Typecheck | `pnpm --filter @svelte-vitals/vite typecheck` | exit 0              |
+| Lint      | `pnpm lint`                                   | exit 0              |
 
 ## Scope
 
@@ -136,7 +141,7 @@
 倣う):
 
 ```yaml
-  jsdom: ^27.0.0
+jsdom: ^27.0.0
 ```
 
 (実際の最新安定版バージョンを確認して埋めること — 推測でバージョン番号を固定しない。
@@ -269,34 +274,34 @@ dispatch することで `fetchSnapshot()` を間接的に駆動する必要が�
 テスト本体:
 
 ```ts
-  it('discards an out-of-order response with a lower or equal sequence', async () => {
-    // fetchSnapshot() is called once on 'open' (boot()'s open handler) — resolve it
-    // with sequence 5 so state.snapshot.sequence becomes 5.
-    fetchMock.mockResolvedValueOnce({ json: () => Promise.resolve(JSON.parse(snapshotJson(5))) });
+it('discards an out-of-order response with a lower or equal sequence', async () => {
+  // fetchSnapshot() is called once on 'open' (boot()'s open handler) — resolve it
+  // with sequence 5 so state.snapshot.sequence becomes 5.
+  fetchMock.mockResolvedValueOnce({ json: () => Promise.resolve(JSON.parse(snapshotJson(5))) });
 
-    (0, eval)(DASHBOARD_SCRIPT);
-    esInstances[0]!.dispatch('open');
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+  (0, eval)(DASHBOARD_SCRIPT);
+  esInstances[0]!.dispatch('open');
+  await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
 
-    // Now simulate a SECOND 'update' event whose fetch resolves with an OLDER
-    // sequence (4) than what's already rendered (5) — the guard must discard it.
-    fetchMock.mockResolvedValueOnce({ json: () => Promise.resolve(JSON.parse(snapshotJson(4, { analyzing: true }))) });
-    esInstances[0]!.dispatch('update');
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  // Now simulate a SECOND 'update' event whose fetch resolves with an OLDER
+  // sequence (4) than what's already rendered (5) — the guard must discard it.
+  fetchMock.mockResolvedValueOnce({ json: () => Promise.resolve(JSON.parse(snapshotJson(4, { analyzing: true }))) });
+  esInstances[0]!.dispatch('update');
+  await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
 
-    // Assert the stale response was NOT applied: the topbar (rendered from
-    // state.snapshot) must still reflect analyzing: false, not the stale true.
-    // (Exact assertion depends on what renderTopbar() actually reflects for
-    // `analyzing` — read renderTopbar()'s implementation in Step 2 and assert on
-    // whatever DOM output distinguishes sequence-5 state from sequence-4 state.)
-    expect(document.getElementById('dv-topbar')!.innerHTML).not.toContain(/* sequence-4-specific marker */);
-  });
+  // Assert the stale response was NOT applied: the topbar (rendered from
+  // state.snapshot) must still reflect analyzing: false, not the stale true.
+  // (Exact assertion depends on what renderTopbar() actually reflects for
+  // `analyzing` — read renderTopbar()'s implementation in Step 2 and assert on
+  // whatever DOM output distinguishes sequence-5 state from sequence-4 state.)
+  expect(document.getElementById('dv-topbar')!.innerHTML).not.toContain(/* sequence-4-specific marker */);
+});
 
-  it('applies a newer response and updates the rendered state', async () => {
-    // Mirror of the above: resolve 'open' with sequence 5, then 'update' with
-    // sequence 6, and assert the NEW content IS reflected — proves the guard
-    // isn't simply discarding everything.
-  });
+it('applies a newer response and updates the rendered state', async () => {
+  // Mirror of the above: resolve 'open' with sequence 5, then 'update' with
+  // sequence 6, and assert the NEW content IS reflected — proves the guard
+  // isn't simply discarding everything.
+});
 ```
 
 具体的な DOM アサーション(コメントの `/* sequence-4-specific marker */` の部分)

--- a/plans/035-dashboard-sse-staleness-guard-test.md
+++ b/plans/035-dashboard-sse-staleness-guard-test.md
@@ -1,0 +1,361 @@
+# Plan 035: dashboard の SSE staleness guard を実行して検証するテストを追加する
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat 3341587..HEAD -- packages/vite/src/ui/dashboard-script.ts packages/vite/test/ui-dashboard.test.ts`
+> 差分があれば下記「Current state」の抜粋と実ファイルを突き合わせ、不一致なら STOP。
+
+## Status
+
+- **Priority**: P2
+- **Effort**: M
+- **Risk**: LOW(テスト追加のみ。プロダクションコードは変更しない — jsdom という
+  新しい devDependency の追加を伴うが、`packages/vite` のみのテスト依存であり
+  実行時の配布物には影響しない)
+- **Depends on**: none
+- **Category**: tests
+- **Planned at**: commit `3341587`, 2026-07-13
+
+## Why this matters
+
+`packages/vite/src/ui/dashboard-script.ts` は、Vite dev dashboard が配信する
+**手書きのバニラ JS クライアントスクリプト**(バンドラーなし、フレームワークなし —
+ファイル冒頭のコメントに明記された意図的な設計)。この中の `fetchSnapshot()`
+(435行目)は SSE(`EventSource`)の `update`/`open` イベントで再フェッチした
+`/data.json` のレスポンスに対して、`sequence` フィールドで新しいものだけを採用する
+ガードを持つ:
+
+```js
+  function fetchSnapshot() {
+    fetch('/__svelte-vitals/data.json').then(function (r) { return r.json(); }).then(function (data) {
+      if (state.snapshot && data.sequence <= state.snapshot.sequence) return;
+      state.snapshot = data;
+      renderAll();
+    }).catch(function () {});
+  }
+```
+
+これは「複数回の再解析がほぼ同時に走ったとき、古いレスポンスが後から届いて新しい
+状態を上書きしてしまう」という競合状態を防ぐための唯一の防御線。ところが
+`packages/vite/test/ui-dashboard.test.ts` の既存テストは `renderDashboardShell`
+(サーバー側で HTML 文字列を組み立てる関数)が**このスクリプト文字列を埋め込んで
+いること**を確認するだけで、スクリプト自体を一度も実行していない。つまり、この
+ガードの条件式が壊れても(例えば `<=` を `<` に変えてしまう、`data.sequence` の
+参照先を間違える、等)、既存テストは一切検知できない。
+
+## Design
+
+`DASHBOARD_SCRIPT` はハンドオーサーの単一 IIFE 文字列であり、この設計自体は変更
+しない(バンドラーなし、という意図的な選択を尊重する)。かわりに、**jsdom 環境で
+このスクリプト文字列を実際に評価・実行し**、`document`/`fetch`/`EventSource`/
+`localStorage` をテスト側で用意した上で、`fetchSnapshot` の staleness ガードが
+実際に機能することを検証する。これは「ロジックを別ファイルに抽出してテストする」
+方式ではなく「本物のスクリプトをブラウザに近い環境で動かして観測する」方式であり、
+ハンドオーサー・ノーバンドルという設計意図と衝突しない。
+
+`packages/vite` には現状 jsdom(または同等の DOM 実装)への依存がない。このプランで
+新規に devDependency として追加する(`pnpm-workspace.yaml` の `catalog:` に追加し、
+`packages/vite/package.json` はそこから参照する — リポジトリの hard rule)。
+
+## Current state
+
+- `packages/vite/src/ui/dashboard-script.ts`(該当箇所は上記引用の通り、
+  433-439行目)。スクリプト全体は約465行の1つの IIFE 文字列。
+- **DOM 依存箇所**(`grep -n "getElementById|mount("` で確認済み): スクリプトは
+  以下の要素の存在を前提にする:
+  - `document.getElementById('svelte-vitals-data')`(442行目、`boot()` が
+    初期スナップショットの JSON を読み取る `<script type="application/json">`
+    相当の要素)
+  - `mount('dv-topbar', ...)`(170行目)、`mount('dv-sidebar', ...)`(270行目)、
+    `mount('dv-detail', ...)`(408/414/417行目)— それぞれ `document.getElementById(id)`
+    の存在を前提に `clear()`+`appendChild()` する(41行目の `mount` 定義)。
+  - `document.documentElement.setAttribute('data-theme', ...)`(134行目、
+    `applyTheme()`)。
+  - `localStorage.getItem/setItem('svelte-vitals-theme', ...)`(137行目付近)。
+  - `location.hash`(427-430行目、`restoreSelectionFromHash`)。
+  - `window.addEventListener('hashchange', ...)`(449行目)。
+- **`boot()` の全体像**(441-461行目、既に読了済み): `raw.textContent` から
+  `JSON.parse` して初期スナップショットを読み込み、`applyTheme()` →
+  `renderSidebar()` → `restoreSelectionFromHash()` → `renderAll()` の順に呼び、
+  最後に `EventSource` が存在すれば `/__svelte-vitals/events` に接続して
+  `open`/`update`/`error` イベントをそれぞれ処理する。
+- **実際に埋め込まれる際のマークアップ** — `packages/vite/src/ui/dashboard.ts`
+  (`renderDashboardShell` — 既存テスト `ui-dashboard.test.ts` が対象にしている
+  関数)を読み、`svelte-vitals-data`/`dv-topbar`/`dv-sidebar`/`dv-detail` の各
+  要素が実際にどんな tag/属性で生成されているかを確認し、テストのフィクスチャは
+  それに近い形にする(完全one致でなくてよいが、`id` と `textContent` に
+  JSON が入る形は一致させる必要がある)。
+- **`packages/vite/test/ui-dashboard.test.ts` の先頭**(既に読了済み、
+  `baseSnapshot: DashboardSnapshot` のフィクスチャ定義がある — 新テストでも
+  この型・値を再利用できる)。
+
+## Commands you will need
+
+| Purpose   | Command                                    | Expected on success |
+| --------- | --------------------------------------------- | -------------------- |
+| Install   | `pnpm install`(jsdom 追加後)                | exit 0                |
+| Tests     | `pnpm --filter @svelte-vitals/vite test`     | all pass              |
+| Typecheck | `pnpm --filter @svelte-vitals/vite typecheck`| exit 0                |
+| Lint      | `pnpm lint`                                    | exit 0                |
+
+## Scope
+
+**In scope**:
+
+- `pnpm-workspace.yaml`(`catalog:` に `jsdom` を追加)
+- `packages/vite/package.json`(devDependencies に `jsdom: catalog:` を追加)
+- `packages/vite/test/dashboard-script-staleness.test.ts`(新規作成)
+
+**Out of scope**:
+
+- `packages/vite/src/ui/dashboard-script.ts` のプロダクションコード変更(このプラン
+  はテストのみ)。
+- ダッシュボードスクリプト全体の網羅的なレンダリングテスト(サイドバーの検索/
+  ソート、ルート詳細表示などの UI ロジック全体)— このプランは staleness ガード
+  1点にスコープを絞る。
+- `packages/core/src/reporter/html.ts` の `SCRIPT` 定数(静的レポートの HTML —
+  無関係な別のスクリプト)。
+
+## Git workflow
+
+- Branch: `advisor/035-dashboard-sse-staleness-guard-test`
+- コミット: `test(vite): execute the dashboard client script to verify its SSE staleness guard`
+  (英語、1コミットでよい)。
+- push / PR 作成はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: `jsdom` を catalog 経由の devDependency として追加する
+
+`pnpm-workspace.yaml` の `catalog:` ブロックにアルファベット順で追加(既存の並びに
+倣う):
+
+```yaml
+  jsdom: ^27.0.0
+```
+
+(実際の最新安定版バージョンを確認して埋めること — 推測でバージョン番号を固定しない。
+`npm view jsdom version` 相当の方法で確認できない場合、`package.json` の他の
+devDependency と同程度に新しいメジャーを選ぶ。)
+
+`packages/vite/package.json` の `devDependencies` に追加:
+
+```json
+    "jsdom": "catalog:",
+```
+
+**Verify**: `pnpm install` → exit 0。
+
+### Step 2: 対象ファイル全体を読み、DOM フィクスチャの要件を確定する
+
+`packages/vite/src/ui/dashboard-script.ts` を最初から最後まで読み(この計画書の
+「Current state」に挙げた箇所以外にも `getElementById`/DOM API 呼び出しがないか
+再確認する)、`packages/vite/src/ui/dashboard.ts` を読んで実際に生成される
+HTML の要素 ID と `svelte-vitals-data` 要素の中身の形を確認する。これにより、
+テストで用意すべき最小限の DOM フィクスチャ(`svelte-vitals-data`・`dv-topbar`・
+`dv-sidebar`・`dv-detail` の4要素、それぞれ適切なタグで)を確定させる。
+
+### Step 3: テストファイルを新規作成する
+
+`packages/vite/test/dashboard-script-staleness.test.ts` を作成する。ファイル冒頭に
+jsdom 環境を指定する vitest のマジックコメントを置く:
+
+```ts
+// @vitest-environment jsdom
+```
+
+テストの骨格:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { DASHBOARD_SCRIPT } from '../src/ui/dashboard-script.js';
+
+function snapshotJson(sequence: number, overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    sequence,
+    report: { version: '1', score: 80, weights: { seo: 1 }, categories: {}, summary: {}, routes: [], siteIssues: [] },
+    badges: {},
+    analyzing: false,
+    ...overrides
+  });
+}
+
+describe('dashboard client script — SSE staleness guard', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <script type="application/json" id="svelte-vitals-data">${snapshotJson(1)}</script>
+      <div id="dv-topbar"></div>
+      <div id="dv-sidebar"></div>
+      <div id="dv-detail"></div>
+    `;
+    // jsdom has no EventSource — stub it so `boot()`'s `typeof EventSource !== 'undefined'`
+    // check is false and the script never tries to open a real connection; this test
+    // drives fetchSnapshot()'s staleness guard directly via fetch responses instead.
+    // (If a later test needs to exercise the `open`/`update` handlers themselves, add a
+    // minimal EventSource stub class at that point — not needed for this guard.)
+    // @ts-expect-error jsdom has no EventSource
+    delete window.EventSource;
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('discards an out-of-order response with a lower or equal sequence', async () => {
+    // eslint-disable-next-line no-eval -- executing the hand-authored client script under test, by design (see plan)
+    (0, eval)(DASHBOARD_SCRIPT); // runs boot() immediately, reads the seeded snapshot (sequence: 1)
+
+    // Simulate a fetchSnapshot() call that resolves with an OLDER/EQUAL sequence than
+    // what's already rendered (state.snapshot.sequence === 1 from the seeded element).
+    fetchMock.mockResolvedValueOnce({ json: () => Promise.resolve(JSON.parse(snapshotJson(1))) });
+    // The script has no exported handle to call fetchSnapshot() directly (IIFE, no
+    // globals leaked) — trigger it the same way production code does: dispatch a
+    // fake 'update'-shaped call is not possible without EventSource, so instead
+    // assert indirectly via the DOM: a stale response must not change rendered output.
+    // ... (see STOP conditions: if this indirection proves impossible, escalate)
+  });
+});
+```
+
+**この骨格には未解決の設計課題がある — 執筆者(あなた)が Step 4 で解決すること**:
+`DASHBOARD_SCRIPT` の IIFE はグローバルに何も公開しない(`fetchSnapshot`/`state`
+はすべてクロージャの中)。そのため、テストから直接 `fetchSnapshot()` を呼んだり
+`state.snapshot.sequence` を読んだりすることができない。呼び出しの引き金は
+`EventSource` の `open`/`update` イベントしかない(`boot()` 内、455-459行目)。
+したがって、このテストは **`EventSource` を削除するのではなく、テスト用の
+フェイク `EventSource` クラスを `window.EventSource` に設定してから** スクリプト
+を評価し、フェイクのインスタンスに対して手動で `open`/`update` イベントを
+dispatch することで `fetchSnapshot()` を間接的に駆動する必要がある。上記の骨格
+コードの `delete window.EventSource` は誤り — Step 4 で正しい形に直すこと。
+
+### Step 4: フェイク `EventSource` で `fetchSnapshot` を駆動し、staleness を検証する
+
+`window.EventSource` に、`new` されると `boot()` からインスタンスを受け取れる
+フェイクを設定する:
+
+```ts
+  let esInstances: FakeEventSource[] = [];
+  class FakeEventSource {
+    listeners: Record<string, Array<() => void>> = {};
+    constructor(public url: string) {
+      esInstances.push(this);
+    }
+    addEventListener(type: string, cb: () => void) {
+      (this.listeners[type] ??= []).push(cb);
+    }
+    dispatch(type: string) {
+      (this.listeners[type] ?? []).forEach((cb) => cb());
+    }
+  }
+
+  beforeEach(() => {
+    ...
+    esInstances = [];
+    vi.stubGlobal('EventSource', FakeEventSource);
+    ...
+  });
+```
+
+テスト本体:
+
+```ts
+  it('discards an out-of-order response with a lower or equal sequence', async () => {
+    // fetchSnapshot() is called once on 'open' (boot()'s open handler) — resolve it
+    // with sequence 5 so state.snapshot.sequence becomes 5.
+    fetchMock.mockResolvedValueOnce({ json: () => Promise.resolve(JSON.parse(snapshotJson(5))) });
+
+    (0, eval)(DASHBOARD_SCRIPT);
+    esInstances[0]!.dispatch('open');
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    // Now simulate a SECOND 'update' event whose fetch resolves with an OLDER
+    // sequence (4) than what's already rendered (5) — the guard must discard it.
+    fetchMock.mockResolvedValueOnce({ json: () => Promise.resolve(JSON.parse(snapshotJson(4, { analyzing: true }))) });
+    esInstances[0]!.dispatch('update');
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    // Assert the stale response was NOT applied: the topbar (rendered from
+    // state.snapshot) must still reflect analyzing: false, not the stale true.
+    // (Exact assertion depends on what renderTopbar() actually reflects for
+    // `analyzing` — read renderTopbar()'s implementation in Step 2 and assert on
+    // whatever DOM output distinguishes sequence-5 state from sequence-4 state.)
+    expect(document.getElementById('dv-topbar')!.innerHTML).not.toContain(/* sequence-4-specific marker */);
+  });
+
+  it('applies a newer response and updates the rendered state', async () => {
+    // Mirror of the above: resolve 'open' with sequence 5, then 'update' with
+    // sequence 6, and assert the NEW content IS reflected — proves the guard
+    // isn't simply discarding everything.
+  });
+```
+
+具体的な DOM アサーション(コメントの `/* sequence-4-specific marker */` の部分)
+は、`renderTopbar`/`renderOverview` の実装を Step 2 で読んだ内容に基づいて、
+`analyzing` フラグや `score`/`sequence` に紐づく実際の描画差分(例: analyzing
+中は特定の class や文言が topbar に出る、スコア数値がテキストとして表示される、
+等)を使って具体化すること。単に「呼ばれた回数」ではなく「**古い方の内容が
+DOM に反映されていないこと**」を直接見るのが、このテストの核心的な価値。
+
+**Verify**: `pnpm --filter @svelte-vitals/vite test` → 新規2ケースが green。
+
+### Step 5: 全体検証
+
+**Verify**: `pnpm --filter @svelte-vitals/vite typecheck && pnpm lint` → 両方
+exit 0(`eval` の使用について ESLint が `no-eval` を既定で禁止している場合、
+該当行に `// eslint-disable-next-line no-eval` を付ける — 上記コード例に既に
+含めてある。lint 設定が別のルール名/コメント形式を要求する場合はそれに従う)。
+
+## Test plan
+
+- 新規: 古い(または同じ)`sequence` を持つ SSE 駆動のレスポンスが state を
+  上書きしないことを、実際にスクリプトを実行して確認するテスト。
+- 新規: 新しい `sequence` を持つレスポンスは正しく適用されることを確認するテスト
+  (ガードが「常に何もしない」壊れ方をしていないことの反証)。
+- 検証: `pnpm --filter @svelte-vitals/vite test` → all pass、新規2ケース以上を
+  含む。
+
+## Done criteria
+
+- [ ] `jsdom` が `pnpm-workspace.yaml` の catalog 経由で `packages/vite` に
+      devDependency として追加されている
+- [ ] `packages/vite/test/dashboard-script-staleness.test.ts` が新規作成され、
+      `DASHBOARD_SCRIPT` を実際に実行して staleness ガードを検証している
+- [ ] 「古いレスポンスは反映されない」「新しいレスポンスは反映される」の両方が
+      テストされている
+- [ ] `pnpm --filter @svelte-vitals/vite test` が all pass
+- [ ] `pnpm --filter @svelte-vitals/vite typecheck && pnpm lint` が exit 0
+- [ ] `packages/vite/src/ui/dashboard-script.ts` に変更がない(`git diff` で確認)
+- [ ] `plans/README.md` の該当行を更新済み
+
+## STOP conditions
+
+- `eval`(または `new Function`)でスクリプトを実行する方式が、vitest の jsdom
+  環境と噛み合わずに動かない(例: `document`/`window` がグローバルスコープに
+  正しく見えない)ことが判明した場合、`happy-dom` への切り替えを検討し、それでも
+  解決しなければ STOP して報告する。
+- `renderTopbar`/`renderOverview` の実装が、`analyzing`/`sequence` の違いを判別
+  できるような具体的な DOM 出力の差を持たない(= どちらのレスポンスが反映されたか
+  を DOM から見分けられない)ことが判明した場合、別の観測可能な差分(例:
+  `state.snapshot` 相当の値を window に一時的に漏らすデバッグフックを**テスト
+  ビルドでだけ**追加する、等)を検討する前に、まず STOP して報告する
+  (プロダクションコードへの変更が必要になる可能性があるため)。
+- 検証コマンドが修正1回を挟んで2回失敗した場合。
+
+## Maintenance notes
+
+- 今後 `dashboard-script.ts` の `fetchSnapshot`/`boot` を変更する場合、このテスト
+  が最初に red になるはず — レビュアーはその変化が意図したものかを確認すること。
+- `eval` によるスクリプト実行というテスト手法は、`DASHBOARD_SCRIPT` が今後
+  「バンドラーなしの手書き文字列」という設計から離れた場合(例: 実際に TS
+  モジュールとしてコンパイルされる形に変わった場合)には不要になる — その時点で
+  このテストをより直接的な import ベースのテストに書き換えることを検討する。

--- a/plans/036-design-spike-scoped-diff-baseline-analysis.md
+++ b/plans/036-design-spike-scoped-diff-baseline-analysis.md
@@ -69,10 +69,10 @@
 このプランは実装ではなく調査/設計が主だが、プロトタイプ(Step 3)を書く場合は
 以下を使う:
 
-| Purpose   | Command                                  | Expected on success |
-| --------- | ------------------------------------------ | -------------------- |
-| Tests     | `pnpm --filter svelte-vitals test`       | all pass              |
-| Typecheck | `pnpm --filter svelte-vitals typecheck`  | exit 0                |
+| Purpose   | Command                                 | Expected on success |
+| --------- | --------------------------------------- | ------------------- |
+| Tests     | `pnpm --filter svelte-vitals test`      | all pass            |
+| Typecheck | `pnpm --filter svelte-vitals typecheck` | exit 0              |
 
 ## Scope
 

--- a/plans/036-design-spike-scoped-diff-baseline-analysis.md
+++ b/plans/036-design-spike-scoped-diff-baseline-analysis.md
@@ -1,0 +1,202 @@
+# Plan 036: 設計スパイク — `--diff`/`--staged`/`--baseline` のフルプロジェクト解析を回避する
+
+> **Executor instructions**: This is a **design/spike plan**, not a build-everything
+> plan. The deliverable is a design doc under `docs/superpowers/specs/` (following
+> this repo's existing convention) that answers the open questions below — not a
+> shipped code change. Follow the steps, produce the design doc, and STOP for
+> maintainer review before implementing anything beyond the prototype described in
+> Step 3. If anything in "STOP conditions" occurs, stop and report.
+>
+> **Drift check (run first)**: `git diff --stat 3341587..HEAD -- packages/cli/src/index.ts packages/cli/src/baseline.ts packages/cli/src/changed-files.ts`
+> 差分があれば下記「Current state」の抜粋と実ファイルを突き合わせ、不一致なら STOP。
+
+## Status
+
+- **Priority**: P3
+- **Effort**: M(設計スパイクとしての工数。フル実装は別プランに切り出す)
+- **Risk**: MED(一部ルールはプロジェクト全体のコンテキストを正当に必要とするため、
+  ナイーブな「変更ファイルだけ解析する」実装は正しさを壊しうる — このプランの目的は
+  その境界を明確にすること)
+- **Depends on**: none(Plan 034 のパースキャッシュが実装されていると、このプランの
+  プロトタイプで再利用できる可能性がある — 独立に実施可能)
+- **Category**: perf / direction
+- **Planned at**: commit `3341587`, 2026-07-13
+
+## Why this matters
+
+`--diff`/`--staged`/`--baseline` は「PR ゲートが本当に気にする変更だけを見る」ための
+スコープ絞り込み機能だが、実装は**常にプロジェクト全体を解析してから**結果を絞り込む
+(`packages/cli/src/index.ts:172-207` の `analyzeProject` は変更ファイルの情報を一切
+受け取らず、常に全ルート・全コンポーネントを対象に全ルールを実行する。
+`packages/cli/src/index.ts:235-288` の `applyScope` はその**後**に
+`filterToChangedFiles`/`filterToNewFindings` で結果を絞り込むだけ)。`--baseline` は
+さらに `checkoutBaseline`(`packages/cli/src/baseline.ts`)で git worktree を切って
+**2回目のフル解析**まで行う。
+
+大規模な SvelteKit アプリで1ファイルだけ変更した pre-commit フックや PR ゲートが、
+「スコープ絞り込み」という機能の趣旨に反して毎回フルコストを払う。
+
+一方で、一部のルールは**正しく動作するために全ルート/全コンポーネントのコンテキスト
+を必要とする**(例: `packages/core/src/rules/seo/seo028-029-uniqueness.ts` の
+重複タイトル/ディスクリプション検出は、他の全ルートとの比較が本質)。この境界を
+無視して「変更ファイルだけ解析する」実装をすると、変更されていないルートとの重複が
+検出できなくなるという**サイレントな不正確さ**を生む。だからこのプランは「実装」で
+はなく「設計スパイク」— 安全に高速化できる部分とできない部分を明確に線引きしてから、
+実装プランを別途起票する。
+
+## Current state
+
+- **`analyzeProject`** — `packages/cli/src/index.ts:172-207`(既に全文読了済み)。
+  `route` オプションによる絞り込み(191-195行目)は存在するが、これは「ユーザーが
+  明示的に指定したグロブでルートを絞る」機能であり、`--diff`/`--staged`/`--baseline`
+  の変更ファイル検出とは連動していない。
+- **`applyScope`** — 同ファイル209-288行目(既に全文読了済み)。`getChangedFiles`/
+  `filterToChangedFiles`(`packages/cli/src/changed-files.ts`)と
+  `checkoutBaseline`/`filterToNewFindings`(`packages/cli/src/baseline.ts`)を
+  `analyzeProject` の**結果に対して事後的に**適用する。
+- **重複検出ルール** — `packages/core/src/rules/seo/seo028-029-uniqueness.ts`
+  (ファイル名から推測 — 実装の詳細をこのスパイクの Step 1 で読むこと)。
+  `ctx`(`RuleContext`)にプロジェクト全体の `heads`(`ResolvedHead[]`)が渡される
+  前提で、全ルートを横断してタイトル/ディスクリプションの重複を判定していると
+  想定される。
+- **`ParseCache`** — Plan 034 で導入(または導入予定)の、ファイル単位の読込+パース
+  結果キャッシュ。これは「ファイルを読み直さない」レベルの最適化であり、本プランが
+  扱う「ルールをどのルートに対して実行するか」というより高いレベルの最適化とは
+  別の層にある — 両者は併用可能。
+
+## Commands you will need
+
+このプランは実装ではなく調査/設計が主だが、プロトタイプ(Step 3)を書く場合は
+以下を使う:
+
+| Purpose   | Command                                  | Expected on success |
+| --------- | ------------------------------------------ | -------------------- |
+| Tests     | `pnpm --filter svelte-vitals test`       | all pass              |
+| Typecheck | `pnpm --filter svelte-vitals typecheck`  | exit 0                |
+
+## Scope
+
+**In scope**:
+
+- 調査: どのルールが「全ルート/全プロジェクトのコンテキスト」を正当に必要とするか
+  の棚卸し。
+- 調査: `--diff`/`--staged`/`--baseline` それぞれについて、「変更ファイルの
+  layout chain に含まれるルートだけを解析する」という絞り込みが安全に導入できるか。
+- 設計ドキュメントの作成: `docs/superpowers/specs/<date>-scoped-diff-analysis-design.md`
+  (このリポジトリの既存の設計ドキュメント群と同じ形式 — 例えば
+  `docs/superpowers/specs/2026-07-08-dev-dashboard-whole-project-design.md` を
+  参考にする)。
+- (オプション、Step 3)技術的に成立するかを確認するための小さなプロトタイプ/
+  スパイクコード。**マージを前提としない使い捨てコード** — 動くことを確認したら
+  設計ドキュメントに知見を反映し、プロトタイプ自体は破棄するか別ブランチに残す。
+
+**Out of scope**:
+
+- 本番採用する実装そのもの(このスパイクの結論を踏まえて、別の実装プランとして
+  改めて起票する)。
+- `--baseline` の git worktree 機構自体の変更(このプランは「何を解析するか」の
+  スコープ絞り込みが主眼であり、worktree の作り方は変更しない)。
+
+## Git workflow
+
+- Branch: `advisor/036-design-spike-scoped-diff-baseline-analysis`
+- コミット: 設計ドキュメントの追加(`docs: add design spike for scoped diff/baseline analysis`)。
+  プロトタイプコードを書いた場合、それは別コミットにし、最終的にマージしない
+  (ドラフト PR の説明に「プロトタイプは参考実装であり別プランで正式に実装する」
+  旨を明記)。
+- push / PR 作成はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: 全ルール(49個)を「ルート単位で独立に判定できるか」で分類する
+
+`packages/core/src/rules/index.ts` の `allRules` を一覧し、各ルールの `check`
+関数が `ctx`(`RuleContext`)のうちプロジェクト全体のコレクション
+(`ctx.heads`/`ctx.components`/`ctx.project` など)をどう使っているかを読む。
+分類は2つ:
+
+- **ルート/ファイル独立**: そのルート(またはそのコンポーネントファイル)の情報
+  だけで判定が完結する(例: `SEO001` の `<title>` 有無)。
+- **プロジェクト横断**: 他のルート/ファイルとの比較や集計が必要(例:
+  `SEO028`/`SEO029` の重複検出、`ARCH` 系のプロジェクト全体のファイル数/構造に
+  依存するルールがあれば)。
+
+この分類結果を設計ドキュメントの表として残す(ルールID・分類・根拠の3列)。
+
+### Step 2: レイアウトチェーンによる「影響を受けるルート」の算出方法を検討する
+
+`chainFiles`(`packages/cli/src/providers/source/resolve.ts` — 既に部分的に読了、
+`resolveRoute` が使っている)は、あるページに対してそのレイアウトチェーン
+(祖先レイアウト全て)を返す。これの**逆引き**(あるファイルが変更されたとき、
+それを layout chain に含むページ = 影響を受けるルート、を求める関数)を実装する
+ための設計を検討する:
+
+- 全ルートの `chainFiles` 結果を一度計算してファイル→ルートの逆引きマップを作る
+  コストは、結局「全ルートを列挙する」処理を要するため、「フル解析を避ける」という
+  目的とどこまで両立するか(列挙自体は軽いが、各ルートの `resolveFileTags` の
+  ような重い処理まで避けられるかを見極める)。
+- 変更ファイルがコンポーネント(ルート/レイアウトではなく `$lib` 配下など)の場合、
+  どのルートがそれを import しているかを静的に追跡するのは、レイアウトチェーンの
+  比ではないコストがかかる可能性がある(import グラフの構築が必要)— この場合、
+  「安全側に倒してプロジェクト全体を解析する」フォールバックが必要かどうかを
+  検討する。
+
+### Step 3(オプション): 小さなプロトタイプで技術的成立性を確認する
+
+Step 1 で「ルート/ファイル独立」に分類したルールだけを対象に、変更ファイルの
+layout chain に含まれるルートのみを解析する簡易プロトタイプを、既存のテスト
+フィクスチャ(`packages/cli/test/fixtures/`)の1つを使って書いてみる。目的は
+「本当に結果が変わらないか」を実測することであり、本番コードへの統合は行わない。
+
+### Step 4: 設計ドキュメントを書く
+
+`docs/superpowers/specs/<today>-scoped-diff-analysis-design.md` を作成し、以下を
+含める:
+
+- Step 1 の分類結果(全ルール表)。
+- Step 2 の検討結果と、推奨するアプローチ(例: 「ルート/レイアウトファイルの変更は
+  layout chain 逆引きで安全に絞れるが、コンポーネント変更やプロジェクト横断ルール
+  が絡む場合は全体解析にフォールバックする」といった具体的な設計)。
+- 未決事項(Open questions)を明示し、メンテナーが判断すべき点をリストアップする
+  (例: 「フォールバックの閾値をどう決めるか」「`--baseline` の2回目の解析にも
+  同じ絞り込みを適用するか」)。
+- 見積もり: 本実装に必要な効果(どの程度のプロジェクト規模でどれくらいの時間短縮
+  が見込めるか、Step 3 のプロトタイプがあれば実測値)と工数(粗い見積もりでよい)。
+
+## Test plan
+
+このプランはスパイクであり、本番コードへの変更を伴わない場合はテスト追加も不要。
+Step 3 でプロトタイプを書いた場合、それが既存のテストスイートを壊さないことだけを
+確認する(`pnpm --filter svelte-vitals test`)— プロトタイプ用の新規テストを本気で
+書き込む必要はない(使い捨てである旨をコードコメントに明記する)。
+
+## Done criteria
+
+- [ ] 全49ルールの「ルート/ファイル独立」 vs 「プロジェクト横断」分類が完了している
+- [ ] レイアウトチェーン逆引きのアプローチと、その限界(コンポーネント変更時の
+      フォールバック)が設計ドキュメントに明記されている
+- [ ] `docs/superpowers/specs/` に設計ドキュメントが追加されている
+- [ ] 未決事項がメンテナー向けに明示されている
+- [ ] (Step 3 を実施した場合)プロトタイプが既存テストスイートを壊していない
+- [ ] `plans/README.md` の該当行を更新済み(ステータスは「設計完了、実装は別プラン
+      待ち」であることを明記)
+
+## STOP conditions
+
+- ルールの分類作業中に、「ルート/ファイル独立」と「プロジェクト横断」の境界が
+  ルールの実装から明確に読み取れない(ドキュメントコメントもテストも手がかりに
+  ならない)ケースに複数遭遇した場合、無理に推測で分類せず、それらのルールIDを
+  「要確認」として設計ドキュメントに残し、報告する。
+- Step 3 のプロトタイプで、レイアウトチェーン逆引きが「変更されていないはずの
+  ルートの所見が変わってしまう」という不正確さを生むケースが見つかった場合、
+  そのケースを詳しく記録して報告する(これは実装を諦める理由にはならず、むしろ
+  このスパイクが見つけるべき最も重要な知見)。
+
+## Maintenance notes
+
+- このプランの成果物(設計ドキュメント)は、メンテナーが実装するかどうかを判断
+  するための材料。承認された場合、別の実装プラン(番号は次の advisor セッションで
+  採番)として改めて起票すること — このプラン自体を「実装済み」として閉じない。
+- Plan 034(dev dashboard の永続パースキャッシュ)と本プランは異なる層の最適化
+  であり、両方を実装する場合は互いに干渉しないことを確認する(パースキャッシュは
+  「ファイルを読み直さない」、本プランは「どのルートを解析対象にするか」)。

--- a/plans/037-design-spike-dev-server-analysis-isolation.md
+++ b/plans/037-design-spike-dev-server-analysis-isolation.md
@@ -57,10 +57,10 @@ SSE/`data.json` リクエストの応答が遅延する可能性がある。
 
 ## Commands you will need
 
-| Purpose                     | Command                                          | Expected on success |
-| ----------------------------- | --------------------------------------------------- | -------------------- |
-| ベンチマーク用の一時プロジェクト生成 | (Step 2 で作成するスクリプト、`node scripts/...` 相当) | 実行完了 |
-| 既存テスト                    | `pnpm --filter @svelte-vitals/vite test`          | all pass              |
+| Purpose                              | Command                                                | Expected on success |
+| ------------------------------------ | ------------------------------------------------------ | ------------------- |
+| ベンチマーク用の一時プロジェクト生成 | (Step 2 で作成するスクリプト、`node scripts/...` 相当) | 実行完了            |
+| 既存テスト                           | `pnpm --filter @svelte-vitals/vite test`               | all pass            |
 
 ## Scope
 

--- a/plans/037-design-spike-dev-server-analysis-isolation.md
+++ b/plans/037-design-spike-dev-server-analysis-isolation.md
@@ -1,0 +1,180 @@
+# Plan 037: 設計スパイク — whole-project 解析の dev-server イベントループ専有を計測・検討する
+
+> **Executor instructions**: This is a **measure-first design spike**, not a build
+> plan. The original finding behind this plan is MED confidence — it identifies a
+> plausible blocking pattern by reading the code, but nobody has measured actual
+> blocking duration under realistic load. Your first and most important deliverable
+> is a measurement; only design a worker-thread migration if the measurement shows
+> a real problem. Do not implement `worker_threads` isolation speculatively. If
+> anything in "STOP conditions" occurs, stop and report.
+>
+> **Drift check (run first)**: `git diff --stat 3341587..HEAD -- packages/vite/src/ui/analysis.ts packages/cli/src/providers/source/parse.ts packages/cli/src/providers/source/routes.ts`
+> 差分があれば下記「Current state」の抜粋と実ファイルを突き合わせ、不一致なら STOP。
+
+## Status
+
+- **Priority**: P3
+- **Effort**: L(計測 + 設計。worker_threads 移行の本実装は対象外)
+- **Risk**: MED(計測自体は無害だが、結論次第で L 工数の実装プランに繋がる可能性)
+- **Depends on**: Plan 034(パースキャッシュが入っていると、計測対象の「保存の
+  たびに何が起きるか」の実態が変わるため、Plan 034 の後に計測する方がより正確な
+  「今後実際に困るケース」を測れる — 順序は必須ではないが推奨)
+- **Category**: perf
+- **Planned at**: commit `3341587`, 2026-07-13
+
+## Why this matters
+
+Vite dev dashboard の whole-project 解析(`packages/vite/src/ui/analysis.ts` の
+`runOnce`)は、`svelte/compiler` の同期パース(`packages/cli/src/providers/source/parse.ts`
+が使う `parse` エクスポート)を、dev サーバーと同じ Node プロセス・同じイベント
+ループ上で実行する。`packages/vite/src/ui/middleware.ts` は同じイベントループ上で
+`/ingest`・`/events`(SSE)・`/data.json` を処理している。理論上、大規模プロジェクト
+での保存時に、解析がイベントループを長時間占有し、HMR ping やダッシュボード自身の
+SSE/`data.json` リクエストの応答が遅延する可能性がある。
+
+ただし監査時点でこれは**未計測の推測**であり、実際にどの程度のプロジェクト規模で
+どの程度のブロッキングが発生するのか(あるいは全く問題にならない程度なのか)は
+分かっていない。`worker_threads` によるプロセス内分離は L 工数・MED リスク
+(メッセージパッシングでの `Result[]`/エラー伝播、ワーカーのライフサイクル管理が
+必要)の実装であり、実際に問題がある確証がないまま着手するのは過剰投資になりうる。
+このプランはまず**測る**ことを最優先にする。
+
+## Current state
+
+- **同期パース** — `packages/cli/src/providers/source/parse.ts:1` 付近
+  (`svelte/compiler` の同期 `parse` を使用 — 実装の詳細は Step 1 で再確認する)。
+- **並列だが同期処理を含む解決** — `packages/cli/src/providers/source/routes.ts:196`
+  (`Promise.all(pages.map((page) => resolveRoute(...)))` — 各 `resolveRoute` は
+  `await` を挟むが、内部の `parse` 呼び出し自体は同期でイベントループをブロック
+  する)。
+- **dev dashboard の呼び出し元** — `packages/vite/src/ui/analysis.ts` の
+  `runOnce`(既に全文読了済み)、`packages/vite/src/ui/middleware.ts` が同じ
+  イベントループ上で `/ingest`・`/events`・`/data.json` を処理する
+  (既にセキュリティ監査で読了済み、ファイル冒頭に loopback チェックあり)。
+- **既存のテストインフラ** — `packages/cli/test/fixtures/` に既存の SvelteKit
+  プロジェクトフィクスチャがあるが、「大規模プロジェクト」を模した規模のフィクス
+  チャ(数百ルート)は存在しない可能性が高い(Step 1 で確認)。
+
+## Commands you will need
+
+| Purpose                     | Command                                          | Expected on success |
+| ----------------------------- | --------------------------------------------------- | -------------------- |
+| ベンチマーク用の一時プロジェクト生成 | (Step 2 で作成するスクリプト、`node scripts/...` 相当) | 実行完了 |
+| 既存テスト                    | `pnpm --filter @svelte-vitals/vite test`          | all pass              |
+
+## Scope
+
+**In scope**:
+
+- 計測: 大規模プロジェクト(合成フィクスチャ)に対する whole-project 解析1回の
+  所要時間と、その間イベントループが実際にどの程度ブロックされるか(例: 解析実行中
+  に定期的な `setImmediate`/`setInterval` の tick 遅延を測る、という古典的な
+  イベントループ遅延測定手法)を測るベンチマークスクリプトの作成と実行。
+- 計測結果に基づく設計ドキュメントの作成(`docs/superpowers/specs/`)。
+- (計測が実際の問題を示した場合のみ)`worker_threads` 移行のごく簡単な技術検証
+  (メッセージパッシングで `Result[]` を往復できるかの smoke test 程度)。
+
+**Out of scope**:
+
+- `worker_threads` を使った本実装(このプランで問題が実証された場合、別の実装
+  プランとして改めて起票する)。
+- Plan 034/036 が扱う「何を解析するか」の絞り込み最適化(本プランは「解析自体を
+  どこで実行するか」という別の軸)。
+
+## Git workflow
+
+- Branch: `advisor/037-design-spike-dev-server-analysis-isolation`
+- コミット: 計測スクリプト + 結果 + 設計ドキュメントをまとめて1つでよい
+  (`docs: measure dev-dashboard analysis blocking and spike worker isolation`)。
+- push / PR 作成はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: 既存フィクスチャの規模を確認する
+
+`packages/cli/test/fixtures/` にある既存の SvelteKit プロジェクトフィクスチャの
+ルート数を数える(`find <fixture> -name '+page.svelte' | wc -l` 相当)。既存の
+最大フィクスチャが小規模(数ルート程度)であれば、Step 2 で合成フィクスチャを
+新規生成する必要があることを確認する。
+
+### Step 2: 大規模プロジェクトを合成するスクリプトを書く
+
+一時ディレクトリに、N 個(例: 50, 200, 500 の3段階)のルート(`+page.svelte`)と
+それぞれ現実的な量の `<head>` タグ・コンポーネントを持つ SvelteKit ライクな
+プロジェクト構造を機械的に生成する小さなスクリプトを書く(`packages/vite/scripts/`
+などの一時的な場所に置いてよい — 本番コードではないので `packages/vite/src/` には
+置かない)。
+
+### Step 3: イベントループのブロッキングを計測する
+
+生成したプロジェクトそれぞれに対して、`packages/cli` の `analyzeProject`(または
+`collectRoutes`)を直接呼び出しつつ、以下のいずれかの方法でイベントループの
+ブロッキングを計測する:
+
+- **古典的な手法**: 解析呼び出しの直前から一定間隔(例: 10ms)で `setInterval`
+  の tick を記録しておき、解析中に tick 間隔が異常に開く(例: 100ms 以上)瞬間が
+  あるか、あるとすれば合計でどれくらいの時間 loop が「詰まって」いたかを算出する。
+- 代替として Node の `perf_hooks`(`monitorEventLoopDelay`)が使えるならそちらを
+  使ってもよい。
+
+各プロジェクト規模(50/200/500ルート)について、解析の総所要時間と、イベント
+ループの最大遅延・累積遅延を記録する。
+
+### Step 4: 結果を評価し、設計ドキュメントを書く
+
+`docs/superpowers/specs/<today>-dev-server-analysis-isolation-design.md` を作成
+し、以下を含める:
+
+- Step 3 の計測結果(表: プロジェクト規模・解析所要時間・イベントループ最大遅延・
+  累積遅延)。
+- **判断**: 遅延が実用上無視できる範囲(具体的な閾値はメンテナーの感覚に委ねる
+  必要があるが、目安として「HMR の典型的な応答時間(数十ms)に対して顕著に大きい
+  遅延が繰り返し発生するか」を基準に評価する)であれば、**このプランはここで
+  完了とし、`worker_threads` 移行は「見送り」として記録する**(元の finding が
+  「未計測の匂い」であったことを踏まえ、実測の結果「問題なし」であれば、それ自体
+  が価値ある成果 — 見送りの理由を明記して次回の再監査を防ぐ)。
+- 遅延が無視できない規模で確認された場合のみ、`worker_threads` 移行の設計
+  (メッセージ形式、`Result[]` のシリアライズ境界、ワーカーのライフサイクルと
+  `runner.stop()` との連携、フォールバック(ワーカー起動失敗時はインライン実行))
+  を記述し、Step 5 に進む。
+
+### Step 5(条件付き・遅延が実証された場合のみ): 技術的成立性の最小検証
+
+`worker_threads` でメッセージパッシングを使い、`analyzeProject` の呼び出しと
+`Result[]` の返却が正しく行える最小限のプロトタイプを書き、動作を確認する
+(本実装ではなく成立性の確認)。
+
+## Test plan
+
+このプランはスパイクであり、既存のテストスイートへの変更は必須ではない。Step 2 の
+合成スクリプトと Step 3 の計測コードは使い捨てであり、テストは書かない
+(その旨をコードコメントに明記する)。
+
+## Done criteria
+
+- [ ] 50/200/500 ルート規模での解析所要時間とイベントループ遅延が計測されている
+- [ ] 計測結果に基づき「worker_threads 移行が必要か」の判断が設計ドキュメントに
+      明記されている
+- [ ] 判断が「見送り」の場合、その理由(閾値と実測値)が `plans/README.md` の
+      「considered and rejected」相当のセクションに転記されている
+- [ ] 判断が「移行を推奨」の場合、設計ドキュメントに移行方針と未決事項が明記され、
+      別の実装プランとして起票する準備ができている
+- [ ] `plans/README.md` の該当行を更新済み
+
+## STOP conditions
+
+- 合成プロジェクトの生成やイベントループ遅延の計測方法自体に技術的な障害
+  (例: サンドボックス環境で `perf_hooks` が使えない、大規模ファイル生成が
+  ディスク制約に引っかかる)がある場合、代替の計測手法を検討し、それでも測れ
+  なければ「計測不能」として正直に報告する — 推測で結論を出さない。
+- 計測結果が測定誤差の範囲内で判断がつかない(何度測っても閾値付近で揺れる)場合、
+  無理に結論を出さず、その旨を報告してメンテナーの判断を仰ぐ。
+
+## Maintenance notes
+
+- このプランの合成フィクスチャ生成スクリプトは、将来 Plan 034/036 の効果測定
+  (「変更していないファイルを読み直さない」「影響のないルートを解析しない」)
+  にも再利用できる可能性がある — 使い捨てにせず `packages/vite/scripts/` や
+  `docs/superpowers/` 配下に残しておくことを検討してもよい(必須ではない)。
+- 「見送り」の判断をした場合でも、将来プロジェクト規模が今回計測した上限
+  (500ルート)を大きく超えるユーザー報告があれば、この計測を再度行う価値がある。

--- a/plans/038-config-file-vite-wiring-and-scaffolder.md
+++ b/plans/038-config-file-vite-wiring-and-scaffolder.md
@@ -51,7 +51,7 @@
 
 - **`loadConfigFile`** — `packages/cli/src/config-file.ts`(冒頭60行を既に読了
   済み)。`CONFIG_FILENAMES = ['svelte-vitals.config.mjs', 'svelte-vitals.config.js',
-  'svelte-vitals.config.ts']`(16行目)、`cwd` 直下のみ探索(上方探索なし)。戻り値
+'svelte-vitals.config.ts']`(16行目)、`cwd` 直下のみ探索(上方探索なし)。戻り値
   `LoadedConfigFile { config: Partial<Config>; warnings: string[] }`。
 - **`analyzeProject` での使用パターン**(参考にすべき精度の高い前例) —
   `packages/cli/src/index.ts:172-187`:
@@ -133,12 +133,12 @@ export async function analyze(
 
 ## Commands you will need
 
-| Purpose   | Command                                                                  | Expected on success |
-| --------- | --------------------------------------------------------------------------- | -------------------- |
-| Build     | `pnpm --filter svelte-vitals --filter @svelte-vitals/vite build`         | exit 0                |
-| Typecheck | 同2パッケージ `typecheck`                                                | exit 0                |
-| Tests     | 同2パッケージ `test`                                                     | all pass              |
-| Lint      | `pnpm lint`                                                                | exit 0                |
+| Purpose   | Command                                                          | Expected on success |
+| --------- | ---------------------------------------------------------------- | ------------------- |
+| Build     | `pnpm --filter svelte-vitals --filter @svelte-vitals/vite build` | exit 0              |
+| Typecheck | 同2パッケージ `typecheck`                                        | exit 0              |
+| Tests     | 同2パッケージ `test`                                             | all pass            |
+| Lint      | `pnpm lint`                                                      | exit 0              |
 
 ## Git workflow
 

--- a/plans/038-config-file-vite-wiring-and-scaffolder.md
+++ b/plans/038-config-file-vite-wiring-and-scaffolder.md
@@ -1,0 +1,397 @@
+# Plan 038: config file を vite プラグインに配線し、`install` にスキャフォルダーを追加する
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. This plan has two independent parts (Part A:
+> scaffolder, Part B: vite wiring) — you may implement them in either order,
+> but STOP between parts and confirm each part's verification passes before
+> starting the next. When done, update the status row for this plan in
+> `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat 3341587..HEAD -- packages/cli/src/config-file.ts packages/cli/src/install/index.ts packages/cli/src/install/vite-targets.ts packages/vite/src/plugin.ts packages/vite/src/analyze.ts`
+> 差分があれば下記「Current state」の抜粋と実ファイルを突き合わせ、不一致なら STOP。
+
+## Status
+
+- **Priority**: P3
+- **Effort**: M
+- **Risk**: LOW(Part A: 新規ファイルのスキャフォルダー追加、既存機能への影響なし)
+  / MED(Part B: vite の実効設定解決順序を変える — 既に config ファイルと plugin
+  オプションの両方を設定済みのユーザーの挙動が変わりうる)
+- **Depends on**: none
+- **Category**: direction / dx
+- **Planned at**: commit `3341587`, 2026-07-13
+
+## Why this matters
+
+`svelte-vitals.config.{mjs,js,ts}` は CLI(`run()`)と MCP の `analyze` ツールには
+配線済み(`packages/cli/src/config-file.ts` の `loadConfigFile`、
+`packages/cli/src/index.ts:176` の `analyzeProject` 内での呼び出し)。しかし2つの
+点で機能が中途半端:
+
+1. **スキャフォルダーがない**: `loadConfigFile` 自身のエラーメッセージ(162行目
+   付近)がユーザーに「`export default defineConfig({...})` を手で書け」と指示する
+   だけ。`install` ウィザードは `vite-plugin`/`vite-hooks`/`claude-skill`/
+   `cursor-rules` という4種の対象を既に自動生成しているのに、config file だけは
+   この体験から外れている。
+2. **vite プラグインが config file を一切読まない**: `packages/vite/src/plugin.ts`
+   (build-mode)と `packages/vite/src/analyze.ts`(prerendered 解析)はどちらも
+   `defineConfig({...options...})` を直接呼ぶだけで、`loadConfigFile` を import
+   すらしていない(`grep -rn "loadConfigFile" packages/vite/src` は0件)。
+   `packages/vite/src/plugin.ts` の `CONFIG_BASENAMES` は dev dashboard の
+   再解析トリガーとして `svelte-vitals.config.*` を含めている(ファイルを保存する
+   と再スキャンする素振りを見せる)のに、**その中身は一切読まれず無視される** —
+   ユーザーが config file に `weights` を設定して CLI ではそれが反映されるのに、
+   同じプロジェクトの vite dev dashboard/build ゲートでは黙って無視される、という
+   矛盾した体験になっている。
+
+## Current state
+
+- **`loadConfigFile`** — `packages/cli/src/config-file.ts`(冒頭60行を既に読了
+  済み)。`CONFIG_FILENAMES = ['svelte-vitals.config.mjs', 'svelte-vitals.config.js',
+  'svelte-vitals.config.ts']`(16行目)、`cwd` 直下のみ探索(上方探索なし)。戻り値
+  `LoadedConfigFile { config: Partial<Config>; warnings: string[] }`。
+- **`analyzeProject` での使用パターン**(参考にすべき精度の高い前例) —
+  `packages/cli/src/index.ts:172-187`:
+
+```ts
+export async function analyzeProject(opts: AnalyzeOptions = {}): Promise<AnalyzeResult> {
+  const cwd = opts.cwd ?? process.cwd();
+  const rt = createNodeRuntime();
+
+  const loaded = await loadConfigFile(cwd);
+  const file = loaded?.config;
+  const warnings = loaded?.warnings ?? [];
+
+  const weights = opts.weights ?? file?.weights;
+  const config = defineConfig({
+    treatDynamicAs: opts.treatDynamicAs ?? file?.treatDynamicAs ?? 'pass',
+    metaComponents: opts.metaComponents ?? file?.metaComponents ?? [],
+    rules: opts.rules ?? file?.rules ?? {},
+    failOn: opts.failOn ?? file?.failOn ?? 'critical',
+    ...(weights !== undefined ? { weights } : {})
+  });
+  ...
+```
+
+**優先順位のルール(既に確立済み・このプランはこれを踏襲する)**: 「明示的な
+オプション > config file の値 > 組み込みデフォルト」— `analyzeProject` の docblock
+(161-171行目)にも明記: "Config precedence is per field: an explicit option here
+wins, otherwise the config file's value is used, otherwise the built-in default
+(design doc 2026-07-05-config-file-design.md §3)."
+
+- **vite の build-mode plugin** — `packages/vite/src/plugin.ts:73-85`
+  (`closeBundle` 内、既に全文読了済み)は `options`(`SvelteVitalsOptions`、
+  plugin 呼び出し時の引数)から `analyze(resolved, root, options)` を呼ぶ。
+- **vite の解析本体** — `packages/vite/src/analyze.ts:34-44`(全文読了済み):
+
+```ts
+export async function analyze(
+  prerenderPagesDir: string,
+  cwd: string,
+  options: SvelteVitalsOptions
+): Promise<AnalyzeResult> {
+  const config = defineConfig({
+    treatDynamicAs: options.treatDynamicAs ?? 'pass',
+    metaComponents: options.metaComponents ?? [],
+    rules: options.rules ?? {},
+    failOn: options.failOn ?? 'critical'
+  });
+  ...
+```
+
+- **vite の dev dashboard(UI プラグイン)** — `packages/vite/src/plugin.ts:120-125`
+  (`configureServer` 内)も同様に `defineConfig({ ...options... })` を直接呼ぶ。
+- **`CONFIG_BASENAMES`** — `packages/vite/src/plugin.ts:13-19`(既に読了済み)。
+  `svelte-vitals.config.{mjs,js,ts}` が既に「再解析トリガー」の一覧に入っている
+  (= 保存すると再スキャンする素振りは既にある)。
+- **install ウィザードの対象一覧** — `packages/cli/src/install/vite-targets.ts`
+  (全文読了済み、`vite-plugin`/`vite-hooks` の2つ)、`agent-targets.ts`
+  (`claude-skill`/`cursor-rules`)。`packages/cli/src/install/index.ts`
+  (1-160行目、既に読了済み)の `planForAgentTarget`(103-109行目)が
+  「完全に再生成されるコンテンツ、`--force` で上書き可」という、config file
+  スキャフォルダーに最も近いパターン。
+
+## Scope
+
+**In scope**:
+
+- **Part A(スキャフォルダー)**: `install` に config file を生成する新しい対象
+  を追加する。
+- **Part B(vite 配線)**: `packages/vite/src/plugin.ts`・`packages/vite/src/analyze.ts`
+  が `loadConfigFile` を呼び、既存の「明示的オプション > config file > デフォルト」
+  の優先順位を踏襲する。
+
+**Out of scope**:
+
+- `loadConfigFile` 自体のロジック変更(上方ディレクトリ探索の追加など — 設計
+  ドキュメントが明示的にスコープ外としている)。
+- CLI 側の `analyzeProject`/`run()` の変更(既に配線済み、無変更)。
+- MCP 側(既に配線済み、無変更)。
+
+## Commands you will need
+
+| Purpose   | Command                                                                  | Expected on success |
+| --------- | --------------------------------------------------------------------------- | -------------------- |
+| Build     | `pnpm --filter svelte-vitals --filter @svelte-vitals/vite build`         | exit 0                |
+| Typecheck | 同2パッケージ `typecheck`                                                | exit 0                |
+| Tests     | 同2パッケージ `test`                                                     | all pass              |
+| Lint      | `pnpm lint`                                                                | exit 0                |
+
+## Git workflow
+
+- Branch: `advisor/038-config-file-vite-wiring-and-scaffolder`
+- コミット: Part A / Part B を別コミットにする(`feat(cli): scaffold svelte-vitals.config via install` /
+  `feat(vite): read svelte-vitals.config.* in the plugin and build-mode analyze`)。
+- push / PR 作成はオペレーターの指示があるまで行わない。
+
+---
+
+## Part A: `install` に config file スキャフォルダーを追加する
+
+### Step A1: 生成するテンプレート内容を決める
+
+`docs/src/content/docs/guides/configuration.md`(既存 — Step 2 で参照)を読み、
+`Config` 型(`packages/core/src/index.ts` から re-export される型定義、
+`treatDynamicAs`/`metaComponents`/`rules`/`failOn`/`weights`)を確認した上で、
+コメントアウトされたサンプルフィールドを持つ `svelte-vitals.config.mjs` の
+テンプレート文字列を生成する関数を書く(`packages/cli/src/install/skill-content.ts`
+に既にある `buildSkillMarkdown`/`buildCursorRules` と同じファイルに
+`buildConfigFileTemplate()` として追加するか、新規ファイル
+`packages/cli/src/install/config-content.ts` を作る — 既存の `skill-content.ts`
+の責務(agent 向けコンテンツ生成)とは性質が異なるため、新規ファイルを推奨)。
+
+生成する内容の例(全フィールドをコメントアウトしたサンプル):
+
+```js
+// svelte-vitals config file — https://oekazuma.github.io/svelte-vitals/guides/configuration/
+export default {
+  // treatDynamicAs: 'pass', // 'pass' | 'warn' | 'fail' — how {data.title}-style dynamic values are scored
+  // metaComponents: ['Seo'], // component names that resolve SEO tags into <head>
+  // rules: {}, // e.g. { SEO001: 'off' } to disable a rule
+  // failOn: 'critical', // 'critical' | 'warning' | 'info'
+  // weights: {} // e.g. { seo: 2 } — per-category weight for the combined Health score
+};
+```
+
+(`defineConfig` ヘルパーを使うかどうかは、CLI 側の実際の使用例
+(`docs/src/content/docs/guides/configuration.md` の既存サンプル)に合わせる —
+ドキュメントを読んで既存の推奨パターンと一致させること。)
+
+### Step A2: 新しい対象 ID を定義する
+
+`packages/cli/src/install/vite-targets.ts` や `agent-targets.ts` と同じパターンで
+`config-targets.ts`(新規)を作る:
+
+```ts
+export type ConfigTargetId = 'config-file';
+
+export interface ConfigTarget {
+  id: ConfigTargetId;
+  label: string;
+  hint: string;
+  relPath: string;
+}
+
+export const CONFIG_TARGETS: ConfigTarget[] = [
+  {
+    id: 'config-file',
+    label: 'Config file',
+    hint: 'Scaffolds svelte-vitals.config.mjs with every option commented out',
+    relPath: 'svelte-vitals.config.mjs'
+  }
+];
+
+export function configTargetById(id: string): ConfigTarget | undefined {
+  return CONFIG_TARGETS.find((t) => t.id === id);
+}
+
+export function isConfigTargetId(id: string): id is ConfigTargetId {
+  return CONFIG_TARGETS.some((t) => t.id === id);
+}
+```
+
+(`.mjs` を選ぶ理由: `loadConfigFile` の候補優先順位の先頭が `.mjs`
+— `packages/cli/src/config-file.ts:16` の `CONFIG_FILENAMES` 配列の並び順を
+確認し、それに合わせる。)
+
+### Step A3: `install/index.ts` に配線する
+
+`TargetId` 型に `ConfigTargetId` を追加し、`planForAgentTarget` と同じ形の
+`planForConfigTarget` を追加する(完全再生成、`--force` で上書き可):
+
+```ts
+function planForConfigTarget(target: ConfigTarget, io: InstallIO, force: boolean): PlanRow {
+  const path = join(io.cwd, target.relPath);
+  const existing = io.readFile(path);
+  const content = buildConfigFileTemplate();
+  const status: WriteStatus = existing === undefined ? 'created' : force ? 'updated' : 'exists';
+  return { id: target.id, label: target.label, path, status, content };
+}
+```
+
+`runInstall`(またはメインの実行フロー — 実際の関数名は `index.ts` を最後まで
+読んで確認する)の中で、`viteIds`/`agentIds` と同じパターンで `configIds` を
+フィルタし、選択されていれば `planForConfigTarget` を呼ぶ処理を追加する。
+`--client` のヘルプテキスト(`packages/cli/src/install/cli.ts` の
+`INSTALL_HELP`)に `config-file` を追記する。対話式ウィザードの選択肢一覧
+(`SelectableOption` を組み立てている箇所)にも `CONFIG_TARGETS` を追加する。
+
+**Verify**: `pnpm --filter svelte-vitals typecheck && pnpm --filter svelte-vitals build`
+→ exit 0。
+
+### Step A4: テストを追加する
+
+`packages/cli/test/install/` の既存テスト(`agent-targets` 関連のテストファイルを
+参考にする)と同じパターンで、`config-file` ターゲットの `created`/`exists`/
+`--force` での `updated` の3状態を検証するテストを追加する。
+
+**Verify**: `pnpm --filter svelte-vitals test` → all pass、新規ケース green。
+
+---
+
+## Part B: vite プラグイン/analyze に `loadConfigFile` を配線する
+
+### Step B1: `packages/vite/src/analyze.ts` に配線する
+
+`analyze` 関数内の `defineConfig({...})` の前に `loadConfigFile(cwd)` を呼び、
+CLI の `analyzeProject` と全く同じ優先順位(明示的な `options.*` > config file の
+値 > デフォルト)を適用する:
+
+```ts
+import { loadConfigFile } from 'svelte-vitals';
+...
+export async function analyze(
+  prerenderPagesDir: string,
+  cwd: string,
+  options: SvelteVitalsOptions
+): Promise<AnalyzeResult> {
+  const loaded = await loadConfigFile(cwd);
+  const file = loaded?.config;
+  const weights = options.weights ?? file?.weights;
+  const config = defineConfig({
+    treatDynamicAs: options.treatDynamicAs ?? file?.treatDynamicAs ?? 'pass',
+    metaComponents: options.metaComponents ?? file?.metaComponents ?? [],
+    rules: options.rules ?? file?.rules ?? {},
+    failOn: options.failOn ?? file?.failOn ?? 'critical',
+    ...(weights !== undefined ? { weights } : {})
+  });
+  ...
+```
+
+`loadConfigFile` は `svelte-vitals`(CLI パッケージ)からの公開エクスポート
+(`packages/cli/src/index.ts:525` の `export { loadConfigFile } from
+'./config-file.js';` — 既に確認済み)。`packages/vite` は既に `svelte-vitals` を
+peer/optional な形で参照しているか(`packages/vite/src/ui/analysis.ts` が
+`await import('svelte-vitals')` している前例がある)を確認し、同じ dynamic
+import のパターンを使うべきか、それとも静的 import でよいかを判断する
+(build-mode の `analyze.ts` は既に `@svelte-vitals/core` を静的 import して
+いるため、`svelte-vitals` も静的 import で問題ないはず — ただし `packages/vite`
+の `package.json` の `dependencies` に `svelte-vitals` が入っているか確認し、
+入っていなければ追加すること)。
+
+`loaded?.warnings`(config file の不正なフィールドに対する警告)をどう扱うかも
+決める — CLI は `warnings` を呼び出し元に返している(`AnalyzeResult.warnings`)。
+build-mode の `AnalyzeResult` 型(`packages/vite/src/analyze.ts:22-31`)にも
+`warnings: string[]` を追加し、`plugin.ts` の `closeBundle` でそれを
+`console.warn` するか判断する(CLI がどう表示しているか
+`packages/cli/src/index.ts` の `run()` 内の warnings 処理を確認して揃える)。
+
+**Verify**: `pnpm --filter @svelte-vitals/vite typecheck` → exit 0。
+
+### Step B2: 既存テストへの影響を確認する
+
+`packages/vite/test/plugin-error.test.ts`(既に読了済み — `analyze` をモックする
+既存テスト)や、build-mode の他のテストが `cwd` に `svelte-vitals.config.*` を
+持たない前提で動いているか確認する。`loadConfigFile` は config file が存在
+しなければ `undefined`(または空の `config`)を返すはずなので、既存のテスト用
+一時ディレクトリには影響しないはずだが、念のため実行して確認する。
+
+**Verify**: `pnpm --filter @svelte-vitals/vite test` → all pass(既存ケース、
+新規ケース追加前の時点で)。
+
+### Step B3: dev dashboard 側(`plugin.ts` の `configureServer`)にも同じ配線をする
+
+`packages/vite/src/plugin.ts` の `configureServer` 内の `defineConfig({...})`
+(120-125行目)にも、Step B1 と同じ優先順位ロジックを適用する。
+`packages/vite/src/ui/analysis.ts` の `createAnalysisRunner` が呼ぶ
+`analyzeProject`(dynamic import 経由、`svelte-vitals` パッケージの本体)は
+**既にそれ自身の内部で `loadConfigFile` を呼んでいる**(`analyzeProject` の
+実装、既に確認済み)ため、dev dashboard の whole-project 解析パスは実は**既に
+config file を読んでいる可能性が高い** — この点を実装前に必ず確認すること
+(`configureServer` 内で `defineConfig({...options...})` を呼んでいるのは
+`installUiMiddleware` に渡す `config`(表示/フィルタリング用の設定オブジェクト)
+であり、`runner`(実際の解析)が使う設定とは**別の経路**かもしれない — 2つの
+`config` オブジェクトが実際に同じものを指しているか、独立した2つの解決になって
+いるかを、`packages/vite/src/plugin.ts` の `configureServer` 全文と
+`installUiMiddleware` の `config` パラメータの使われ方を読んで確認し、もし
+「whole-project 解析(`runner`)は既に config file を読んでいるが、UI 側の
+`config`(フィルタ用)は読んでいない」という食い違いがあれば、UI 側の
+`config` にも同じ配線をする)。
+
+**Verify**: `pnpm --filter @svelte-vitals/vite typecheck && test` → exit 0 / all pass。
+
+### Step B4: テストを追加する
+
+`packages/vite/test/` に、`svelte-vitals.config.mjs` を一時ディレクトリに置いた
+状態で `analyze()`(build-mode)を呼び、config file の `rules`/`weights` が
+実際に反映されることを確認する統合テストを追加する。CLI 側の
+`packages/cli/test/fixtures/config-file-project`(MCP のテストが再利用している
+ことを Plan 033 の調査で確認済み)を同様に再利用できないか検討する。
+
+**Verify**: `pnpm --filter @svelte-vitals/vite test` → all pass、新規ケース green。
+
+### Step B5: docs を更新する
+
+`docs/src/content/docs/guides/configuration.md` + ja に、「vite プラグインも
+config file を読む」旨を追記する(現状「CLI と MCP が読む」とだけ書かれている
+可能性が高い — 実際の記載を確認して更新する)。
+
+---
+
+## 全体検証
+
+**Verify**: `pnpm build && pnpm typecheck && pnpm test && pnpm lint` → 全て
+exit 0 / all pass。changeset を2つ追加(`svelte-vitals`: minor — config file
+スキャフォルダー追加、`@svelte-vitals/vite`: minor — config file を読むように
+なったという振る舞いの変更)。
+
+## Test plan
+
+- Part A: `config-file` ターゲットの `created`/`exists`/`--force updated` の3状態。
+- Part B: build-mode `analyze()` が config file の `rules`/`weights` を反映する
+  こと、dev dashboard の UI 側 `config` も同様であること(Step B3 の調査結果次第)。
+- 既存の `packages/vite/test`・`packages/cli/test` の全ケースが green のまま。
+
+## Done criteria
+
+- [ ] `install --client config-file` が `svelte-vitals.config.mjs` を生成する
+- [ ] `packages/vite/src/analyze.ts` が `loadConfigFile` を呼び、CLI と同じ優先
+      順位を適用している
+- [ ] dev dashboard の UI 側 `config` が whole-project 解析と同じ config file
+      解決を共有している(Step B3 の調査結果に基づき、必要なら配線)
+- [ ] `pnpm build && pnpm typecheck && pnpm test && pnpm lint` が全て exit 0 / all pass
+- [ ] docs(en/ja)が更新されている
+- [ ] changeset が2つ存在する
+- [ ] `plans/README.md` の該当行を更新済み
+
+## STOP conditions
+
+- Step B3 の調査で、dev dashboard の `runner`(whole-project 解析)と UI の
+  `config`(フィルタ用)が実は同じ設定解決を共有する単一の経路であることが判明
+  した場合(= 追加配線が不要と分かった場合)、Part B のこの部分は「既に対応済み」
+  として Done criteria から除外し、その根拠を Maintenance notes に記録する —
+  無理に二重配線を作らない。
+- config file の `.ts` 拡張子ロード(Node のネイティブ TS サポート、design doc
+  2026-07-05 の "best-effort" 扱い)が vite の実行コンテキスト(esbuild/Vite の
+  トランスパイル環境)で CLI と異なる挙動をする可能性がある場合、その差異を
+  実際に確認してから進める — 予想と異なれば STOP して報告する。
+
+## Maintenance notes
+
+- Part A と Part B は独立に価値があるため、レビュー時に別々にマージすることも
+  検討できる(1つの PR にまとめる場合はコミットを分けておくと分割レビューしやすい)。
+- 今後 `Config` 型に新しいフィールドが追加された場合、Step A1 のテンプレート
+  ジェネレーターにもコメントアウトされたサンプル行を追加することを忘れないこと。

--- a/plans/039-design-spike-i18n-lang-ja.md
+++ b/plans/039-design-spike-i18n-lang-ja.md
@@ -73,10 +73,10 @@ core の reporter 設計にそのまま乗るので、core/CLI/vite を CLI フ�
 
 このプランは調査/設計が主。関連ファイルを読むための grep 程度:
 
-| Purpose                        | Command                                                                 |
-| --------------------------------- | -------------------------------------------------------------------------- |
+| Purpose                                      | Command                                                                           |
+| -------------------------------------------- | --------------------------------------------------------------------------------- |
 | ルール文字列の再カウント(issue の数値を検証) | `grep -rc "message:\|recommendation:\|description:" packages/core/src/rules/*.ts` |
-| reporter の文字列棚卸し           | `packages/core/src/reporter/*.ts` を読む                                  |
+| reporter の文字列棚卸し                      | `packages/core/src/reporter/*.ts` を読む                                          |
 
 ## Scope
 

--- a/plans/039-design-spike-i18n-lang-ja.md
+++ b/plans/039-design-spike-i18n-lang-ja.md
@@ -1,0 +1,221 @@
+# Plan 039: 設計スパイク — `lang: 'ja'` i18n(CLI / Action / vite dashboard)
+
+> **Executor instructions**: This is a **design spike**, not a build plan. GitHub
+> issue #165(オープン、メンテナー自身が調査済み)がこの設計スパイクの出発点 —
+> issue 自体が "investigation-only... a bigger lift than the option name implies"
+> と明記している。このプランの deliverable は `docs/superpowers/specs/` 配下の
+> 設計ドキュメント(Accepted 前段階、メンテナーレビュー待ち)であり、実装(rule
+> copy の翻訳や `lang` オプションの配線)はこのプランのスコープ外。If anything in
+> "STOP conditions" occurs, stop and report.
+>
+> **Drift check (run first)**: `gh issue view 165` を実行し、issue の内容(特に
+> "What's affected" セクションのファイル数・行数)が下記「Current state」の引用と
+> 一致するか確認する。差分があれば実際の issue の記述を優先し、下記の古い数値は
+> 参考情報として扱う。
+
+## Status
+
+- **Priority**: P3
+- **Effort**: L(設計スパイクとしての工数。翻訳作業・実装は別プランのスコープ)
+- **Risk**: MED(`packages/core` は意図的に薄く保たれている設計原則があり、
+  i18n のためのカタログ機構をどこに置くかが core の純粋性に影響しうる)
+- **Depends on**: none
+- **Category**: direction
+- **Planned at**: commit `3341587`, 2026-07-13
+
+## Why this matters
+
+`svelte-vitals` のランタイム出力(rule のタイトル/メッセージ/推奨文、reporter の
+見出し、CLI のヘルプ/プロンプト文言、vite dev dashboard の UI 文言)はすべて
+ハードコードされた英語であり、i18n の仕組みが一切ない。一方でこのプロジェクトの
+docs サイトは既に en/ja 両方をネイティブに提供しており(Starlight の `ja` ロケール)、
+同じユーザー層に対してツール自体の出力だけが英語限定という非対称がある。
+メンテナー自身が issue #165 でこれを調査済みで、オープンな実プロダクト課題として
+存在する(架空の提案ではない)。
+
+## Current state(issue #165 からの引用 — 2026-07-13 時点)
+
+> There is currently **no i18n infrastructure anywhere in the codebase** — no
+> message catalog, no `t()`-style helper, nothing. Every user-facing string is a
+> hardcoded English literal.
+>
+> - **`packages/core/src/rules/`**(32 files, ~2265 lines)— 最大の作業量。各ルールが
+>   `title`/`message`/`recommendation`/`rationale`/`fix.description` を個別にハード
+>   コード。概算: `message:` 約44件、`recommendation:` 約64件、fix `description:`
+>   約28件、文字列プロパティ総数217件。
+> - **`packages/core/src/reporter/`**(7 files, 879 lines)— reporter ごとに見出し/
+>   ラベルがハードコード:`console.ts`(約10文字列)、`html.ts`(最大・333行・30+
+>   文字列、`lang="en"` 含む)、`markdown.ts`(約10)、`agent.ts`(数段落の説明文)。
+>   `github.ts`/`sarif.ts` はプロトコル語彙(SARIF レベル・GitHub アノテーション
+>   レベル)であり、そもそも翻訳すべきでない可能性が高い。
+> - **`packages/cli/src/`** — ヘルプテキスト(`bin.ts` の `Usage:`、`install/cli.ts`
+>   の `INSTALL_HELP`、`ci/cli.ts` の `CI_HELP`)、`@clack/prompts` のプロンプト
+>   文言、散在する約15件の `console.error`/thrown `Error` メッセージ。
+> - **`packages/vite/src/ui/dashboard-script.ts`**(434行)— 約20件の UI 文言
+>   (aria-label・placeholder・ソートオプション・見出し・空状態)+ 動的カウント
+>   文字列(`"N critical"` 等)。`dashboard.ts` は `<html lang="en">` をハードコード。
+> - **`packages/action/src/`** — 自前の文字列はほぼなく(全118行)、PR コメント/
+>   サマリー本文は完全に core の `formatMarkdownReport`/`formatGithubReport` に
+>   委譲している — **core の reporter が `lang` を受け付けるようになれば、
+>   Action はほぼ無償で日本語出力を手に入れる**。
+> - **Out of scope**(issue 自身が明記): `packages/mcp`(エージェント向け構造化
+>   JSON がほとんどで human-facing UI テキストではないため)、SARIF/GitHub
+>   Actions のアノテーションレベル語彙(プロトコル用語)、docs サイト(既に
+>   Starlight で別途ローカライズ済み)。
+
+issue は「core は意図的に薄く/純粋に保たれている設計方針であり、翻訳済み rule
+copy をどこに置くか(ルールファイル内 vs 別カタログ)の設計判断が先」「Action は
+core の reporter 設計にそのまま乗るので、core/CLI/vite を CLI ファーストではなく
+一体で設計すべき」「vite dashboard はバンドラーなしの手書きクライアントスクリプト
+なので、core のカタログ機構とは別の小さなラベルマップが要る」と述べている。
+
+## Commands you will need
+
+このプランは調査/設計が主。関連ファイルを読むための grep 程度:
+
+| Purpose                        | Command                                                                 |
+| --------------------------------- | -------------------------------------------------------------------------- |
+| ルール文字列の再カウント(issue の数値を検証) | `grep -rc "message:\|recommendation:\|description:" packages/core/src/rules/*.ts` |
+| reporter の文字列棚卸し           | `packages/core/src/reporter/*.ts` を読む                                  |
+
+## Scope
+
+**In scope**:
+
+- issue #165 の調査結果を検証し、最新のコード状態と照合する。
+- カタログ機構の設計判断: 翻訳済み文字列をどこに置くか(ルールファイルへの
+  インライン `{ en, ja }` オブジェクト vs 中央集約されたカタログファイル
+  vs 外部ライブラリ)。
+- `core`/`cli`/`vite` 間で `lang` オプションをどう伝播させるかの API 設計
+  (`analyzeProject`/`AnalyzeOptions` への `lang` 追加が既存の優先順位ルール
+  ―「明示的オプション > config file > デフォルト」―とどう整合するか)。
+- 翻訳の網羅性(33番目のルールが追加されたとき、翻訳が漏れていたら何が起きる
+  べきか — ビルド時エラーか、実行時に英語へフォールバックか)の方針決定。
+- 設計ドキュメントの作成: `docs/superpowers/specs/<date>-i18n-lang-ja-design.md`。
+
+**Out of scope**:
+
+- 実際の翻訳作業(32ファイル・217文字列の日本語訳)。
+- `lang` オプションの実装・配線。
+- `packages/mcp`(issue 自身が明示的にスコープ外としている)。
+- SARIF/GitHub Actions のプロトコル語彙の翻訳。
+- docs サイト自体(既に別途ローカライズ済み)。
+
+## Git workflow
+
+- Branch: `advisor/039-design-spike-i18n-lang-ja`
+- コミット: 設計ドキュメントの追加のみ(`docs: design spike for lang:'ja' i18n (issue #165)`)。
+- push / PR 作成はオペレーターの指示があるまで行わない。issue #165 へのコメントは
+  行わない(オペレーターの判断に委ねる — このプランは docs 追加のみ)。
+
+## Steps
+
+### Step 1: issue #165 の調査結果を最新コードで検証する
+
+`gh issue view 165` で全文を再確認し、`packages/core/src/rules/`・
+`packages/core/src/reporter/`・`packages/cli/src/`・`packages/vite/src/ui/`
+それぞれについて、issue が挙げたファイル数・行数・文字列数が現在のコードベース
+とおおむね一致するか(2026-07-13 以降の変更で増減している可能性がある)を grep
+で確認し、乖離があれば設計ドキュメントにその旨(数値は目安であり実装時に再計測
+が必要)を記録する。
+
+### Step 2: カタログ機構の設計判断を行う
+
+3つの選択肢を比較検討し、設計ドキュメントに表(選択肢・core purity への影響・
+実装コスト・翻訳漏れの検知しやすさ)としてまとめる:
+
+- **A. ルールファイルへのインライン多言語オブジェクト**: 各ルールの
+  `title`/`message` 等を `{ en: '...', ja: '...' }` のような形に変える。
+  メリット: 翻訳が該当ルールの定義のすぐそばにあり見つけやすい。デメリット:
+  32ファイル全てに手を入れる必要があり、`componentRule`/`headTagRule` 等の
+  ルールビルダー関数のシグネチャ変更を伴う可能性がある(既存の型を壊す)。
+- **B. 中央集約カタログファイル**(例: `packages/core/src/i18n/ja.ts` に
+  ルールIDをキーにした翻訳マップ): メリット: ルール定義自体は変更不要
+  (後方互換)、翻訳漏れを一覧で確認しやすい。デメリット: ルールIDと翻訳の
+  対応がルール定義から離れた場所にあり、新規ルール追加時に2箇所を同期する
+  必要がある(`AGENTS.md` の「ルール追加は4箇所」がさらに増える)。
+- **C. 外部 i18n ライブラリの導入**: `packages/core` の「軽量・依存最小」という
+  設計原則(`AGENTS.md`)と衝突する可能性が高く、issue 自身も implicitly
+  否定的なニュアンス — 比較のためだけに軽く触れ、却下する場合はその理由を明記。
+
+**推奨案を1つ選び、理由を明記する**(メンテナーが別の判断をしてもよいが、
+執筆者としての推奨を示すこと — 手がかりとして、`AGENTS.md` の
+「ルール追加は4箇所に登録」という既存の負担モデルと比較して、選択肢Bが
+本質的に同じ性質の「複数箇所同期」の負担を1箇所増やすだけなのに対し、選択肢A
+はルールビルダー関数(`componentRule`/`headTagRule`等)のシグネチャという
+型レベルの破壊的変更を伴う点を比較材料にする)。
+
+### Step 3: `lang` オプションの伝播経路を設計する
+
+- `AnalyzeOptions`(`packages/cli/src/index.ts`)に `lang?: 'en' | 'ja'` を追加
+  する場合の、config file(`svelte-vitals.config.*`)経由の指定との優先順位
+  (既存の「明示的オプション > config file > デフォルト」パターンに従うことを
+  推奨する)。
+- `runRules`(`packages/core/src/rule.ts` or 該当箇所)が `lang` をどう受け取り、
+  各ルールの `check` 関数にどう渡すか — `RuleContext` に `lang` を追加するのが
+  自然かを検討する。
+- `formatMarkdownReport`/`formatGithubReport`/`formatConsoleReport`/
+  `formatHtmlReport`(reporter 群)への `lang` の伝播 — `Action` がこれらを
+  そのまま呼んでいる(`packages/action/src/index.ts`)ため、Action 側は
+  `core.getInput('lang')` を追加して素通しするだけで済むはず、という issue の
+  指摘を検証する。
+- `packages/vite/src/ui/dashboard-script.ts` は手書きのハンドオーサー文字列
+  (`DASHBOARD_SCRIPT` — Plan 035 で扱った同じファイル)であり、core のカタログ
+  機構を再利用できない。小さなラベルマップをこのスクリプト内に直接持たせる
+  設計(例: `var LABELS = { en: {...}, ja: {...} }`)を検討し、`lang` をどう
+  このスクリプトに渡すか(サーバー側でスクリプト文字列に埋め込む/クエリ
+  パラメータ/dashboard.ts が生成する HTML の data 属性経由、等)を提案する。
+
+### Step 4: 翻訳網羅性の方針を決める
+
+新しいルールが追加されたとき、日本語訳が用意されていない場合にどうすべきかの
+方針を決める(候補: ビルド時に全ルールの `ja` エントリの存在をチェックする
+テスト/lint を追加し、欠落があればビルドを失敗させる — これが最も安全だが、
+新規ルール追加のハードルが上がる。あるいは、欠落時は英語にフォールバックし、
+警告だけ出す — ハードルは低いが `ja` モードで英語が混在する体験になる)。
+推奨案を1つ選び、理由を明記する。
+
+### Step 5: 設計ドキュメントを書く
+
+`docs/superpowers/specs/<today>-i18n-lang-ja-design.md` を作成し、issue #165 の
+内容を踏まえつつ、Step 1〜4 の検討結果(カタログ機構の選択、`lang` の伝播設計、
+翻訳網羅性の方針、影響を受けるファイルの一覧、見積もり工数)をまとめる。
+「Status: Proposed」(メンテナーレビュー待ち、まだ Accepted ではない)として
+明記する。
+
+## Test plan
+
+このプランは設計ドキュメントの作成であり、コード変更もテストも伴わない。
+
+## Done criteria
+
+- [ ] issue #165 の調査結果が最新コードと照合され、乖離があれば記録されている
+- [ ] カタログ機構(インライン vs 中央集約 vs 外部ライブラリ)の比較と推奨案が
+      明記されている
+- [ ] `lang` オプションの `core`/`cli`/`action`/`vite dashboard` 間の伝播設計が
+      具体的に記述されている
+- [ ] 翻訳網羅性(ビルド時チェック vs フォールバック)の方針が決まっている
+- [ ] `docs/superpowers/specs/<date>-i18n-lang-ja-design.md` が作成されている
+      (Status: Proposed)
+- [ ] `plans/README.md` の該当行を更新済み(ステータスは「設計完了、メンテナー
+      レビュー待ち」)
+
+## STOP conditions
+
+- カタログ機構の設計判断が、`packages/core` の「軽量・依存最小・純粋」という
+  設計原則(`AGENTS.md`/`packages/core/CLAUDE.md`)と明確に矛盾する結論にしか
+  至らない場合、無理に妥協案を出さず、その矛盾自体を設計ドキュメントに明記し、
+  メンテナーの判断を仰ぐ。
+- issue #165 の記述と実際のコードの間に大きな乖離(例: 想定より遥かに文字列数が
+  増えている)が見つかった場合、見積もり工数を issue の記載のまま使わず、実測
+  ベースで更新する。
+
+## Maintenance notes
+
+- このプランの成果物は設計ドキュメントのみ。承認された場合、実装は「core の
+  カタログ機構 + 32ルールの翻訳」「CLI/Action の `lang` 配線」「vite dashboard
+  のラベルマップ」という複数の実装プランに分割して起票することを推奨する
+  (L 工数の単一プランにまとめると、レビューもテストも巨大になりすぎる)。
+- `packages/mcp` は明示的にスコープ外だが、将来 human-facing な出力
+  (例: `explain_rule` ツールの説明文)を追加する場合、この設計の対象に含める
+  かどうかを再検討する必要がある。

--- a/plans/040-ci-step-level-parallelism.md
+++ b/plans/040-ci-step-level-parallelism.md
@@ -1,0 +1,282 @@
+# Plan 040: CI の `check`/`docs` ジョブに GitHub Actions のステップ並列化を適用する
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat 3341587..HEAD -- .github/workflows/ci.yml`
+> 差分があれば下記「Current state」の抜粋と実ファイルを突き合わせ、不一致なら STOP。
+> **この計画は Plan 027(dist キャッシュ)と同じファイルを扱う** — Plan 027 が
+> まだ `main` にマージされていない場合、このプランは `main`(= Plan 027 適用前の
+> 状態)を基準に書かれている。Plan 027 のブランチ(`advisor/027-ci-build-cache`)
+> が既にマージ済みなら、drift check がその差分を検出するので、下記の「Current
+> state」と実ファイルを突き合わせて不一致箇所(キャッシュ関連のステップが追加
+> されている)を踏まえた上で、このプランの変更(ステップの並べ替え・`parallel:`
+> 化)を該当箇所に適用すること — 矛盾するものではなく、Plan 027 のキャッシュ
+> ステップの後ろに続けて `parallel:` 化すればよい。
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: LOW(GitHub Actions のネイティブ機能を使うだけで、各ステップの
+  実行内容自体は変えない。並列化グループ内の1ステップが失敗すれば、実装の
+  仕様どおりグループ末尾の暗黙 `wait` でジョブ全体が失敗する — 現在の「1つでも
+  ステップが失敗したらジョブ失敗」という挙動と同じ)
+- **Depends on**: 027(同じファイルを扱うため、027 を先にマージしてからこの
+  プランを適用することを推奨。027 未マージのまま両方を worktree で作業する場合、
+  マージ時にコンフリクトが起きうる)
+- **Category**: perf / dx
+- **Planned at**: commit `3341587`, 2026-07-13
+
+## Why this matters
+
+2026-06-25 に GitHub Actions が正式提供したステップレベル並列化機能
+(`background`/`wait`/`wait-all`/`cancel`/`parallel` の4キーワード、
+`jobs.<job_id>.steps[*].background` / `jobs.<job_id>.steps[*].parallel` の
+公式ドキュメントで仕様確認済み)を使うと、**同一ジョブ・同一ランナー内**で
+独立したステップを並列実行できる(ジョブを分ける job-level 並列とは異なり、
+`actions/checkout`/`setup-node` のセットアップを共有できる)。
+
+`check` ジョブの `pnpm build` 実行後、以下の3ステップは互いに独立している:
+
+1. `Verify action dist is up to date`(`git diff --exit-code -- packages/action/dist`
+   — ビルド済みの `packages/action/dist` を git の記録と比較するだけ)
+2. `Typecheck`(`pnpm typecheck` = `pnpm -r typecheck`、各パッケージの
+   `tsc --noEmit` — ビルド済みの他パッケージの型定義を読むだけで、他の2ステップ
+   の結果には依存しない)
+3. `Validate publishable packages`(`pnpm check:publish` = `publint` +
+   `attw --pack`、ビルド済みの `dist/` を検査するだけ)
+
+3つとも「ビルド後の成果物を読み取って検査するだけ」で、互いの出力に依存しない
+ため、`parallel:` でまとめて同時実行できる。同様に `docs` ジョブの
+`Check docs`(`astro check`)と `Build docs`(`astro build`)も、互いの出力に
+依存せず同じソースを読むだけなので並列化できる。
+
+**`test` ジョブの `pnpm test` はこのプランでは並列化しない**(理由は
+Non-goals 参照)。
+
+## Current state
+
+`.github/workflows/ci.yml` の `check` ジョブ(全文、Plan 027 未適用の場合。
+Plan 027 適用後は `Build packages` の前に cache ステップが追加されているはず
+— 上記ヘッダーの drift check 指示を参照):
+
+```yaml
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Setup Node.js and dependencies
+        uses: ./.github/workflows/setup-node
+      - name: Build packages
+        run: pnpm build
+      - name: Verify action dist is up to date
+        run: git diff --exit-code -- packages/action/dist
+      - name: Typecheck
+        run: pnpm typecheck
+      - name: Validate publishable packages
+        run: pnpm check:publish
+```
+
+`docs` ジョブ(全文):
+
+```yaml
+  docs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Setup Node.js and dependencies
+        uses: ./.github/workflows/setup-node
+      - name: Check docs
+        run: pnpm --filter docs check
+      - name: Build docs
+        run: pnpm --filter docs build
+```
+
+- `root package.json` の `check:publish` は `check:publint && check:types`
+  (2つの子コマンドを1つの npm script 内で直列実行 — このプランではこの内部を
+  分割しない、`check:publish` を1ステップのまま `parallel:` グループに入れる)。
+- `docs/package.json` の `check` = `astro check`(型チェック)、`build` =
+  `astro build`(本番ビルド)。互いに独立(`grep -A6 '"scripts"' docs/package.json`
+  で確認済み)。
+- **並列化機能の正式仕様**(GitHub 公式ドキュメント、ユーザー提供の引用を
+  正として採用):
+  - `background: true` を `run`/`uses` ステップに付けると非同期実行になり、
+    ジョブは次のステップにすぐ進む。同一ジョブ内で同時に実行できる
+    background ステップは最大10個(超過分はキューイング)。
+  - `wait: <step-id>` で指定した background ステップの完了を待つ。
+    background ステップが失敗した場合、その `wait`/`wait-all` の時点でジョブが
+    失敗する(`continue-on-error` が付いていない限り)。
+  - `parallel:` はステップのグループをまとめて `background: true` にし、
+    グループ末尾に暗黙の `wait` を置くシンタックスシュガー。個別の `id` は
+    不要で、「このグループが全部終わってから先に進みたい」という単純なケースに
+    使う。
+  - コンポジットアクション内では `background`/`parallel` は使えない(このプラン
+    が対象にするステップはどれも通常の `run` ステップであり、コンポジット
+    アクションではないため問題ない)。
+
+## Commands you will need
+
+| Purpose                     | Command                                              | Expected on success |
+| ---------------------------- | ----------------------------------------------------- | -------------------- |
+| YAML 妥当性(ローカル簡易チェック) | `ruby -ryaml -e "YAML.load_file('.github/workflows/ci.yml'); puts 'YAML OK'"`(pyyaml がサンドボックスで導入不能な場合の代替 — Plan 027 の executor が使った方法) | `YAML OK` |
+| 参考(ローカルで意味のある検証はここまで) | `pnpm build && pnpm typecheck && pnpm check:publish`(手元で3コマンドが個別に成功することの確認 — 並列実行そのものはローカルで再現できない) | 全て exit 0 |
+
+このプランの変更は CI ワークフロー YAML のみで、GitHub Actions 上でしか
+「本当に並列実行されているか」「壁時計時間が短縮したか」を確認できない。
+ローカル環境(このサンドボックスを含む)では YAML の構文妥当性と、各ステップの
+コマンド自体が独立して成功することしか検証できない。
+
+## Scope
+
+**In scope**(変更してよいファイル):
+
+- `.github/workflows/ci.yml`
+
+**Out of scope**:
+
+- `test` ジョブの `pnpm test` ステップ(Non-goals 参照 — 並列化しない)。
+- `lint` ジョブの `pnpm lint` ステップ(prettier + eslint が1つの npm script に
+  まとまっており、分割するには `package.json` の `lint` スクリプト自体を分ける
+  必要がある — このプランのスコープ外。将来必要になれば別プランで検討)。
+- `.github/workflows/setup-node/action.yml`(コンポジットアクション — 上記の
+  とおり `background`/`parallel` はコンポジットアクション内では使えないため、
+  そもそも対象外)。
+- `packages/*/tsup.config.ts`・`package.json` の各スクリプト定義自体。
+
+## Non-goals
+
+- **`test` ジョブを並列化しない**: `pnpm test` はパッケージごとに vitest を
+  実行し(core 401・cli 563・vite・mcp・action)、それぞれが CPU を使う重い
+  処理。GitHub 公式ドキュメントの `parallel`/`background` の説明は「独立した
+  作業を同時に走らせる」ためのものだが、**同一ランナー上で複数の CPU 律速な
+  処理を同時に走らせると、コア数の制約から実質的な高速化にならない、またはむしろ
+  ランナーの CPU 競合で遅くなるリスクがある**(標準の `ubuntu-latest` ランナーの
+  vCPU 数は限られている)。テストの並列化は既に `test` ジョブ自体の
+  3-way node マトリクス(job-level 並列、別ランナー)で実現されており、
+  同一ジョブ内でさらに5パッケージを `parallel:` にする追加の複雑さとリスクに
+  見合う確証がない。実測で「めぼしい時間短縮効果があり、かつランナーの
+  リソースが十分」という証拠が出るまでは見送る。
+- **`lint` ジョブの分割**: prettier と eslint を分けて並列実行するには
+  `package.json` の `lint` スクリプト定義を変更する必要があり(現状1つの
+  npm script)、ローカル開発者が実行する `pnpm lint` の意味と CI の並列実行が
+  乖離する複雑さを増やす割に、`lint` ジョブは既に `timeout-minutes: 5` と
+  最も軽い部類 — 費用対効果が低いと判断し見送る。
+
+## Git workflow
+
+- Branch: `advisor/040-ci-step-level-parallelism`
+- コミット: `ci: run independent post-build checks in parallel`(英語、
+  1コミットでよい)。
+- push / PR 作成はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: `check` ジョブの3ステップを `parallel:` でまとめる
+
+`Build packages` ステップ(または Plan 027 適用後ならそのキャッシュ復元ステップ
+群)の後、`Verify action dist is up to date`・`Typecheck`・
+`Validate publishable packages` の3ステップを、`parallel:` の下に1つのステップ
+としてまとめる:
+
+```yaml
+      - name: Build packages
+        run: pnpm build
+      - parallel:
+          - name: Verify action dist is up to date
+            run: git diff --exit-code -- packages/action/dist
+          - name: Typecheck
+            run: pnpm typecheck
+          - name: Validate publishable packages
+            run: pnpm check:publish
+```
+
+(Plan 027 が既にマージされている場合、`Build packages` の前に
+`Restore/Cache package builds` ステップがあるはずだが、それらはこの
+`parallel:` グループの対象外 — ビルド自体とそのキャッシュ処理は
+`parallel:` グループの**前に**そのまま残す。)
+
+**Verify**: YAML として妥当であること(上記コマンドで確認)。
+
+### Step 2: `docs` ジョブの2ステップを `parallel:` でまとめる
+
+```yaml
+      - name: Setup Node.js and dependencies
+        uses: ./.github/workflows/setup-node
+      - parallel:
+          - name: Check docs
+            run: pnpm --filter docs check
+          - name: Build docs
+            run: pnpm --filter docs build
+```
+
+**Verify**: YAML として妥当であること(同上)。
+
+### Step 3: CI 上で実測して確認する
+
+このプランの変更もワークフロー YAML のみで、ローカル実行では並列化の効果を
+確認できない。ドラフト PR を開き、GitHub Actions の実行結果を見て確認する:
+
+1. `check` ジョブのログで、`Verify action dist is up to date`・`Typecheck`・
+   `Validate publishable packages` の3ステップが同時に開始されている(タイム
+   スタンプがほぼ同一)ことを確認する。
+2. いずれか1つのステップ(例えば意図的に typecheck エラーを混入させたテスト
+   ブランチなどで)が失敗した場合、他の並列ステップも実行されたうえでジョブ
+   全体が失敗することを確認する(部分的にしか実行されない、という誤動作が
+   ないこと)。
+3. `check`/`docs` ジョブそれぞれの壁時計時間(ジョブ開始から終了まで)が、
+   このプラン適用前と比べて短縮していることを確認する(3つの逐次ステップの
+   合計時間 → 最も遅い1つのステップの時間に近づくはず)。
+
+**Verify**: 上記1〜3が GitHub Actions の実行ログで確認できること。
+**このリポジトリの executor 環境では実際に GitHub Actions を走らせることが
+できないため、この Step 3 は実行不能であることを NOTES に明記し、スキップして
+よい**(Plan 027 の Step 3 と同じ扱い)— その他のステップ(YAML の妥当性)を
+verify できれば STATUS: COMPLETE として報告してよい。
+
+## Test plan
+
+このプランは CI ワークフローの変更であり、vitest によるテストは追加しない。
+検証は Step 3 の CI 実測が全てであり、それが唯一の「テスト」に相当する。
+
+## Done criteria
+
+- [ ] `.github/workflows/ci.yml` の YAML が妥当(パース可能)
+- [ ] `check` ジョブの `Verify action dist is up to date`/`Typecheck`/
+      `Validate publishable packages` が `parallel:` の下に1つのステップとして
+      まとまっている
+- [ ] `docs` ジョブの `Check docs`/`Build docs` が `parallel:` の下に1つの
+      ステップとしてまとまっている
+- [ ] `test` ジョブ・`lint` ジョブには変更がない(`git diff` で確認)
+- [ ] ドラフト PR 上での実測で、並列実行と壁時計時間の短縮を確認済み
+      (実行不能な場合はその旨を NOTES に明記)
+- [ ] `plans/README.md` の該当行を更新済み
+
+## STOP conditions
+
+- `parallel:`/`background` の構文が、このリポジトリの GitHub Actions
+  ランナーが対応しているバージョン(GA から日が浅い機能のため、Enterprise
+  ランナーや古いランナーイメージでは未対応の可能性がある)で認識されない
+  ことが判明した場合、無理に強行せず STOP して報告する。
+- Step 3 の実測で、並列化した3ステップのうちどれか1つが「他のステップの
+  ファイルシステム状態を暗黙に前提にしていた」ことが判明し(例えば
+  `check:publish` が `git diff` コマンドの副作用に依存していた、等)、
+  並列実行で不正確な結果になる場合、`parallel:` 化を撤回して STOP し報告する。
+
+## Maintenance notes
+
+- 将来 `test` ジョブの並列化を検討する場合、まず実際のランナーの vCPU 数と
+  現在の `pnpm test` の CPU 使用率プロファイルを計測してから判断すること
+  (このプランの Non-goals で見送った理由の裏付けを取ってから着手する)。
+- `lint` ジョブの分割も同様に、実測でめぼしい時間短縮が見込めることを確認
+  してから検討する。
+- GitHub Actions のこの機能は2026-06-25 に GA されたばかり(このプラン作成の
+  約3週間前)— ランナーイメージやサードパーティの `act` のようなローカル実行
+  ツールが追従していない可能性がある。ローカル CI エミュレーターを使っている
+  場合、この構文で失敗する可能性を考慮すること。

--- a/plans/040-ci-step-level-parallelism.md
+++ b/plans/040-ci-step-level-parallelism.md
@@ -66,37 +66,37 @@ Plan 027 適用後は `Build packages` の前に cache ステップが追加さ�
 — 上記ヘッダーの drift check 指示を参照):
 
 ```yaml
-  check:
-    runs-on: ubuntu-latest
-    timeout-minutes: 8
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Setup Node.js and dependencies
-        uses: ./.github/workflows/setup-node
-      - name: Build packages
-        run: pnpm build
-      - name: Verify action dist is up to date
-        run: git diff --exit-code -- packages/action/dist
-      - name: Typecheck
-        run: pnpm typecheck
-      - name: Validate publishable packages
-        run: pnpm check:publish
+check:
+  runs-on: ubuntu-latest
+  timeout-minutes: 8
+  steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - name: Setup Node.js and dependencies
+      uses: ./.github/workflows/setup-node
+    - name: Build packages
+      run: pnpm build
+    - name: Verify action dist is up to date
+      run: git diff --exit-code -- packages/action/dist
+    - name: Typecheck
+      run: pnpm typecheck
+    - name: Validate publishable packages
+      run: pnpm check:publish
 ```
 
 `docs` ジョブ(全文):
 
 ```yaml
-  docs:
-    runs-on: ubuntu-latest
-    timeout-minutes: 8
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Setup Node.js and dependencies
-        uses: ./.github/workflows/setup-node
-      - name: Check docs
-        run: pnpm --filter docs check
-      - name: Build docs
-        run: pnpm --filter docs build
+docs:
+  runs-on: ubuntu-latest
+  timeout-minutes: 8
+  steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - name: Setup Node.js and dependencies
+      uses: ./.github/workflows/setup-node
+    - name: Check docs
+      run: pnpm --filter docs check
+    - name: Build docs
+      run: pnpm --filter docs build
 ```
 
 - `root package.json` の `check:publish` は `check:publint && check:types`
@@ -123,10 +123,10 @@ Plan 027 適用後は `Build packages` の前に cache ステップが追加さ�
 
 ## Commands you will need
 
-| Purpose                     | Command                                              | Expected on success |
-| ---------------------------- | ----------------------------------------------------- | -------------------- |
-| YAML 妥当性(ローカル簡易チェック) | `ruby -ryaml -e "YAML.load_file('.github/workflows/ci.yml'); puts 'YAML OK'"`(pyyaml がサンドボックスで導入不能な場合の代替 — Plan 027 の executor が使った方法) | `YAML OK` |
-| 参考(ローカルで意味のある検証はここまで) | `pnpm build && pnpm typecheck && pnpm check:publish`(手元で3コマンドが個別に成功することの確認 — 並列実行そのものはローカルで再現できない) | 全て exit 0 |
+| Purpose                                  | Command                                                                                                                                                          | Expected on success |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| YAML 妥当性(ローカル簡易チェック)        | `ruby -ryaml -e "YAML.load_file('.github/workflows/ci.yml'); puts 'YAML OK'"`(pyyaml がサンドボックスで導入不能な場合の代替 — Plan 027 の executor が使った方法) | `YAML OK`           |
+| 参考(ローカルで意味のある検証はここまで) | `pnpm build && pnpm typecheck && pnpm check:publish`(手元で3コマンドが個別に成功することの確認 — 並列実行そのものはローカルで再現できない)                       | 全て exit 0         |
 
 このプランの変更は CI ワークフロー YAML のみで、GitHub Actions 上でしか
 「本当に並列実行されているか」「壁時計時間が短縮したか」を確認できない。
@@ -186,15 +186,15 @@ Plan 027 適用後は `Build packages` の前に cache ステップが追加さ�
 としてまとめる:
 
 ```yaml
-      - name: Build packages
-        run: pnpm build
-      - parallel:
-          - name: Verify action dist is up to date
-            run: git diff --exit-code -- packages/action/dist
-          - name: Typecheck
-            run: pnpm typecheck
-          - name: Validate publishable packages
-            run: pnpm check:publish
+- name: Build packages
+  run: pnpm build
+- parallel:
+    - name: Verify action dist is up to date
+      run: git diff --exit-code -- packages/action/dist
+    - name: Typecheck
+      run: pnpm typecheck
+    - name: Validate publishable packages
+      run: pnpm check:publish
 ```
 
 (Plan 027 が既にマージされている場合、`Build packages` の前に
@@ -207,13 +207,13 @@ Plan 027 適用後は `Build packages` の前に cache ステップが追加さ�
 ### Step 2: `docs` ジョブの2ステップを `parallel:` でまとめる
 
 ```yaml
-      - name: Setup Node.js and dependencies
-        uses: ./.github/workflows/setup-node
-      - parallel:
-          - name: Check docs
-            run: pnpm --filter docs check
-          - name: Build docs
-            run: pnpm --filter docs build
+- name: Setup Node.js and dependencies
+  uses: ./.github/workflows/setup-node
+- parallel:
+    - name: Check docs
+      run: pnpm --filter docs check
+    - name: Build docs
+      run: pnpm --filter docs build
 ```
 
 **Verify**: YAML として妥当であること(同上)。

--- a/plans/README.md
+++ b/plans/README.md
@@ -31,6 +31,22 @@ improve スキルによる監査(2026-07-05、commit `1f6f233` 時点)から生�
 | 024 | `ci upgrade` — 生成済みワークフローの Action ピンだけを外科的に更新 | P3 | S | — | DONE(2026-07-13 レビュー承認[Sonnet 5 executor、逸脱なし]→ [PR #197](https://github.com/oekazuma/svelte-vitals/pull/197)。CLI テスト 523 本 green、実機で「偽旧ピン→対象行のみ復元→カスタマイズ保持→冪等」を確認。レビュー対応: Copilot 指摘[CRLF ファイルで全行不一致→no-reference 誤判定]は実バグと検証し `c24252f` で行末正規化+回帰テスト3本) |
 | 025 | `install --refresh` — 生成済みエージェントファイル(SKILL.md / .mdc)を現行ルールセットで一括再生成 | P3 | S | 016 | DONE(2026-07-13 レビュー承認[Sonnet 5 executor、逸脱なし — 実装裁量2件(warning 時のフラグ非除去・行別成功ログ)は既存流儀に合致]→ [PR #198](https://github.com/oekazuma/svelte-vitals/pull/198)。CLI テスト 518 本 green、実機で「0件案内 / 存在ファイルのみ再生成 / .mdc 非生成」を確認。レビュー対応: Copilot 指摘[ENOENT 以外の readFile 例外でクラッシュ]は妥当と検証し `a3f3684` でターゲット単位の失敗継続+exit 2 に統一) |
 | 026 | Action に suppressions を配線 + cli の日本語コメント一掃(dist 再ビルド1回に同梱) | P3 | S | 023 | DONE(2026-07-13 レビュー承認[Sonnet 5 executor。自己申告の陳腐化 JSDoc(ApplyScopeOptions.config)も追加修正させた]→ [PR #199](https://github.com/oekazuma/svelte-vitals/pull/199)。CLI テスト 563 本 green、CJK grep 0 件。**マージ前にオペレーターの実機 dist 再ビルドが必須**[#196 と同フロー]) |
+| 027 | CI の `pnpm build` 重複実行を dist キャッシュで排除する | P1 | S | — | IN PROGRESS([PR #212](https://github.com/oekazuma/svelte-vitals/pull/212) オープン、CI 全ジョブ green。Plan 040 とスタック — [PR #213](https://github.com/oekazuma/svelte-vitals/pull/213) が本 PR をベースにしている) |
+| 028 | PERF009(heavy import)の finding に正しい行番号を持たせる | P1 | S | — | DONE([PR #200](https://github.com/oekazuma/svelte-vitals/pull/200) マージ済み。レビュー対応: Copilot 指摘[`ComponentFacts` は公開型のため、旧バージョン向けにビルドされた外部呼び出し元は `importSpans` なしでインスタンス化しうる]は妥当と検証し `c31e622` で `imports`(行番号なし)へのフォールバックを追加) |
+| 029 | `@svelte-vitals/action` の `main()` にテストを追加する | P1 | M | — | DONE([PR #201](https://github.com/oekazuma/svelte-vitals/pull/201) マージ済み。CI失敗[モックの型不一致 TS2493]の初回修正[`_params` 引数追加]が `@typescript-eslint/no-unused-vars` の回帰を招いたため、既存の `vi.fn<Type>(impl)` ジェネリック型パターンに修正) |
+| 030 | ドキュメント/ワークスペースの陳腐化した記載を修正する(3件まとめ) | P2 | S | — | IN PROGRESS([PR #208](https://github.com/oekazuma/svelte-vitals/pull/208) オープン、CI 全ジョブ green) |
+| 031 | watcher → 再解析の結線を end-to-end でテストする | P2 | S | —(034 と同一ファイルを扱うため順序に注意) | DONE([PR #202](https://github.com/oekazuma/svelte-vitals/pull/202) マージ済み) |
+| 032 | `ci upgrade` が YAML アンカー付き `uses:` 行を扱えるようにする | P2 | S | — | DONE([PR #203](https://github.com/oekazuma/svelte-vitals/pull/203) マージ済み) |
+| 033 | MCP `analyze` tool に `applyScope`(diff/baseline/suppressions)を配線する | P2 | S | — | DONE([PR #204](https://github.com/oekazuma/svelte-vitals/pull/204) マージ済み。CI失敗[テストの `git commit` が CI ランナーにグローバル git identity がなく失敗]を `-c user.name=... -c user.email=...` の明示指定で修正) |
+| 034 | dev dashboard の再解析で変更していないファイルの再パースを避ける | P3 | M | 031 | IN PROGRESS([PR #210](https://github.com/oekazuma/svelte-vitals/pull/210) オープン、CI 全ジョブ green) |
+| 035 | dashboard の SSE staleness guard を実行して検証するテストを追加する | P2 | M | — | IN PROGRESS([PR #209](https://github.com/oekazuma/svelte-vitals/pull/209) オープン、CI 全ジョブ green) |
+| 036 | 設計スパイク — `--diff`/`--staged`/`--baseline` のフルプロジェクト解析を回避する | P3 | M | —(034 と相互作用) | DONE([PR #205](https://github.com/oekazuma/svelte-vitals/pull/205) マージ済み。CI失敗[prettier 整形漏れ]を `--write` で修正) |
+| 037 | 設計スパイク — whole-project 解析の dev-server イベントループ専有を計測・検討する | P3 | L | 034 | DONE([PR #206](https://github.com/oekazuma/svelte-vitals/pull/206) マージ済み。結論: 500ルートまで実測上問題なし、`worker_threads` 移行は見送り。レビュー対応: Copilot 指摘[ベンチマークの `summarizeTicks()` がグローバル定数 `TICK_MS` に暗黙依存/存在しない `docs/superpowers/plans/037-...` パスへの参照3件]は妥当と検証し修正) |
+| 038 | config file を vite プラグインに配線し、`install` にスキャフォルダーを追加する | P3 | M | — | IN PROGRESS([PR #211](https://github.com/oekazuma/svelte-vitals/pull/211) オープン、CI 全ジョブ green) |
+| 039 | 設計スパイク — `lang: 'ja'` i18n(CLI / Action / vite dashboard) | P3 | L | — | IN PROGRESS([PR #207](https://github.com/oekazuma/svelte-vitals/pull/207) オープン、CI 全ジョブ green。レビュー対応: Copilot 指摘[Action 配線の節がレポーター API 設計の節(`formatGithubReport` は翻訳対象外)と矛盾/PR 説明文が当時未コミットだった plan ファイルを参照]は妥当と検証し修正) |
+| 040 | CI の `check`/`docs` ジョブに GitHub Actions のステップ並列化を適用する | P2 | S | 027 | IN PROGRESS([PR #213](https://github.com/oekazuma/svelte-vitals/pull/213) オープン、base は `advisor/027-ci-build-cache`。CI 全ジョブ green) |
+
+2026-07-13 の `/improve deep` セッション(commit `3341587` 時点)から生成された 027–040 に共通する注記: この `plans/` ディレクトリ自体が本セッション終了までリポジトリにコミットされておらず、各 PR の説明文が(実際には存在しない)`plans/0NN-*.md` を参照する形になっていた。Copilot のレビューがこれを実際に指摘した(037・039)。本コミットで解消。
 
 (012/013 は欠番 — 副産物対応の advisor ブランチ名 `advisor/012-*`/`advisor/013-*` として消費済みのため、混同を避けて 014 から採番。014–018 は 2026-07-08 のギャップ分析(commit `d0c76c9` 時点)から生成。テーマは「CI 組み込み体験」と「エージェント統合の入口拡大」— 部品[reporter 群、`--diff`、`--fail-on`、MCP]は揃っているのに、ユーザーがワークフローや指示ファイルを手で組み立てる必要がある状態を解消する。)
 
@@ -41,6 +57,8 @@ Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJE
 - **015 は 014 の後**: 生成するワークフローが `--baseline origin/${{ github.base_ref }}` を前提にする(015 の Drift check が 014 の未マージを検出して STOP する)。
 - **018 は最後に推奨**: 014/015 と同じ CLI ファイル(bin.ts / resolve-args.ts / index.ts)を触るため、コンフリクト回避として直列の末尾に置く。016/017 は独立で並行可。
 - 014 の `--baseline`(ref 比較)と方向性メモ DIR-03 の「抑制ファイル型 baseline」(現状を記録して受け入れ)は別物。両方導入する場合はフラグ命名の整合に注意(014 の Maintenance notes 参照)。
+- **031 → 034 → 037 は同じファイル `packages/vite/src/ui/analysis.ts` を触る連鎖**: 031(watcher→再解析の e2e テスト)がある状態で 034(パースキャッシュ)を実装し、037(dev-server のイベントループ計測)は 034 のキャッシュ有無で計測結果が変わるため 034 の後に読む。実行順は 031→034→037 だが、031・037 は独立に先行マージ済み(034 は本 README 更新時点でまだ PR オープン)。
+- **027 → 040 は同じファイル `.github/workflows/ci.yml` を触る**: 040(ステップ並列化)は 027(dist キャッシュ)の変更を前提にスタックした PR(#213、base = `advisor/027-ci-build-cache`)として出している。027 のマージ後に 040 を main に向け直す。
 
 - **003 は 002 の後**: 空 facts フォールバックの挙動を固定するテスト(002)がある状態で collector を動かす(003)。
 - **007 は 002 の後**: パースキャッシュは「パース失敗時に何が起きるか」の契約(002 が固定)を保存しなければならない。


### PR DESCRIPTION
## Summary
- This session's `/improve deep` audit generated plans 027-040 in `plans/` (repo root), but the directory was never committed — it only ever existed in the advisor session's local working copy.
- As a result, several PR descriptions this session referenced `plans/0NN-*.md` files that didn't actually exist in the repo, which Copilot correctly flagged as dead references on PR #206 and PR #207.
- This PR commits the 14 plan files plus an updated `plans/README.md` status table (DONE for merged plans, IN PROGRESS + PR link + CI status for plans still open), matching the pattern already established for plans 001-026.

## Test plan
- Docs only, no code changes. `prettier --check plans/README.md` passes.