### PR TITLE
fix(core): exempt relative-path lib/server imports from SEC003 set-call detection

### DIFF
--- a/.changeset/sec003-relative-lib-server.md
+++ b/.changeset/sec003-relative-lib-server.md
@@ -1,0 +1,5 @@
+---
+'@svelte-vitals/core': patch
+---
+
+SEC003 no longer flags `.set()`/`.update()` calls on modules imported from `src/lib/server/**` via a relative path — the exemption now checks the resolved path, not just the `$lib/server/` alias form.

--- a/docs/src/content/docs/ja/rules/sec003.md
+++ b/docs/src/content/docs/ja/rules/sec003.md
@@ -9,7 +9,7 @@ description: load 関数や action が import したモジュール状態に書�
 
 サーバーで実行される handler(`load`、form action、`+server` の HTTP handler、`hooks.server` の handler)の内部から、**import した binding** への書き込みを検出します — プロパティ代入(`state.user = …`)、インクリメント/`delete`、`.set(...)` / `.update(...)` 呼び出しが対象です。universal な `+page.ts`/`+layout.ts` の load も対象です — SSR 時はサーバーで実行されるためです。
 
-読み取り、その他のメソッド呼び出し(`logger.info(…)`)、ローカル変数への書き込みは検出対象外です。インストール済みパッケージや、解決先が `src/lib/server/**` になる import への `.set()`/`.update()`(Drizzle の `db.update(...).set(...)` など DB/KV クライアント)も対象外です — この除外は `$lib/server/` alias 経由でも相対パス(`../../lib/server/db`)経由でも同様に適用されます。永続化であり共有状態への書き込みではないためです。
+読み取り、その他のメソッド呼び出し(`logger.info(…)`)、ローカル変数への書き込みは検出対象外です。インストール済みパッケージや、解決先が `src/lib/server` になる import — ディレクトリエントリポイントの import(`import { db } from '$lib/server'`)および `src/lib/server/**` 配下 — への `.set()`/`.update()`(Drizzle の `db.update(...).set(...)` など DB/KV クライアント)も対象外です — この除外は解決後のパスに対して適用されるため、`$lib/server/` alias 経由でも相対パス(`../../lib/server/db`)経由でも同様に働き、`..` がプロジェクトルートの外へ抜ける specifier は保守的にリポジトリ内の共有状態として扱われません。永続化であり共有状態への書き込みではないためです。
 
 ## 重要な理由
 

--- a/docs/src/content/docs/ja/rules/sec003.md
+++ b/docs/src/content/docs/ja/rules/sec003.md
@@ -9,7 +9,7 @@ description: load 関数や action が import したモジュール状態に書�
 
 サーバーで実行される handler(`load`、form action、`+server` の HTTP handler、`hooks.server` の handler)の内部から、**import した binding** への書き込みを検出します — プロパティ代入(`state.user = …`)、インクリメント/`delete`、`.set(...)` / `.update(...)` 呼び出しが対象です。universal な `+page.ts`/`+layout.ts` の load も対象です — SSR 時はサーバーで実行されるためです。
 
-読み取り、その他のメソッド呼び出し(`logger.info(…)`)、ローカル変数への書き込みは検出対象外です。インストール済みパッケージや `$lib/server/**` からの import への `.set()`/`.update()`(Drizzle の `db.update(...).set(...)` など DB/KV クライアント)も、永続化であり共有状態への書き込みではないため対象外です。
+読み取り、その他のメソッド呼び出し(`logger.info(…)`)、ローカル変数への書き込みは検出対象外です。インストール済みパッケージや、解決先が `src/lib/server/**` になる import への `.set()`/`.update()`(Drizzle の `db.update(...).set(...)` など DB/KV クライアント)も対象外です — この除外は `$lib/server/` alias 経由でも相対パス(`../../lib/server/db`)経由でも同様に適用されます。永続化であり共有状態への書き込みではないためです。
 
 ## 重要な理由
 

