### PR TITLE
feat(cli): make svelte-vitals install monorepo-aware for app-scoped targets

### DIFF
--- a/.changeset/install-monorepo-app-picker.md
+++ b/.changeset/install-monorepo-app-picker.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': minor
+---
+
+`svelte-vitals install` now understands monorepos. The app-scoped targets — `vite-plugin`, `vite-hooks`, and `config-file` — resolve the SvelteKit app directory the same way the analyzer does: an explicit `--app apps/web` wins, a cwd that is itself an app is used as-is, one detected app is used automatically with a notice, several prompt a picker on a TTY, and non-interactive runs exit 2 asking for `--app`. The `@svelte-vitals/vite` auto-install also runs inside the chosen app (with the package manager still detected from the workspace root's lockfile). Root-scoped targets (MCP client configs, agent skills/rules, `ci-workflow`) keep writing at the current directory, which is their correct home in a monorepo.

--- a/docs/src/content/docs/guides/install.md
+++ b/docs/src/content/docs/guides/install.md
@@ -37,6 +37,21 @@ Where to write the config. Applies to all selected clients; **Codex is always gl
 | Cursor      | `.cursor/mcp.json` | `~/.cursor/mcp.json`   |
 | Codex       | —                  | `~/.codex/config.toml` |
 
+## `--app <dir>` — monorepos
+
+The `vite-plugin`, `vite-hooks`, and `config-file` targets must land in the SvelteKit **app** directory — that's where `vite.config.*` and `src/hooks.server.*` live, and a `svelte-vitals.config.*` is only [loaded from the analyzed directory](/svelte-vitals/guides/configuration/#where-it-lives). When you run `install` from a monorepo root, these targets resolve their app the same way [the analyzer does](/svelte-vitals/guides/cli/#monorepos):
+
+- An explicit `--app apps/web` always wins (and fails with exit `2` if that directory has no `svelte.config.{js,ts}`).
+- Otherwise, if the current directory is itself a SvelteKit app, it's used as-is.
+- Otherwise detection kicks in: exactly one app found → used automatically with a notice; several found → a picker prompt on an interactive terminal, or exit `2` asking for `--app` when non-interactive.
+
+Everything else — MCP client configs, agent skills/rules, `ci-workflow` — always writes relative to the current directory, since the repo root is those files' correct home in a monorepo.
+
+```bash
+cd my-monorepo
+npx svelte-vitals@latest install --client vite-plugin,config-file --app apps/web --yes
+```
+
 ## `--yes`, `-y`
 
 Skip the confirmation prompt.

--- a/docs/src/content/docs/ja/guides/install.md
+++ b/docs/src/content/docs/ja/guides/install.md
@@ -37,6 +37,21 @@ npx svelte-vitals@latest install
 | Cursor       | `.cursor/mcp.json` | `~/.cursor/mcp.json`   |
 | Codex        | —                  | `~/.codex/config.toml` |
 
+## `--app <dir>` — モノレポ
+
+`vite-plugin`・`vite-hooks`・`config-file` の3ターゲットは SvelteKit の**アプリ**ディレクトリに書き込む必要があります — `vite.config.*` や `src/hooks.server.*` があるのはそこですし、`svelte-vitals.config.*` は[分析対象ディレクトリからしか読み込まれません](/svelte-vitals/ja/guides/configuration/#探索場所)。モノレポのルートで `install` を実行した場合、これらのターゲットは[アナライザーと同じ方法](/svelte-vitals/ja/guides/cli/#モノレポ)で対象アプリを解決します:
+
+- 明示的な `--app apps/web` が常に最優先です(そのディレクトリに `svelte.config.{js,ts}` がなければ終了コード `2` で失敗します)。
+- それ以外で、カレントディレクトリ自体が SvelteKit アプリならそのまま使われます。
+- それ以外は自動検出が働きます: 見つかったアプリが1件ならそのまま使用(通知あり)、複数ならインタラクティブな端末では選択プロンプト、非対話環境では `--app` を求めて終了コード `2` になります。
+
+それ以外のターゲット — MCP クライアント設定・エージェントスキル/ルール・`ci-workflow` — は常にカレントディレクトリ基準で書き込みます。モノレポではリポジトリルートがそれらの正しい置き場所だからです。
+
+```bash
+cd my-monorepo
+npx svelte-vitals@latest install --client vite-plugin,config-file --app apps/web --yes
+```
+
 ## `--yes`, `-y`
 
 確認プロンプトをスキップします。

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -56985,7 +56985,7 @@ function applyRuleSeverities(results, config) {
   });
 }
 
-// ../cli/dist/chunk-NRQKNTAB.js
+// ../cli/dist/chunk-O5VMXV2Q.js
 import { readFile, access as access2 } from "fs/promises";
 import { join } from "path";
 
@@ -57763,7 +57763,7 @@ async function glob(globInput, options) {
   return crawler ? formatPaths(await crawler.withPromise(), relative2) : [];
 }
 
-// ../cli/dist/chunk-NRQKNTAB.js
+// ../cli/dist/chunk-O5VMXV2Q.js
 import { readFileSync as readFileSync2 } from "fs";
 import { execFileSync } from "child_process";
 import { execFileSync as execFileSync2 } from "child_process";

--- a/packages/cli/src/install/args.ts
+++ b/packages/cli/src/install/args.ts
@@ -52,6 +52,8 @@ export function resolveInstallArgs(argv: mri.Argv): ResolvedInstallArgs {
     else errors.push(`svelte-vitals: unknown --scope '${rawScope}'; expected project|global.`);
   }
 
