### PR TITLE
feat(vite): add a copy-to-clipboard AI prompt to each dashboard finding

### DIFF
--- a/.changeset/ai-prompt-finding.md
+++ b/.changeset/ai-prompt-finding.md
@@ -1,0 +1,5 @@
+---
+'@svelte-vitals/vite': minor
+---
+
+The live dashboard's finding cards now have a collapsed **AI Prompt** disclosure. Expand it and hit **Copy** to get a ready-to-paste prompt for a coding agent, built from that finding's rule id, location, recommendation, fix, and docs link — no network round-trip, assembled client-side from data already in the dashboard's snapshot.

--- a/.changeset/ai-prompt-finding.md
+++ b/.changeset/ai-prompt-finding.md
@@ -2,4 +2,4 @@
 '@svelte-vitals/vite': minor
 ---
 
-The live dashboard's finding cards now have a collapsed **AI Prompt** disclosure. Expand it and hit **Copy** to get a ready-to-paste prompt for a coding agent, built from that finding's rule id, location, recommendation, fix, and docs link — no network round-trip, assembled client-side from data already in the dashboard's snapshot.
+The live dashboard's finding cards now have a collapsed **AI Prompt** disclosure. Expand it and hit **Copy** to get a ready-to-paste prompt for a coding agent, built instantly from that finding's rule id, location, recommendation, fix, and docs link — no AI call generates it, so it can't hallucinate a fix that isn't the rule's actual recommendation.

--- a/docs/src/content/docs/guides/dev-dashboard.md
+++ b/docs/src/content/docs/guides/dev-dashboard.md
@@ -75,6 +75,32 @@ Notes:
 - Live updates only flow over a loopback origin (`localhost`, `127.0.0.1`, `[::1]`). When you run `vite dev --host` and open the app via a LAN IP, the handle skips the ingest POST (a guard against a spoofed `Host` header), so visited routes won't refine to `measured` — open it from `localhost` instead.
 - Set `SVELTE_VITALS_DEBUG=true` to surface swallowed internal errors (analysis failures, skipped ingests) to the terminal for troubleshooting.
 
+## Copy a fix prompt for any finding
+
+Every finding card has a collapsed **AI Prompt** disclosure — expand it and hit **Copy** to get a ready-to-paste prompt for whichever coding agent you're using, built from that finding's rule id, location, recommendation, fix, and docs link:
+
+````text
+Fix this svelte-vitals finding:
+
+- Rule: SEO001 — Missing <title> (critical)
+- Route: /blog/hello
+- Location: src/routes/blog/hello/+page.svelte:3
+- Recommendation: Add a <title> inside <svelte:head>.
+- Fix: Add a <title> tag.
+
+```svelte
+<svelte:head>
+  <title>Hello</title>
+</svelte:head>
+```
+
+- Docs: https://oekazuma.github.io/svelte-vitals/rules/seo001/
+
+After fixing, re-run `svelte-vitals --diff` (or revisit this route) to confirm SEO001 passes for /blog/hello.
+````
+
+No network round-trip involved — the prompt is assembled client-side from data already in the dashboard's snapshot, the same fields the [`agent` reporter](/svelte-vitals/guides/reporters/) uses for its remediation document.
+
 ## Disabling it
 
 The dashboard is on by default. If you only want the [build-time gate](/svelte-vitals/guides/plugin-mode/) and not the dev-time dashboard — for example on a very large project where you'd rather avoid the startup/re-analysis cost — pass `ui: false`:

--- a/docs/src/content/docs/guides/dev-dashboard.md
+++ b/docs/src/content/docs/guides/dev-dashboard.md
@@ -99,7 +99,7 @@ Fix this svelte-vitals finding:
 After fixing, re-run `svelte-vitals --diff` (or revisit this route) to confirm SEO001 passes for /blog/hello.
 ````
 