--- a/docs/src/content/docs/rules/sec003.md
+++ b/docs/src/content/docs/rules/sec003.md
@@ -9,7 +9,7 @@ description: A load function or action writes to imported module state — share
 
 Flags writes to an **imported binding** from inside a server-executed handler — `load`, a form action, a `+server` HTTP handler, or a `hooks.server` handler: property assignment (`state.user = …`), increment/`delete`, and `.set(...)` / `.update(...)` calls. Universal `+page.ts`/`+layout.ts` load functions are included — they run on the server during SSR.
 
-Reads, other method calls (`logger.info(…)`), and writes to local variables are not flagged. Nor are `.set()`/`.update()` calls on imports from installed packages or anything resolving to `src/lib/server/**` (database/KV clients — e.g. Drizzle's `db.update(...).set(...)`) — that exemption applies however the module is imported, whether via the `$lib/server/` alias or a relative path (`../../lib/server/db`); those are persistence, not shared module state.
+Reads, other method calls (`logger.info(…)`), and writes to local variables are not flagged. Nor are `.set()`/`.update()` calls on imports from installed packages or anything resolving to `src/lib/server` — the directory-entrypoint import (`import { db } from '$lib/server'`) as well as anything under `src/lib/server/**` (database/KV clients — e.g. Drizzle's `db.update(...).set(...)`) — that exemption is applied to the resolved path, so it holds however the module is imported, whether via the `$lib/server/` alias or a relative path (`../../lib/server/db`), and a specifier whose `..` segments escape the project root is conservatively never treated as repo-local state; those are persistence, not shared module state.
 
 ## Why it matters
 

--- a/docs/src/content/docs/rules/sec003.md
+++ b/docs/src/content/docs/rules/sec003.md
@@ -9,7 +9,7 @@ description: A load function or action writes to imported module state — share
 
 Flags writes to an **imported binding** from inside a server-executed handler — `load`, a form action, a `+server` HTTP handler, or a `hooks.server` handler: property assignment (`state.user = …`), increment/`delete`, and `.set(...)` / `.update(...)` calls. Universal `+page.ts`/`+layout.ts` load functions are included — they run on the server during SSR.
 
-Reads, other method calls (`logger.info(…)`), and writes to local variables are not flagged. Nor are `.set()`/`.update()` calls on imports from installed packages or `$lib/server/**` (database/KV clients — e.g. Drizzle's `db.update(...).set(...)`); those are persistence, not shared module state.
+Reads, other method calls (`logger.info(…)`), and writes to local variables are not flagged. Nor are `.set()`/`.update()` calls on imports from installed packages or anything resolving to `src/lib/server/**` (database/KV clients — e.g. Drizzle's `db.update(...).set(...)`) — that exemption applies however the module is imported, whether via the `$lib/server/` alias or a relative path (`../../lib/server/db`); those are persistence, not shared module state.
 
 ## Why it matters
 

--- a/docs/superpowers/specs/2026-07-16-sec003-005-ssr-shared-state-design.md
+++ b/docs/superpowers/specs/2026-07-16-sec003-005-ssr-shared-state-design.md
@@ -138,15 +138,26 @@ calls on the imported binding (covers svelte stores AND imported module-scope
 Other method calls (`logger.info()`) do not — conservative. Scope-aware via
 the existing shadow tracking. The `.set(...)`/`.update(...)` call-form is
 additionally gated to repo-local specifiers (relative or `$lib/`) whose
-specifier RESOLVES to a path outside `src/lib/server/**`, so `.set`/`.update`
-on installed packages (Drizzle, KV/redis clients) or `src/lib/server`
-singletons — persistence, not shared module state — is not flagged (finding
-from the final branch review). Resolving before gating means the exemption
-applies regardless of import style: both the `$lib/server/` alias and an
-equivalent relative import (`../../lib/server/db` from a route file) resolve
-to the same `src/lib/server/**` path and are exempt alike (2026-07-16
-follow-up to PR #235, which only string-matched the raw `$lib/server/` alias
-and false-positived on the relative form).
+specifier RESOLVES to `src/lib/server` itself or a path under
+`src/lib/server/**`, so `.set`/`.update` on installed packages (Drizzle,
+KV/redis clients) or `src/lib/server` singletons — persistence, not shared
+module state — is not flagged (finding from the final branch review).
+Resolving before gating means the exemption applies regardless of import
+style: both the `$lib/server/` alias and an equivalent relative import
+(`../../lib/server/db` from a route file) resolve to the same
+`src/lib/server/**` path and are exempt alike (2026-07-16 follow-up to PR
+#235, which only string-matched the raw `$lib/server/` alias and
+false-positived on the relative form). The exemption also covers the
+directory-entrypoint import (`$lib/server`, or an equivalent relative form,
+resolving to exactly `src/lib/server` with no trailing segment) — the common
+`import { db } from '$lib/server'` index-file form, which the `/**`-suffixed
+match alone would miss (Copilot review follow-up). Path resolution is
+conservative about escapes: a relative specifier whose `..` segments pop past
+the repo root (e.g. `../../../../src/lib/server/db` from a shallow route
+file) resolves to undefined rather than to a local-looking path — it is
+treated as NOT local state (so `.set`/`.update` on it isn't flagged, since the
+real file is outside the repo tree we can see) and never matches SEC005
+either.
 
 **SEC004 — `Server module state` (warning).** Flag reassignments (`=`,
 compound, `??=`/`||=`/`&&=`, `UpdateExpression`) of module-scope `let`/`var`

--- a/docs/superpowers/specs/2026-07-16-sec003-005-ssr-shared-state-design.md
+++ b/docs/superpowers/specs/2026-07-16-sec003-005-ssr-shared-state-design.md
@@ -137,10 +137,16 @@ calls on the imported binding (covers svelte stores AND imported module-scope
 `Map`s — both shared). Namespace imports (`* as s` → `s.user = …`) count.
 Other method calls (`logger.info()`) do not — conservative. Scope-aware via
 the existing shadow tracking. The `.set(...)`/`.update(...)` call-form is
-additionally gated to repo-local specifiers (relative or `$lib/`, excluding
-`$lib/server/`), so `.set`/`.update` on installed packages (Drizzle, KV/redis
-clients) or `$lib/server` singletons — persistence, not shared module state —
-is not flagged (finding from the final branch review).
+additionally gated to repo-local specifiers (relative or `$lib/`) whose
+specifier RESOLVES to a path outside `src/lib/server/**`, so `.set`/`.update`
+on installed packages (Drizzle, KV/redis clients) or `src/lib/server`
+singletons — persistence, not shared module state — is not flagged (finding
+from the final branch review). Resolving before gating means the exemption
+applies regardless of import style: both the `$lib/server/` alias and an
+equivalent relative import (`../../lib/server/db` from a route file) resolve
+to the same `src/lib/server/**` path and are exempt alike (2026-07-16
+follow-up to PR #235, which only string-matched the raw `$lib/server/` alias
+and false-positived on the relative form).
 
 **SEC004 — `Server module state` (warning).** Flag reassignments (`=`,
 compound, `??=`/`||=`/`&&=`, `UpdateExpression`) of module-scope `let`/`var`

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -55384,21 +55384,26 @@ function normalizePosix(path) {
   }
   return out.join("/");
 }
-function resolveRunesModuleSpecifier(spec, importerFile) {
+function resolveRepoLocalPath(spec, importerFile) {
   let path;
   if (spec.startsWith("$lib/")) path = `src/lib/${spec.slice("$lib/".length)}`;
   else if (spec.startsWith("./") || spec.startsWith("../")) {
     const dir = importerFile.split("/").slice(0, -1).join("/");
     path = `${dir}/${spec}`;
   } else return void 0;
-  path = normalizePosix(path);
+  return normalizePosix(path);
+}
+function resolveRunesModuleSpecifier(spec, importerFile) {
+  const path = resolveRepoLocalPath(spec, importerFile);
+  if (path === void 0) return void 0;
   if (/\.svelte\.(ts|js)$/.test(path)) return path;
   if (path.endsWith(".svelte")) return `${path}.ts`;
   return void 0;
 }
-function isLocalStateSpecifier(spec) {
-  if (spec.startsWith("./") || spec.startsWith("../")) return true;
-  return spec.startsWith("$lib/") && !spec.startsWith("$lib/server/");
+function isLocalStateSpecifier(spec, importerFile) {
+  const path = resolveRepoLocalPath(spec, importerFile);
+  if (path === void 0) return false;
+  return !path.startsWith("src/lib/server/");
 }
 function parseKitModuleFacts(source2, filename2) {
   const suppressions = collectSuppressions(source2);
@@ -55476,7 +55481,7 @@ function parseKitModuleFacts(source2, filename2) {
       const method2 = n.callee.property?.type === "Identifier" ? n.callee.property.name : void 0;
       if (method2 === "set" || method2 === "update") {
         const r = importedRoot(n.callee.object);
-        if (r && isLocalStateSpecifier(importedSpecifiers.get(r))) write = { name: r, via: "set-call" };
+        if (r && isLocalStateSpecifier(importedSpecifiers.get(r), filename2)) write = { name: r, via: "set-call" };
       }
     } else if (n.type === "AssignmentExpression" && (n.left?.type === "ObjectPattern" || n.left?.type === "ArrayPattern")) {
       const scanPatternTargets = (pat) => {

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -55379,8 +55379,10 @@ function normalizePosix(path) {
   const out = [];
   for (const seg of path.split("/")) {
     if (seg === "" || seg === ".") continue;
-    if (seg === "..") out.pop();
-    else out.push(seg);
+    if (seg === "..") {
+      if (out.length === 0) return void 0;
+      out.pop();
+    } else out.push(seg);
   }
   return out.join("/");
 }
@@ -55403,7 +55405,7 @@ function resolveRunesModuleSpecifier(spec, importerFile) {
 function isLocalStateSpecifier(spec, importerFile) {
   const path = resolveRepoLocalPath(spec, importerFile);
   if (path === void 0) return false;
-  return !path.startsWith("src/lib/server/");
+  return path !== "src/lib/server" && !path.startsWith("src/lib/server/");
 }
 function parseKitModuleFacts(source2, filename2) {
   const suppressions = collectSuppressions(source2);

--- a/packages/core/src/kit-module-parse.ts
+++ b/packages/core/src/kit-module-parse.ts
@@ -209,13 +209,21 @@ function walkKit(
   }
 }
 
-/** Normalize a posix path, resolving `.` and `..` segments — string-only, no I/O. */
-function normalizePosix(path: string): string {
+/**
+ * Normalize a posix path, resolving `.` and `..` segments — string-only, no I/O.
+ * Returns undefined when a `..` segment pops an empty stack, i.e. the path escapes
+ * its root (e.g. `../../../../src/lib/server/db` from a shallow route file): the
+ * real target lies outside the repo tree we can see, so there is no repo-relative
+ * path to return at all.
+ */
+function normalizePosix(path: string): string | undefined {
   const out: string[] = [];
   for (const seg of path.split('/')) {
     if (seg === '' || seg === '.') continue;
-    if (seg === '..') out.pop();
-    else out.push(seg);
+    if (seg === '..') {
+      if (out.length === 0) return undefined;
+      out.pop();
+    } else out.push(seg);
   }
   return out.join('/');
 }
@@ -224,7 +232,8 @@ function normalizePosix(path: string): string {
  * Resolve an import specifier to a repo-relative path against the importing file, or
  * undefined when it cannot be a repo-local module: `$lib/` maps to `src/lib/`, `./`/`../`
  * resolve against the importing file's directory; bare packages and other aliases are
- * skipped (they can't be resolved to a repo-local path at all).
+ * skipped (they can't be resolved to a repo-local path at all). Also undefined when a
+ * relative specifier's `..` segments escape the repo root — see `normalizePosix`.
  */
 function resolveRepoLocalPath(spec: string, importerFile: string): string | undefined {
   let path: string;
@@ -239,9 +248,10 @@ function resolveRepoLocalPath(spec: string, importerFile: string): string | unde
 /**
  * Resolve an import specifier to a repo-relative `.svelte.ts`/`.svelte.js` path, or
  * undefined when it cannot be a runes module: `$lib/` maps to `src/lib/`, `./`/`../`
- * resolve against the importing file's directory; bare packages and other aliases are
- * skipped. An extensionless `…/x.svelte` specifier canonicalises to `….svelte.ts`
- * (SEC005 also tries the `.js` sibling when matching).
+ * resolve against the importing file's directory; bare packages, other aliases, and
+ * a relative specifier whose `..` segments escape the repo root are skipped. An
+ * extensionless `…/x.svelte` specifier canonicalises to `….svelte.ts` (SEC005 also
+ * tries the `.js` sibling when matching).
  */
 export function resolveRunesModuleSpecifier(spec: string, importerFile: string): string | undefined {
   const path = resolveRepoLocalPath(spec, importerFile);
@@ -253,17 +263,24 @@ export function resolveRunesModuleSpecifier(spec: string, importerFile: string):
 
 /**
  * Whether an import specifier points at repo-local module state that would be
- * SHARED on the server: relative or `$lib/` — but not `src/lib/server/**`, where
- * legitimate singletons (DB connections, KV/API clients) live. The check resolves
- * the specifier to its repo-relative path first, so a relative import that lands in
- * `src/lib/server/**` is exempt exactly like the `$lib/server/**` alias form.
- * Installed packages (drizzle, redis, @vercel/kv, …) are excluded: `.set()`/`.update()`
- * on those is persistence, not shared-module-state mutation.
+ * SHARED on the server: relative or `$lib/` — but not `src/lib/server` itself or
+ * anything under `src/lib/server/**`, where legitimate singletons (DB connections,
+ * KV/API clients) live. The check resolves the specifier to its repo-relative path
+ * first, so a relative import that lands in `src/lib/server/**` is exempt exactly
+ * like the `$lib/server/**` alias form, and the directory-entrypoint import itself
+ * (`$lib/server`, or an equivalent `../../lib/server`, resolving to exactly
+ * `src/lib/server` — importing the index file rather than a named submodule) is
+ * exempt too. A specifier that resolves to undefined — a bare package, an alias
+ * that can't map to a repo path, or a relative specifier whose `..` segments escape
+ * the repo root (see `normalizePosix`) — is conservatively NOT local state: we
+ * can't see that file, so we don't flag writes to it. Installed packages (drizzle,
+ * redis, @vercel/kv, …) are excluded: `.set()`/`.update()` on those is persistence,
+ * not shared-module-state mutation.
  */
 function isLocalStateSpecifier(spec: string, importerFile: string): boolean {
   const path = resolveRepoLocalPath(spec, importerFile);
   if (path === undefined) return false;
-  return !path.startsWith('src/lib/server/');
+  return path !== 'src/lib/server' && !path.startsWith('src/lib/server/');
 }
 
 /**

--- a/packages/core/src/kit-module-parse.ts
+++ b/packages/core/src/kit-module-parse.ts
@@ -221,6 +221,22 @@ function normalizePosix(path: string): string {
 }
 
 /**
+ * Resolve an import specifier to a repo-relative path against the importing file, or
+ * undefined when it cannot be a repo-local module: `$lib/` maps to `src/lib/`, `./`/`../`
+ * resolve against the importing file's directory; bare packages and other aliases are
+ * skipped (they can't be resolved to a repo-local path at all).
+ */
+function resolveRepoLocalPath(spec: string, importerFile: string): string | undefined {
+  let path: string;
+  if (spec.startsWith('$lib/')) path = `src/lib/${spec.slice('$lib/'.length)}`;
+  else if (spec.startsWith('./') || spec.startsWith('../')) {
+    const dir = importerFile.split('/').slice(0, -1).join('/');
+    path = `${dir}/${spec}`;
+  } else return undefined;
+  return normalizePosix(path);
+}
+
+/**
  * Resolve an import specifier to a repo-relative `.svelte.ts`/`.svelte.js` path, or
  * undefined when it cannot be a runes module: `$lib/` maps to `src/lib/`, `./`/`../`
  * resolve against the importing file's directory; bare packages and other aliases are
@@ -228,13 +244,8 @@ function normalizePosix(path: string): string {
  * (SEC005 also tries the `.js` sibling when matching).
  */
 export function resolveRunesModuleSpecifier(spec: string, importerFile: string): string | undefined {
-  let path: string;
-  if (spec.startsWith('$lib/')) path = `src/lib/${spec.slice('$lib/'.length)}`;
-  else if (spec.startsWith('./') || spec.startsWith('../')) {
-    const dir = importerFile.split('/').slice(0, -1).join('/');
-    path = `${dir}/${spec}`;
-  } else return undefined;
-  path = normalizePosix(path);
+  const path = resolveRepoLocalPath(spec, importerFile);
+  if (path === undefined) return undefined;
   if (/\.svelte\.(ts|js)$/.test(path)) return path;
   if (path.endsWith('.svelte')) return `${path}.ts`;
   return undefined;
@@ -242,14 +253,17 @@ export function resolveRunesModuleSpecifier(spec: string, importerFile: string):
 
 /**
  * Whether an import specifier points at repo-local module state that would be
- * SHARED on the server: relative or `$lib/` — but not `$lib/server/**`, where
- * legitimate singletons (DB connections, KV/API clients) live. Installed packages
- * (drizzle, redis, @vercel/kv, …) are excluded: `.set()`/`.update()` on those is
- * persistence, not shared-module-state mutation.
+ * SHARED on the server: relative or `$lib/` — but not `src/lib/server/**`, where
+ * legitimate singletons (DB connections, KV/API clients) live. The check resolves
+ * the specifier to its repo-relative path first, so a relative import that lands in
+ * `src/lib/server/**` is exempt exactly like the `$lib/server/**` alias form.
+ * Installed packages (drizzle, redis, @vercel/kv, …) are excluded: `.set()`/`.update()`
+ * on those is persistence, not shared-module-state mutation.
  */
-function isLocalStateSpecifier(spec: string): boolean {
-  if (spec.startsWith('./') || spec.startsWith('../')) return true;
-  return spec.startsWith('$lib/') && !spec.startsWith('$lib/server/');
+function isLocalStateSpecifier(spec: string, importerFile: string): boolean {
+  const path = resolveRepoLocalPath(spec, importerFile);
+  if (path === undefined) return false;
+  return !path.startsWith('src/lib/server/');
 }
 
 /**
@@ -345,7 +359,7 @@ export function parseKitModuleFacts(source: string, filename: string): Omit<KitM
       const method = n.callee.property?.type === 'Identifier' ? n.callee.property.name : undefined;
       if (method === 'set' || method === 'update') {
         const r = importedRoot(n.callee.object);
-        if (r && isLocalStateSpecifier(importedSpecifiers.get(r)!)) write = { name: r, via: 'set-call' };
+        if (r && isLocalStateSpecifier(importedSpecifiers.get(r)!, filename)) write = { name: r, via: 'set-call' };
       }
     } else if (
       n.type === 'AssignmentExpression' &&

--- a/packages/core/test/kit-module-parse.test.ts
+++ b/packages/core/test/kit-module-parse.test.ts
@@ -202,6 +202,24 @@ describe('parseKitModuleFacts — imported-state writes (SEC003/SEC005)', () => 
       { name: 'user', line: 3, via: 'set-call' }
     ]);
   });
+  it('does not flag .set on a $lib/server directory-entrypoint import', () => {
+    const src = [
+      "import { db } from '$lib/server';",
+      'export const actions = {',
+      '  default: async () => {',
+      '    await db.set("k", 1);',
+      '  }',
+      '};'
+    ].join('\n');
+    expect(facts(src).importedStateWrites).toEqual([]);
+  });
+  it('treats a ..-escaping specifier conservatively (not local, not a runes module)', () => {
+    const src = "import { store } from '../../../../src/lib/user.js';\nexport function load() {\n  store.set(1);\n}";
+    expect(facts(src, 'src/routes/a/+page.server.ts').importedStateWrites).toEqual([]);
+    expect(
+      resolveRunesModuleSpecifier('../../../../src/lib/quiz.svelte.ts', 'src/routes/a/+page.server.ts')
+    ).toBeUndefined();
+  });
 });
 
 describe('parseKitModuleFacts — runes-module imports (SEC005)', () => {

--- a/packages/core/test/kit-module-parse.test.ts
+++ b/packages/core/test/kit-module-parse.test.ts
@@ -183,6 +183,25 @@ describe('parseKitModuleFacts — imported-state writes (SEC003/SEC005)', () => 
       { name: 'state', line: 3, via: 'assignment' }
     ]);
   });
+  it('does not flag .set/.update on a relative-path import into lib/server', () => {
+    const src = [
+      "import { db } from '../../lib/server/db';",
+      'export const actions = {',
+      '  default: async () => {',
+      '    await db.update(users).set({ name: "x" });',
+      '  }',
+      '};'
+    ].join('\n');
+    const f = facts(src, 'src/routes/a/+page.server.ts');
+    expect(f.importedStateWrites).toEqual([]);
+    expect(f.importedStateWritesOutsideHandlers).toEqual([]);
+  });
+  it('still flags .set on a relative-path store import outside lib/server', () => {
+    const src = "import { user } from '../user-store.js';\nexport function load() {\n  user.set({});\n}";
+    expect(facts(src, 'src/routes/a/+page.server.ts').importedStateWrites).toEqual([
+      { name: 'user', line: 3, via: 'set-call' }
+    ]);
+  });
 });
 
 describe('parseKitModuleFacts — runes-module imports (SEC005)', () => {


### PR DESCRIPTION
## Summary

Closes the follow-up documented in #235: SEC003's `.set()`/`.update()` exemption for server singletons only string-matched the raw `$lib/server/` alias, so importing the same module via a relative path (`import { db } from '../../lib/server/db'`) still produced a **critical** finding on `db.update(...).set(...)` — a CI-breaking false positive for projects that don't use the `$lib` alias.

`isLocalStateSpecifier` now resolves the specifier to a repo-relative path first (shared `resolveRepoLocalPath` helper, also used by `resolveRunesModuleSpecifier` whose behavior is unchanged) and checks the resolved `src/lib/server/` prefix, so the exemption applies however the module is imported.

- New tests: relative `../../lib/server/db` `.update().set()` not flagged; relative non-server store `.set()` still flagged (RED→GREEN)
- sec003 docs (en/ja) and the design spec updated; changeset: `@svelte-vitals/core` patch

## Test plan

- Root `pnpm build` / `pnpm typecheck` / `pnpm test` (468 core tests) / `pnpm lint` all green
- Reviewed: resolution traced by hand incl. the out-of-repo `..`-escape edge (no crash, conservatively non-exempt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)