### PR TITLE
feat(core): add CORRECT007 — flag lifecycle calls outside component initialisation

### DIFF
--- a/.changeset/correct007-orphan-lifecycle.md
+++ b/.changeset/correct007-orphan-lifecycle.md
@@ -1,0 +1,8 @@
+---
+'@svelte-vitals/core': minor
+'svelte-vitals': minor
+'@svelte-vitals/vite': minor
+'@svelte-vitals/mcp': minor
+---
+
+Add CORRECT007 (critical): flag Svelte lifecycle/context calls (`onMount`, `getContext`, `setContext`, …) that run outside component initialisation and throw `lifecycle_outside_component` at runtime — at module scope in runes modules and `<script module>`, in constructors of module-scope-instantiated classes, and inside SvelteKit load/action/endpoint handlers (the classic `getContext`-in-`load` trap).

--- a/docs/src/content/docs/guides/cli.md
+++ b/docs/src/content/docs/guides/cli.md
@@ -214,7 +214,7 @@ An unknown category or a negative/non-numeric value is an error (exit `2`).
 
 For one intentional occurrence that `--ignore` would silence project-wide, add a
 `svelte-vitals-disable-next-line` comment on the line directly above it. Works for
-any component-scoped rule (Correctness, Security, Architecture, Performance): CORRECT001–006,
+any component-scoped rule (Correctness, Security, Architecture, Performance): CORRECT001–007,
 SEC001–005, ARCH001–002, PERF009–010.
 
 ```svelte

--- a/docs/src/content/docs/ja/guides/cli.md
+++ b/docs/src/content/docs/ja/guides/cli.md
@@ -212,7 +212,7 @@ svelte-vitals --weights seo=2,performance=1
 
 ### 特定の指摘だけをインラインで抑制する
 
-`--ignore` はプロジェクト全体でルールを無効にしますが、意図的な1箇所だけを黙らせたい場合は、対象行の直前に `svelte-vitals-disable-next-line` コメントを書きます。コンポーネントスコープの全ルール（Correctness、Security、Architecture、Performance）に対応: CORRECT001–006、SEC001–005、ARCH001–002、PERF009–010。
+`--ignore` はプロジェクト全体でルールを無効にしますが、意図的な1箇所だけを黙らせたい場合は、対象行の直前に `svelte-vitals-disable-next-line` コメントを書きます。コンポーネントスコープの全ルール（Correctness、Security、Architecture、Performance）に対応: CORRECT001–007、SEC001–005、ARCH001–002、PERF009–010。
 
 ```svelte
 <script>