-No network round-trip involved — the prompt is assembled client-side from data already in the dashboard's snapshot, the same fields the [`agent` reporter](/svelte-vitals/guides/reporters/) uses for its remediation document.
+No AI call generates it — the prompt is assembled instantly from svelte-vitals' own rule data already in the dashboard's snapshot, the same fields the [`agent` reporter](/svelte-vitals/guides/reporters/) uses for its remediation document. It can't hallucinate a fix that isn't the rule's actual recommendation.
 
 ## Disabling it
 

--- a/docs/src/content/docs/ja/guides/dev-dashboard.md
+++ b/docs/src/content/docs/ja/guides/dev-dashboard.md
@@ -99,7 +99,7 @@ Fix this svelte-vitals finding:
 After fixing, re-run `svelte-vitals --diff` (or revisit this route) to confirm SEO001 passes for /blog/hello.
 ````
 
-ネットワーク通信は発生しません — プロンプトはダッシュボードのスナップショットに既にあるデータからクライアント側で組み立てられます。[`agent` レポーター](/svelte-vitals/ja/guides/reporters/)が修正ドキュメントに使うのと同じフィールドです。
+プロンプトの生成にAI呼び出しは一切ありません — ダッシュボードのスナップショットに既にある svelte-vitals 自身のルールデータから即座に組み立てられます。[`agent` レポーター](/svelte-vitals/ja/guides/reporters/)が修正ドキュメントに使うのと同じフィールドです。ルールの実際の推奨事項ではない修正を捏造することはできません。
 
 ## 無効化する
 

--- a/docs/src/content/docs/ja/guides/dev-dashboard.md
+++ b/docs/src/content/docs/ja/guides/dev-dashboard.md
@@ -75,6 +75,32 @@ export const handle = sequence(
 - ライブ更新はループバックオリジン(`localhost`・`127.0.0.1`・`[::1]`)でのみ流れます。`vite dev --host` で LAN の IP からアプリを開いた場合、ハンドルは ingest の POST をスキップする(`Host` ヘッダー偽装への防御)ため、訪問したルートが `measured` に精緻化されません。その場合は `localhost` から開いてください。
 - `SVELTE_VITALS_DEBUG=true` を設定すると、飲み込まれた内部エラー(分析失敗、ingestのスキップ)がトラブルシューティング用にターミナルへ表示されます。
 
+## 指摘ごとに修正プロンプトをコピーする
+
+各指摘カードには、デフォルトで閉じている **AI Prompt** というディスクロージャーがあります。開いて **Copy** を押すと、その指摘のルールID・場所・推奨対応・fix・ドキュメントリンクから組み立てられた、お使いのコーディングエージェントにそのまま貼り付けられるプロンプトが手に入ります:
+
+````text
+Fix this svelte-vitals finding:
+
+- Rule: SEO001 — Missing <title> (critical)
+- Route: /blog/hello
+- Location: src/routes/blog/hello/+page.svelte:3
+- Recommendation: Add a <title> inside <svelte:head>.
+- Fix: Add a <title> tag.
+
+```svelte
+<svelte:head>
+  <title>Hello</title>
+</svelte:head>
+```
+
+- Docs: https://oekazuma.github.io/svelte-vitals/rules/seo001/
+
+After fixing, re-run `svelte-vitals --diff` (or revisit this route) to confirm SEO001 passes for /blog/hello.
+````
+
+ネットワーク通信は発生しません — プロンプトはダッシュボードのスナップショットに既にあるデータからクライアント側で組み立てられます。[`agent` レポーター](/svelte-vitals/ja/guides/reporters/)が修正ドキュメントに使うのと同じフィールドです。
+
 ## 無効化する
 
 ダッシュボードはデフォルトで有効です。[ビルド時ゲート](/svelte-vitals/ja/guides/plugin-mode/)だけが必要で、dev時のダッシュボードは不要な場合(例:起動時/再解析のコストを避けたい非常に大きなプロジェクトなど)は、`ui: false` を指定してください:

--- a/packages/vite/src/ui/dashboard-script.ts
+++ b/packages/vite/src/ui/dashboard-script.ts
@@ -144,10 +144,12 @@ export const DASHBOARD_SCRIPT = `
 
   function copyToClipboard(text, btn) {
     var original = 'Copy';
-    function done() {
-      btn.textContent = 'Copied!';
+    function reset(label) {
+      btn.textContent = label;
       setTimeout(function () { btn.textContent = original; }, 1500);
     }
+    function done() { reset('Copied!'); }
+    function fail() { reset('Copy failed'); }
     function fallbackCopy() {
       var ta = document.createElement('textarea');
       ta.value = text;
@@ -156,14 +158,15 @@ export const DASHBOARD_SCRIPT = `
       ta.style.opacity = '0';
       document.body.appendChild(ta);
       ta.select();
-      try { document.execCommand('copy'); } catch (e) {}
+      var ok = false;
+      try { ok = document.execCommand('copy'); } catch (e) {}
       document.body.removeChild(ta);
+      return ok;
     }
     if (navigator.clipboard && navigator.clipboard.writeText) {
-      navigator.clipboard.writeText(text).then(done, function () { fallbackCopy(); done(); });
+      navigator.clipboard.writeText(text).then(done, function () { fallbackCopy() ? done() : fail(); });
     } else {
-      fallbackCopy();
-      done();
+      fallbackCopy() ? done() : fail();
     }
   }
 