+  const app = typeof argv.app === 'string' && argv.app.trim() !== '' ? argv.app.trim() : undefined;
+
   const refresh = Boolean(argv.refresh);
   if (refresh && rawClients.length > 0) {
     errors.push('svelte-vitals: --refresh regenerates existing files and cannot be combined with --client.');
@@ -59,14 +61,15 @@ export function resolveInstallArgs(argv: mri.Argv): ResolvedInstallArgs {
 
   if (errors.length > 0) return { flags: null, warnings, errors };
 
-  if (refresh && (scope !== undefined || Boolean(argv.yes) || Boolean(argv.force))) {
-    warnings.push('svelte-vitals: --scope, --yes, and --force are ignored with --refresh.');
+  if (refresh && (scope !== undefined || Boolean(argv.yes) || Boolean(argv.force) || app !== undefined)) {
+    warnings.push('svelte-vitals: --scope, --yes, --force, and --app are ignored with --refresh.');
   }
 
   return {
     flags: {
       ...(client.length > 0 ? { client } : {}),
       ...(scope ? { scope } : {}),
+      ...(app !== undefined && !refresh ? { app } : {}),
       yes: Boolean(argv.yes),
       dryRun: Boolean(argv['dry-run']),
       force: Boolean(argv.force),

--- a/packages/cli/src/install/cli.ts
+++ b/packages/cli/src/install/cli.ts
@@ -42,6 +42,13 @@ Options:
                     the same pass as everything else; supports --force to regenerate. \`svelte-vitals
                     ci upgrade\` remains the way to bump an existing workflow's pinned action version.
   --scope <scope>   project | global (applies to all selected clients; codex is always global)
+  --app <dir>       Monorepo: the SvelteKit app directory the vite-plugin/vite-hooks/config-file
+                    targets write into (e.g. --app apps/web). Without it, when the current
+                    directory isn't itself a SvelteKit app, one detected app is used
+                    automatically (with a notice), several prompt a picker on a TTY, and
+                    non-interactive runs exit 2 asking for --app. All other targets (MCP
+                    configs, skills, ci-workflow) always write at the current directory —
+                    the repo root is their correct home.
   --yes, -y         Skip the confirmation prompt
   --dry-run         Print the planned changes and exit without writing
   --force           Overwrite an existing svelte-vitals entry
@@ -114,6 +121,14 @@ function clackPrompts(): InstallPrompts {
       });
       return p.isCancel(res) ? null : (res as Scope);
     },
+    selectApp: async (apps: string[]) => {
+      const res = await p.select({
+        message: 'Multiple SvelteKit apps found — which one should the Vite/config targets go into?',
+        options: apps.map((a) => ({ value: a, label: a })),
+        initialValue: apps[0]
+      });
+      return p.isCancel(res) ? null : (res as string);
+    },
     confirm: async (planText: string) => {
       const res = await p.confirm({ message: `Apply this plan?\n${planText}` });
       return p.isCancel(res) ? false : Boolean(res);
@@ -125,7 +140,7 @@ function clackPrompts(): InstallPrompts {
 export async function runInstallCli(args: string[]): Promise<number> {
   const argv = mri(args, {
     boolean: ['yes', 'dry-run', 'force', 'refresh', 'help'],
-    string: ['client', 'scope'],
+    string: ['client', 'scope', 'app'],
     alias: { y: 'yes', h: 'help' }
   });
   if (argv.help) {

--- a/packages/cli/src/install/index.ts
+++ b/packages/cli/src/install/index.ts
@@ -28,7 +28,13 @@ import {
 } from './config-file-format.js';
 import { codemodViteConfig } from './codemod-vite-config.js';
 import { codemodHooksServer } from './codemod-hooks.js';
-import { detectPackageManager, hasVitePackage, installCommand, readInstalledViteVersion } from './package-manager.js';
+import {
+  detectPackageManager,
+  detectPackageManagerFromLockfile,
+  hasVitePackage,
+  installCommand,
+  readInstalledViteVersion
+} from './package-manager.js';
 import type { WriteStatus } from './codemod-types.js';
 import { planWorkflowWrite, buildWorkflowYaml } from '../ci/workflow.js';
 import { ACTION_SHA, ACTION_VERSION } from '../ci/action-pin.generated.js';
@@ -102,14 +108,13 @@ interface PlanRow {
 
 /**
  * Package-manager detection for a monorepo app dir: the app's own lockfile wins if it
- * has one, but in a workspace setup the lockfile lives at the repo root, so fall back
- * to detecting from cwd. `detectPackageManager` alone would default to npm for an app
- * dir inside a pnpm workspace — the exact case this exists for.
+ * has one (including a real package-lock.json — distinct from npm-as-fallback), but in
+ * a workspace setup the lockfile lives at the repo root, so fall back to detecting
+ * from cwd. `detectPackageManager` alone would default to npm for an app dir inside a
+ * pnpm workspace — the exact case this exists for.
  */
 function detectPackageManagerNear(io: InstallIO, appDir: string): ReturnType<typeof detectPackageManager> {
-  const inApp = detectPackageManager({ ...io, cwd: appDir });
-  if (inApp !== 'npm') return inApp;
-  return detectPackageManager(io);
+  return detectPackageManagerFromLockfile({ ...io, cwd: appDir }) ?? detectPackageManager(io);
 }
 
 function planForClient(client: ClientWriter, scope: Scope, io: InstallIO, force: boolean): PlanRow {

--- a/packages/cli/src/install/index.ts
+++ b/packages/cli/src/install/index.ts
@@ -32,6 +32,7 @@ import { detectPackageManager, hasVitePackage, installCommand, readInstalledVite
 import type { WriteStatus } from './codemod-types.js';
 import { planWorkflowWrite, buildWorkflowYaml } from '../ci/workflow.js';
 import { ACTION_SHA, ACTION_VERSION } from '../ci/action-pin.generated.js';
+import { discoverApps } from '../discover-apps.js';
 
 export type TargetId = ClientId | ViteTargetId | AgentTargetId | ConfigTargetId | CiTargetId;
 
@@ -50,6 +51,9 @@ export interface InstallIO {
   /** `process.version` — used only to decide whether a fresh config-file scaffold can pick
    * `.ts` (native TypeScript stripping support). Falls back to `process.version` if omitted. */
   nodeVersion?: string;
+  /** Monorepo SvelteKit-app discovery (the analyzer's own `discoverApps`). Injectable for
+   * tests, which use a virtual filesystem the real (fs-backed) implementation can't see. */
+  discoverApps?(cwd: string): Promise<string[]>;
 }
 
 export interface SelectableOption {
@@ -68,6 +72,8 @@ export interface InstallPrompts {
   selectClients(groups: Record<string, SelectableOption[]>, defaults: TargetId[]): Promise<TargetId[] | null>;
   /** Returns chosen scope, or null when cancelled. */
   selectScope(client: ClientWriter): Promise<Scope | null>;
+  /** Monorepo: returns the chosen app directory (cwd-relative), or null when cancelled. */
+  selectApp(apps: string[]): Promise<string | null>;
   confirm(planText: string): Promise<boolean>;
 }
 
@@ -79,6 +85,9 @@ export interface InstallFlags {
   force?: boolean;
   /** Regenerate only the agent target files (AGENT_TARGETS) that already exist on disk. */
   refresh?: boolean;
+  /** Monorepo: cwd-relative SvelteKit app directory the app-scoped targets (vite-plugin,
+   * vite-hooks, config-file) should write into. Skips app auto-detection when given. */
+  app?: string;
 }
 
 interface PlanRow {
@@ -91,6 +100,18 @@ interface PlanRow {
   snippet?: string;
 }
 
+/**
+ * Package-manager detection for a monorepo app dir: the app's own lockfile wins if it
+ * has one, but in a workspace setup the lockfile lives at the repo root, so fall back
+ * to detecting from cwd. `detectPackageManager` alone would default to npm for an app
+ * dir inside a pnpm workspace — the exact case this exists for.
+ */
+function detectPackageManagerNear(io: InstallIO, appDir: string): ReturnType<typeof detectPackageManager> {
+  const inApp = detectPackageManager({ ...io, cwd: appDir });
+  if (inApp !== 'npm') return inApp;
+  return detectPackageManager(io);
+}
+
 function planForClient(client: ClientWriter, scope: Scope, io: InstallIO, force: boolean): PlanRow {
   const path = client.resolvePath(scope, io.cwd, io.home);
   const existing = io.readFile(path);
@@ -100,23 +121,27 @@ function planForClient(client: ClientWriter, scope: Scope, io: InstallIO, force:
 }
 
 /** Read the first candidate path that exists; otherwise report the first candidate as the (nonexistent) path. */
-function resolveCandidate(io: InstallIO, candidates: string[]): { path: string; content: string | undefined } {
+function resolveCandidate(
+  io: InstallIO,
+  baseDir: string,
+  candidates: string[]
+): { path: string; content: string | undefined } {
   for (const rel of candidates) {
-    const path = join(io.cwd, rel);
+    const path = join(baseDir, rel);
     const content = io.readFile(path);
     if (content !== undefined) return { path, content };
   }
-  return { path: join(io.cwd, candidates[0]!), content: undefined };
+  return { path: join(baseDir, candidates[0]!), content: undefined };
 }
 
-function planForVitePlugin(io: InstallIO): PlanRow {
-  const { path, content } = resolveCandidate(io, ['vite.config.ts', 'vite.config.js', 'vite.config.mjs']);
+function planForVitePlugin(io: InstallIO, appDir: string): PlanRow {
+  const { path, content } = resolveCandidate(io, appDir, ['vite.config.ts', 'vite.config.js', 'vite.config.mjs']);
   const result = codemodViteConfig(content);
   return { id: 'vite-plugin', label: viteTargetById('vite-plugin')!.label, path, ...result };
 }
 
-function planForViteHooks(io: InstallIO): PlanRow {
-  const { path, content } = resolveCandidate(io, ['src/hooks.server.ts', 'src/hooks.server.js']);
+function planForViteHooks(io: InstallIO, appDir: string): PlanRow {
+  const { path, content } = resolveCandidate(io, appDir, ['src/hooks.server.ts', 'src/hooks.server.js']);
   const result = codemodHooksServer(content);
   return { id: 'vite-hooks', label: viteTargetById('vite-hooks')!.label, path, ...result };
 }
@@ -168,25 +193,25 @@ function planForAgentTarget(target: AgentTarget, io: InstallIO, force: boolean, 
  * Only a fresh scaffold (nothing exists yet) auto-picks the best extension for this
  * environment (see detectBestConfigExtension in config-file-format.ts).
  */
-function planForConfigTarget(target: ConfigTarget, io: InstallIO, force: boolean): PlanRow {
-  const existingRel = findExistingConfigFile(io.readFile, io.cwd);
+function planForConfigTarget(target: ConfigTarget, io: InstallIO, force: boolean, appDir: string): PlanRow {
+  const existingRel = findExistingConfigFile(io.readFile, appDir);
   if (existingRel !== undefined) {
-    const path = join(io.cwd, existingRel);
+    const path = join(appDir, existingRel);
     const status: WriteStatus = force ? 'updated' : 'exists';
     const content = force
       ? buildConfigFileTemplate({
-          useDefineConfig: existingRel.endsWith('.ts') && hasSvelteVitalsDependency(io.readFile, io.cwd),
-          useCommonJs: existingRel.endsWith('.js') && !isEsmProject(io.readFile, io.cwd)
+          useDefineConfig: existingRel.endsWith('.ts') && hasSvelteVitalsDependency(io.readFile, appDir),
+          useCommonJs: existingRel.endsWith('.js') && !isEsmProject(io.readFile, appDir)
         })
       : undefined;
     return { id: target.id, label: target.label, path, status, content };
   }
   const ext = detectBestConfigExtension({
     readFile: io.readFile,
-    cwd: io.cwd,
+    cwd: appDir,
     nodeVersion: io.nodeVersion ?? process.version
   });
-  const path = join(io.cwd, `svelte-vitals.config.${ext}`);
+  const path = join(appDir, `svelte-vitals.config.${ext}`);
   const content = buildConfigFileTemplate({ useDefineConfig: ext === 'ts' });
   return { id: target.id, label: target.label, path, status: 'created', content };
 }
@@ -362,7 +387,59 @@ export async function runInstall(
     return 2;
   }
 
-  // 2. Resolve a scope per client and build the plan.
+  // 2. Monorepo: resolve the app directory the app-scoped targets write into.
+  // vite-plugin/vite-hooks/config-file must land in the SvelteKit app itself (that's
+  // where vite.config/hooks.server live, and the config file is only loaded from the
+  // analyzed directory) — everything else (MCP project configs, skills, the CI
+  // workflow) belongs at the repo root and ignores this. Mirrors the analyzer's own
+  // app picker (design doc 2026-07-08-monorepo-app-picker-design.md): cwd-is-an-app
+  // short-circuits, a single detected app is used with a notice, several prompt on a
+  // TTY, and non-interactive runs get told to pass --app.
+  const hasSvelteConfig = (dir: string): boolean => {
+    try {
+      return (
+        io.readFile(join(dir, 'svelte.config.js')) !== undefined ||
+        io.readFile(join(dir, 'svelte.config.ts')) !== undefined
+      );
+    } catch {
+      return false;
+    }
+  };
+  const needsApp = viteIds.length > 0 || configIds.length > 0;
+  let appDir = io.cwd;
+  if (needsApp) {
+    if (flags.app) {
+      const candidate = join(io.cwd, flags.app);
+      if (!hasSvelteConfig(candidate)) {
+        io.errorLog(`svelte-vitals: --app '${flags.app}' is not a SvelteKit app (no svelte.config.{js,ts} there).`);
+        return 2;
+      }
+      appDir = candidate;
+    } else if (!hasSvelteConfig(io.cwd)) {
+      const apps = await (io.discoverApps ?? discoverApps)(io.cwd);
+      if (apps.length === 1) {
+        io.errorLog(`svelte-vitals: detected SvelteKit app at ${apps[0]}; targeting it for the Vite/config targets.`);
+        appDir = join(io.cwd, apps[0]!);
+      } else if (apps.length > 1) {
+        if (io.isTTY) {
+          const picked = await prompts.selectApp(apps);
+          if (picked === null) {
+            io.log('Cancelled.');
+            return 0;
+          }
+          appDir = join(io.cwd, picked);
+        } else {
+          io.errorLog(`svelte-vitals: multiple SvelteKit apps found: ${apps.join(', ')}.`);
+          io.errorLog(`svelte-vitals: pass one with --app, e.g. \`svelte-vitals install --app ${apps[0]}\`.`);
+          return 2;
+        }
+      }
+      // 0 apps found → keep cwd, same as before this feature existed (install has
+      // never hard-required a SvelteKit project).
+    }
+  }
+
+  // 3. Resolve a scope per client and build the plan.
   const rows: PlanRow[] = [];
   for (const client of clients) {
     let scope: Scope;
@@ -391,7 +468,7 @@ export async function runInstall(
     }
   }
   for (const viteId of viteIds) {
-    rows.push(viteId === 'vite-plugin' ? planForVitePlugin(io) : planForViteHooks(io));
+    rows.push(viteId === 'vite-plugin' ? planForVitePlugin(io, appDir) : planForViteHooks(io, appDir));
   }
   for (const agentId of agentIds) {
     const target = agentTargetById(agentId)!;
@@ -410,7 +487,7 @@ export async function runInstall(
   for (const configId of configIds) {
     const target = configTargetById(configId)!;
     try {
-      rows.push(planForConfigTarget(target, io, flags.force ?? false));
+      rows.push(planForConfigTarget(target, io, flags.force ?? false, appDir));
     } catch (err) {
       io.errorLog(
         `svelte-vitals: could not check existing config file: ${err instanceof Error ? err.message : String(err)}`
@@ -430,12 +507,12 @@ export async function runInstall(
     }
   }
 
-  // 3. Preview.
+  // 4. Preview.
   const planText = rows.map(rowLine).join('\n');
   io.log('Plan:');
   io.log(planText);
 
-  // 4. Dry-run / confirm.
+  // 5. Dry-run / confirm.
   if (flags.dryRun) {
     io.log('Dry run — no files written.');
     return 0;
@@ -448,7 +525,7 @@ export async function runInstall(
     }
   }
 
-  // 5. Write.
+  // 6. Write.
   let hadFailure = false;
   let viteWasWritten = false;
   for (const r of rows) {
@@ -480,22 +557,26 @@ export async function runInstall(
       io.errorLog(`svelte-vitals: failed to write ${r.path}: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
-  // 6. Auto-install @svelte-vitals/vite if a Vite target was actually written —
+  // 7. Auto-install @svelte-vitals/vite if a Vite target was actually written —
   // run this even if another row failed, so a partial failure elsewhere doesn't
   // silently strand a freshly-registered vite.config without its dependency
   // (once written, the codemod reports 'exists' on every later run, so this is
-  // the only chance to install it).
-  if (viteWasWritten && io.runCommand && !hasVitePackage(io)) {
-    const pm = detectPackageManager(io);
+  // the only chance to install it). In a monorepo, the dependency belongs to the
+  // app's own package.json, so both the check and the install run in appDir; the
+  // package manager is still detected from wherever the lockfile lives (the repo
+  // root in a workspace setup — an app dir usually has none).
+  const appIo = { ...io, cwd: appDir };
+  if (viteWasWritten && io.runCommand && !hasVitePackage(appIo)) {
+    const pm = appDir === io.cwd ? detectPackageManager(io) : detectPackageManagerNear(io, appDir);
     const { command, args } = installCommand(pm);
     io.log(`Installing @svelte-vitals/vite via ${pm}...`);
-    const code = io.runCommand(command, args, io.cwd);
+    const code = io.runCommand(command, args, appDir);
     if (code !== 0) {
       io.errorLog(
         `svelte-vitals: failed to install @svelte-vitals/vite (${command} ${args.join(' ')} exited ${code}). Install it manually.`
       );
     } else {
-      const installedVersion = readInstalledViteVersion(io);
+      const installedVersion = readInstalledViteVersion(appIo) ?? readInstalledViteVersion(io);
       io.log(
         installedVersion
           ? `svelte-vitals: installed @svelte-vitals/vite@${installedVersion} — compare against \`svelte-vitals --version\`'s core number if findings ever seem out of sync.`

--- a/packages/cli/src/install/package-manager.ts
+++ b/packages/cli/src/install/package-manager.ts
@@ -14,15 +14,25 @@ const LOCKFILE_TO_PM: Record<string, PackageManager> = {
   'pnpm-lock.yaml': 'pnpm',
   'yarn.lock': 'yarn',
   'bun.lock': 'bun',
-  'bun.lockb': 'bun'
+  'bun.lockb': 'bun',
+  'package-lock.json': 'npm'
 };
 
-/** Detect the project's package manager from its lockfile; defaults to npm. */
-export function detectPackageManager(io: ReadCwd): PackageManager {
+/**
+ * The package manager whose lockfile exists in `io.cwd`, or undefined when none does.
+ * Distinct from `detectPackageManager`'s npm fallback so callers with their own
+ * fallback chain (e.g. app dir → workspace root) can tell "really npm" from "no signal".
+ */
+export function detectPackageManagerFromLockfile(io: ReadCwd): PackageManager | undefined {
   for (const [file, pm] of Object.entries(LOCKFILE_TO_PM)) {
     if (io.readFile(join(io.cwd, file)) !== undefined) return pm;
   }
-  return 'npm';
+  return undefined;
+}
+
+/** Detect the project's package manager from its lockfile; defaults to npm. */
+export function detectPackageManager(io: ReadCwd): PackageManager {
+  return detectPackageManagerFromLockfile(io) ?? 'npm';
 }
 
 /** Whether @svelte-vitals/vite is already a (dev)dependency in package.json. */

--- a/packages/cli/test/install/args.test.ts
+++ b/packages/cli/test/install/args.test.ts
@@ -110,6 +110,22 @@ describe('resolveInstallArgs — ci target', () => {
   });
 });
 
+describe('resolveInstallArgs — --app', () => {
+  it('passes --app through', () => {
+    const r = resolveInstallArgs(parse(['--client', 'vite-plugin', '--app', 'apps/web']));
+    expect(r.errors).toEqual([]);
+    expect(r.flags).toMatchObject({ app: 'apps/web' });
+  });
+  it('omits the app key when not provided', () => {
+    const r = resolveInstallArgs(parse(['--client', 'vite-plugin']));
+    expect(r.flags).not.toHaveProperty('app');
+  });
+  it('ignores an empty --app value', () => {
+    const r = resolveInstallArgs(parse(['--client', 'vite-plugin', '--app', ' ']));
+    expect(r.flags).not.toHaveProperty('app');
+  });
+});
+
 describe('resolveInstallArgs — --refresh', () => {
   it('accepts a bare --refresh', () => {
     const r = resolveInstallArgs(parse(['--refresh']));
@@ -127,5 +143,12 @@ describe('resolveInstallArgs — --refresh', () => {
     expect(r.errors).toEqual([]);
     expect(r.flags).toMatchObject({ refresh: true });
     expect(r.warnings.join('\n')).toContain('--refresh');
+  });
+  it('warns and drops --app when combined with --refresh', () => {
+    const r = resolveInstallArgs(parse(['--refresh', '--app', 'apps/web']));
+    expect(r.errors).toEqual([]);
+    expect(r.flags).toMatchObject({ refresh: true });
+    expect(r.flags).not.toHaveProperty('app');
+    expect(r.warnings.join('\n')).toContain('--app');
   });
 });

--- a/packages/cli/test/install/cli.test.ts
+++ b/packages/cli/test/install/cli.test.ts
@@ -32,6 +32,16 @@ describe('runInstallCli --help', () => {
     expect(help).toContain('claude-skill-improve');
   });
 
+  it('documents --app for monorepos', async () => {
+    const lines: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((line: string) => {
+      lines.push(line);
+    });
+    const code = await runInstallCli(['--help']);
+    expect(code).toBe(0);
+    expect(lines.join('\n')).toContain('--app <dir>');
+  });
+
   it('lists the ci-workflow target id', async () => {
     const lines: string[] = [];
     vi.spyOn(console, 'log').mockImplementation((line: string) => {

--- a/packages/cli/test/install/package-manager.test.ts
+++ b/packages/cli/test/install/package-manager.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { detectPackageManager, hasVitePackage, installCommand } from '../../src/install/package-manager.js';
+import {
+  detectPackageManager,
+  detectPackageManagerFromLockfile,
+  hasVitePackage,
+  installCommand
+} from '../../src/install/package-manager.js';
 
 function fakeReadCwd(files: Record<string, string>) {
   return {
@@ -21,8 +26,20 @@ describe('detectPackageManager', () => {
   it('detects bun from bun.lock (the newer text-based format)', () => {
     expect(detectPackageManager(fakeReadCwd({ '/proj/bun.lock': '' }))).toBe('bun');
   });
+  it('detects npm from a real package-lock.json', () => {
+    expect(detectPackageManager(fakeReadCwd({ '/proj/package-lock.json': '{}' }))).toBe('npm');
+  });
   it('falls back to npm when no lockfile is found', () => {
     expect(detectPackageManager(fakeReadCwd({}))).toBe('npm');
+  });
+});
+
+describe('detectPackageManagerFromLockfile', () => {
+  it('returns npm for a real package-lock.json — distinct from the no-lockfile case', () => {
+    expect(detectPackageManagerFromLockfile(fakeReadCwd({ '/proj/package-lock.json': '{}' }))).toBe('npm');
+  });
+  it('returns undefined when no lockfile is found, so callers can apply their own fallback', () => {
+    expect(detectPackageManagerFromLockfile(fakeReadCwd({}))).toBeUndefined();
   });
 });
 

--- a/packages/cli/test/install/run.test.ts
+++ b/packages/cli/test/install/run.test.ts
@@ -9,6 +9,7 @@ function fakeIO(
     throwOnRead?: string;
     runCommand?: (command: string, args: string[], cwd: string) => number;
     nodeVersion?: string;
+    discoverApps?: (cwd: string) => Promise<string[]>;
   } = {}
 ) {
   const files = over.files ?? {};
@@ -34,6 +35,9 @@ function fakeIO(
     nodeVersion: over.nodeVersion ?? 'v22.13.0',
     log: (l) => out.push(l),
     errorLog: (l) => err.push(l),
+    // Tests use a virtual filesystem, so the real fs-backed discoverApps would
+    // scan the actual repo — default to "no apps found" unless a test injects one.
+    discoverApps: over.discoverApps ?? (async () => []),
     ...(over.runCommand ? { runCommand: over.runCommand } : {})
   };
   return { io, writes, out, err };
@@ -42,6 +46,7 @@ function fakeIO(
 const noPrompts: InstallPrompts = {
   selectClients: async () => null,
   selectScope: async () => null,
+  selectApp: async () => null,
   confirm: async () => true
 };
 
@@ -757,6 +762,188 @@ describe('runInstall — grouped interactive picker', () => {
     };
     await runInstall({}, io, prompts);
     expect(mcpGroup).toEqual(['claude-code', 'cursor', 'codex']);
+  });
+});
+
+describe('runInstall — monorepo app resolution (vite/config targets)', () => {
+  it('cwd itself is a SvelteKit app → no discovery, writes stay at cwd', async () => {
+    let discoveryCalls = 0;
+    const { io, writes } = fakeIO({
+      files: { '/proj/svelte.config.js': 'export default {};' },
+      discoverApps: async () => {
+        discoveryCalls++;
+        return ['apps/web'];
+      }
+    });
+    const code = await runInstall({ client: ['config-file'], yes: true }, io, noPrompts);
+    expect(code).toBe(0);
+    expect(discoveryCalls).toBe(0);
+    expect(writes['/proj/svelte-vitals.config.mjs']).toBeDefined();
+  });
+
+  it('exactly one app detected → used automatically with a notice, config lands in the app dir', async () => {
+    const { io, writes, err } = fakeIO({
+      files: { '/proj/apps/web/svelte.config.js': 'export default {};' },
+      discoverApps: async () => ['apps/web']
+    });
+    const code = await runInstall({ client: ['config-file'], yes: true }, io, noPrompts);
+    expect(code).toBe(0);
+    expect(err.join('\n')).toContain('detected SvelteKit app at apps/web');
+    expect(writes['/proj/apps/web/svelte-vitals.config.mjs']).toBeDefined();
+    expect(writes['/proj/svelte-vitals.config.mjs']).toBeUndefined();
+  });
+
+  it("vite-plugin's candidate lookup and manual snippet path are app-relative", async () => {
+    const { io, writes, out } = fakeIO({
+      files: { '/proj/apps/web/svelte.config.js': 'export default {};' },
+      discoverApps: async () => ['apps/web']
+    });
+    const code = await runInstall({ client: ['vite-plugin'], yes: true }, io, noPrompts);
+    expect(code).toBe(0);
+    expect(writes).toEqual({});
+    expect(out.join('\n')).toContain('/proj/apps/web/vite.config.ts');
+  });
+
+  it('several apps, non-interactive → exit 2 pointing at --app', async () => {
+    const { io, writes, err } = fakeIO({
+      files: {
+        '/proj/apps/web/svelte.config.js': 'x',
+        '/proj/apps/admin/svelte.config.js': 'x'
+      },
+      discoverApps: async () => ['apps/admin', 'apps/web']
+    });
+    const code = await runInstall({ client: ['config-file'], yes: true }, io, noPrompts);
+    expect(code).toBe(2);
+    expect(writes).toEqual({});
+    expect(err.join('\n')).toContain('multiple SvelteKit apps found');
+    expect(err.join('\n')).toContain('--app');
+  });
+
+  it('several apps on a TTY → selectApp prompt decides the app dir', async () => {
+    let promptedWith: string[] = [];
+    const prompts: InstallPrompts = {
+      ...noPrompts,
+      selectApp: async (apps) => {
+        promptedWith = apps;
+        return 'apps/admin';
+      }
+    };
+    const { io, writes } = fakeIO({
+      isTTY: true,
+      files: {
+        '/proj/apps/web/svelte.config.js': 'x',
+        '/proj/apps/admin/svelte.config.js': 'x'
+      },
+      discoverApps: async () => ['apps/admin', 'apps/web']
+    });
+    const code = await runInstall({ client: ['config-file'], yes: true }, io, prompts);
+    expect(code).toBe(0);
+    expect(promptedWith).toEqual(['apps/admin', 'apps/web']);
+    expect(writes['/proj/apps/admin/svelte-vitals.config.mjs']).toBeDefined();
+  });
+
+  it('cancelling the app picker exits 0 without writing', async () => {
+    const prompts: InstallPrompts = { ...noPrompts, selectApp: async () => null };
+    const { io, writes, out } = fakeIO({
+      isTTY: true,
+      files: {
+        '/proj/apps/web/svelte.config.js': 'x',
+        '/proj/apps/admin/svelte.config.js': 'x'
+      },
+      discoverApps: async () => ['apps/admin', 'apps/web']
+    });
+    const code = await runInstall({ client: ['config-file'], yes: true }, io, prompts);
+    expect(code).toBe(0);
+    expect(writes).toEqual({});
+    expect(out.join('\n')).toContain('Cancelled');
+  });
+
+  it('--app skips detection and targets the named app', async () => {
+    let discoveryCalls = 0;
+    const { io, writes } = fakeIO({
+      files: {
+        '/proj/apps/web/svelte.config.js': 'x',
+        '/proj/apps/admin/svelte.config.ts': 'x'
+      },
+      discoverApps: async () => {
+        discoveryCalls++;
+        return ['apps/admin', 'apps/web'];
+      }
+    });
+    const code = await runInstall({ client: ['config-file'], app: 'apps/admin', yes: true }, io, noPrompts);
+    expect(code).toBe(0);
+    expect(discoveryCalls).toBe(0);
+    expect(writes['/proj/apps/admin/svelte-vitals.config.mjs']).toBeDefined();
+  });
+
+  it('--app pointing at a non-SvelteKit dir is a fatal error (exit 2)', async () => {
+    const { io, writes, err } = fakeIO();
+    const code = await runInstall({ client: ['config-file'], app: 'packages/lib', yes: true }, io, noPrompts);
+    expect(code).toBe(2);
+    expect(writes).toEqual({});
+    expect(err.join('\n')).toContain("--app 'packages/lib' is not a SvelteKit app");
+  });
+
+  it('root-scoped targets are unaffected: MCP config stays at cwd while the config file goes into the app', async () => {
+    const { io, writes } = fakeIO({
+      files: { '/proj/apps/web/svelte.config.js': 'x' },
+      discoverApps: async () => ['apps/web']
+    });
+    const code = await runInstall(
+      { client: ['claude-code', 'config-file'], scope: 'project', yes: true },
+      io,
+      noPrompts
+    );
+    expect(code).toBe(0);
+    expect(Object.keys(writes).sort()).toEqual(['/proj/.mcp.json', '/proj/apps/web/svelte-vitals.config.mjs']);
+  });
+
+  it('no apps found anywhere → previous behavior, writes at cwd', async () => {
+    const { io, writes } = fakeIO({ discoverApps: async () => [] });
+    const code = await runInstall({ client: ['config-file'], yes: true }, io, noPrompts);
+    expect(code).toBe(0);
+    expect(writes['/proj/svelte-vitals.config.mjs']).toBeDefined();
+  });
+
+  it('targets without app scope never trigger discovery', async () => {
+    let discoveryCalls = 0;
+    const { io } = fakeIO({
+      discoverApps: async () => {
+        discoveryCalls++;
+        return ['apps/web'];
+      }
+    });
+    await runInstall(
+      { client: ['claude-code', 'claude-skill', 'ci-workflow'], scope: 'project', yes: true },
+      io,
+      noPrompts
+    );
+    expect(discoveryCalls).toBe(0);
+  });
+
+  it('the vite auto-install runs in the app dir and detects the PM from the root lockfile', async () => {
+    const viteConfig = `
+import { sveltekit } from '@sveltejs/kit/vite';
+export default { plugins: [sveltekit()] };
+`;
+    const runCalls: Array<{ command: string; args: string[]; cwd: string }> = [];
+    const { io, writes } = fakeIO({
+      files: {
+        '/proj/pnpm-lock.yaml': '',
+        '/proj/apps/web/svelte.config.js': 'x',
+        '/proj/apps/web/vite.config.ts': viteConfig,
+        '/proj/apps/web/package.json': '{}'
+      },
+      discoverApps: async () => ['apps/web'],
+      runCommand: (command, args, cwd) => {
+        runCalls.push({ command, args, cwd });
+        return 0;
+      }
+    });
+    const code = await runInstall({ client: ['vite-plugin'], yes: true }, io, noPrompts);
+    expect(code).toBe(0);
+    expect(writes['/proj/apps/web/vite.config.ts']).toContain('svelteVitals()');
+    expect(runCalls).toEqual([{ command: 'pnpm', args: ['add', '-D', '@svelte-vitals/vite'], cwd: '/proj/apps/web' }]);
   });
 });
 

--- a/packages/cli/test/install/run.test.ts
+++ b/packages/cli/test/install/run.test.ts
@@ -945,6 +945,33 @@ export default { plugins: [sveltekit()] };
     expect(writes['/proj/apps/web/vite.config.ts']).toContain('svelteVitals()');
     expect(runCalls).toEqual([{ command: 'pnpm', args: ['add', '-D', '@svelte-vitals/vite'], cwd: '/proj/apps/web' }]);
   });
+
+  it('an app with its own package-lock.json keeps npm even when the repo root uses pnpm', async () => {
+    const viteConfig = `
+import { sveltekit } from '@sveltejs/kit/vite';
+export default { plugins: [sveltekit()] };
+`;
+    const runCalls: Array<{ command: string; args: string[]; cwd: string }> = [];
+    const { io } = fakeIO({
+      files: {
+        '/proj/pnpm-lock.yaml': '',
+        '/proj/apps/web/package-lock.json': '{}',
+        '/proj/apps/web/svelte.config.js': 'x',
+        '/proj/apps/web/vite.config.ts': viteConfig,
+        '/proj/apps/web/package.json': '{}'
+      },
+      discoverApps: async () => ['apps/web'],
+      runCommand: (command, args, cwd) => {
+        runCalls.push({ command, args, cwd });
+        return 0;
+      }
+    });
+    const code = await runInstall({ client: ['vite-plugin'], yes: true }, io, noPrompts);
+    expect(code).toBe(0);
+    expect(runCalls).toEqual([
+      { command: 'npm', args: ['install', '-D', '@svelte-vitals/vite'], cwd: '/proj/apps/web' }
+    ]);
+  });
 });
 
 describe('runInstall — --refresh', () => {


### PR DESCRIPTION
## Summary
`svelte-vitals install` wrote every target relative to cwd, so from a monorepo root the app-scoped targets were useless: `vite-plugin`/`vite-hooks` couldn't find `vite.config.*`/`src/hooks.server.*` (they live in the app), and `config-file` scaffolded a `svelte-vitals.config.*` at the root that the analyzer never loads (configs are read from the analyzed directory only).

Those three targets now resolve the SvelteKit app directory the same way the analyzer's monorepo picker does (design doc 2026-07-08-monorepo-app-picker-design.md), reusing its `discoverApps`:

- **`--app apps/web`** (new flag) always wins — exits 2 if the directory has no `svelte.config.{js,ts}`.
- cwd that is itself a SvelteKit app → used as-is (zero behavior change for single-app projects).
- Exactly one app detected → used automatically with a stderr notice.
- Several detected → single-select prompt on a TTY; non-interactive runs exit 2 pointing at `--app`.
- No apps found → previous behavior (cwd), since install has never hard-required a SvelteKit project.

The `@svelte-vitals/vite` auto-install runs inside the chosen app (dependency lands in the app's own `package.json`) while the package manager is still detected from the workspace root's lockfile — `detectPackageManager` alone would fall back to npm inside a pnpm workspace's app dir.

**Root-scoped targets are intentionally unchanged:** MCP client configs (`.mcp.json` etc.), agent skills/rules, and `ci-workflow` (`.github/`) keep writing at cwd — the repo root is their correct home in a monorepo.

## Test plan
- [x] `pnpm --filter svelte-vitals typecheck` / `test` (668 tests, up from 651) — clean
- [x] New `runInstall — monorepo app resolution` suite (11 cases): cwd-is-app short-circuit, single-app auto-pick + notice, app-relative vite candidate/manual-snippet paths, multi-app non-TTY exit 2, TTY picker + cancel, `--app` skip-detection / invalid-dir exit 2, root-scoped targets unaffected in the same run, zero-apps fallback, no-discovery-when-no-app-scoped-target, and the auto-install running in the app dir with root-lockfile PM detection
- [x] `resolveInstallArgs` tests for `--app` (pass-through, omitted, empty, ignored+warned with `--refresh`) and a `--help` assertion
- [x] Manually verified end-to-end with the real built CLI on disk fixtures: multi-app non-TTY exit 2 with the `--app` hint, `--app apps/web` writing into the app, single-app auto-detection notice with the vite codemod targeting `apps/web/vite.config.ts`, and `--app nope` exit 2
- [x] Docs: new `--app <dir>` section in install.md (en/ja), cross-linking the analyzer's Monorepos section and configuration's "Where it lives"; changeset (`svelte-vitals` minor)

## Note
`packages/action/dist` needs a rebuild on this branch (the shared cli chunk's hash changes because `discover-apps` is now imported from the bin side too) — will follow up on this PR before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--app <dir>` support for installing Vite and configuration targets in monorepos.
  * Automatically detects the appropriate SvelteKit app or prompts for selection when needed.
  * Added clear guidance and validation for ambiguous or invalid app directories.
  * Kept repository-level targets relative to the current directory.
* **Documentation**
  * Updated installation guides with monorepo workflows and examples.
  * Added Japanese documentation for the new option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->