--- a/docs/src/content/docs/ja/rules/correct007.md
+++ b/docs/src/content/docs/ja/rules/correct007.md
@@ -11,9 +11,9 @@ Svelte の lifecycle / context 関数(`onMount`、`onDestroy`、`beforeUpdate`�
 
 - `.svelte.ts`/`.svelte.js` runes モジュールや `.svelte` の `<script module>` ブロックの**モジュールスコープ**
 - **モジュールスコープでインスタンス化されるクラスの constructor** 内(同一ファイル)
-- SvelteKit の **`load` 関数・form action・エンドポイント/フック handler・`init` フック**内 — 典型は `load` 内での `getContext`
+- SvelteKit の **`load` 関数・form action・エンドポイント/フック handler・`init` フック内、またはそれらのファイルのトップレベル** — 典型は `load` 内での `getContext`
 
-検出対象外: 通常の関数内の呼び出し(コンポーネントが初期化中に呼べば合法)、`createContext()`(モジュールスコープでの作成が新 context API の公式パターン)、context を要求しない svelte export(`mount`、`tick` など)、他モジュールからの同名 import、ファクトリ関数/IIFE/クロスファイルクラス、`svelte/legacy` の `createBubbler`。
+検出対象外: 通常の関数内の呼び出し(コンポーネントが初期化中に呼べば合法)、`createContext()`(モジュールスコープでの作成が新 context API の公式パターン)、context を要求しない svelte export(`mount`、`tick` など)、他モジュールからの同名 import、ファクトリ関数/IIFE/クロスファイルクラス、`svelte/legacy` の `createBubbler`。load/handler/`init` の本体の**内側で定義された関数**もそこで実行されるものとして扱われ、フラグを継承します — そのようなクロージャを意図的に返してコンポーネント側の初期化中に呼び出させる場合は、インラインで抑制してください(`svelte-vitals-disable-next-line CORRECT007`)。
 
 ## 重要な理由
 

--- a/docs/src/content/docs/ja/rules/correct007.md
+++ b/docs/src/content/docs/ja/rules/correct007.md
@@ -1,0 +1,47 @@
+---
+title: CORRECT007 · コンポーネント初期化外での lifecycle 呼び出し
+description: onMount や getContext などをコンポーネント初期化の外で呼ぶと、ランタイムで lifecycle_outside_component エラーになります。
+---
+
+**重大度:** critical · **カテゴリ:** correctness
+
+## チェック内容
+
+Svelte の lifecycle / context 関数(`onMount`、`onDestroy`、`beforeUpdate`、`afterUpdate`、`createEventDispatcher`、`getContext`、`setContext`、`hasContext`、`getAllContexts` — `svelte` からの value import が対象で、エイリアスと namespace import も追跡)の、コンポーネント初期化外での実行が確定している呼び出しを検出します:
+
+- `.svelte.ts`/`.svelte.js` runes モジュールや `.svelte` の `<script module>` ブロックの**モジュールスコープ**
+- **モジュールスコープでインスタンス化されるクラスの constructor** 内(同一ファイル)
+- SvelteKit の **`load` 関数・form action・エンドポイント/フック handler・`init` フック**内 — 典型は `load` 内での `getContext`
+
+検出対象外: 通常の関数内の呼び出し(コンポーネントが初期化中に呼べば合法)、`createContext()`(モジュールスコープでの作成が新 context API の公式パターン)、context を要求しない svelte export(`mount`、`tick` など)、他モジュールからの同名 import、ファクトリ関数/IIFE/クロスファイルクラス、`svelte/legacy` の `createBubbler`。
+
+## 重要な理由
+
+これらの関数はアクティブなコンポーネントコンテキストを必要とします。ない状態で呼ぶとランタイムで `lifecycle_outside_component` エラーになります — コンパイラはどのパターンも警告なしでコンパイルするため、コードパスが実行されて初めて顕在化し、典型的には本番クラッシュになります(`load` 内なら、そのルートへの全アクセスが 500 に)。
+
+## 修正方法
+
+```ts
+// +page.ts
+import { getContext } from 'svelte';
+
+export async function load({ fetch }) {
+  const user = getContext('user'); // ❌ lifecycle_outside_component — load はコンポーネント初期化ではない
+
+  return { user: await (await fetch('/api/user')).json() }; // ✅ 代わりにデータを返す
+}
+```
+
+呼び出しをコンポーネント初期化へ移します:
+
+```svelte
+<!-- +page.svelte -->
+<script>
+  import { setContext } from 'svelte';
+
+  let { data } = $props();
+  setContext('user', () => data.user); // ✅ コンポーネント初期化中 — 合法
+</script>
+```
+
+共有モジュールでは、モジュールスコープで lifecycle を呼ぶ代わりに、コンポーネントが初期化時に呼ぶ setup 関数として公開してください。

--- a/docs/src/content/docs/rules/correct007.md
+++ b/docs/src/content/docs/rules/correct007.md
@@ -1,0 +1,47 @@
+---
+title: CORRECT007 · Lifecycle call outside component initialisation
+description: onMount, getContext and friends called outside component initialisation throw lifecycle_outside_component at runtime.
+---
+
+**Severity:** critical · **Category:** correctness
+
+## What it checks
+
+Flags calls to Svelte's lifecycle and context functions (`onMount`, `onDestroy`, `beforeUpdate`, `afterUpdate`, `createEventDispatcher`, `getContext`, `setContext`, `hasContext`, `getAllContexts` — value-imported from `svelte`, aliases and namespace imports included) that are guaranteed to run outside component initialisation:
+
+- at **module scope** in a `.svelte.ts`/`.svelte.js` runes module or a `.svelte` `<script module>` block,
+- in the **constructor of a class instantiated at module scope** (same file),
+- in a SvelteKit **`load` function, form action, endpoint or hooks handler, or the `init` hook** — the classic trap is `getContext` inside `load`.
+
+Not flagged: calls inside ordinary functions (a component may legally call them during its own initialisation), `createContext()` (module-scope creation is the official pattern of the new context API), non-context svelte exports (`mount`, `tick`, …), same-named functions imported from other modules, factory functions/IIFEs/cross-file classes, and `svelte/legacy`'s `createBubbler`.
+
+## Why it matters
+
+These functions require an active component context. Called without one they throw Svelte's `lifecycle_outside_component` error at runtime — the compiler compiles all of these patterns without a warning, so the failure only surfaces when the code path runs, typically as a production crash (in a `load` function: a 500 on every visit to that route).
+
+## How to fix
+
+```ts
+// +page.ts
+import { getContext } from 'svelte';
+
+export async function load({ fetch }) {
+  const user = getContext('user'); // ❌ lifecycle_outside_component — load is not component init
+
+  return { user: await (await fetch('/api/user')).json() }; // ✅ return data instead
+}
+```
+
+Move the call into component initialisation:
+
+```svelte
+<!-- +page.svelte -->
+<script>
+  import { setContext } from 'svelte';
+
+  let { data } = $props();
+  setContext('user', () => data.user); // ✅ component init — legal
+</script>
+```
+
+For shared modules, expose a setup function that components call during init instead of running lifecycle calls at module scope.

--- a/docs/src/content/docs/rules/correct007.md
+++ b/docs/src/content/docs/rules/correct007.md
@@ -11,9 +11,9 @@ Flags calls to Svelte's lifecycle and context functions (`onMount`, `onDestroy`,
 
 - at **module scope** in a `.svelte.ts`/`.svelte.js` runes module or a `.svelte` `<script module>` block,
 - in the **constructor of a class instantiated at module scope** (same file),
-- in a SvelteKit **`load` function, form action, endpoint or hooks handler, or the `init` hook** — the classic trap is `getContext` inside `load`.
+- in a SvelteKit **`load` function, form action, endpoint or hooks handler, or the `init` hook, or at the top level of such a file** — the classic trap is `getContext` inside `load`.
 
-Not flagged: calls inside ordinary functions (a component may legally call them during its own initialisation), `createContext()` (module-scope creation is the official pattern of the new context API), non-context svelte exports (`mount`, `tick`, …), same-named functions imported from other modules, factory functions/IIFEs/cross-file classes, and `svelte/legacy`'s `createBubbler`.
+Not flagged: calls inside ordinary functions (a component may legally call them during its own initialisation), `createContext()` (module-scope creation is the official pattern of the new context API), non-context svelte exports (`mount`, `tick`, …), same-named functions imported from other modules, factory functions/IIFEs/cross-file classes, and `svelte/legacy`'s `createBubbler`. A function defined _inside_ a load/handler/`init` body is treated as running there too and inherits the flag — if you deliberately return such a closure for a component to call during its own initialisation, add an inline suppression (`svelte-vitals-disable-next-line CORRECT007`).
 
 ## Why it matters
 

--- a/docs/superpowers/plans/2026-07-16-correct007-orphan-lifecycle.md
+++ b/docs/superpowers/plans/2026-07-16-correct007-orphan-lifecycle.md
@@ -1,0 +1,876 @@
+# CORRECT007 — Orphan Lifecycle Call Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add CORRECT007 — a `critical` correctness rule flagging Svelte lifecycle/context calls (`onMount`, `getContext`, …) guaranteed to run outside component initialisation and throw the runtime `lifecycle_outside_component` error, across both the runes-module surface and the Kit route/hooks surface.
+
+**Architecture:** Generalise CORRECT006's eval-scope collectors in `component-parse.ts` to matcher-parameterised versions (the `$effect` instantiation stays byte-identical — existing CORRECT006 tests are the regression bar) and add `ComponentFacts.orphanLifecycleCalls`. Add the same svelte-import tracking to `parseKitModuleFacts` for `KitModuleFacts.lifecycleCalls` (top level / handler bodies / `init` only). One rule with a custom `check(ctx)` reads both channels.
+
+**Tech Stack:** TypeScript, Vitest, pnpm workspaces, `svelte/compiler` `parse`, Astro Starlight docs, Changesets.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-16-correct007-orphan-lifecycle-design.md`. Branch: `feat/correct007-orphan-lifecycle` (already exists with the spec commit; work on it).
+- **Rebase check before starting**: PR #237 (`fix/sec003-relative-lib-server`) also touches `packages/core/src/kit-module-parse.ts`. Run `git fetch origin` — if origin/main has moved past `399ef6e`, rebase this branch onto `origin/main` first and re-verify the file state before editing.
+- Tracked callees (canonical): `onMount`, `onDestroy`, `beforeUpdate`, `afterUpdate`, `createEventDispatcher`, `getContext`, `setContext`, `hasContext`, `getAllContexts` — ONLY when value-imported from `'svelte'` (named specifiers with alias resolution; namespace imports via non-computed member access). `import type`/type-only specifiers excluded. `createContext`, `mount`, `hydrate`, `tick`, `untrack`, `flushSync`, and `svelte/legacy` are never flagged.
+- `orphanEffects` (CORRECT006) output must be byte-identical after the collector generalisation — no existing test assertion changes.
+- New facts are REQUIRED fields: `ComponentFacts.orphanLifecycleCalls` and `KitModuleFacts.lifecycleCalls` — every existing literal gains an empty array (file lists in Tasks 1–2).
+- Kit surface flags calls at top level, in handler bodies, and in the `init` hook (`!inFunction || inHandler || inStartup`); helper functions are NOT flagged. Module surface mirrors CORRECT006's two patterns exactly.
+- Rule: `id 'CORRECT007'`, `title 'Lifecycle call outside component initialisation'`, `category 'correctness'`, `severity 'critical'`, `scope 'component'`; message/recommendation/rationale strings verbatim from the spec §4.
+- en/ja docs ship together; CLI-guide suppression range (en/ja) `CORRECT001–006` → `CORRECT001–007`. Changeset: core / `svelte-vitals` / vite / mcp — all **minor**.
+- `packages/core/src`: no `node:` imports, no I/O. Conventional commits scoped by package. cli tests/typecheck need `pnpm --filter @svelte-vitals/core build` after core changes. Verify from repo root: `pnpm build && pnpm typecheck && pnpm test && pnpm lint` (2 pre-existing warnings in `packages/cli/test/meta-object.test.ts` are not yours). `pnpm build` regenerates `packages/action/dist/index.js` — commit it as a final `chore(action)` commit.
+
+---
+
+## File Structure
+
+- Modify: `packages/core/src/component-parse.ts` — generalised collectors, svelte-import tracking helpers (exported for the Kit parser), `orphanLifecycleCalls` wiring (Task 1).
+- Modify: `packages/core/src/component.ts` (`OrphanLifecycleCallFact` + field), `packages/core/src/component-collect.ts` (`emptyComponentFacts`) — Task 1.
+- Modify (literal fixups, Task 1): `packages/core/test/component-collect.test.ts`, `component-rule.test.ts`, `security-rules.test.ts`, `bundle-rules.test.ts`, `correctness-rules.test.ts`, `architecture-rules.test.ts`, `security-kit-rules.test.ts` (the `stateModule` helper), `packages/cli/test/malformed-svelte.test.ts`, `packages/cli/test/suppression-e2e.test.ts`.
+- Modify: `packages/core/src/kit-module.ts`, `packages/core/src/kit-module-parse.ts`, `packages/core/src/kit-module-collect.ts` (`emptyKitModuleFacts`), `packages/core/test/kit-module-parse.test.ts`, `packages/core/test/kit-module-collect.test.ts` + `security-kit-rules.test.ts` `kit()` helper — Task 2.
+- Create: `packages/core/src/rules/correctness/correct007-orphan-lifecycle.ts`; Modify: `packages/core/src/rules/index.ts` (3 spots), `packages/core/src/index.ts` (1 spot), `packages/core/test/correctness-rules.test.ts` — Task 3.
+- Create: `docs/src/content/docs/rules/correct007.md` + `ja/rules/correct007.md`; Modify: `docs/src/content/docs/guides/cli.md`, `ja/guides/cli.md`; Create: `.changeset/correct007-orphan-lifecycle.md` — Task 4.
+
+---
+
+### Task 1: Generalised collectors + `ComponentFacts.orphanLifecycleCalls`
+
+**Files:**
+
+- Modify: `packages/core/src/component-parse.ts` (the CORRECT006 section: `collectEvalScopeEffectLines` ~line 605, `collectOrphanEffects` ~line 645, `parseModuleFacts` ~line 770, and the `.svelte` path of `parseComponentFacts`)
+- Modify: `packages/core/src/component.ts` (new interface after `OrphanEffectFact`; field after `orphanEffects` in `ComponentFacts`)
+- Modify: `packages/core/src/component-collect.ts` (`emptyComponentFacts`)
+- Modify: `packages/core/test/component-parse.test.ts` (new describe at end)
+- Modify (add `orphanLifecycleCalls: []` next to each `orphanEffects: []` / in each `ComponentFacts` literal): the 7 core + 2 cli test files listed in File Structure
+
+**Interfaces:**
+
+- Consumes: existing `walkEvalScope`, `isEffectCall`, `isEffectRootCall`, `unwrapExport`, `lineOf`.
+- Produces (Task 2 imports these from `./component-parse.js`): `LIFECYCLE_NAMES: Set<string>`, `collectSvelteLifecycleImports(program): { locals: Map<string, string>; namespaces: Set<string> }`, `matchLifecycleCall(n, imports): { canonical: string; local: string } | undefined`. Plus `ComponentFacts.orphanLifecycleCalls: OrphanLifecycleCallFact[]` (Task 3 reads it).
+
+- [ ] **Step 1: Rebase check**
+
+```bash
+git switch feat/correct007-orphan-lifecycle
+git fetch origin
+git log --oneline origin/main -1   # if not 399ef6e, run: git rebase origin/main
+```
+
+- [ ] **Step 2: Write the failing capture tests**
+
+Append to `packages/core/test/component-parse.test.ts`:
+
+```ts
+describe('parseComponentFacts — orphan lifecycle calls (CORRECT007)', () => {
+  const calls = (src: string, file = 'src/lib/store.svelte.ts') => parseComponentFacts(src, file).orphanLifecycleCalls;
+
+  it('flags top-level lifecycle/context calls imported from svelte', () => {
+    const src = "import { onMount, getContext } from 'svelte';\nonMount(() => {});\nconst theme = getContext('theme');";
+    expect(calls(src)).toEqual([
+      { name: 'onMount', line: 2, kind: 'top-level' },
+      { name: 'getContext', line: 3, kind: 'top-level' }
+    ]);
+  });
+  it('flags every tracked callee at top level', () => {
+    const names = [
+      'onMount',
+      'onDestroy',
+      'beforeUpdate',
+      'afterUpdate',
+      'createEventDispatcher',
+      'getContext',
+      'setContext',
+      'hasContext',
+      'getAllContexts'
+    ];
+    for (const name of names) {
+      expect(calls(`import { ${name} } from 'svelte';\n${name}();`)).toEqual([{ name, line: 2, kind: 'top-level' }]);
+    }
+  });
+  it('records the canonical name for aliased imports and namespace member calls', () => {
+    expect(calls("import { onMount as om } from 'svelte';\nom(() => {});")).toEqual([
+      { name: 'onMount', line: 2, kind: 'top-level' }
+    ]);
+    expect(calls("import * as s from 'svelte';\ns.setContext('k', 1);")).toEqual([
+      { name: 'setContext', line: 2, kind: 'top-level' }
+    ]);
+  });
+  it('flags a module-scope new of a class whose constructor calls a tracked function', () => {
+    const src = [
+      "import { getContext } from 'svelte';",
+      'class Store {',
+      '  constructor() {',
+      "    this.user = getContext('user');",
+      '  }',
+      '}',
+      'export const store = new Store();'
+    ].join('\n');
+    expect(calls(src)).toEqual([{ name: 'getContext', line: 7, kind: 'constructor-instantiated', className: 'Store' }]);
+  });
+  it('does not flag calls inside functions, createContext, non-context svelte exports, or other packages', () => {
+    expect(calls("import { onMount } from 'svelte';\nexport function setup() {\n  onMount(() => {});\n}")).toEqual([]);
+    expect(calls("import { createContext } from 'svelte';\nconst ctx = createContext();")).toEqual([]);
+    expect(calls("import { getContext } from './my-di.js';\nconst x = getContext('k');")).toEqual([]);
+    expect(calls("import { tick } from 'svelte';\ntick();")).toEqual([]);
+  });
+  it('flags <script module> calls but not instance-script calls in .svelte files', () => {
+    const mod = "<script module>\nimport { setContext } from 'svelte';\nsetContext('k', 1);\n</script>";
+    expect(parseComponentFacts(mod, 'C.svelte').orphanLifecycleCalls).toEqual([
+      { name: 'setContext', line: 3, kind: 'top-level' }
+    ]);
+    const inst = "<script>\nimport { onMount } from 'svelte';\nonMount(() => {});\n</script>";
+    expect(parseComponentFacts(inst, 'C.svelte').orphanLifecycleCalls).toEqual([]);
+  });
+  it('keeps orphanEffects unchanged through the generalised collectors', () => {
+    const f = parseComponentFacts('$effect(() => {});', 'src/lib/s.svelte.ts');
+    expect(f.orphanEffects).toEqual([{ line: 1, kind: 'top-level' }]);
+    expect(f.orphanLifecycleCalls).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 3: Run to verify they fail**
+
+Run: `pnpm --filter @svelte-vitals/core test -- component-parse`
+Expected: FAIL — `orphanLifecycleCalls` is `undefined`.
+
+- [ ] **Step 4: Add the fact type**
+
+In `packages/core/src/component.ts`, after the `OrphanEffectFact` interface:
+
+```ts
+/** A svelte lifecycle/context call guaranteed to run outside component initialisation — it throws `lifecycle_outside_component` at runtime (CORRECT007). */
+export interface OrphanLifecycleCallFact {
+  /** Canonical svelte export name (alias-resolved), e.g. 'onMount'. */
+  name: string;
+  /** 1-based source line, or 0 if unknown. For 'constructor-instantiated', the module-scope `new` site. */
+  line: number;
+  /** 'top-level' = runs at module evaluation; 'constructor-instantiated' = module-scope `new` of a same-file class whose constructor calls a tracked function. */
+  kind: 'top-level' | 'constructor-instantiated';
+  /** Class name when kind is 'constructor-instantiated' (used in the finding message). */
+  className?: string;
+}
+```
+
+In `ComponentFacts`, after the `orphanEffects` field:
+
+```ts
+/** Svelte lifecycle/context calls guaranteed to run outside component initialisation — module scope in `.svelte.ts`/`.svelte.js` or `<script module>` (CORRECT007). */
+orphanLifecycleCalls: OrphanLifecycleCallFact[];
+```
+
+- [ ] **Step 5: Generalise the collectors and add the lifecycle matcher**
+
+In `packages/core/src/component-parse.ts`:
+
+1. Add `OrphanLifecycleCallFact` to the type import from `./component.js`.
+2. Directly below `walkEvalScope`, REPLACE `collectEvalScopeEffectLines` with the generalised collector — and DELETE `collectEvalScopeEffectLines` entirely (its only caller was the old `collectOrphanEffects` body, which step 3 rewrites; leaving it would be dead code eslint flags):
+
+```ts
+/**
+ * Calls matching `matcher` that run when `root` itself is evaluated (CORRECT006/007).
+ * `skipSubtree` exempts a call's children — CORRECT006 uses it for `$effect.root(...)`
+ * callbacks, which are a legal standalone reactive scope.
+ */
+function collectEvalScopeCalls(
+  root: Node,
+  source: string,
+  matcher: (n: Node) => string | undefined,
+  skipSubtree?: (n: Node) => boolean
+): { name: string; line: number }[] {
+  const out: { name: string; line: number }[] = [];
+  walkEvalScope(root, (n) => {
+    if (n.type !== 'CallExpression') return undefined;
+    if (skipSubtree?.(n)) return true;
+    const name = matcher(n);
+    if (name) out.push({ name, line: lineOf(source, n.start) });
+    return undefined;
+  });
+  return out;
+}
+```
+
+3. REPLACE the body of `collectOrphanEffects` with a call to a generalised orphan collector, keeping its exported behavior and doc comment (append one sentence: `Generalised as \`collectOrphanCalls\` — CORRECT007 reuses the same walk with a lifecycle-import matcher.`):
+
+```ts
+/**
+ * Matcher-parameterised orphan-call collector (CORRECT006/007): (1) matching calls that
+ * run at module evaluation time, (2) a module-scope `new` (direct top-level statements
+ * only, export-unwrapped) of a same-file top-level class whose constructor directly
+ * makes a matching call. See `collectOrphanEffects`'s doc comment for why pattern 2 is
+ * restricted to top-level `ClassDeclaration`s and top-level `new` statements.
+ */
+function collectOrphanCalls(
+  program: Node,
+  source: string,
+  matcher: (n: Node) => string | undefined,
+  skipSubtree?: (n: Node) => boolean
+): { name: string; line: number; kind: 'top-level' | 'constructor-instantiated'; className?: string }[] {
+  const out: { name: string; line: number; kind: 'top-level' | 'constructor-instantiated'; className?: string }[] =
+    collectEvalScopeCalls(program, source, matcher, skipSubtree).map((c) => ({ ...c, kind: 'top-level' as const }));
+
+  const body: Node[] = program.body ?? [];
+
+  const matchingClasses = new Map<string, string>(); // class name → canonical callee name
+  for (const stmt of body) {
+    const decl = unwrapExport(stmt);
+    if (decl?.type !== 'ClassDeclaration' || decl.id?.type !== 'Identifier') continue;
+    const ctor = (decl.body?.body ?? []).find(
+      (m: Node) => m?.type === 'MethodDefinition' && m.kind === 'constructor' && m.value?.body
+    );
+    if (!ctor) continue;
+    const calls = collectEvalScopeCalls(ctor.value.body, source, matcher, skipSubtree);
+    if (calls.length > 0) matchingClasses.set(decl.id.name, calls[0]!.name);
+  }
+
+  if (matchingClasses.size > 0) {
+    for (const stmt of body) {
+      const decl = unwrapExport(stmt);
+      const isCandidate =
+        decl?.type === 'VariableDeclaration' ||
+        decl?.type === 'ExpressionStatement' ||
+        (stmt.type === 'ExportDefaultDeclaration' &&
+          decl?.type !== 'FunctionDeclaration' &&
+          decl?.type !== 'ClassDeclaration');
+      if (!isCandidate) continue;
+      walkEvalScope(decl, (n) => {
+        if (n.type === 'NewExpression' && n.callee?.type === 'Identifier' && matchingClasses.has(n.callee.name)) {
+          out.push({
+            name: matchingClasses.get(n.callee.name)!,
+            line: lineOf(source, n.start),
+            kind: 'constructor-instantiated',
+            className: n.callee.name
+          });
+        }
+        return undefined;
+      });
+    }
+  }
+  return out.sort((a, b) => a.line - b.line);
+}
+
+function collectOrphanEffects(program: Node, source: string): OrphanEffectFact[] {
+  return collectOrphanCalls(program, source, (n) => (isEffectCall(n) ? '$effect' : undefined), isEffectRootCall).map(
+    ({ line, kind, className }) => ({ line, kind, ...(className !== undefined ? { className } : {}) })
+  );
+}
+```
+
+(Move the long CORRECT006 rationale comment onto `collectOrphanEffects`/`collectOrphanCalls` as described; do not delete its content. Preserve the existing inline comments about TS constructor overloads and the pattern-2 candidate shapes inside `collectOrphanCalls`.)
+
+4. Add the lifecycle tracking (exported — Task 2 reuses them), below `collectOrphanEffects`:
+
+```ts
+/** Svelte exports that throw `lifecycle_outside_component` when called without an active component context (CORRECT007). */
+export const LIFECYCLE_NAMES = new Set([
+  'onMount',
+  'onDestroy',
+  'beforeUpdate',
+  'afterUpdate',
+  'createEventDispatcher',
+  'getContext',
+  'setContext',
+  'hasContext',
+  'getAllContexts'
+]);
+
+/**
+ * Tracked svelte lifecycle/context bindings in a module program (CORRECT007): local
+ * alias → canonical name for named value imports from 'svelte', plus namespace locals
+ * (`import * as s from 'svelte'`). Type-only imports/specifiers excluded; same-named
+ * imports from any other module are never tracked. Shared with the Kit-module parser.
+ */
+export function collectSvelteLifecycleImports(program: Node): { locals: Map<string, string>; namespaces: Set<string> } {
+  const locals = new Map<string, string>();
+  const namespaces = new Set<string>();
+  for (const stmt of program.body ?? []) {
+    if (stmt?.type !== 'ImportDeclaration' || stmt.importKind === 'type' || stmt.source?.value !== 'svelte') continue;
+    for (const s of stmt.specifiers ?? []) {
+      if (s?.importKind === 'type' || s?.local?.type !== 'Identifier') continue;
+      if (s.type === 'ImportSpecifier' && s.imported?.type === 'Identifier' && LIFECYCLE_NAMES.has(s.imported.name)) {
+        locals.set(s.local.name, s.imported.name);
+      } else if (s.type === 'ImportNamespaceSpecifier') {
+        namespaces.add(s.local.name);
+      }
+    }
+  }
+  return { locals, namespaces };
+}
+
+/**
+ * Whether a CallExpression calls a tracked svelte lifecycle/context binding (CORRECT007):
+ * a direct call to a (possibly aliased) named import, or a non-computed member call on a
+ * `svelte` namespace import. Returns the canonical name plus the local root binding (for
+ * shadow checks in the Kit parser). Shared with the Kit-module parser.
+ */
+export function matchLifecycleCall(
+  n: Node,
+  imports: { locals: Map<string, string>; namespaces: Set<string> }
+): { canonical: string; local: string } | undefined {
+  const c = n?.callee;
+  if (c?.type === 'Identifier') {
+    const canonical = imports.locals.get(c.name);
+    return canonical ? { canonical, local: c.name } : undefined;
+  }
+  if (
+    c?.type === 'MemberExpression' &&
+    !c.computed &&
+    c.object?.type === 'Identifier' &&
+    imports.namespaces.has(c.object.name) &&
+    c.property?.type === 'Identifier' &&
+    LIFECYCLE_NAMES.has(c.property.name)
+  ) {
+    return { canonical: c.property.name, local: c.object.name };
+  }
+  return undefined;
+}
+
+/** Orphan lifecycle-call facts for a module-context program (CORRECT007). */
+function collectOrphanLifecycleCalls(program: Node, source: string): OrphanLifecycleCallFact[] {
+  const imports = collectSvelteLifecycleImports(program);
+  if (imports.locals.size === 0 && imports.namespaces.size === 0) return [];
+  return collectOrphanCalls(program, source, (n) => matchLifecycleCall(n, imports)?.canonical);
+}
+```
+
+(Also add `OrphanLifecycleCallFact` to the return-type usage — `ParsedFacts` picks it up automatically via `ComponentFacts`.)
+
+5. Wire it: in `parseModuleFacts`, alongside `orphanEffects`/`moduleStateDecls`:
+
+```ts
+const orphanLifecycleCalls = program
+  ? collectOrphanLifecycleCalls(program, wrapped).map((f) => ({ ...f, line: shift(f.line) }))
+  : [];
+```
+
+and add `orphanLifecycleCalls` to its return object. In `parseComponentFacts`'s `.svelte` path, next to the `orphanEffects` line:
+
+```ts
+const orphanLifecycleCalls: OrphanLifecycleCallFact[] = ast.module?.content
+  ? collectOrphanLifecycleCalls(ast.module.content, source)
+  : [];
+```
+
+and add it to the return object. Update `parseModuleFacts`'s doc comment to mention `orphanLifecycleCalls`.
+
+- [ ] **Step 6: `emptyComponentFacts` + literal fixups**
+
+Add `orphanLifecycleCalls: [],` after `orphanEffects: [],` in `packages/core/src/component-collect.ts`. Run root `pnpm typecheck` and add `orphanLifecycleCalls: []` to every flagged `ComponentFacts` literal — known sites: the `emptyComponentFacts` `toEqual` in `component-collect.test.ts`, the `comp()`/literal helpers in `component-rule.test.ts`, `security-rules.test.ts`, `bundle-rules.test.ts`, `correctness-rules.test.ts`, `architecture-rules.test.ts`, the `stateModule` helper in `security-kit-rules.test.ts`, and the two cli test files (`malformed-svelte.test.ts`, `suppression-e2e.test.ts`). Re-run until clean.
+
+- [ ] **Step 7: Run tests to verify pass (incl. the CORRECT006 regression bar)**
+
+Run: `pnpm --filter @svelte-vitals/core test` then `pnpm --filter @svelte-vitals/core build && pnpm --filter svelte-vitals test`
+Expected: PASS — including every pre-existing `orphanEffects` test, unchanged.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/core packages/cli
+git commit -m "feat(core): collect orphan svelte lifecycle calls in runes modules and <script module>"
+```
+
+---
+
+### Task 2: `KitModuleFacts.lifecycleCalls`
+
+**Files:**
+
+- Modify: `packages/core/src/kit-module.ts` (new field after `runesModuleImports`)
+- Modify: `packages/core/src/kit-module-parse.ts` (import tracking + visitor branch + return)
+- Modify: `packages/core/src/kit-module-collect.ts` (`emptyKitModuleFacts`)
+- Modify: `packages/core/test/kit-module-parse.test.ts` (new describe), `packages/core/test/security-kit-rules.test.ts` (the `kit()` helper gains `lifecycleCalls: []`), `packages/core/test/kit-module-collect.test.ts` (the `emptyKitModuleFacts` expectation if it enumerates fields)
+
+**Interfaces:**
+
+- Consumes (from Task 1, `./component-parse.js`): `collectSvelteLifecycleImports`, `matchLifecycleCall`.
+- Produces: `KitModuleFacts.lifecycleCalls: { name: string; line: number; inHandler: boolean }[]` (Task 3 reads it).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/core/test/kit-module-parse.test.ts`:
+
+```ts
+describe('parseKitModuleFacts — lifecycle calls (CORRECT007)', () => {
+  it('flags getContext inside load (the classic trap)', () => {
+    const src =
+      "import { getContext } from 'svelte';\nexport function load() {\n  const user = getContext('user');\n  return { user };\n}";
+    expect(facts(src).lifecycleCalls).toEqual([{ name: 'getContext', line: 3, inHandler: true }]);
+  });
+  it('flags top-level and init-hook calls with inHandler false', () => {
+    const src =
+      "import { onMount, setContext } from 'svelte';\nonMount(() => {});\nexport async function init() {\n  setContext('k', 1);\n}";
+    expect(facts(src, 'src/hooks.server.ts').lifecycleCalls).toEqual([
+      { name: 'onMount', line: 2, inHandler: false },
+      { name: 'setContext', line: 4, inHandler: false }
+    ]);
+  });
+  it('does not flag calls inside non-handler helper functions', () => {
+    const src = "import { getContext } from 'svelte';\nexport function useUser() {\n  return getContext('user');\n}";
+    expect(facts(src, 'src/routes/+page.ts').lifecycleCalls).toEqual([]);
+  });
+  it('resolves aliases and ignores same-named imports from other modules', () => {
+    const src =
+      "import { getContext as ctx } from 'svelte';\nimport { setContext } from './di.js';\nexport const load = () => {\n  ctx('a');\n  setContext('b', 1);\n};";
+    expect(facts(src).lifecycleCalls).toEqual([{ name: 'getContext', line: 4, inHandler: true }]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pnpm --filter @svelte-vitals/core test -- kit-module-parse`
+Expected: FAIL — `lifecycleCalls` is `undefined`.
+
+- [ ] **Step 3: Implement**
+
+1. `packages/core/src/kit-module.ts` — after `runesModuleImports`:
+
+```ts
+/** Svelte lifecycle/context calls that run outside component initialisation — top level, handler bodies, or the `init` hook (CORRECT007). */
+lifecycleCalls: {
+  name: string;
+  line: number;
+  inHandler: boolean;
+}
+[];
+```
+
+2. `packages/core/src/kit-module-parse.ts`:
+   - Add `collectSvelteLifecycleImports, matchLifecycleCall` to the import from `./component-parse.js`.
+   - Declare `const lifecycleCalls: KitModuleFacts['lifecycleCalls'] = [];` with the other arrays and include `lifecycleCalls` in BOTH return objects (the `!program` early return and the final return, the latter as `byLine(lifecycleCalls)`).
+   - Before the `walkKit` call: `const svelteImports = collectSvelteLifecycleImports(program);`
+   - Inside the visitor, after the imported-write detection block:
+
+```ts
+// CORRECT007 — svelte lifecycle/context calls outside component initialisation:
+// top level (crashes at import), handler bodies (crashes per request — getContext
+// in load), and the `init` hook (crashes at boot). Helper functions are exempt:
+// a component may legally call them during its own initialisation.
+if (n.type === 'CallExpression' && (!inFunction || inHandler || inStartup)) {
+  const m = matchLifecycleCall(n, svelteImports);
+  if (m && !shadowed.has(m.local)) {
+    lifecycleCalls.push({ name: m.canonical, line: line(n.start), inHandler });
+  }
+}
+```
+
+3. `packages/core/src/kit-module-collect.ts` — add `lifecycleCalls: [],` to `emptyKitModuleFacts`.
+4. Fixups: add `lifecycleCalls: [],` to the `kit()` helper in `packages/core/test/security-kit-rules.test.ts`; run `pnpm --filter @svelte-vitals/core typecheck` and fix anything else it flags (the `emptyKitModuleFacts` equality test in `kit-module-collect.test.ts` compares via the function itself, so it usually needs no edit — verify).
+
+- [ ] **Step 4: Run to verify pass, then commit**
+
+Run: `pnpm --filter @svelte-vitals/core test && pnpm --filter @svelte-vitals/core typecheck`
+Expected: PASS.
+
+```bash
+git add packages/core
+git commit -m "feat(core): collect svelte lifecycle calls in Kit route/hooks files"
+```
+
+---
+
+### Task 3: The CORRECT007 rule + registration
+
+**Files:**
+
+- Create: `packages/core/src/rules/correctness/correct007-orphan-lifecycle.ts`
+- Modify: `packages/core/src/rules/index.ts` (import + `allRules` + re-export, each directly after the `correct006OrphanEffect` entry), `packages/core/src/index.ts` (after `correct006OrphanEffect`)
+- Modify: `packages/core/test/correctness-rules.test.ts`
+
+**Interfaces:**
+
+- Consumes: `ComponentFacts.orphanLifecycleCalls` (Task 1), `KitModuleFacts.lifecycleCalls` (Task 2), `docsUrlFor`.
+- Produces: exported `correct007OrphanLifecycle: Rule`.
+
+- [ ] **Step 1: Write the failing rule tests**
+
+In `packages/core/test/correctness-rules.test.ts`: add `correct007OrphanLifecycle` to the `../src/index.js` import, add `import type { KitModuleFacts } from '../src/kit-module.js';`, add a local kit helper after `comp()`:
+
+```ts
+const kitFacts = (over: Partial<KitModuleFacts>): KitModuleFacts => ({
+  file: 'src/routes/+page.ts',
+  kind: 'universal',
+  moduleStateReassignments: [],
+  importedStateWrites: [],
+  importedStateWritesOutsideHandlers: [],
+  runesModuleImports: [],
+  lifecycleCalls: [],
+  suppressions: [],
+  ...over
+});
+```
+
+Append:
+
+```ts
+describe('CORRECT007 lifecycle call outside component initialisation', () => {
+  it('flags a module top-level call as critical with the module message', async () => {
+    const rs = await correct007OrphanLifecycle.check(
+      ctx([
+        comp({ file: 'src/lib/s.svelte.ts', orphanLifecycleCalls: [{ name: 'onMount', line: 2, kind: 'top-level' }] })
+      ])
+    );
+    expect(fails(rs)).toHaveLength(1);
+    expect(rs[0]!.severity).toBe('critical');
+    expect(rs[0]!.category).toBe('correctness');
+    expect(rs[0]!.line).toBe(2);
+    expect(rs[0]!.message).toContain('onMount()');
+    expect(rs[0]!.message).toContain('lifecycle_outside_component');
+  });
+  it('names the class in the constructor-instantiated message', async () => {
+    const rs = await correct007OrphanLifecycle.check(
+      ctx([
+        comp({
+          orphanLifecycleCalls: [{ name: 'getContext', line: 7, kind: 'constructor-instantiated', className: 'Store' }]
+        })
+      ])
+    );
+    expect(fails(rs)[0]!.message).toContain('"Store"');
+    expect(fails(rs)[0]!.message).toContain('getContext()');
+  });
+  it('uses the load/handler message for kit inHandler calls and the module message otherwise', async () => {
+    const rs = await correct007OrphanLifecycle.check({
+      ...ctx([]),
+      kitModules: [
+        kitFacts({ lifecycleCalls: [{ name: 'getContext', line: 3, inHandler: true }] }),
+        kitFacts({
+          file: 'src/hooks.server.ts',
+          kind: 'server',
+          lifecycleCalls: [{ name: 'onMount', line: 2, inHandler: false }]
+        })
+      ]
+    });
+    expect(fails(rs)).toHaveLength(2);
+    expect(fails(rs)[0]!.message).toContain('load/handler');
+    expect(fails(rs)[1]!.message).toContain('module evaluation');
+  });
+  it('reads both channels in one run and honours suppressions on each', async () => {
+    const rs = await correct007OrphanLifecycle.check({
+      ...ctx([
+        comp({
+          orphanLifecycleCalls: [{ name: 'onMount', line: 2, kind: 'top-level' }],
+          suppressions: [{ line: 2, ruleIds: ['CORRECT007'] }]
+        })
+      ]),
+      kitModules: [
+        kitFacts({
+          lifecycleCalls: [{ name: 'getContext', line: 3, inHandler: true }],
+          suppressions: [{ line: 3, ruleIds: ['CORRECT007'] }]
+        })
+      ]
+    });
+    expect(fails(rs)).toHaveLength(0);
+    expect(rs).toHaveLength(2); // two PASS units (signal present, all findings suppressed)
+  });
+  it('emits nothing without signal or in rendered mode', async () => {
+    expect(await correct007OrphanLifecycle.check(ctx([comp({})]))).toHaveLength(0);
+    expect(await correct007OrphanLifecycle.check(base as RuleContext)).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pnpm --filter @svelte-vitals/core test -- correctness-rules`
+Expected: FAIL — `correct007OrphanLifecycle` not exported.
+
+- [ ] **Step 3: Implement the rule**
+
+Create `packages/core/src/rules/correctness/correct007-orphan-lifecycle.ts`:
+
+```ts
+import type { Result } from '../../types.js';
+import { docsUrlFor, type Rule, type RuleContext } from '../../rule.js';
+import type { SuppressionDirective } from '../../component.js';
+
+const PENALIZED = { presence: 'none', value: 'absent' } as const;
+const PASS = { presence: 'own', value: 'static' } as const;
+
+const ID = 'CORRECT007';
+const DOCS_URL = docsUrlFor(ID);
+const LABEL = 'Lifecycle-call context';
+const RECOMMENDATION =
+  "Call lifecycle/context functions during component initialisation (the top level of a component's <script>). In load, return the data and call setContext in a layout/page component; in shared modules, expose a setup function that components call during init.";
+
+const topLevelMessage = (name: string) =>
+  `${name}() runs at module evaluation, outside component initialisation — it throws lifecycle_outside_component at runtime`;
+
+function isSuppressed(suppressions: SuppressionDirective[] | undefined, line: number): boolean {
+  return (suppressions ?? []).some((s) => s.line === line && (!s.ruleIds || s.ruleIds.includes(ID)));
+}
+
+/** Emit one file's PASS/PENALIZED results — same shapes as componentRule/kitModuleRule. */
+function emitFile(
+  out: Result[],
+  file: string,
+  issues: { line: number; message: string }[],
+  suppressions: SuppressionDirective[] | undefined
+): void {
+  const bad = issues.filter((b) => !(b.line > 0 && isSuppressed(suppressions, b.line)));
+  if (bad.length === 0) {
+    out.push({
+      id: ID,
+      category: 'correctness',
+      severity: 'critical',
+      detection: PASS,
+      route: file,
+      message: LABEL,
+      recommendation: RECOMMENDATION,
+      docsUrl: DOCS_URL
+    });
+    return;
+  }
+  for (const b of bad) {
+    out.push({
+      id: ID,
+      category: 'correctness',
+      severity: 'critical',
+      detection: PENALIZED,
+      route: file,
+      location: file,
+      ...(b.line > 0 ? { line: b.line } : {}),
+      message: b.message,
+      recommendation: RECOMMENDATION,
+      docsUrl: DOCS_URL
+    });
+  }
+}
+
+/**
+ * CORRECT007 — svelte lifecycle/context calls guaranteed to run outside component
+ * initialisation: module scope in runes modules / `<script module>`, the constructor of
+ * a module-scope-instantiated class, and Kit load/handler/`init` bodies. A custom check
+ * because the facts live on BOTH the component channel and the Kit-module channel.
+ */
+export const correct007OrphanLifecycle: Rule = {
+  id: ID,
+  title: 'Lifecycle call outside component initialisation',
+  category: 'correctness',
+  severity: 'critical',
+  scope: 'component',
+  rationale:
+    'Svelte lifecycle and context functions require an active component context; called at module scope, in a shared-state class constructor, or in a load/handler they throw lifecycle_outside_component at runtime — the compiler does not catch it, and it surfaces as a production crash.',
+  async check(ctx: RuleContext): Promise<Result[]> {
+    const out: Result[] = [];
+    for (const c of ctx.components ?? []) {
+      const calls = c.orphanLifecycleCalls ?? [];
+      if (calls.length === 0) continue;
+      emitFile(
+        out,
+        c.file,
+        calls.map((o) => ({
+          line: o.line,
+          message:
+            o.kind === 'top-level'
+              ? topLevelMessage(o.name)
+              : `class "${o.className}" calls ${o.name}() in its constructor and is instantiated at module scope — it throws lifecycle_outside_component at runtime`
+        })),
+        c.suppressions
+      );
+    }
+    for (const m of ctx.kitModules ?? []) {
+      const calls = m.lifecycleCalls ?? [];
+      if (calls.length === 0) continue;
+      emitFile(
+        out,
+        m.file,
+        calls.map((l) => ({
+          line: l.line,
+          message: l.inHandler
+            ? `${l.name}() is called in a load/handler — it runs on every request, outside component initialisation, and throws lifecycle_outside_component at runtime`
+            : topLevelMessage(l.name)
+        })),
+        m.suppressions
+      );
+    }
+    return out;
+  }
+};
+```
+
+- [ ] **Step 4: Register (four sites) and verify**
+
+Add `import { correct007OrphanLifecycle } from './correctness/correct007-orphan-lifecycle.js';` + `allRules` entry + re-export in `packages/core/src/rules/index.ts` (each directly after the `correct006OrphanEffect` line), and the re-export in `packages/core/src/index.ts` after `correct006OrphanEffect,`.
+
+Run: `grep -rn "correct007OrphanLifecycle" packages/core/src`
+Expected: 5 hits (rule file + 3 + 1).
+
+- [ ] **Step 5: Run to verify, then commit**
+
+Run: `pnpm --filter @svelte-vitals/core test`
+Expected: PASS. (cli `docs-links` will fail until Task 4 — expected.)
+
+```bash
+git add packages/core
+git commit -m "feat(core): add CORRECT007 — flag lifecycle calls outside component initialisation"
+```
+
+---
+
+### Task 4: Docs (en/ja), suppression range, changeset, full verification
+
+**Files:**
+
+- Create: `docs/src/content/docs/rules/correct007.md`, `docs/src/content/docs/ja/rules/correct007.md`
+- Modify: `docs/src/content/docs/guides/cli.md` (line ~217), `docs/src/content/docs/ja/guides/cli.md` (line ~215) — `CORRECT001–006` → `CORRECT001–007` (keep each file's dash; nothing else on the line)
+- Create: `.changeset/correct007-orphan-lifecycle.md`
+
+- [ ] **Step 1: Write the English rule page**
+
+Create `docs/src/content/docs/rules/correct007.md`:
+
+````md
+---
+title: CORRECT007 · Lifecycle call outside component initialisation
+description: onMount, getContext and friends called outside component initialisation throw lifecycle_outside_component at runtime.
+---
+
+**Severity:** critical · **Category:** correctness
+
+## What it checks
+
+Flags calls to Svelte's lifecycle and context functions (`onMount`, `onDestroy`, `beforeUpdate`, `afterUpdate`, `createEventDispatcher`, `getContext`, `setContext`, `hasContext`, `getAllContexts` — value-imported from `svelte`, aliases and namespace imports included) that are guaranteed to run outside component initialisation:
+
+- at **module scope** in a `.svelte.ts`/`.svelte.js` runes module or a `.svelte` `<script module>` block,
+- in the **constructor of a class instantiated at module scope** (same file),
+- in a SvelteKit **`load` function, form action, endpoint or hooks handler, or the `init` hook** — the classic trap is `getContext` inside `load`.
+
+Not flagged: calls inside ordinary functions (a component may legally call them during its own initialisation), `createContext()` (module-scope creation is the official pattern of the new context API), non-context svelte exports (`mount`, `tick`, …), same-named functions imported from other modules, factory functions/IIFEs/cross-file classes, and `svelte/legacy`'s `createBubbler`.
+
+## Why it matters
+
+These functions require an active component context. Called without one they throw Svelte's `lifecycle_outside_component` error at runtime — the compiler compiles all of these patterns without a warning, so the failure only surfaces when the code path runs, typically as a production crash (in a `load` function: a 500 on every visit to that route).
+
+## How to fix
+
+```ts
+// +page.ts
+import { getContext } from 'svelte';
+
+export async function load({ fetch }) {
+  const user = getContext('user'); // ❌ lifecycle_outside_component — load is not component init
+
+  return { user: await (await fetch('/api/user')).json() }; // ✅ return data instead
+}
+```
+
+Move the call into component initialisation:
+
+```svelte
+<!-- +page.svelte -->
+<script>
+  import { setContext } from 'svelte';
+
+  let { data } = $props();
+  setContext('user', () => data.user); // ✅ component init — legal
+</script>
+```
+
+For shared modules, expose a setup function that components call during init instead of running lifecycle calls at module scope.
+````
+
+- [ ] **Step 2: Write the Japanese rule page**
+
+Create `docs/src/content/docs/ja/rules/correct007.md`:
+
+````md
+---
+title: CORRECT007 · コンポーネント初期化外での lifecycle 呼び出し
+description: onMount や getContext などをコンポーネント初期化の外で呼ぶと、ランタイムで lifecycle_outside_component エラーになります。
+---
+
+**重大度:** critical · **カテゴリ:** correctness
+
+## チェック内容
+
+Svelte の lifecycle / context 関数(`onMount`、`onDestroy`、`beforeUpdate`、`afterUpdate`、`createEventDispatcher`、`getContext`、`setContext`、`hasContext`、`getAllContexts` — `svelte` からの value import が対象で、エイリアスと namespace import も追跡)の、コンポーネント初期化外での実行が確定している呼び出しを検出します:
+
+- `.svelte.ts`/`.svelte.js` runes モジュールや `.svelte` の `<script module>` ブロックの**モジュールスコープ**
+- **モジュールスコープでインスタンス化されるクラスの constructor** 内(同一ファイル)
+- SvelteKit の **`load` 関数・form action・エンドポイント/フック handler・`init` フック**内 — 典型は `load` 内での `getContext`
+
+検出対象外: 通常の関数内の呼び出し(コンポーネントが初期化中に呼べば合法)、`createContext()`(モジュールスコープでの作成が新 context API の公式パターン)、context を要求しない svelte export(`mount`、`tick` など)、他モジュールからの同名 import、ファクトリ関数/IIFE/クロスファイルクラス、`svelte/legacy` の `createBubbler`。
+
+## 重要な理由
+
+これらの関数はアクティブなコンポーネントコンテキストを必要とします。ない状態で呼ぶとランタイムで `lifecycle_outside_component` エラーになります — コンパイラはどのパターンも警告なしでコンパイルするため、コードパスが実行されて初めて顕在化し、典型的には本番クラッシュになります(`load` 内なら、そのルートへの全アクセスが 500 に)。
+
+## 修正方法
+
+```ts
+// +page.ts
+import { getContext } from 'svelte';
+
+export async function load({ fetch }) {
+  const user = getContext('user'); // ❌ lifecycle_outside_component — load はコンポーネント初期化ではない
+
+  return { user: await (await fetch('/api/user')).json() }; // ✅ 代わりにデータを返す
+}
+```
+
+呼び出しをコンポーネント初期化へ移します:
+
+```svelte
+<!-- +page.svelte -->
+<script>
+  import { setContext } from 'svelte';
+
+  let { data } = $props();
+  setContext('user', () => data.user); // ✅ コンポーネント初期化中 — 合法
+</script>
+```
+
+共有モジュールでは、モジュールスコープで lifecycle を呼ぶ代わりに、コンポーネントが初期化時に呼ぶ setup 関数として公開してください。
+````
+
+- [ ] **Step 3: Update the suppression range and verify docs-links**
+
+Edit the two guide lines (`CORRECT001–006` → `CORRECT001–007`). Then:
+
+Run: `pnpm --filter @svelte-vitals/core build && pnpm --filter svelte-vitals test -- docs-links`
+Expected: PASS.
+
+- [ ] **Step 4: Add the changeset**
+
+Create `.changeset/correct007-orphan-lifecycle.md`:
+
+```md
+---
+'@svelte-vitals/core': minor
+'svelte-vitals': minor
+'@svelte-vitals/vite': minor
+'@svelte-vitals/mcp': minor
+---
+
+Add CORRECT007 (critical): flag Svelte lifecycle/context calls (`onMount`, `getContext`, `setContext`, …) that run outside component initialisation and throw `lifecycle_outside_component` at runtime — at module scope in runes modules and `<script module>`, in constructors of module-scope-instantiated classes, and inside SvelteKit load/action/endpoint handlers (the classic `getContext`-in-`load` trap).
+```
+
+- [ ] **Step 5: Full verification and commits**
+
+```bash
+pnpm build
+pnpm typecheck
+pnpm test
+pnpm lint
+```
+
+All green (`pnpm format` + re-run if formatting fails; include any reformatted files in the matching commit).
+
+```bash
+git add docs/src/content/docs .changeset
+git commit -m "docs: add CORRECT007 rule reference (en/ja), extend suppression range, changeset"
+git add packages/action/dist/index.js
+git commit -m "chore(action): rebuild dist/ with the CORRECT007 core changes"
+```
+
+(Skip the second commit if `git status` shows no dist change.)
+
+---
+
+## Done criteria
+
+- `pnpm build && pnpm typecheck && pnpm test && pnpm lint` all green from the repo root.
+- `grep -rn "correct007OrphanLifecycle" packages/core/src` → 5 hits.
+- Every pre-existing `orphanEffects` (CORRECT006) test passes unchanged.
+- Manual smoke (`/verify` before the PR): a fixture project with `getContext` inside `load` reports a critical CORRECT007 finding at the call line.
+- PR body in English.

--- a/docs/superpowers/specs/2026-07-16-correct007-orphan-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-07-16-correct007-orphan-lifecycle-design.md
@@ -176,3 +176,14 @@ Rendered mode (both channels unset) emits nothing.
 - **`svelte/legacy` (`createBubbler`)** — not tracked.
 - **Class-constructor patterns inside Kit files** — not tracked (module
   surface covers the shared-state-class shape).
+- **Functions nested inside a handler/`init` body inherit the flag.** A
+  closure defined inside `load`/a handler/`init` and merely _returned_ for
+  later use (e.g. `export function load() { return { getUser: () =>
+getContext('user') }; }`) is flagged even though, if invoked from
+  component initialisation rather than from within the handler, the call
+  would be legal — a false positive in principle. Accepted because the
+  invoked-within-handler case (a nested helper actually called during the
+  request) dominates and is a genuine crash; suppress inline
+  (`svelte-vitals-disable-next-line CORRECT007`) when the closure is
+  deliberately returned for component-side use (finding from the final
+  branch review).

--- a/docs/superpowers/specs/2026-07-16-correct007-orphan-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-07-16-correct007-orphan-lifecycle-design.md
@@ -1,0 +1,178 @@
+# CORRECT007 — Lifecycle call outside component initialisation
+
+**Date:** 2026-07-16
+**Status:** Approved design
+**Packages:** `@svelte-vitals/core` (facts + rule), `svelte-vitals` / `@svelte-vitals/vite` / `@svelte-vitals/mcp` (surface automatically)
+
+## Goal
+
+Add **CORRECT007**: flag calls to Svelte lifecycle/context functions that are
+guaranteed to run outside component initialisation and therefore throw the
+runtime `lifecycle_outside_component` error — the sibling crash class of
+CORRECT006's `effect_orphan`. Two surfaces:
+
+- **Runes modules / `<script module>`** — `onMount(...)` etc. at module
+  evaluation time, or in the constructor of a module-scope-instantiated class
+  (the CORRECT006 twin patterns).
+- **Kit route/hooks files** — the same calls at top level, inside
+  load/action/endpoint handlers, or inside the `init` startup hook. The
+  highest-frequency real-world instance of this class is **`getContext` inside
+  `load`** — a documented beginner trap.
+
+`critical` severity (CORRECT006 precedent: compile-clean, runtime-only,
+production 500), `category: 'correctness'`, `scope: 'component'`.
+
+## Background (verified 2026-07-16 against svelte 5.56.4 source)
+
+Functions that throw `lifecycle_outside_component` when `component_context`
+is null, from the `svelte` package:
+
+- `src/index-client.js`: `onMount`, `onDestroy`, `beforeUpdate`,
+  `afterUpdate`, `createEventDispatcher`
+- `src/internal/{client,server}/context.js` (`get_or_init_context_map`):
+  `getContext`, `setContext`, `hasContext`, `getAllContexts`
+
+Explicitly NOT flagged: `createContext()` — calling it at module scope is the
+official pattern of the new context API (only its returned get/set need init
+context, which is not statically trackable); `mount`/`hydrate`/`tick`/
+`untrack`/`flushSync` — no context requirement; `svelte/legacy`'s
+`createBubbler` — legacy-only, out of scope v1.
+
+These are plain imported function calls: the compiler performs no placement
+validation, svelte-check and eslint-plugin-svelte have no rule, and the
+failure is runtime-only. Same product justification as CORRECT006 (rule
+criterion: caught before deploy, hurts users in production).
+
+## Design
+
+### Approach decision
+
+**A (chosen): generalise CORRECT006's collector, one rule reading both
+channels.** The `$effect` detectors in `component-parse.ts` are parameterised
+by a callee-matcher; `orphanEffects` becomes the `$effect` instantiation with
+byte-identical behavior (existing CORRECT006 tests are the regression bar),
+and a new fact family feeds CORRECT007. Rejected: B — separate rules per
+channel (one failure class split across two ids complicates docs and
+suppression); C — piggybacking on `OrphanEffectFact` with new kinds (muddies
+CORRECT006's fact semantics and makes per-rule suppression ambiguous).
+
+### 1. Tracked callees (canonical names)
+
+`LIFECYCLE_NAMES = { onMount, onDestroy, beforeUpdate, afterUpdate,
+createEventDispatcher, getContext, setContext, hasContext, getAllContexts }`
+
+Tracked only when **value-imported from `'svelte'`**: named specifiers (alias
+`import { onMount as om }` → calls to `om(...)` recorded under the canonical
+name `onMount`) and namespace imports (`import * as s from 'svelte'` →
+`s.onMount(...)`, property must be in the set). `import type` and type-only
+specifiers excluded. A same-named function imported from any other module is
+never flagged.
+
+### 2. Module surface — `ComponentFacts.orphanLifecycleCalls`
+
+```ts
+/** A svelte lifecycle/context call guaranteed to run outside component initialisation — throws lifecycle_outside_component at runtime (CORRECT007). */
+orphanLifecycleCalls: {
+  /** Canonical svelte export name (alias-resolved), e.g. 'onMount'. */
+  name: string;
+  line: number;
+  kind: 'top-level' | 'constructor-instantiated';
+  className?: string;
+}[];
+```
+
+Analysed sources and patterns mirror CORRECT006 exactly:
+
+- the whole program of `.svelte.ts`/`.svelte.js` files and the
+  `<script module>` block of `.svelte` files (instance scripts are component
+  init — legal);
+- pattern 1: direct calls at module evaluation (top-level statements,
+  incl. top-level blocks/`if`; never crossing a function boundary);
+- pattern 2: a module-scope `new` (top-level statements only,
+  export-unwrapped) of a same-file top-level `ClassDeclaration` whose
+  constructor body directly calls a tracked function; reported at the `new`
+  site with the class name.
+
+Implementation: `collectEvalScopeEffectLines` / `collectOrphanEffects`
+generalise to matcher-parameterised collectors (`(node) => canonicalName |
+undefined`); the `$effect` matcher keeps the `$effect.root` child-skip;
+the lifecycle matcher has no root-exemption. `orphanEffects` output is
+unchanged.
+
+### 3. Kit surface — `KitModuleFacts.lifecycleCalls`
+
+```ts
+/** A svelte lifecycle/context call in a Kit route/hooks file that runs outside component initialisation (CORRECT007). */
+lifecycleCalls: {
+  name: string;
+  line: number;
+  inHandler: boolean;
+}
+[];
+```
+
+Same import tracking added to `parseKitModuleFacts`. Flagged positions:
+
+- **top level** (module evaluation — crashes at import; `inHandler: false`);
+- **inside handler bodies** (load/actions/HTTP methods/hooks handlers —
+  crashes per request; `inHandler: true`; this is `getContext` in `load`);
+- **inside the `init` startup hook** (crashes at boot; `inHandler: false`).
+
+NOT flagged: calls inside non-handler/non-`init` functions — a helper defined
+in a Kit file may legally be called from a component during init
+(conservative, same stance as CORRECT006's function-boundary rule).
+Class-constructor patterns inside Kit files are out of scope v1 (rare).
+
+### 4. Rule — CORRECT007
+
+`packages/core/src/rules/correctness/correct007-orphan-lifecycle.ts` —
+custom `check(ctx)` (both channels; neither `componentRule` nor
+`kitModuleRule` alone fits), reusing each channel's suppression semantics and
+emitting the same PASS/PENALIZED shapes with the file as the scoring unit.
+Rendered mode (both channels unset) emits nothing.
+
+- `id: 'CORRECT007'`, `title: 'Lifecycle call outside component initialisation'`,
+  `category: 'correctness'`, `severity: 'critical'`, `scope: 'component'`.
+- Messages (`name` = canonical):
+  - module top-level: `` `${name}() runs at module evaluation, outside component initialisation — it throws lifecycle_outside_component at runtime` ``
+  - constructor-instantiated: `` `class "${className}" calls ${name}() in its constructor and is instantiated at module scope — it throws lifecycle_outside_component at runtime` ``
+  - kit, `inHandler`: `` `${name}() is called in a load/handler — it runs on every request, outside component initialisation, and throws lifecycle_outside_component at runtime` ``
+  - kit, top-level/`init`: `` `${name}() runs at module evaluation, outside component initialisation — it throws lifecycle_outside_component at runtime` `` (same as module top-level)
+- `recommendation`: `"Call lifecycle/context functions during component initialisation (the top level of a component's <script>). In load, return the data and call setContext in a layout/page component; in shared modules, expose a setup function that components call during init."`
+- `rationale`: `'Svelte lifecycle and context functions require an active component context; called at module scope, in a shared-state class constructor, or in a load/handler they throw lifecycle_outside_component at runtime — the compiler does not catch it, and it surfaces as a production crash.'`
+
+### 5. Registration, docs, changeset
+
+- The usual four registration sites + grep check.
+- Docs: `docs/src/content/docs/rules/correct007.md` + ja mirror; CLI-guide
+  suppression range (en/ja) `CORRECT001–006` → `CORRECT001–007`.
+- Changeset: core / svelte-vitals / vite / mcp — **minor**.
+
+## Testing
+
+- **Module parse**: top-level detection for representative callees + a loop
+  over all nine; alias records the canonical name; namespace-member call;
+  constructor + module-scope `new` (class name + `new`-site line);
+  `<script module>` positive / instance-script negative; NOT flagged: calls
+  inside functions, `createContext()`, `mount`/`tick`, same-named import from
+  another package, `import type`.
+- **Kit parse**: `getContext` inside `load` → `inHandler: true`; top-level →
+  `false`; inside `init` → `false`; NOT flagged: helper function, exported
+  `use*` function.
+- **Rule**: all message variants; severity critical; both channels in one
+  run; suppression on each channel; rendered-mode no-op.
+- **Regression bar**: every existing `orphanEffects` (CORRECT006) test passes
+  unchanged through the generalised collectors.
+- Root `pnpm build` / `typecheck` / `test` / `lint` green.
+
+## Known limitations / out of scope (v1, documented in the rule docs)
+
+- **Deferred calls inside components** (`onMount` in `setTimeout`/event
+  handlers) — needs call-graph analysis; declined at design time.
+- **Factory functions, IIFEs, cross-file classes** — same conservative misses
+  as CORRECT006.
+- **Wrapper re-exports** (`export { onMount } from 'svelte'` consumed via
+  another module) — not tracked.
+- **`svelte/legacy` (`createBubbler`)** — not tracked.
+- **Class-constructor patterns inside Kit files** — not tracked (module
+  surface covers the shared-state-class shape).

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -55020,52 +55020,103 @@ function walkEvalScope(node, visit) {
     walkEvalScope(node[key2], visit);
   }
 }
-function collectEvalScopeEffectLines(root, source2) {
-  const lines = [];
+function collectEvalScopeCalls(root, source2, matcher, skipSubtree) {
+  const out = [];
   walkEvalScope(root, (n) => {
     if (n.type !== "CallExpression") return void 0;
-    if (isEffectRootCall(n)) return true;
-    if (isEffectCall(n)) lines.push(lineOf(source2, n.start));
+    if (skipSubtree?.(n)) return true;
+    const name = matcher(n);
+    if (name) out.push({ name, line: lineOf(source2, n.start) });
     return void 0;
   });
-  return lines;
+  return out;
 }
 function unwrapExport(stmt2) {
   if (stmt2.type === "ExportNamedDeclaration") return stmt2.declaration ?? stmt2;
   if (stmt2.type === "ExportDefaultDeclaration") return stmt2.declaration;
   return stmt2;
 }
-function collectOrphanEffects(program, source2) {
-  const out = collectEvalScopeEffectLines(program, source2).map((line) => ({
-    line,
-    kind: "top-level"
-  }));
+function collectOrphanCalls(program, source2, matcher, skipSubtree) {
+  const out = collectEvalScopeCalls(program, source2, matcher, skipSubtree).map((c) => ({ ...c, kind: "top-level" }));
   const body = program.body ?? [];
-  const effectfulClasses = /* @__PURE__ */ new Set();
+  const matchingClasses = /* @__PURE__ */ new Map();
   for (const stmt2 of body) {
     const decl = unwrapExport(stmt2);
     if (decl?.type !== "ClassDeclaration" || decl.id?.type !== "Identifier") continue;
     const ctor = (decl.body?.body ?? []).find(
       (m) => m?.type === "MethodDefinition" && m.kind === "constructor" && m.value?.body
     );
-    if (ctor && collectEvalScopeEffectLines(ctor.value.body, source2).length > 0) {
-      effectfulClasses.add(decl.id.name);
-    }
+    if (!ctor) continue;
+    const calls = collectEvalScopeCalls(ctor.value.body, source2, matcher, skipSubtree);
+    if (calls.length > 0) matchingClasses.set(decl.id.name, calls[0].name);
   }
-  if (effectfulClasses.size > 0) {
+  if (matchingClasses.size > 0) {
     for (const stmt2 of body) {
       const decl = unwrapExport(stmt2);
       const isCandidate = decl?.type === "VariableDeclaration" || decl?.type === "ExpressionStatement" || stmt2.type === "ExportDefaultDeclaration" && decl?.type !== "FunctionDeclaration" && decl?.type !== "ClassDeclaration";
       if (!isCandidate) continue;
       walkEvalScope(decl, (n) => {
-        if (n.type === "NewExpression" && n.callee?.type === "Identifier" && effectfulClasses.has(n.callee.name)) {
-          out.push({ line: lineOf(source2, n.start), kind: "constructor-instantiated", className: n.callee.name });
+        if (n.type === "NewExpression" && n.callee?.type === "Identifier" && matchingClasses.has(n.callee.name)) {
+          out.push({
+            name: matchingClasses.get(n.callee.name),
+            line: lineOf(source2, n.start),
+            kind: "constructor-instantiated",
+            className: n.callee.name
+          });
         }
         return void 0;
       });
     }
   }
   return out.sort((a, b) => a.line - b.line);
+}
+function collectOrphanEffects(program, source2) {
+  return collectOrphanCalls(program, source2, (n) => isEffectCall(n) ? "$effect" : void 0, isEffectRootCall).map(
+    ({ line, kind, className }) => ({ line, kind, ...className !== void 0 ? { className } : {} })
+  );
+}
+var LIFECYCLE_NAMES = /* @__PURE__ */ new Set([
+  "onMount",
+  "onDestroy",
+  "beforeUpdate",
+  "afterUpdate",
+  "createEventDispatcher",
+  "getContext",
+  "setContext",
+  "hasContext",
+  "getAllContexts"
+]);
+function collectSvelteLifecycleImports(program) {
+  const locals = /* @__PURE__ */ new Map();
+  const namespaces = /* @__PURE__ */ new Set();
+  for (const stmt2 of program.body ?? []) {
+    if (stmt2?.type !== "ImportDeclaration" || stmt2.importKind === "type" || stmt2.source?.value !== "svelte") continue;
+    for (const s of stmt2.specifiers ?? []) {
+      if (s?.importKind === "type" || s?.local?.type !== "Identifier") continue;
+      if (s.type === "ImportSpecifier" && s.imported?.type === "Identifier" && LIFECYCLE_NAMES.has(s.imported.name)) {
+        locals.set(s.local.name, s.imported.name);
+      } else if (s.type === "ImportNamespaceSpecifier") {
+        namespaces.add(s.local.name);
+      }
+    }
+  }
+  return { locals, namespaces };
+}
+function matchLifecycleCall(n, imports2) {
+  const c = n?.callee;
+  if (c?.type === "Identifier") {
+    const canonical = imports2.locals.get(c.name);
+    return canonical ? { canonical, local: c.name } : void 0;
+  }
+  if (c?.type === "MemberExpression" && !c.computed && c.object?.type === "Identifier" && imports2.namespaces.has(c.object.name) && c.property?.type === "Identifier" && LIFECYCLE_NAMES.has(c.property.name)) {
+    return { canonical: c.property.name, local: c.object.name };
+  }
+  return void 0;
+}
+function collectOrphanLifecycleCalls(program, source2) {
+  const imports2 = collectSvelteLifecycleImports(program);
+  if (imports2.locals.size === 0 && imports2.namespaces.size === 0) return [];
+  return collectOrphanCalls(program, source2, (n) => matchLifecycleCall(n, imports2)?.canonical);
 }
 var MODULE_FILE_RE = /\.svelte\.(ts|js)$/;
 function parseModuleProgram(source2, filename2) {
@@ -55115,6 +55166,7 @@ function parseModuleFacts(source2, filename2) {
   const { program, wrapped } = parseModuleProgram(source2, filename2);
   const shift = (line) => Math.max(0, line - 1);
   const orphanEffects = program ? collectOrphanEffects(program, wrapped).map((f) => ({ ...f, line: shift(f.line) })) : [];
+  const orphanLifecycleCalls = program ? collectOrphanLifecycleCalls(program, wrapped).map((f) => ({ ...f, line: shift(f.line) })) : [];
   const moduleStateDecls = program ? collectModuleStateDecls(program, wrapped).map((d) => ({ ...d, line: shift(d.line) })) : [];
   return {
     eachBlocks: [],
@@ -55130,6 +55182,7 @@ function parseModuleFacts(source2, filename2) {
     mutatedProps: [],
     suppressions: collectSuppressions(source2),
     orphanEffects,
+    orphanLifecycleCalls,
     moduleStateDecls
   };
 }
@@ -55150,6 +55203,7 @@ function parseComponentFacts(source2, filename2) {
     collectNamespaceImports(ast.module.content, source2, namespaceImports);
   }
   const orphanEffects = ast.module?.content ? collectOrphanEffects(ast.module.content, source2) : [];
+  const orphanLifecycleCalls = ast.module?.content ? collectOrphanLifecycleCalls(ast.module.content, source2) : [];
   const effects = [];
   const constableStates = [];
   const mutatedProps = [];
@@ -55208,6 +55262,7 @@ function parseComponentFacts(source2, filename2) {
     constableStates,
     mutatedProps,
     orphanEffects,
+    orphanLifecycleCalls,
     moduleStateDecls: [],
     suppressions
   };
@@ -55227,6 +55282,7 @@ function emptyComponentFacts(file) {
     constableStates: [],
     mutatedProps: [],
     orphanEffects: [],
+    orphanLifecycleCalls: [],
     moduleStateDecls: [],
     suppressions: []
   };
@@ -55407,12 +55463,14 @@ function parseKitModuleFacts(source2, filename2) {
   const importedStateWrites = [];
   const importedStateWritesOutsideHandlers = [];
   const runesModuleImports = [];
+  const lifecycleCalls = [];
   if (!program) {
     return {
       moduleStateReassignments,
       importedStateWrites,
       importedStateWritesOutsideHandlers,
       runesModuleImports,
+      lifecycleCalls,
       suppressions
     };
   }
@@ -55440,6 +55498,7 @@ function parseKitModuleFacts(source2, filename2) {
   }
   const handlerFns = collectHandlerFunctions(program);
   const startupFns = collectStartupFunctions(program);
+  const svelteImports = collectSvelteLifecycleImports(program);
   walkKit(program, handlerFns, startupFns, (n, shadowed, inFunction, inHandler, inStartup) => {
     if (inFunction && !inStartup) {
       const flagLet = (name) => {
@@ -55503,6 +55562,12 @@ function parseKitModuleFacts(source2, filename2) {
       if (inHandler) importedStateWrites.push({ ...write, line: line(n.start) });
       else importedStateWritesOutsideHandlers.push({ name: write.name, line: line(n.start) });
     }
+    if (n.type === "CallExpression" && (!inFunction || inHandler || inStartup)) {
+      const m = matchLifecycleCall(n, svelteImports);
+      if (m && !shadowed.has(m.local)) {
+        lifecycleCalls.push({ name: m.canonical, line: line(n.start), inHandler });
+      }
+    }
   });
   const byLine = (arr) => arr.sort((a, b) => a.line - b.line);
   return {
@@ -55510,6 +55575,7 @@ function parseKitModuleFacts(source2, filename2) {
     importedStateWrites: byLine(importedStateWrites),
     importedStateWritesOutsideHandlers: byLine(importedStateWritesOutsideHandlers),
     runesModuleImports: byLine(runesModuleImports),
+    lifecycleCalls: byLine(lifecycleCalls),
     suppressions
   };
 }
@@ -55521,6 +55587,7 @@ function emptyKitModuleFacts(file, kind) {
     importedStateWrites: [],
     importedStateWritesOutsideHandlers: [],
     runesModuleImports: [],
+    lifecycleCalls: [],
     suppressions: []
   };
 }
@@ -57044,6 +57111,84 @@ var correct006OrphanEffect = componentRule({
     message: o.kind === "top-level" ? "$effect at module scope runs outside component initialisation \u2014 it throws effect_orphan at runtime" : `class "${o.className}" runs $effect in its constructor and is instantiated at module scope \u2014 it throws effect_orphan at runtime`
   }))
 });
+var PENALIZED3 = { presence: "none", value: "absent" };
+var PASS3 = { presence: "own", value: "static" };
+var ID = "CORRECT007";
+var DOCS_URL = docsUrlFor(ID);
+var LABEL = "Lifecycle-call context";
+var RECOMMENDATION = "Call lifecycle/context functions during component initialisation (the top level of a component's <script>). In load, return the data and call setContext in a layout/page component; in shared modules, expose a setup function that components call during init.";
+var topLevelMessage = (name) => `${name}() runs at module evaluation, outside component initialisation \u2014 it throws lifecycle_outside_component at runtime`;
+function isSuppressed2(suppressions, line) {
+  return (suppressions ?? []).some((s) => s.line === line && (!s.ruleIds || s.ruleIds.includes(ID)));
+}
+function emitFile(out, file, issues, suppressions) {
+  const bad = issues.filter((b) => !(b.line > 0 && isSuppressed2(suppressions, b.line)));
+  if (bad.length === 0) {
+    out.push({
+      id: ID,
+      category: "correctness",
+      severity: "critical",
+      detection: PASS3,
+      route: file,
+      message: LABEL,
+      recommendation: RECOMMENDATION,
+      docsUrl: DOCS_URL
+    });
+    return;
+  }
+  for (const b of bad) {
+    out.push({
+      id: ID,
+      category: "correctness",
+      severity: "critical",
+      detection: PENALIZED3,
+      route: file,
+      location: file,
+      ...b.line > 0 ? { line: b.line } : {},
+      message: b.message,
+      recommendation: RECOMMENDATION,
+      docsUrl: DOCS_URL
+    });
+  }
+}
+var correct007OrphanLifecycle = {
+  id: ID,
+  title: "Lifecycle call outside component initialisation",
+  category: "correctness",
+  severity: "critical",
+  scope: "component",
+  rationale: "Svelte lifecycle and context functions require an active component context; called at module scope, in a shared-state class constructor, or in a load/handler they throw lifecycle_outside_component at runtime \u2014 the compiler does not catch it, and it surfaces as a production crash.",
+  async check(ctx) {
+    const out = [];
+    for (const c of ctx.components ?? []) {
+      const calls = c.orphanLifecycleCalls ?? [];
+      if (calls.length === 0) continue;
+      emitFile(
+        out,
+        c.file,
+        calls.map((o) => ({
+          line: o.line,
+          message: o.kind === "top-level" ? topLevelMessage(o.name) : `class "${o.className}" calls ${o.name}() in its constructor and is instantiated at module scope \u2014 it throws lifecycle_outside_component at runtime`
+        })),
+        c.suppressions
+      );
+    }
+    for (const m of ctx.kitModules ?? []) {
+      const calls = m.lifecycleCalls ?? [];
+      if (calls.length === 0) continue;
+      emitFile(
+        out,
+        m.file,
+        calls.map((l) => ({
+          line: l.line,
+          message: l.inHandler ? `${l.name}() is called in a load/handler \u2014 it runs on every request, outside component initialisation, and throws lifecycle_outside_component at runtime` : topLevelMessage(l.name)
+        })),
+        m.suppressions
+      );
+    }
+    return out;
+  }
+};
 var sec001Html = componentRule({
   id: "SEC001",
   title: "Raw HTML render",
@@ -57064,9 +57209,9 @@ var sec002JavascriptUrl = componentRule({
   applies: (c) => c.javascriptUrls.length > 0,
   bad: (c) => c.javascriptUrls.map((u) => ({ line: u.line, message: "javascript: URL in an attribute" }))
 });
-var PENALIZED3 = { presence: "none", value: "absent" };
-var PASS3 = { presence: "own", value: "static" };
-function isSuppressed2(m, ruleId, line) {
+var PENALIZED4 = { presence: "none", value: "absent" };
+var PASS4 = { presence: "own", value: "static" };
+function isSuppressed3(m, ruleId, line) {
   return (m.suppressions ?? []).some((s) => s.line === line && (!s.ruleIds || s.ruleIds.includes(ruleId)));
 }
 function kitModuleRule(opts) {
@@ -57083,13 +57228,13 @@ function kitModuleRule(opts) {
       const out = [];
       for (const m of ctx.kitModules ?? []) {
         if (!opts.applies(m, ctx)) continue;
-        const bad = opts.bad(m, ctx).filter((b) => !(b.line > 0 && isSuppressed2(m, opts.id, b.line)));
+        const bad = opts.bad(m, ctx).filter((b) => !(b.line > 0 && isSuppressed3(m, opts.id, b.line)));
         if (bad.length === 0) {
           out.push({
             id: opts.id,
             category: opts.category,
             severity,
-            detection: PASS3,
+            detection: PASS4,
             route: m.file,
             message: opts.label,
             recommendation: opts.recommendation,
@@ -57102,7 +57247,7 @@ function kitModuleRule(opts) {
             id: opts.id,
             category: opts.category,
             severity,
-            detection: PENALIZED3,
+            detection: PENALIZED4,
             route: m.file,
             location: m.file,
             ...b.line > 0 ? { line: b.line } : {},
@@ -57292,6 +57437,7 @@ var allRules = [
   correct004UnmutatedState,
   correct005PropMutation,
   correct006OrphanEffect,
+  correct007OrphanLifecycle,
   sec001Html,
   sec002JavascriptUrl,
   sec003LoadStateWrite,

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -55007,28 +55007,34 @@ var EVAL_SCOPE_BOUNDARIES = /* @__PURE__ */ new Set([
   "ClassDeclaration",
   "ClassExpression"
 ]);
-function walkEvalScope(node, visit) {
+function walkEvalScope(node, visit, shadowed = /* @__PURE__ */ new Set()) {
   if (Array.isArray(node)) {
-    for (const child of node) walkEvalScope(child, visit);
+    for (const child of node) walkEvalScope(child, visit, shadowed);
     return;
   }
   if (!node || typeof node !== "object" || typeof node.type !== "string") return;
-  if (visit(node)) return;
+  const introduced = scopeIntroducedNames(node);
+  const scope = introduced.size > 0 ? /* @__PURE__ */ new Set([...shadowed, ...introduced]) : shadowed;
+  if (visit(node, scope)) return;
   if (EVAL_SCOPE_BOUNDARIES.has(node.type)) return;
   for (const key2 of Object.keys(node)) {
     if (WALK_IGNORED_KEYS.has(key2)) continue;
-    walkEvalScope(node[key2], visit);
+    walkEvalScope(node[key2], visit, scope);
   }
 }
-function collectEvalScopeCalls(root, source2, matcher, skipSubtree) {
+function collectEvalScopeCalls(root, source2, matcher, skipSubtree, initialShadowed) {
   const out = [];
-  walkEvalScope(root, (n) => {
-    if (n.type !== "CallExpression") return void 0;
-    if (skipSubtree?.(n)) return true;
-    const name = matcher(n);
-    if (name) out.push({ name, line: lineOf(source2, n.start) });
-    return void 0;
-  });
+  walkEvalScope(
+    root,
+    (n, shadowed) => {
+      if (n.type !== "CallExpression") return void 0;
+      if (skipSubtree?.(n)) return true;
+      const name = matcher(n, shadowed);
+      if (name) out.push({ name, line: lineOf(source2, n.start) });
+      return void 0;
+    },
+    initialShadowed
+  );
   return out;
 }
 function unwrapExport(stmt2) {
@@ -55047,7 +55053,9 @@ function collectOrphanCalls(program, source2, matcher, skipSubtree) {
       (m) => m?.type === "MethodDefinition" && m.kind === "constructor" && m.value?.body
     );
     if (!ctor) continue;
-    const calls = collectEvalScopeCalls(ctor.value.body, source2, matcher, skipSubtree);
+    const ctorShadow = /* @__PURE__ */ new Set();
+    for (const p of ctor.value.params ?? []) addBoundNames(p, ctorShadow);
+    const calls = collectEvalScopeCalls(ctor.value.body, source2, matcher, skipSubtree, ctorShadow);
     if (calls.length > 0) matchingClasses.set(decl.id.name, calls[0].name);
   }
   if (matchingClasses.size > 0) {
@@ -55116,7 +55124,10 @@ function matchLifecycleCall(n, imports2) {
 function collectOrphanLifecycleCalls(program, source2) {
   const imports2 = collectSvelteLifecycleImports(program);
   if (imports2.locals.size === 0 && imports2.namespaces.size === 0) return [];
-  return collectOrphanCalls(program, source2, (n) => matchLifecycleCall(n, imports2)?.canonical);
+  return collectOrphanCalls(program, source2, (n, shadowed) => {
+    const m = matchLifecycleCall(n, imports2);
+    return m && !shadowed.has(m.local) ? m.canonical : void 0;
+  });
 }
 var MODULE_FILE_RE = /\.svelte\.(ts|js)$/;
 function parseModuleProgram(source2, filename2) {
@@ -57181,7 +57192,7 @@ var correct007OrphanLifecycle = {
         m.file,
         calls.map((l) => ({
           line: l.line,
-          message: l.inHandler ? `${l.name}() is called in a load/handler \u2014 it runs on every request, outside component initialisation, and throws lifecycle_outside_component at runtime` : topLevelMessage(l.name)
+          message: l.inHandler ? `${l.name}() is called in a load/handler \u2014 it runs on every request, outside component initialisation, and throws lifecycle_outside_component at runtime` : `${l.name}() runs outside component initialisation (module evaluation or the init hook) \u2014 it throws lifecycle_outside_component at runtime`
         })),
         m.suppressions
       );

--- a/packages/cli/test/malformed-svelte.test.ts
+++ b/packages/cli/test/malformed-svelte.test.ts
@@ -49,6 +49,7 @@ describe('collectComponentFacts: malformed .svelte files (component path)', () =
       constableStates: [],
       mutatedProps: [],
       orphanEffects: [],
+      orphanLifecycleCalls: [],
       moduleStateDecls: [],
       suppressions: []
     });
@@ -109,6 +110,7 @@ describe('collectComponentFacts: malformed .svelte files (component path)', () =
       constableStates: [],
       mutatedProps: [],
       orphanEffects: [],
+      orphanLifecycleCalls: [],
       moduleStateDecls: [],
       suppressions: []
     });

--- a/packages/cli/test/suppression-e2e.test.ts
+++ b/packages/cli/test/suppression-e2e.test.ts
@@ -27,6 +27,7 @@ const comp = (over: Partial<ComponentFacts>): ComponentFacts => ({
   constableStates: [],
   mutatedProps: [],
   orphanEffects: [],
+  orphanLifecycleCalls: [],
   moduleStateDecls: [],
   suppressions: [],
   ...over

--- a/packages/core/src/component-collect.ts
+++ b/packages/core/src/component-collect.ts
@@ -23,6 +23,7 @@ export function emptyComponentFacts(file: string): ComponentFacts {
     constableStates: [],
     mutatedProps: [],
     orphanEffects: [],
+    orphanLifecycleCalls: [],
     moduleStateDecls: [],
     suppressions: []
   };

--- a/packages/core/src/component-parse.ts
+++ b/packages/core/src/component-parse.ts
@@ -586,41 +586,57 @@ const EVAL_SCOPE_BOUNDARIES = new Set([
  * Walk only the code that executes when `node` itself is evaluated: every node is
  * visited, but children of eval-scope boundaries (function/class bodies) are not
  * entered. `visit` returning true skips a node's children — used to exempt
- * `$effect.root(...)` callbacks (CORRECT006).
+ * `$effect.root(...)` callbacks (CORRECT006). Like `walkScoped`, threads a "shadowed
+ * names" set down through scope-introducing constructs (`scopeIntroducedNames`) so
+ * `visit` can check whether a candidate identifier is locally shadowed before
+ * treating it as a match against an outer (e.g. imported) binding (CORRECT007).
  */
-function walkEvalScope(node: Node, visit: (n: Node) => boolean | undefined): void {
+function walkEvalScope(
+  node: Node,
+  visit: (n: Node, shadowed: Set<string>) => boolean | undefined,
+  shadowed: Set<string> = new Set()
+): void {
   if (Array.isArray(node)) {
-    for (const child of node) walkEvalScope(child, visit);
+    for (const child of node) walkEvalScope(child, visit, shadowed);
     return;
   }
   if (!node || typeof node !== 'object' || typeof node.type !== 'string') return;
-  if (visit(node)) return;
+  const introduced = scopeIntroducedNames(node);
+  const scope = introduced.size > 0 ? new Set([...shadowed, ...introduced]) : shadowed;
+  if (visit(node, scope)) return;
   if (EVAL_SCOPE_BOUNDARIES.has(node.type)) return;
   for (const key of Object.keys(node)) {
     if (WALK_IGNORED_KEYS.has(key)) continue;
-    walkEvalScope(node[key], visit);
+    walkEvalScope(node[key], visit, scope);
   }
 }
 
 /**
  * Calls matching `matcher` that run when `root` itself is evaluated (CORRECT006/007).
  * `skipSubtree` exempts a call's children — CORRECT006 uses it for `$effect.root(...)`
- * callbacks, which are a legal standalone reactive scope.
+ * callbacks, which are a legal standalone reactive scope. `initialShadowed` seeds the
+ * shadow set threaded through `walkEvalScope` (CORRECT007 uses it to seed a
+ * constructor's own parameters before scanning its body).
  */
 function collectEvalScopeCalls(
   root: Node,
   source: string,
-  matcher: (n: Node) => string | undefined,
-  skipSubtree?: (n: Node) => boolean
+  matcher: (n: Node, shadowed: Set<string>) => string | undefined,
+  skipSubtree?: (n: Node) => boolean,
+  initialShadowed?: Set<string>
 ): { name: string; line: number }[] {
   const out: { name: string; line: number }[] = [];
-  walkEvalScope(root, (n) => {
-    if (n.type !== 'CallExpression') return undefined;
-    if (skipSubtree?.(n)) return true;
-    const name = matcher(n);
-    if (name) out.push({ name, line: lineOf(source, n.start) });
-    return undefined;
-  });
+  walkEvalScope(
+    root,
+    (n, shadowed) => {
+      if (n.type !== 'CallExpression') return undefined;
+      if (skipSubtree?.(n)) return true;
+      const name = matcher(n, shadowed);
+      if (name) out.push({ name, line: lineOf(source, n.start) });
+      return undefined;
+    },
+    initialShadowed
+  );
   return out;
 }
 
@@ -646,7 +662,7 @@ export function unwrapExport(stmt: Node): Node {
 function collectOrphanCalls(
   program: Node,
   source: string,
-  matcher: (n: Node) => string | undefined,
+  matcher: (n: Node, shadowed: Set<string>) => string | undefined,
   skipSubtree?: (n: Node) => boolean
 ): { name: string; line: number; kind: 'top-level' | 'constructor-instantiated'; className?: string }[] {
   const out: { name: string; line: number; kind: 'top-level' | 'constructor-instantiated'; className?: string }[] =
@@ -664,7 +680,13 @@ function collectOrphanCalls(
       (m: Node) => m?.type === 'MethodDefinition' && m.kind === 'constructor' && m.value?.body
     );
     if (!ctor) continue;
-    const calls = collectEvalScopeCalls(ctor.value.body, source, matcher, skipSubtree);
+    // Seed the shadow set with the constructor's own parameters — a parameter that
+    // shadows an imported lifecycle name makes a same-named call inside the body a
+    // legal local call, not the tracked import (CORRECT007 false positive).
+    const ctorShadow = new Set<string>();
+    for (const p of ctor.value.params ?? []) addBoundNames(p, ctorShadow);
+    const calls = collectEvalScopeCalls(ctor.value.body, source, matcher, skipSubtree, ctorShadow);
+    // calls are in walk (source) order — a constructor mixing callees reports the first one.
     if (calls.length > 0) matchingClasses.set(decl.id.name, calls[0]!.name);
   }
 
@@ -790,7 +812,10 @@ export function matchLifecycleCall(
 function collectOrphanLifecycleCalls(program: Node, source: string): OrphanLifecycleCallFact[] {
   const imports = collectSvelteLifecycleImports(program);
   if (imports.locals.size === 0 && imports.namespaces.size === 0) return [];
-  return collectOrphanCalls(program, source, (n) => matchLifecycleCall(n, imports)?.canonical);
+  return collectOrphanCalls(program, source, (n, shadowed) => {
+    const m = matchLifecycleCall(n, imports);
+    return m && !shadowed.has(m.local) ? m.canonical : undefined;
+  });
 }
 
 /** A Svelte runes module file — the whole file is one module-scope program (CORRECT006). */

--- a/packages/core/src/component-parse.ts
+++ b/packages/core/src/component-parse.ts
@@ -4,6 +4,7 @@ import type {
   EachBlockFact,
   EffectFact,
   OrphanEffectFact,
+  OrphanLifecycleCallFact,
   SourceSpan,
   SuppressionDirective
 } from './component.js';
@@ -601,16 +602,26 @@ function walkEvalScope(node: Node, visit: (n: Node) => boolean | undefined): voi
   }
 }
 
-/** Lines of `$effect`/`$effect.pre` calls that run when `root` itself is evaluated (CORRECT006). */
-function collectEvalScopeEffectLines(root: Node, source: string): number[] {
-  const lines: number[] = [];
+/**
+ * Calls matching `matcher` that run when `root` itself is evaluated (CORRECT006/007).
+ * `skipSubtree` exempts a call's children — CORRECT006 uses it for `$effect.root(...)`
+ * callbacks, which are a legal standalone reactive scope.
+ */
+function collectEvalScopeCalls(
+  root: Node,
+  source: string,
+  matcher: (n: Node) => string | undefined,
+  skipSubtree?: (n: Node) => boolean
+): { name: string; line: number }[] {
+  const out: { name: string; line: number }[] = [];
   walkEvalScope(root, (n) => {
     if (n.type !== 'CallExpression') return undefined;
-    if (isEffectRootCall(n)) return true;
-    if (isEffectCall(n)) lines.push(lineOf(source, n.start));
+    if (skipSubtree?.(n)) return true;
+    const name = matcher(n);
+    if (name) out.push({ name, line: lineOf(source, n.start) });
     return undefined;
   });
-  return lines;
+  return out;
 }
 
 /**
@@ -623,6 +634,68 @@ export function unwrapExport(stmt: Node): Node {
   if (stmt.type === 'ExportNamedDeclaration') return stmt.declaration ?? stmt;
   if (stmt.type === 'ExportDefaultDeclaration') return stmt.declaration;
   return stmt;
+}
+
+/**
+ * Matcher-parameterised orphan-call collector (CORRECT006/007): (1) matching calls that
+ * run at module evaluation time, (2) a module-scope `new` (direct top-level statements
+ * only, export-unwrapped) of a same-file top-level class whose constructor directly
+ * makes a matching call. See `collectOrphanEffects`'s doc comment for why pattern 2 is
+ * restricted to top-level `ClassDeclaration`s and top-level `new` statements.
+ */
+function collectOrphanCalls(
+  program: Node,
+  source: string,
+  matcher: (n: Node) => string | undefined,
+  skipSubtree?: (n: Node) => boolean
+): { name: string; line: number; kind: 'top-level' | 'constructor-instantiated'; className?: string }[] {
+  const out: { name: string; line: number; kind: 'top-level' | 'constructor-instantiated'; className?: string }[] =
+    collectEvalScopeCalls(program, source, matcher, skipSubtree).map((c) => ({ ...c, kind: 'top-level' as const }));
+
+  const body: Node[] = program.body ?? [];
+
+  const matchingClasses = new Map<string, string>(); // class name → canonical callee name
+  for (const stmt of body) {
+    const decl = unwrapExport(stmt);
+    if (decl?.type !== 'ClassDeclaration' || decl.id?.type !== 'Identifier') continue;
+    // A TS constructor overload signature is bodiless — require a body so the FIRST
+    // matching MethodDefinition is the actual implementation, not a signature.
+    const ctor = (decl.body?.body ?? []).find(
+      (m: Node) => m?.type === 'MethodDefinition' && m.kind === 'constructor' && m.value?.body
+    );
+    if (!ctor) continue;
+    const calls = collectEvalScopeCalls(ctor.value.body, source, matcher, skipSubtree);
+    if (calls.length > 0) matchingClasses.set(decl.id.name, calls[0]!.name);
+  }
+
+  if (matchingClasses.size > 0) {
+    for (const stmt of body) {
+      const decl = unwrapExport(stmt);
+      // A direct top-level `VariableDeclaration`/`ExpressionStatement`, or an
+      // `export default <expression>` (whose "declaration" IS the expression itself,
+      // not wrapped in a statement node) — anything else (if/for/block/try, …) is a
+      // conservative miss by design.
+      const isCandidate =
+        decl?.type === 'VariableDeclaration' ||
+        decl?.type === 'ExpressionStatement' ||
+        (stmt.type === 'ExportDefaultDeclaration' &&
+          decl?.type !== 'FunctionDeclaration' &&
+          decl?.type !== 'ClassDeclaration');
+      if (!isCandidate) continue;
+      walkEvalScope(decl, (n) => {
+        if (n.type === 'NewExpression' && n.callee?.type === 'Identifier' && matchingClasses.has(n.callee.name)) {
+          out.push({
+            name: matchingClasses.get(n.callee.name)!,
+            line: lineOf(source, n.start),
+            kind: 'constructor-instantiated',
+            className: n.callee.name
+          });
+        }
+        return undefined;
+      });
+    }
+  }
+  return out.sort((a, b) => a.line - b.line);
 }
 
 /**
@@ -640,53 +713,84 @@ export function unwrapExport(stmt: Node): Node {
  * expression, never as a module-scope binding. This matches the design spec's own wording
  * for pattern 2: "flag top-level `new ClassName(...)` statements". Pattern 1 (top-level
  * `$effect`, including inside top-level blocks/if) is unaffected — see
- * `collectEvalScopeEffectLines` above.
+ * `collectEvalScopeCalls` above. Generalised as `collectOrphanCalls` — CORRECT007 reuses
+ * the same walk with a lifecycle-import matcher.
  */
 function collectOrphanEffects(program: Node, source: string): OrphanEffectFact[] {
-  const out: OrphanEffectFact[] = collectEvalScopeEffectLines(program, source).map((line) => ({
-    line,
-    kind: 'top-level' as const
-  }));
+  return collectOrphanCalls(program, source, (n) => (isEffectCall(n) ? '$effect' : undefined), isEffectRootCall).map(
+    ({ line, kind, className }) => ({ line, kind, ...(className !== undefined ? { className } : {}) })
+  );
+}
 
-  const body: Node[] = program.body ?? [];
+/** Svelte exports that throw `lifecycle_outside_component` when called without an active component context (CORRECT007). */
+export const LIFECYCLE_NAMES = new Set([
+  'onMount',
+  'onDestroy',
+  'beforeUpdate',
+  'afterUpdate',
+  'createEventDispatcher',
+  'getContext',
+  'setContext',
+  'hasContext',
+  'getAllContexts'
+]);
 
-  const effectfulClasses = new Set<string>();
-  for (const stmt of body) {
-    const decl = unwrapExport(stmt);
-    if (decl?.type !== 'ClassDeclaration' || decl.id?.type !== 'Identifier') continue;
-    // A TS constructor overload signature is bodiless — require a body so the FIRST
-    // matching MethodDefinition is the actual implementation, not a signature.
-    const ctor = (decl.body?.body ?? []).find(
-      (m: Node) => m?.type === 'MethodDefinition' && m.kind === 'constructor' && m.value?.body
-    );
-    if (ctor && collectEvalScopeEffectLines(ctor.value.body, source).length > 0) {
-      effectfulClasses.add(decl.id.name);
+/**
+ * Tracked svelte lifecycle/context bindings in a module program (CORRECT007): local
+ * alias → canonical name for named value imports from 'svelte', plus namespace locals
+ * (`import * as s from 'svelte'`). Type-only imports/specifiers excluded; same-named
+ * imports from any other module are never tracked. Shared with the Kit-module parser.
+ */
+export function collectSvelteLifecycleImports(program: Node): { locals: Map<string, string>; namespaces: Set<string> } {
+  const locals = new Map<string, string>();
+  const namespaces = new Set<string>();
+  for (const stmt of program.body ?? []) {
+    if (stmt?.type !== 'ImportDeclaration' || stmt.importKind === 'type' || stmt.source?.value !== 'svelte') continue;
+    for (const s of stmt.specifiers ?? []) {
+      if (s?.importKind === 'type' || s?.local?.type !== 'Identifier') continue;
+      if (s.type === 'ImportSpecifier' && s.imported?.type === 'Identifier' && LIFECYCLE_NAMES.has(s.imported.name)) {
+        locals.set(s.local.name, s.imported.name);
+      } else if (s.type === 'ImportNamespaceSpecifier') {
+        namespaces.add(s.local.name);
+      }
     }
   }
+  return { locals, namespaces };
+}
 
-  if (effectfulClasses.size > 0) {
-    for (const stmt of body) {
-      const decl = unwrapExport(stmt);
-      // A direct top-level `VariableDeclaration`/`ExpressionStatement`, or an
-      // `export default <expression>` (whose "declaration" IS the expression itself,
-      // not wrapped in a statement node) — anything else (if/for/block/try, …) is a
-      // conservative miss by design.
-      const isCandidate =
-        decl?.type === 'VariableDeclaration' ||
-        decl?.type === 'ExpressionStatement' ||
-        (stmt.type === 'ExportDefaultDeclaration' &&
-          decl?.type !== 'FunctionDeclaration' &&
-          decl?.type !== 'ClassDeclaration');
-      if (!isCandidate) continue;
-      walkEvalScope(decl, (n) => {
-        if (n.type === 'NewExpression' && n.callee?.type === 'Identifier' && effectfulClasses.has(n.callee.name)) {
-          out.push({ line: lineOf(source, n.start), kind: 'constructor-instantiated', className: n.callee.name });
-        }
-        return undefined;
-      });
-    }
+/**
+ * Whether a CallExpression calls a tracked svelte lifecycle/context binding (CORRECT007):
+ * a direct call to a (possibly aliased) named import, or a non-computed member call on a
+ * `svelte` namespace import. Returns the canonical name plus the local root binding (for
+ * shadow checks in the Kit parser). Shared with the Kit-module parser.
+ */
+export function matchLifecycleCall(
+  n: Node,
+  imports: { locals: Map<string, string>; namespaces: Set<string> }
+): { canonical: string; local: string } | undefined {
+  const c = n?.callee;
+  if (c?.type === 'Identifier') {
+    const canonical = imports.locals.get(c.name);
+    return canonical ? { canonical, local: c.name } : undefined;
   }
-  return out.sort((a, b) => a.line - b.line);
+  if (
+    c?.type === 'MemberExpression' &&
+    !c.computed &&
+    c.object?.type === 'Identifier' &&
+    imports.namespaces.has(c.object.name) &&
+    c.property?.type === 'Identifier' &&
+    LIFECYCLE_NAMES.has(c.property.name)
+  ) {
+    return { canonical: c.property.name, local: c.object.name };
+  }
+  return undefined;
+}
+
+/** Orphan lifecycle-call facts for a module-context program (CORRECT007). */
+function collectOrphanLifecycleCalls(program: Node, source: string): OrphanLifecycleCallFact[] {
+  const imports = collectSvelteLifecycleImports(program);
+  if (imports.locals.size === 0 && imports.namespaces.size === 0) return [];
+  return collectOrphanCalls(program, source, (n) => matchLifecycleCall(n, imports)?.canonical);
 }
 
 /** A Svelte runes module file — the whole file is one module-scope program (CORRECT006). */
@@ -760,17 +864,21 @@ function collectModuleStateDecls(program: Node, source: string): { name: string;
 }
 
 /**
- * Facts for a `.svelte.ts`/`.svelte.js` runes module (CORRECT006). The whole file runs at
- * import time, so only `orphanEffects`, `moduleStateDecls`, and `suppressions` are
- * populated — component-only facts stay empty and `loc` is 0 so ARCH001/PERF009 don't
- * fire on module files. Uses `parseModuleProgram` to get the ESTree program from the
- * wrapped source; the 1-line wrap prefix is subtracted from every reported line.
+ * Facts for a `.svelte.ts`/`.svelte.js` runes module (CORRECT006/007). The whole file runs
+ * at import time, so only `orphanEffects`, `orphanLifecycleCalls`, `moduleStateDecls`, and
+ * `suppressions` are populated — component-only facts stay empty and `loc` is 0 so
+ * ARCH001/PERF009 don't fire on module files. Uses `parseModuleProgram` to get the ESTree
+ * program from the wrapped source; the 1-line wrap prefix is subtracted from every
+ * reported line.
  */
 function parseModuleFacts(source: string, filename: string): ParsedFacts {
   const { program, wrapped } = parseModuleProgram(source, filename);
   const shift = (line: number) => Math.max(0, line - 1);
   const orphanEffects = program
     ? collectOrphanEffects(program, wrapped).map((f) => ({ ...f, line: shift(f.line) }))
+    : [];
+  const orphanLifecycleCalls = program
+    ? collectOrphanLifecycleCalls(program, wrapped).map((f) => ({ ...f, line: shift(f.line) }))
     : [];
   const moduleStateDecls = program
     ? collectModuleStateDecls(program, wrapped).map((d) => ({ ...d, line: shift(d.line) }))
@@ -789,6 +897,7 @@ function parseModuleFacts(source: string, filename: string): ParsedFacts {
     mutatedProps: [],
     suppressions: collectSuppressions(source),
     orphanEffects,
+    orphanLifecycleCalls,
     moduleStateDecls
   };
 }
@@ -818,6 +927,9 @@ export function parseComponentFacts(source: string, filename: string): ParsedFac
     collectNamespaceImports(ast.module.content, source, namespaceImports);
   }
   const orphanEffects: OrphanEffectFact[] = ast.module?.content ? collectOrphanEffects(ast.module.content, source) : [];
+  const orphanLifecycleCalls: OrphanLifecycleCallFact[] = ast.module?.content
+    ? collectOrphanLifecycleCalls(ast.module.content, source)
+    : [];
 
   const effects: EffectFact[] = [];
   const constableStates: { name: string; line: number }[] = [];
@@ -877,6 +989,7 @@ export function parseComponentFacts(source: string, filename: string): ParsedFac
     constableStates,
     mutatedProps,
     orphanEffects,
+    orphanLifecycleCalls,
     moduleStateDecls: [],
     suppressions
   };

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -32,6 +32,18 @@ export interface OrphanEffectFact {
   className?: string;
 }
 
+/** A svelte lifecycle/context call guaranteed to run outside component initialisation — it throws `lifecycle_outside_component` at runtime (CORRECT007). */
+export interface OrphanLifecycleCallFact {
+  /** Canonical svelte export name (alias-resolved), e.g. 'onMount'. */
+  name: string;
+  /** 1-based source line, or 0 if unknown. For 'constructor-instantiated', the module-scope `new` site. */
+  line: number;
+  /** 'top-level' = runs at module evaluation; 'constructor-instantiated' = module-scope `new` of a same-file class whose constructor calls a tracked function. */
+  kind: 'top-level' | 'constructor-instantiated';
+  /** Class name when kind is 'constructor-instantiated' (used in the finding message). */
+  className?: string;
+}
+
 /** A flagged source position in a component (e.g. an `{@html}` tag or a `javascript:` URL). */
 export interface SourceSpan {
   /** 1-based source line, or 0 if unknown. */
@@ -72,6 +84,8 @@ export interface ComponentFacts {
   mutatedProps: { name: string; line: number }[];
   /** `$effect` calls guaranteed to run outside component initialisation — module scope in `.svelte.ts`/`.svelte.js` or `<script module>` (CORRECT006). */
   orphanEffects: OrphanEffectFact[];
+  /** Svelte lifecycle/context calls guaranteed to run outside component initialisation — module scope in `.svelte.ts`/`.svelte.js` or `<script module>` (CORRECT007). */
+  orphanLifecycleCalls: OrphanLifecycleCallFact[];
   /** Module-scope `$state` declarations in a `.svelte.ts`/`.svelte.js` runes module — on a server, one instance shared by every request (SEC005). Always empty for `.svelte` files. */
   moduleStateDecls: { name: string; line: number }[];
   /** Inline `svelte-vitals-disable-next-line` directives found in this file's source — component-rule escape hatch (issue #92). Optional: absent is equivalent to no directives, so existing external constructors of `ComponentFacts` are unaffected. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,6 +97,7 @@ export {
   correct004UnmutatedState,
   correct005PropMutation,
   correct006OrphanEffect,
+  correct007OrphanLifecycle,
   sec001Html,
   sec002JavascriptUrl,
   sec003LoadStateWrite,

--- a/packages/core/src/kit-module-collect.ts
+++ b/packages/core/src/kit-module-collect.ts
@@ -11,6 +11,7 @@ export function emptyKitModuleFacts(file: string, kind: KitModuleFacts['kind']):
     importedStateWrites: [],
     importedStateWritesOutsideHandlers: [],
     runesModuleImports: [],
+    lifecycleCalls: [],
     suppressions: []
   };
 }

--- a/packages/core/src/kit-module-parse.ts
+++ b/packages/core/src/kit-module-parse.ts
@@ -5,7 +5,9 @@ import {
   addBoundNames,
   scopeIntroducedNames,
   rootObjectName,
-  WALK_IGNORED_KEYS
+  WALK_IGNORED_KEYS,
+  collectSvelteLifecycleImports,
+  matchLifecycleCall
 } from './component-parse.js';
 import { lineOf } from './svelte-ast.js';
 import type { KitModuleFacts } from './kit-module.js';
@@ -264,12 +266,14 @@ export function parseKitModuleFacts(source: string, filename: string): Omit<KitM
   const importedStateWrites: KitModuleFacts['importedStateWrites'] = [];
   const importedStateWritesOutsideHandlers: KitModuleFacts['importedStateWritesOutsideHandlers'] = [];
   const runesModuleImports: KitModuleFacts['runesModuleImports'] = [];
+  const lifecycleCalls: KitModuleFacts['lifecycleCalls'] = [];
   if (!program) {
     return {
       moduleStateReassignments,
       importedStateWrites,
       importedStateWritesOutsideHandlers,
       runesModuleImports,
+      lifecycleCalls,
       suppressions
     };
   }
@@ -303,6 +307,7 @@ export function parseKitModuleFacts(source: string, filename: string): Omit<KitM
 
   const handlerFns = collectHandlerFunctions(program);
   const startupFns = collectStartupFunctions(program);
+  const svelteImports = collectSvelteLifecycleImports(program);
   walkKit(program, handlerFns, startupFns, (n, shadowed, inFunction, inHandler, inStartup) => {
     if (inFunction && !inStartup) {
       // SEC004 — module-scope let/var reassigned from inside a function body.
@@ -378,6 +383,17 @@ export function parseKitModuleFacts(source: string, filename: string): Omit<KitM
       if (inHandler) importedStateWrites.push({ ...write, line: line(n.start) });
       else importedStateWritesOutsideHandlers.push({ name: write.name, line: line(n.start) });
     }
+
+    // CORRECT007 — svelte lifecycle/context calls outside component initialisation:
+    // top level (crashes at import), handler bodies (crashes per request — getContext
+    // in load), and the `init` hook (crashes at boot). Helper functions are exempt:
+    // a component may legally call them during its own initialisation.
+    if (n.type === 'CallExpression' && (!inFunction || inHandler || inStartup)) {
+      const m = matchLifecycleCall(n, svelteImports);
+      if (m && !shadowed.has(m.local)) {
+        lifecycleCalls.push({ name: m.canonical, line: line(n.start), inHandler });
+      }
+    }
   });
 
   const byLine = <T extends { line: number }>(arr: T[]): T[] => arr.sort((a, b) => a.line - b.line);
@@ -387,6 +403,7 @@ export function parseKitModuleFacts(source: string, filename: string): Omit<KitM
     importedStateWrites: byLine(importedStateWrites),
     importedStateWritesOutsideHandlers: byLine(importedStateWritesOutsideHandlers),
     runesModuleImports: byLine(runesModuleImports),
+    lifecycleCalls: byLine(lifecycleCalls),
     suppressions
   };
 }

--- a/packages/core/src/kit-module.ts
+++ b/packages/core/src/kit-module.ts
@@ -17,6 +17,12 @@ export interface KitModuleFacts {
   importedStateWritesOutsideHandlers: { name: string; line: number }[];
   /** Value imports whose specifier resolves to a repo-local `.svelte.ts`/`.svelte.js` runes module (SEC005). */
   runesModuleImports: { source: string; resolved: string; names: string[]; line: number }[];
+  /** Svelte lifecycle/context calls that run outside component initialisation — top level, handler bodies, or the `init` hook (CORRECT007). */
+  lifecycleCalls: {
+    name: string;
+    line: number;
+    inHandler: boolean;
+  }[];
   /** Inline `svelte-vitals-disable-next-line` directives in this file. */
   suppressions: SuppressionDirective[];
 }

--- a/packages/core/src/rules/correctness/correct007-orphan-lifecycle.ts
+++ b/packages/core/src/rules/correctness/correct007-orphan-lifecycle.ts
@@ -1,0 +1,107 @@
+import type { Result } from '../../types.js';
+import { docsUrlFor, type Rule, type RuleContext } from '../../rule.js';
+import type { SuppressionDirective } from '../../component.js';
+
+const PENALIZED = { presence: 'none', value: 'absent' } as const;
+const PASS = { presence: 'own', value: 'static' } as const;
+
+const ID = 'CORRECT007';
+const DOCS_URL = docsUrlFor(ID);
+const LABEL = 'Lifecycle-call context';
+const RECOMMENDATION =
+  "Call lifecycle/context functions during component initialisation (the top level of a component's <script>). In load, return the data and call setContext in a layout/page component; in shared modules, expose a setup function that components call during init.";
+
+const topLevelMessage = (name: string) =>
+  `${name}() runs at module evaluation, outside component initialisation — it throws lifecycle_outside_component at runtime`;
+
+function isSuppressed(suppressions: SuppressionDirective[] | undefined, line: number): boolean {
+  return (suppressions ?? []).some((s) => s.line === line && (!s.ruleIds || s.ruleIds.includes(ID)));
+}
+
+/** Emit one file's PASS/PENALIZED results — same shapes as componentRule/kitModuleRule. */
+function emitFile(
+  out: Result[],
+  file: string,
+  issues: { line: number; message: string }[],
+  suppressions: SuppressionDirective[] | undefined
+): void {
+  const bad = issues.filter((b) => !(b.line > 0 && isSuppressed(suppressions, b.line)));
+  if (bad.length === 0) {
+    out.push({
+      id: ID,
+      category: 'correctness',
+      severity: 'critical',
+      detection: PASS,
+      route: file,
+      message: LABEL,
+      recommendation: RECOMMENDATION,
+      docsUrl: DOCS_URL
+    });
+    return;
+  }
+  for (const b of bad) {
+    out.push({
+      id: ID,
+      category: 'correctness',
+      severity: 'critical',
+      detection: PENALIZED,
+      route: file,
+      location: file,
+      ...(b.line > 0 ? { line: b.line } : {}),
+      message: b.message,
+      recommendation: RECOMMENDATION,
+      docsUrl: DOCS_URL
+    });
+  }
+}
+
+/**
+ * CORRECT007 — svelte lifecycle/context calls guaranteed to run outside component
+ * initialisation: module scope in runes modules / `<script module>`, the constructor of
+ * a module-scope-instantiated class, and Kit load/handler/`init` bodies. A custom check
+ * because the facts live on BOTH the component channel and the Kit-module channel.
+ */
+export const correct007OrphanLifecycle: Rule = {
+  id: ID,
+  title: 'Lifecycle call outside component initialisation',
+  category: 'correctness',
+  severity: 'critical',
+  scope: 'component',
+  rationale:
+    'Svelte lifecycle and context functions require an active component context; called at module scope, in a shared-state class constructor, or in a load/handler they throw lifecycle_outside_component at runtime — the compiler does not catch it, and it surfaces as a production crash.',
+  async check(ctx: RuleContext): Promise<Result[]> {
+    const out: Result[] = [];
+    for (const c of ctx.components ?? []) {
+      const calls = c.orphanLifecycleCalls ?? [];
+      if (calls.length === 0) continue;
+      emitFile(
+        out,
+        c.file,
+        calls.map((o) => ({
+          line: o.line,
+          message:
+            o.kind === 'top-level'
+              ? topLevelMessage(o.name)
+              : `class "${o.className}" calls ${o.name}() in its constructor and is instantiated at module scope — it throws lifecycle_outside_component at runtime`
+        })),
+        c.suppressions
+      );
+    }
+    for (const m of ctx.kitModules ?? []) {
+      const calls = m.lifecycleCalls ?? [];
+      if (calls.length === 0) continue;
+      emitFile(
+        out,
+        m.file,
+        calls.map((l) => ({
+          line: l.line,
+          message: l.inHandler
+            ? `${l.name}() is called in a load/handler — it runs on every request, outside component initialisation, and throws lifecycle_outside_component at runtime`
+            : topLevelMessage(l.name)
+        })),
+        m.suppressions
+      );
+    }
+    return out;
+  }
+};

--- a/packages/core/src/rules/correctness/correct007-orphan-lifecycle.ts
+++ b/packages/core/src/rules/correctness/correct007-orphan-lifecycle.ts
@@ -97,7 +97,7 @@ export const correct007OrphanLifecycle: Rule = {
           line: l.line,
           message: l.inHandler
             ? `${l.name}() is called in a load/handler — it runs on every request, outside component initialisation, and throws lifecycle_outside_component at runtime`
-            : topLevelMessage(l.name)
+            : `${l.name}() runs outside component initialisation (module evaluation or the init hook) — it throws lifecycle_outside_component at runtime`
         })),
         m.suppressions
       );

--- a/packages/core/src/rules/index.ts
+++ b/packages/core/src/rules/index.ts
@@ -41,6 +41,7 @@ import { correct001EachKey, correct002EffectDerived, correct003EffectAsOnMount }
 import { correct004UnmutatedState } from './correctness/correct004-unmutated-state.js';
 import { correct005PropMutation } from './correctness/correct005-prop-mutation.js';
 import { correct006OrphanEffect } from './correctness/correct006-orphan-effect.js';
+import { correct007OrphanLifecycle } from './correctness/correct007-orphan-lifecycle.js';
 import { sec001Html, sec002JavascriptUrl } from './security/sec001-002.js';
 import { sec003LoadStateWrite } from './security/sec003-load-state-write.js';
 import { sec004ServerModuleState } from './security/sec004-server-module-state.js';
@@ -94,6 +95,7 @@ export const allRules: Rule[] = [
   correct004UnmutatedState,
   correct005PropMutation,
   correct006OrphanEffect,
+  correct007OrphanLifecycle,
   sec001Html,
   sec002JavascriptUrl,
   sec003LoadStateWrite,
@@ -150,6 +152,7 @@ export {
   correct004UnmutatedState,
   correct005PropMutation,
   correct006OrphanEffect,
+  correct007OrphanLifecycle,
   sec001Html,
   sec002JavascriptUrl,
   sec003LoadStateWrite,

--- a/packages/core/test/architecture-rules.test.ts
+++ b/packages/core/test/architecture-rules.test.ts
@@ -23,6 +23,7 @@ const comp = (over: Partial<ComponentFacts>): ComponentFacts => ({
   constableStates: [],
   mutatedProps: [],
   orphanEffects: [],
+  orphanLifecycleCalls: [],
   moduleStateDecls: [],
   suppressions: [],
   ...over

--- a/packages/core/test/bundle-rules.test.ts
+++ b/packages/core/test/bundle-rules.test.ts
@@ -26,6 +26,7 @@ const comp = (
   constableStates: [],
   mutatedProps: [],
   orphanEffects: [],
+  orphanLifecycleCalls: [],
   moduleStateDecls: [],
   suppressions
 });

--- a/packages/core/test/component-collect.test.ts
+++ b/packages/core/test/component-collect.test.ts
@@ -43,6 +43,7 @@ describe('emptyComponentFacts', () => {
       constableStates: [],
       mutatedProps: [],
       orphanEffects: [],
+      orphanLifecycleCalls: [],
       moduleStateDecls: [],
       suppressions: []
     });

--- a/packages/core/test/component-parse.test.ts
+++ b/packages/core/test/component-parse.test.ts
@@ -650,3 +650,70 @@ describe('parseComponentFacts — module-scope $state declarations (SEC005)', ()
     expect(facts.moduleStateDecls).toEqual([]);
   });
 });
+
+describe('parseComponentFacts — orphan lifecycle calls (CORRECT007)', () => {
+  const calls = (src: string, file = 'src/lib/store.svelte.ts') => parseComponentFacts(src, file).orphanLifecycleCalls;
+
+  it('flags top-level lifecycle/context calls imported from svelte', () => {
+    const src = "import { onMount, getContext } from 'svelte';\nonMount(() => {});\nconst theme = getContext('theme');";
+    expect(calls(src)).toEqual([
+      { name: 'onMount', line: 2, kind: 'top-level' },
+      { name: 'getContext', line: 3, kind: 'top-level' }
+    ]);
+  });
+  it('flags every tracked callee at top level', () => {
+    const names = [
+      'onMount',
+      'onDestroy',
+      'beforeUpdate',
+      'afterUpdate',
+      'createEventDispatcher',
+      'getContext',
+      'setContext',
+      'hasContext',
+      'getAllContexts'
+    ];
+    for (const name of names) {
+      expect(calls(`import { ${name} } from 'svelte';\n${name}();`)).toEqual([{ name, line: 2, kind: 'top-level' }]);
+    }
+  });
+  it('records the canonical name for aliased imports and namespace member calls', () => {
+    expect(calls("import { onMount as om } from 'svelte';\nom(() => {});")).toEqual([
+      { name: 'onMount', line: 2, kind: 'top-level' }
+    ]);
+    expect(calls("import * as s from 'svelte';\ns.setContext('k', 1);")).toEqual([
+      { name: 'setContext', line: 2, kind: 'top-level' }
+    ]);
+  });
+  it('flags a module-scope new of a class whose constructor calls a tracked function', () => {
+    const src = [
+      "import { getContext } from 'svelte';",
+      'class Store {',
+      '  constructor() {',
+      "    this.user = getContext('user');",
+      '  }',
+      '}',
+      'export const store = new Store();'
+    ].join('\n');
+    expect(calls(src)).toEqual([{ name: 'getContext', line: 7, kind: 'constructor-instantiated', className: 'Store' }]);
+  });
+  it('does not flag calls inside functions, createContext, non-context svelte exports, or other packages', () => {
+    expect(calls("import { onMount } from 'svelte';\nexport function setup() {\n  onMount(() => {});\n}")).toEqual([]);
+    expect(calls("import { createContext } from 'svelte';\nconst ctx = createContext();")).toEqual([]);
+    expect(calls("import { getContext } from './my-di.js';\nconst x = getContext('k');")).toEqual([]);
+    expect(calls("import { tick } from 'svelte';\ntick();")).toEqual([]);
+  });
+  it('flags <script module> calls but not instance-script calls in .svelte files', () => {
+    const mod = "<script module>\nimport { setContext } from 'svelte';\nsetContext('k', 1);\n</script>";
+    expect(parseComponentFacts(mod, 'C.svelte').orphanLifecycleCalls).toEqual([
+      { name: 'setContext', line: 3, kind: 'top-level' }
+    ]);
+    const inst = "<script>\nimport { onMount } from 'svelte';\nonMount(() => {});\n</script>";
+    expect(parseComponentFacts(inst, 'C.svelte').orphanLifecycleCalls).toEqual([]);
+  });
+  it('keeps orphanEffects unchanged through the generalised collectors', () => {
+    const f = parseComponentFacts('$effect(() => {});', 'src/lib/s.svelte.ts');
+    expect(f.orphanEffects).toEqual([{ line: 1, kind: 'top-level' }]);
+    expect(f.orphanLifecycleCalls).toEqual([]);
+  });
+});

--- a/packages/core/test/component-parse.test.ts
+++ b/packages/core/test/component-parse.test.ts
@@ -716,4 +716,24 @@ describe('parseComponentFacts — orphan lifecycle calls (CORRECT007)', () => {
     expect(f.orphanEffects).toEqual([{ line: 1, kind: 'top-level' }]);
     expect(f.orphanLifecycleCalls).toEqual([]);
   });
+  it('does not flag a constructor parameter shadowing an imported lifecycle name', () => {
+    const src = [
+      "import { setContext } from 'svelte';",
+      'class Store {',
+      '  constructor(setContext) {',
+      "    setContext('k', 1);",
+      '  }',
+      '}',
+      'export const s = new Store((k, v) => {});'
+    ].join('\n');
+    expect(calls(src)).toEqual([]);
+  });
+  it('does not flag a top-level block-local shadowing an imported lifecycle name', () => {
+    const src = "import { onMount } from 'svelte';\n{\n  const onMount = (f) => f;\n  onMount(() => {});\n}";
+    expect(calls(src)).toEqual([]);
+  });
+  it('does not track computed namespace member calls or type-only specifiers', () => {
+    expect(calls("import * as s from 'svelte';\ns['setContext']('k', 1);")).toEqual([]);
+    expect(calls("import { type onMount, tick } from 'svelte';\ntick();")).toEqual([]);
+  });
 });

--- a/packages/core/test/component-rule.test.ts
+++ b/packages/core/test/component-rule.test.ts
@@ -23,6 +23,7 @@ const comp = (over: Partial<ComponentFacts>): ComponentFacts => ({
   constableStates: [],
   mutatedProps: [],
   orphanEffects: [],
+  orphanLifecycleCalls: [],
   moduleStateDecls: [],
   suppressions: [],
   ...over

--- a/packages/core/test/correctness-rules.test.ts
+++ b/packages/core/test/correctness-rules.test.ts
@@ -5,10 +5,12 @@ import {
   correct003EffectAsOnMount,
   correct004UnmutatedState,
   correct005PropMutation,
-  correct006OrphanEffect
+  correct006OrphanEffect,
+  correct007OrphanLifecycle
 } from '../src/index.js';
 import { defineConfig, defaultProject, type Result } from '../src/types.js';
 import type { ComponentFacts } from '../src/component.js';
+import type { KitModuleFacts } from '../src/kit-module.js';
 import type { RuleContext } from '../src/rule.js';
 import { parseComponentFacts } from '../src/component-parse.js';
 
@@ -32,6 +34,18 @@ const comp = (over: Partial<ComponentFacts>): ComponentFacts => ({
   orphanEffects: [],
   orphanLifecycleCalls: [],
   moduleStateDecls: [],
+  suppressions: [],
+  ...over
+});
+
+const kitFacts = (over: Partial<KitModuleFacts>): KitModuleFacts => ({
+  file: 'src/routes/+page.ts',
+  kind: 'universal',
+  moduleStateReassignments: [],
+  importedStateWrites: [],
+  importedStateWritesOutsideHandlers: [],
+  runesModuleImports: [],
+  lifecycleCalls: [],
   suppressions: [],
   ...over
 });
@@ -205,5 +219,70 @@ describe('CORRECT006 orphan $effect', () => {
     const legacy = comp({}) as ComponentFacts & { orphanEffects?: undefined };
     delete (legacy as Record<string, unknown>).orphanEffects;
     expect(await correct006OrphanEffect.check(ctx([legacy]))).toHaveLength(0);
+  });
+});
+
+describe('CORRECT007 lifecycle call outside component initialisation', () => {
+  it('flags a module top-level call as critical with the module message', async () => {
+    const rs = await correct007OrphanLifecycle.check(
+      ctx([
+        comp({ file: 'src/lib/s.svelte.ts', orphanLifecycleCalls: [{ name: 'onMount', line: 2, kind: 'top-level' }] })
+      ])
+    );
+    expect(fails(rs)).toHaveLength(1);
+    expect(rs[0]!.severity).toBe('critical');
+    expect(rs[0]!.category).toBe('correctness');
+    expect(rs[0]!.line).toBe(2);
+    expect(rs[0]!.message).toContain('onMount()');
+    expect(rs[0]!.message).toContain('lifecycle_outside_component');
+  });
+  it('names the class in the constructor-instantiated message', async () => {
+    const rs = await correct007OrphanLifecycle.check(
+      ctx([
+        comp({
+          orphanLifecycleCalls: [{ name: 'getContext', line: 7, kind: 'constructor-instantiated', className: 'Store' }]
+        })
+      ])
+    );
+    expect(fails(rs)[0]!.message).toContain('"Store"');
+    expect(fails(rs)[0]!.message).toContain('getContext()');
+  });
+  it('uses the load/handler message for kit inHandler calls and the module message otherwise', async () => {
+    const rs = await correct007OrphanLifecycle.check({
+      ...ctx([]),
+      kitModules: [
+        kitFacts({ lifecycleCalls: [{ name: 'getContext', line: 3, inHandler: true }] }),
+        kitFacts({
+          file: 'src/hooks.server.ts',
+          kind: 'server',
+          lifecycleCalls: [{ name: 'onMount', line: 2, inHandler: false }]
+        })
+      ]
+    });
+    expect(fails(rs)).toHaveLength(2);
+    expect(fails(rs)[0]!.message).toContain('load/handler');
+    expect(fails(rs)[1]!.message).toContain('module evaluation');
+  });
+  it('reads both channels in one run and honours suppressions on each', async () => {
+    const rs = await correct007OrphanLifecycle.check({
+      ...ctx([
+        comp({
+          orphanLifecycleCalls: [{ name: 'onMount', line: 2, kind: 'top-level' }],
+          suppressions: [{ line: 2, ruleIds: ['CORRECT007'] }]
+        })
+      ]),
+      kitModules: [
+        kitFacts({
+          lifecycleCalls: [{ name: 'getContext', line: 3, inHandler: true }],
+          suppressions: [{ line: 3, ruleIds: ['CORRECT007'] }]
+        })
+      ]
+    });
+    expect(fails(rs)).toHaveLength(0);
+    expect(rs).toHaveLength(2); // two PASS units (signal present, all findings suppressed)
+  });
+  it('emits nothing without signal or in rendered mode', async () => {
+    expect(await correct007OrphanLifecycle.check(ctx([comp({})]))).toHaveLength(0);
+    expect(await correct007OrphanLifecycle.check(base as RuleContext)).toHaveLength(0);
   });
 });

--- a/packages/core/test/correctness-rules.test.ts
+++ b/packages/core/test/correctness-rules.test.ts
@@ -30,6 +30,7 @@ const comp = (over: Partial<ComponentFacts>): ComponentFacts => ({
   constableStates: [],
   mutatedProps: [],
   orphanEffects: [],
+  orphanLifecycleCalls: [],
   moduleStateDecls: [],
   suppressions: [],
   ...over

--- a/packages/core/test/kit-module-parse.test.ts
+++ b/packages/core/test/kit-module-parse.test.ts
@@ -202,3 +202,28 @@ describe('parseKitModuleFacts — runes-module imports (SEC005)', () => {
     expect(resolveRunesModuleSpecifier('some-pkg', 'src/routes/+page.ts')).toBeUndefined();
   });
 });
+
+describe('parseKitModuleFacts — lifecycle calls (CORRECT007)', () => {
+  it('flags getContext inside load (the classic trap)', () => {
+    const src =
+      "import { getContext } from 'svelte';\nexport function load() {\n  const user = getContext('user');\n  return { user };\n}";
+    expect(facts(src).lifecycleCalls).toEqual([{ name: 'getContext', line: 3, inHandler: true }]);
+  });
+  it('flags top-level and init-hook calls with inHandler false', () => {
+    const src =
+      "import { onMount, setContext } from 'svelte';\nonMount(() => {});\nexport async function init() {\n  setContext('k', 1);\n}";
+    expect(facts(src, 'src/hooks.server.ts').lifecycleCalls).toEqual([
+      { name: 'onMount', line: 2, inHandler: false },
+      { name: 'setContext', line: 4, inHandler: false }
+    ]);
+  });
+  it('does not flag calls inside non-handler helper functions', () => {
+    const src = "import { getContext } from 'svelte';\nexport function useUser() {\n  return getContext('user');\n}";
+    expect(facts(src, 'src/routes/+page.ts').lifecycleCalls).toEqual([]);
+  });
+  it('resolves aliases and ignores same-named imports from other modules', () => {
+    const src =
+      "import { getContext as ctx } from 'svelte';\nimport { setContext } from './di.js';\nexport const load = () => {\n  ctx('a');\n  setContext('b', 1);\n};";
+    expect(facts(src).lifecycleCalls).toEqual([{ name: 'getContext', line: 4, inHandler: true }]);
+  });
+});

--- a/packages/core/test/kit-module-parse.test.ts
+++ b/packages/core/test/kit-module-parse.test.ts
@@ -226,4 +226,9 @@ describe('parseKitModuleFacts — lifecycle calls (CORRECT007)', () => {
       "import { getContext as ctx } from 'svelte';\nimport { setContext } from './di.js';\nexport const load = () => {\n  ctx('a');\n  setContext('b', 1);\n};";
     expect(facts(src).lifecycleCalls).toEqual([{ name: 'getContext', line: 4, inHandler: true }]);
   });
+  it('flags calls in functions nested inside a handler (deliberate: usually invoked within the handler)', () => {
+    const src =
+      "import { getContext } from 'svelte';\nexport function load() {\n  return { getUser: () => getContext('user') };\n}";
+    expect(facts(src).lifecycleCalls).toEqual([{ name: 'getContext', line: 3, inHandler: true }]);
+  });
 });

--- a/packages/core/test/security-kit-rules.test.ts
+++ b/packages/core/test/security-kit-rules.test.ts
@@ -85,6 +85,7 @@ const stateModule = (file: string): ComponentFacts => ({
   constableStates: [],
   mutatedProps: [],
   orphanEffects: [],
+  orphanLifecycleCalls: [],
   moduleStateDecls: [{ name: 'user', line: 1 }],
   suppressions: []
 });

--- a/packages/core/test/security-kit-rules.test.ts
+++ b/packages/core/test/security-kit-rules.test.ts
@@ -21,6 +21,7 @@ const kit = (over: Partial<KitModuleFacts>): KitModuleFacts => ({
   importedStateWrites: [],
   importedStateWritesOutsideHandlers: [],
   runesModuleImports: [],
+  lifecycleCalls: [],
   suppressions: [],
   ...over
 });

--- a/packages/core/test/security-rules.test.ts
+++ b/packages/core/test/security-rules.test.ts
@@ -23,6 +23,7 @@ const comp = (over: Partial<ComponentFacts>): ComponentFacts => ({
   constableStates: [],
   mutatedProps: [],
   orphanEffects: [],
+  orphanLifecycleCalls: [],
   moduleStateDecls: [],
   suppressions: [],
   ...over


### PR DESCRIPTION
## Summary

Adds **CORRECT007**, a `critical` correctness rule — the sibling of CORRECT006's `effect_orphan` — flagging Svelte lifecycle/context calls that are guaranteed to run outside component initialisation and throw the runtime `lifecycle_outside_component` error. The tracked callees were verified against the svelte 5.56.4 source: `onMount`, `onDestroy`, `beforeUpdate`, `afterUpdate`, `createEventDispatcher`, `getContext`, `setContext`, `hasContext`, `getAllContexts` (value-imported from `svelte`; aliases and namespace imports resolved to canonical names; `import type` excluded). `createContext()` — whose module-scope use is the official pattern — `mount`, `tick`, and `svelte/legacy` are never flagged.

Detected surfaces:

- **Runes modules / `<script module>`** — top-level calls and the constructor-of-a-module-scope-instantiated-class pattern, via CORRECT006's collectors generalised to matcher-parameterised versions (`orphanEffects` output is byte-identical; every pre-existing CORRECT006 test passes unchanged).
- **Kit route/hooks files** (`KitModuleFacts.lifecycleCalls`) — top level, handler bodies, and the `init` hook. The headline catch is the classic **`getContext` inside `load`** trap (a per-request production crash). Helper functions are exempt — a component may legally call them during its own initialisation.

The walk is shadow-aware (constructor parameters, block-scoped locals, `catch`/loop bindings shadowing an imported name are not flagged) and conservative by construction; known limits (deferred calls in components, factory functions, cross-file classes, wrapper re-exports, nested-in-handler closures returned from load) are documented in the spec and rule docs.

Design doc: `docs/superpowers/specs/2026-07-16-correct007-orphan-lifecycle-design.md`
Plan: `docs/superpowers/plans/2026-07-16-correct007-orphan-lifecycle.md`

## Test plan

- 20+ new tests: module-surface capture (all nine callees, alias/namespace canonicalisation, constructor pattern, `<script module>` vs instance script, shadowing negatives, computed-member/type-only negatives), Kit capture (`getContext`-in-`load`, top-level/`init`, helper exemption), rule (message variants, both channels, per-channel suppression, rendered no-op)
- Root `pnpm build` / `pnpm typecheck` / `pnpm test` (1,352 tests) / `pnpm lint` all green
- Final whole-branch review ran ~30 adversarial probes against the built dist (referenced-not-called, factories, `createContext` destructuring, class methods, computed members, assignment aliasing, namespace forms) — the two shadowing false positives it found were fixed with regression tests; verdict "Ready to merge"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CORRECT007, which detects Svelte lifecycle and context calls made outside component initialization.
  * Reports critical findings for affected module-level code, constructors, and SvelteKit handlers.
  * Supports inline suppression for CORRECT007 findings.

* **Documentation**
  * Added English and Japanese guidance, examples, and troubleshooting details for CORRECT007.
  * Updated CLI documentation to include CORRECT007 in supported suppression rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->