--- a/packages/vite/src/ui/dashboard-script.ts
+++ b/packages/vite/src/ui/dashboard-script.ts
@@ -113,6 +113,73 @@ export const DASHBOARD_SCRIPT = `
     return pre;
   }
 
+  // Plain-text, copy-pasteable prompt for a single finding — same ingredients as the
+  // agent reporter's per-finding block (rule id, location, recommendation, fix, docs),
+  // reshaped for a standalone request rather than a whole-project remediation doc.
+  function buildAiPrompt(issue, route) {
+    var lines = ['Fix this svelte-vitals finding:', ''];
+    lines.push('- Rule: ' + issue.id + ' — ' + issue.title + ' (' + issue.severity + ')');
+    if (route) lines.push('- Route: ' + route);
+    if (issue.location) {
+      lines.push('- Location: ' + issue.location + (issue.line !== undefined ? ':' + issue.line : ''));
+    }
+    if (issue.recommendation) lines.push('- Recommendation: ' + issue.recommendation);
+    if (issue.fix) {
+      lines.push('- Fix: ' + issue.fix.description);
+      if (issue.fix.snippet) {
+        lines.push('', '\`\`\`' + (issue.fix.lang || 'svelte'), issue.fix.snippet, '\`\`\`');
+      }
+    }
+    if (issue.docsUrl) lines.push('- Docs: ' + issue.docsUrl);
+    lines.push(
+      '',
+      'After fixing, re-run \`svelte-vitals --diff\` (or revisit this route) to confirm ' +
+        issue.id +
+        ' passes' +
+        (route ? ' for ' + route : '') +
+        '.'
+    );
+    return lines.join('\\n');
+  }
+
+  function copyToClipboard(text, btn) {
+    var original = 'Copy';
+    function done() {
+      btn.textContent = 'Copied!';
+      setTimeout(function () { btn.textContent = original; }, 1500);
+    }
+    function fallbackCopy() {
+      var ta = document.createElement('textarea');
+      ta.value = text;
+      ta.setAttribute('readonly', '');
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      try { document.execCommand('copy'); } catch (e) {}
+      document.body.removeChild(ta);
+    }
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(done, function () { fallbackCopy(); done(); });
+    } else {
+      fallbackCopy();
+      done();
+    }
+  }
+
+  function renderAiPrompt(issue, route) {
+    var text = buildAiPrompt(issue, route);
+    var btn = h('button', { type: 'button', class: 'dv-ai-copy-btn', text: 'Copy' }, []);
+    btn.addEventListener('click', function () { copyToClipboard(text, btn); });
+    return h('details', { class: 'dv-ai-prompt' }, [
+      h('summary', { text: 'AI Prompt' }, []),
+      h('div', { class: 'dv-ai-prompt-body' }, [
+        h('pre', { class: 'dv-ai-prompt-pre', text: text }, []),
+        btn
+      ])
+    ]);
+  }
+
   var state = {
     snapshot: null,
     selected: 'overview',
@@ -300,7 +367,7 @@ export const DASHBOARD_SCRIPT = `
 
   var SEVERITY_ORDER = { critical: 0, warning: 1, info: 2 };
 
-  function renderFinding(issue, route) {
+  function renderFinding(issue, route, promptRoute) {
     var kids = [
       h('div', { class: 'dv-f-head' }, [
         h('span', { class: 'dv-ruleid', text: issue.id }, []),
@@ -323,6 +390,7 @@ export const DASHBOARD_SCRIPT = `
     if (issue.docsUrl) {
       kids.push(h('a', { class: 'dv-f-link', href: issue.docsUrl, text: 'Learn more' }, []));
     }
+    kids.push(renderAiPrompt(issue, promptRoute !== undefined ? promptRoute : route));
     return h('article', { class: 'dv-finding dv-finding-' + issue.severity }, kids);
   }
 
@@ -397,7 +465,7 @@ export const DASHBOARD_SCRIPT = `
     var chips = renderFilterChips(state.snapshot.report.categories);
     var findings = route.issues.filter(passesFilter);
     var body = findings.length
-      ? findings.map(function (issue) { return renderFinding(issue); })
+      ? findings.map(function (issue) { return renderFinding(issue, undefined, route.route); })
       : [h('p', { class: 'dv-empty', text: 'No issues match the current filter.' }, [])];
     return h('div', { class: 'dv-route-detail' }, [header, chips].concat(body));
   }

--- a/packages/vite/src/ui/dashboard-style.ts
+++ b/packages/vite/src/ui/dashboard-style.ts
@@ -91,6 +91,16 @@ body{background:var(--ground);color:var(--ink);font-family:var(--sans);line-heig
 .tok-pn{color:#8da0bd}
 .dv-f-link{display:inline-block;margin-top:12px;font-size:13px;font-weight:600;color:var(--accent);text-decoration:none}
 .dv-f-link:hover{text-decoration:underline}
+.dv-ai-prompt{margin-top:12px;border:1px solid var(--line);border-radius:8px;overflow:hidden}
+.dv-ai-prompt>summary{cursor:pointer;list-style:none;padding:8px 12px;font-size:12px;font-weight:600;color:var(--muted);display:flex;align-items:center;gap:6px;user-select:none}
+.dv-ai-prompt>summary::-webkit-details-marker{display:none}
+.dv-ai-prompt>summary::before{content:"▸";display:inline-block;transition:transform .15s ease}
+.dv-ai-prompt[open]>summary::before{transform:rotate(90deg)}
+.dv-ai-prompt-body{padding:0 12px 12px;display:flex;flex-direction:column;gap:8px}
+.dv-ai-prompt-pre{margin:0;padding:10px 12px;background:var(--code-bg);color:var(--code-ink);border-radius:8px;font-family:var(--mono);font-size:12px;line-height:1.6;white-space:pre-wrap;word-break:break-word;max-height:280px;overflow-y:auto}
+.dv-ai-copy-btn{align-self:flex-start;font:inherit;font-size:12px;font-weight:600;cursor:pointer;background:var(--panel);border:1px solid var(--line-strong);color:var(--ink);padding:5px 12px;border-radius:999px}
+.dv-ai-copy-btn:hover{border-color:var(--faint)}
+.dv-ai-copy-btn:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 .dv-empty{color:var(--muted);font-size:13px}
 @media (max-width:640px){.dv-app{grid-template-columns:1fr;grid-template-areas:"top" "main"}.dv-menu-toggle{display:inline-flex}.dv-sidebar{position:fixed;inset:0 20% 0 0;transform:translateX(-100%);transition:transform .2s ease;z-index:10}.dv-sidebar.open{transform:translateX(0)}}
 @media (prefers-reduced-motion:reduce){*{transition:none!important}}

--- a/packages/vite/test/dashboard-script-ai-prompt.test.ts
+++ b/packages/vite/test/dashboard-script-ai-prompt.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { DASHBOARD_SCRIPT } from '../src/ui/dashboard-script.js';
+
+/**
+ * Executes the hand-authored DASHBOARD_SCRIPT client script (see the doc comment on
+ * dashboard-script-staleness.test.ts for why `eval` — no bundler/framework, nothing to
+ * import) to cover the "AI Prompt" disclosure added to each finding card: the prompt
+ * text itself, and the Copy button's success/failure feedback.
+ */
+
+function snapshotJson(): string {
+  return JSON.stringify({
+    report: {
+      version: '1',
+      score: 50,
+      weights: { seo: 1 },
+      categories: { seo: { score: 50, scoreModel: 'weighted' } },
+      summary: { critical: 1, warning: 0, info: 0, passed: 0, dynamic: 0 },
+      routes: [
+        {
+          route: '/blog/hello',
+          score: 50,
+          issues: [
+            {
+              id: 'SEO001',
+              category: 'seo',
+              title: 'Missing <title>',
+              severity: 'critical',
+              location: 'src/routes/blog/hello/+page.svelte',
+              line: 3,
+              recommendation: 'Add a <title> inside <svelte:head>.',
+              fix: {
+                description: 'Add a <title> tag.',
+                snippet: '<svelte:head>\n  <title>Hello</title>\n</svelte:head>',
+                lang: 'svelte'
+              },
+              docsUrl: 'https://oekazuma.github.io/svelte-vitals/rules/seo001/'
+            }
+          ]
+        }
+      ],
+      siteIssues: []
+    },
+    badges: { '/blog/hello': 'static' },
+    analyzing: false,
+    sequence: 1,
+    meta: { version: '9.9.9' }
+  });
+}
+
+function boot(): void {
+  document.body.innerHTML = `
+    <div class="dv-app" id="dv-app">
+      <header class="dv-topbar" id="dv-topbar"></header>
+      <nav class="dv-sidebar" id="dv-sidebar"></nav>
+      <main class="dv-detail" id="dv-detail"></main>
+    </div>
+    <script type="application/json" id="svelte-vitals-data">${snapshotJson()}</script>
+  `;
+  (0, eval)(DASHBOARD_SCRIPT);
+  location.hash = 'route/route-blog-hello';
+  window.dispatchEvent(new Event('hashchange'));
+}
+
+describe('dashboard client script — AI Prompt disclosure', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('renders a closed-by-default disclosure with a prompt built from the finding', () => {
+    boot();
+    const details = document.querySelector('.dv-ai-prompt') as HTMLDetailsElement;
+    expect(details).not.toBeNull();
+    expect(details.open).toBe(false);
+    expect(details.querySelector('summary')!.textContent).toBe('AI Prompt');
+
+    const text = details.querySelector('.dv-ai-prompt-pre')!.textContent!;
+    expect(text).toContain('SEO001');
+    expect(text).toContain('Route: /blog/hello');
+    expect(text).toContain('src/routes/blog/hello/+page.svelte:3');
+    expect(text).toContain('Add a <title> inside <svelte:head>.');
+    expect(text).toContain('```svelte');
+    expect(text).toContain('https://oekazuma.github.io/svelte-vitals/rules/seo001/');
+  });
+
+  it('shows "Copied!" when navigator.clipboard.writeText succeeds', async () => {
+    boot();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    const btn = document.querySelector('.dv-ai-copy-btn') as HTMLButtonElement;
+
+    btn.click();
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(btn.textContent).toBe('Copied!'));
+  });
+
+  it('falls back to execCommand and still shows "Copied!" when the Clipboard API is unavailable', async () => {
+    boot();
+    vi.stubGlobal('navigator', {});
+    // jsdom doesn't implement execCommand at all, so there's nothing for vi.spyOn to wrap —
+    // define it directly, same as a real browser exposing it on `document`.
+    const execCommand = vi.fn().mockReturnValue(true);
+    document.execCommand = execCommand;
+    const btn = document.querySelector('.dv-ai-copy-btn') as HTMLButtonElement;
+
+    btn.click();
+
+    expect(execCommand).toHaveBeenCalledWith('copy');
+    expect(btn.textContent).toBe('Copied!');
+  });
+
+  it('shows "Copy failed" — not a false-positive "Copied!" — when every copy path fails', async () => {
+    boot();
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'));
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    document.execCommand = vi.fn().mockReturnValue(false);
+    const btn = document.querySelector('.dv-ai-copy-btn') as HTMLButtonElement;
+
+    btn.click();
+
+    await vi.waitFor(() => expect(btn.textContent).toBe('Copy failed'));
+  });
+});

--- a/packages/vite/test/ui-dashboard.test.ts
+++ b/packages/vite/test/ui-dashboard.test.ts
@@ -95,4 +95,49 @@ describe('renderDashboardShell', () => {
     expect(html).toContain('dv-wordmark-title');
     expect(html).not.toContain("text: '↯'"); // old bolt-glyph brand, replaced
   });
+
+  it('the embedded client script is syntactically valid JS once a real finding is present', () => {
+    // Regression guard: DASHBOARD_SCRIPT is one giant template literal, so a stray
+    // unescaped backtick or quote inside a comment/string anywhere in it (e.g. in the
+    // AI-prompt builder) silently breaks the whole script for the browser without
+    // failing the TypeScript build, since the string's *contents* aren't type-checked.
+    const snapshot: DashboardSnapshot = {
+      ...baseSnapshot,
+      report: {
+        ...baseSnapshot.report,
+        routes: [
+          {
+            route: '/a',
+            score: 50,
+            issues: [
+              {
+                id: 'SEO001',
+                category: 'seo',
+                title: 'Missing <title>',
+                severity: 'critical',
+                location: 'src/routes/+page.svelte',
+                line: 3,
+                recommendation: 'Add a title',
+                fix: {
+                  description: 'Add a title',
+                  snippet: '<svelte:head><title>Hi</title></svelte:head>',
+                  lang: 'svelte'
+                },
+                docsUrl: 'https://example.com',
+                detection: { presence: 'none', value: 'absent' }
+              } as never
+            ]
+          }
+        ]
+      }
+    };
+    const html = renderDashboardShell(snapshot);
+    const start = html.lastIndexOf('<script>') + '<script>'.length;
+    const end = html.lastIndexOf('</script>');
+    const script = html.slice(start, end);
+    // `new Function` here only parses (never calls) a string built entirely from this
+    // test's own fixture data and the repo's own DASHBOARD_SCRIPT constant — a syntax
+    // check, not execution of untrusted input.
+    expect(() => new Function(script)).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
- Every finding card in the live dashboard now has a collapsed **AI Prompt** disclosure — expand it and hit **Copy** for a ready-to-paste fix request built from that finding's rule id, location, recommendation, fix, and docs link.
- Assembled entirely client-side from data already in the dashboard's snapshot (same ingredients as the `agent` reporter's per-finding block) — no new network round-trip, no core API changes.
- Native `<details>`/`<summary>` disclosure, closed by default; falls back to `document.execCommand('copy')` if `navigator.clipboard` isn't available.
- Docs: new "Copy a fix prompt for any finding" section in the Live dashboard guide (en/ja).
- Changeset: `@svelte-vitals/vite` minor.

## Test plan
- [x] `pnpm --filter @svelte-vitals/vite typecheck` — clean
- [x] `pnpm --filter @svelte-vitals/vite test` — 146/146 pass, including a new regression test asserting the embedded client script stays syntactically valid JS once a real finding (with fix/docsUrl/etc.) is rendered
- [x] Manually booted the real built script in jsdom against a realistic finding, navigated to its route, and confirmed: disclosure closed by default, prompt text contains rule id/route/location/recommendation/fix snippet/docs link in the expected format, and clicking Copy calls `navigator.clipboard.writeText` with that exact text and flips the button to "Copied!"
- [x] `pnpm exec prettier --check` / `pnpm exec eslint` on all touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **AI Prompt** section to dashboard finding cards.
  * Expand the section and copy a ready-to-use fix prompt containing finding details, recommendations, fixes, and documentation links.
  * Prompts are generated in the browser without network requests.

* **Documentation**
  * Added English and Japanese guidance for copying prompts and rechecking fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->