### PR TITLE
feat(core): add CORRECT008/009 — flag browser globals in server-executed code

### DIFF
--- a/.changeset/correct008-009-browser-globals.md
+++ b/.changeset/correct008-009-browser-globals.md
@@ -1,0 +1,8 @@
+---
+'@svelte-vitals/core': minor
+'svelte-vitals': minor
+'@svelte-vitals/vite': minor
+'@svelte-vitals/mcp': minor
+---
+
+Add CORRECT008 (critical) and CORRECT009 (warning): flag browser-only globals (`window`, `document`, `localStorage`, …) read in server-executed code — module scope of runes modules and `<script module>`, SvelteKit load/handler/`init` bodies and file top levels (CORRECT008), and component instance-script top levels that run during SSR (CORRECT009). Recognises `browser`/`typeof` guards, respects same-file `export const ssr = false`, and never descends into `onMount`/`$effect`/function bodies.

--- a/docs/src/content/docs/guides/cli.md
+++ b/docs/src/content/docs/guides/cli.md
@@ -214,7 +214,7 @@ An unknown category or a negative/non-numeric value is an error (exit `2`).
 
 For one intentional occurrence that `--ignore` would silence project-wide, add a
 `svelte-vitals-disable-next-line` comment on the line directly above it. Works for
-any component-scoped rule (Correctness, Security, Architecture, Performance): CORRECT001–007,
+any component-scoped rule (Correctness, Security, Architecture, Performance): CORRECT001–009,
 SEC001–005, ARCH001–002, PERF009–010.
 
 ```svelte

--- a/docs/src/content/docs/ja/guides/cli.md
+++ b/docs/src/content/docs/ja/guides/cli.md
@@ -212,7 +212,7 @@ svelte-vitals --weights seo=2,performance=1
 
 ### 特定の指摘だけをインラインで抑制する
 
-`--ignore` はプロジェクト全体でルールを無効にしますが、意図的な1箇所だけを黙らせたい場合は、対象行の直前に `svelte-vitals-disable-next-line` コメントを書きます。コンポーネントスコープの全ルール（Correctness、Security、Architecture、Performance）に対応: CORRECT001–007、SEC001–005、ARCH001–002、PERF009–010。
+`--ignore` はプロジェクト全体でルールを無効にしますが、意図的な1箇所だけを黙らせたい場合は、対象行の直前に `svelte-vitals-disable-next-line` コメントを書きます。コンポーネントスコープの全ルール（Correctness、Security、Architecture、Performance）に対応: CORRECT001–009、SEC001–005、ARCH001–002、PERF009–010。
 
 ```svelte
 <script>

--- a/docs/src/content/docs/ja/rules/correct008.md
+++ b/docs/src/content/docs/ja/rules/correct008.md
@@ -12,7 +12,7 @@ description: モジュールスコープや load/handler での window・documen
 - `.svelte.ts`/`.svelte.js` runes モジュールや `.svelte` の `<script module>` ブロックの**モジュールスコープ**(サーバーで import された瞬間にクラッシュ)
 - **SvelteKit のルート/フックファイル** — トップレベル、`load`/action/エンドポイント handler 本体、`init` フック(import 時またはリクエストごとにクラッシュ)
 
-検出対象外: `$app/environment` の `browser`(エイリアス込み)や `typeof window !== 'undefined'` チェックでガードされたコード、`onMount`/`$effect`/通常の関数内(モジュール評価時には実行されない)、裸の `typeof window`(throw しない)、自分で import/宣言した名前(`const document = …`)、handler 内にネストしたクロージャ(典型的にはクライアント側コールバック)、自身が `ssr = false` を export するファイル。
+検出対象外: `$app/environment` の `browser`(エイリアス込み)や `typeof window !== 'undefined'` チェックでガードされたコード(early-return ガードを含む)、`onMount`/`$effect`/通常の関数内(モジュール評価時には実行されない)、裸の `typeof window`(throw しない)、自分で import/宣言した名前(`const document = …`)、handler 内にネストしたクロージャ(典型的にはクライアント側コールバック)、自身が `ssr = false` を export するファイル。
 
 ## 重要な理由
 

--- a/docs/src/content/docs/ja/rules/correct008.md
+++ b/docs/src/content/docs/ja/rules/correct008.md
@@ -1,0 +1,50 @@
+---
+title: CORRECT008 · サーバー実行モジュールコードでの browser global
+description: モジュールスコープや load/handler での window・document・localStorage 参照は SSR を ReferenceError でクラッシュさせます。
+---
+
+**重大度:** critical · **カテゴリ:** correctness
+
+## チェック内容
+
+**必ずサーバーで実行されるコード**での browser 専用 global(`window`、`document`、`localStorage`、`sessionStorage`、`navigator`、`location`、`history`、`screen`、`matchMedia`、`requestAnimationFrame`、`cancelAnimationFrame`、`IntersectionObserver`、`ResizeObserver`、`MutationObserver`、`alert`、`confirm`、`prompt`)の読み取りを検出します:
+
+- `.svelte.ts`/`.svelte.js` runes モジュールや `.svelte` の `<script module>` ブロックの**モジュールスコープ**(サーバーで import された瞬間にクラッシュ)
+- **SvelteKit のルート/フックファイル** — トップレベル、`load`/action/エンドポイント handler 本体、`init` フック(import 時またはリクエストごとにクラッシュ)
+
+検出対象外: `$app/environment` の `browser`(エイリアス込み)や `typeof window !== 'undefined'` チェックでガードされたコード、`onMount`/`$effect`/通常の関数内(モジュール評価時には実行されない)、裸の `typeof window`(throw しない)、自分で import/宣言した名前(`const document = …`)、handler 内にネストしたクロージャ(典型的にはクライアント側コールバック)、自身が `ssr = false` を export するファイル。
+
+## 重要な理由
+
+これらの global は Node に存在しません。モジュールスコープの `window` 参照はファイルがサーバーで import された瞬間に、`load` 内なら SSR リクエストのたびにクラッシュします — `ReferenceError: window is not defined`、コンパイラは一切警告しない本番 500 です。
+
+## 修正方法
+
+```ts
+// +page.ts
+export function load() {
+  const stored = localStorage.getItem('filters'); // ❌ サーバーで ReferenceError
+
+  return {};
+}
+```
+
+ブラウザアクセスをクライアント側へ移します:
+
+```svelte
+<!-- +page.svelte -->
+<script>
+  let stored = $state(null);
+  $effect(() => {
+    stored = localStorage.getItem('filters'); // ✅ effect はサーバーでは実行されない
+  });
+</script>
+```
+
+または明示的にガードします:
+
+```ts
+import { browser } from '$app/environment';
+
+const stored = browser ? localStorage.getItem('filters') : null; // ✅
+```

--- a/docs/src/content/docs/ja/rules/correct009.md
+++ b/docs/src/content/docs/ja/rules/correct009.md
@@ -15,6 +15,8 @@ description: コンポーネントの instance script は SSR 時にサーバー
 
 これが critical ではなく **warning** なのは、親の `{#if browser}` の内側でのみレンダリングされる(またはクライアントで動的 import される)コンポーネントは正当にサーバーで実行されないためです — これはコンポーネントファイル単体からは証明できません。該当する場合は対象行の直前に `// svelte-vitals-disable-next-line CORRECT009` を書いてください。
 
+`$props()` の分割代入デフォルト値としてのみ使われる browser global(`let { width = window.innerWidth } = $props()`)も検出されません — デフォルト値は prop が渡されなかった場合にのみ評価され、それは SSR 時も含まれますが、スキャナーは分割代入のデフォルト値を走査しません。これはガードではなく、静かな見逃し(conservative miss)です。
+
 ## 修正方法
 
 ```svelte

--- a/docs/src/content/docs/ja/rules/correct009.md
+++ b/docs/src/content/docs/ja/rules/correct009.md
@@ -7,7 +7,7 @@ description: コンポーネントの instance script は SSR 時にサーバー
 
 ## チェック内容
 
-**コンポーネントの `<script>` トップレベル**での browser 専用 global([CORRECT008](/svelte-vitals/ja/rules/correct008) と同じリスト)の読み取りを検出します — このコードはコンポーネントの SSR レンダリングのたびにサーバーで実行されます。ガードの扱いも同じです: `$app/environment` の `browser`、`typeof` チェック、`onMount`/`$effect` 本体、自前の binding、シャドーされたローカルは検出されません。
+**コンポーネントの `<script>` トップレベル**での browser 専用 global([CORRECT008](/svelte-vitals/ja/rules/correct008) と同じリスト)の読み取りを検出します — このコードはコンポーネントの SSR レンダリングのたびにサーバーで実行されます。ガードの扱いも同じです: `$app/environment` の `browser`、`typeof` チェック(early-return ガードを含む)、`onMount`/`$effect` 本体、自前の binding、シャドーされたローカルは検出されません。
 
 ## 重要な理由
 

--- a/docs/src/content/docs/ja/rules/correct009.md
+++ b/docs/src/content/docs/ja/rules/correct009.md
@@ -7,7 +7,7 @@ description: コンポーネントの instance script は SSR 時にサーバー
 
 ## チェック内容
 
-**コンポーネントの `<script>` トップレベル**での browser 専用 global([CORRECT008](/svelte-vitals/rules/correct008) と同じリスト)の読み取りを検出します — このコードはコンポーネントの SSR レンダリングのたびにサーバーで実行されます。ガードの扱いも同じです: `$app/environment` の `browser`、`typeof` チェック、`onMount`/`$effect` 本体、自前の binding、シャドーされたローカルは検出されません。
+**コンポーネントの `<script>` トップレベル**での browser 専用 global([CORRECT008](/svelte-vitals/ja/rules/correct008) と同じリスト)の読み取りを検出します — このコードはコンポーネントの SSR レンダリングのたびにサーバーで実行されます。ガードの扱いも同じです: `$app/environment` の `browser`、`typeof` チェック、`onMount`/`$effect` 本体、自前の binding、シャドーされたローカルは検出されません。
 
 ## 重要な理由
 

--- a/docs/src/content/docs/ja/rules/correct009.md
+++ b/docs/src/content/docs/ja/rules/correct009.md
@@ -1,0 +1,29 @@
+---
+title: CORRECT009 · コンポーネント初期化中の browser global
+description: コンポーネントの instance script は SSR 時にサーバーで実行されます — トップレベルの window/document 参照はレンダリングをクラッシュさせます。
+---
+
+**重大度:** warning · **カテゴリ:** correctness
+
+## チェック内容
+
+**コンポーネントの `<script>` トップレベル**での browser 専用 global([CORRECT008](/svelte-vitals/rules/correct008) と同じリスト)の読み取りを検出します — このコードはコンポーネントの SSR レンダリングのたびにサーバーで実行されます。ガードの扱いも同じです: `$app/environment` の `browser`、`typeof` チェック、`onMount`/`$effect` 本体、自前の binding、シャドーされたローカルは検出されません。
+
+## 重要な理由
+
+コンポーネント冒頭の `const width = window.innerWidth;` はブラウザ上とクライアント専用の開発フローでは動きますが、最初の SSR レンダリングで `ReferenceError: window is not defined` になります。
+
+これが critical ではなく **warning** なのは、親の `{#if browser}` の内側でのみレンダリングされる(またはクライアントで動的 import される)コンポーネントは正当にサーバーで実行されないためです — これはコンポーネントファイル単体からは証明できません。該当する場合は対象行の直前に `// svelte-vitals-disable-next-line CORRECT009` を書いてください。
+
+## 修正方法
+
+```svelte
+<script>
+  const width = window.innerWidth; // ❌ SSR がクラッシュ
+
+  let width2 = $state(0);
+  $effect(() => {
+    width2 = window.innerWidth; // ✅ クライアント専用
+  });
+</script>
+```

--- a/docs/src/content/docs/rules/correct008.md
+++ b/docs/src/content/docs/rules/correct008.md
@@ -1,0 +1,50 @@
+---
+title: CORRECT008 · Browser global in server module code
+description: window, document, localStorage accessed in module scope or a load/handler crash SSR with a ReferenceError.
+---
+
+**Severity:** critical · **Category:** correctness
+
+## What it checks
+
+Flags reads of browser-only globals (`window`, `document`, `localStorage`, `sessionStorage`, `navigator`, `location`, `history`, `screen`, `matchMedia`, `requestAnimationFrame`, `cancelAnimationFrame`, `IntersectionObserver`, `ResizeObserver`, `MutationObserver`, `alert`, `confirm`, `prompt`) in code that always runs on the server:
+
+- **module scope** of a `.svelte.ts`/`.svelte.js` runes module or a `.svelte` `<script module>` block (crashes when the module is imported on the server), and
+- **SvelteKit route/hooks files** — top level, `load`/action/endpoint handler bodies, and the `init` hook (crashes at import or on every request).
+
+Not flagged: code guarded by `browser` from `$app/environment` (aliases included) or a `typeof window !== 'undefined'` check; code inside `onMount`/`$effect`/ordinary functions (they don't run at module evaluation); a bare `typeof window` (never throws); names you imported or declared yourself (`const document = …`); closures nested inside handlers (typically client callbacks); and files that export `ssr = false` themselves.
+
+## Why it matters
+
+None of these globals exist in Node. A module-scope `window` read crashes the server the moment the file is imported; in a `load` it crashes every SSR request — `ReferenceError: window is not defined`, a production 500 the compiler never warns about.
+
+## How to fix
+
+```ts
+// +page.ts
+export function load() {
+  const stored = localStorage.getItem('filters'); // ❌ ReferenceError on the server
+
+  return {};
+}
+```
+
+Move the browser access to the client side:
+
+```svelte
+<!-- +page.svelte -->
+<script>
+  let stored = $state(null);
+  $effect(() => {
+    stored = localStorage.getItem('filters'); // ✅ effects never run on the server
+  });
+</script>
+```
+
+Or guard it explicitly:
+
+```ts
+import { browser } from '$app/environment';
+
+const stored = browser ? localStorage.getItem('filters') : null; // ✅
+```

--- a/docs/src/content/docs/rules/correct008.md
+++ b/docs/src/content/docs/rules/correct008.md
@@ -12,7 +12,7 @@ Flags reads of browser-only globals (`window`, `document`, `localStorage`, `sess
 - **module scope** of a `.svelte.ts`/`.svelte.js` runes module or a `.svelte` `<script module>` block (crashes when the module is imported on the server), and
 - **SvelteKit route/hooks files** — top level, `load`/action/endpoint handler bodies, and the `init` hook (crashes at import or on every request).
 
-Not flagged: code guarded by `browser` from `$app/environment` (aliases included) or a `typeof window !== 'undefined'` check; code inside `onMount`/`$effect`/ordinary functions (they don't run at module evaluation); a bare `typeof window` (never throws); names you imported or declared yourself (`const document = …`); closures nested inside handlers (typically client callbacks); and files that export `ssr = false` themselves.
+Not flagged: code guarded by `browser` from `$app/environment` (aliases included) or a `typeof window !== 'undefined'` check (early-return guards included); code inside `onMount`/`$effect`/ordinary functions (they don't run at module evaluation); a bare `typeof window` (never throws); names you imported or declared yourself (`const document = …`); closures nested inside handlers (typically client callbacks); and files that export `ssr = false` themselves.
 
 ## Why it matters
 

--- a/docs/src/content/docs/rules/correct009.md
+++ b/docs/src/content/docs/rules/correct009.md
@@ -7,7 +7,7 @@ description: A component's instance script runs on the server during SSR — win
 
 ## What it checks
 
-Flags reads of browser-only globals (the same list as [CORRECT008](/svelte-vitals/rules/correct008)) at the **top level of a component's `<script>`** — that code runs on the server on every SSR render of the component. The same guards apply: `browser` from `$app/environment`, `typeof` checks, `onMount`/`$effect` bodies, your own bindings, and shadowed locals are never flagged.
+Flags reads of browser-only globals (the same list as [CORRECT008](/svelte-vitals/rules/correct008)) at the **top level of a component's `<script>`** — that code runs on the server on every SSR render of the component. The same guards apply: `browser` from `$app/environment`, `typeof` checks (early-return guards included), `onMount`/`$effect` bodies, your own bindings, and shadowed locals are never flagged.
 
 ## Why it matters
 

--- a/docs/src/content/docs/rules/correct009.md
+++ b/docs/src/content/docs/rules/correct009.md
@@ -1,0 +1,29 @@
+---
+title: CORRECT009 · Browser global during component initialisation
+description: A component's instance script runs on the server during SSR — window/document reads at its top level crash the render.
+---
+
+**Severity:** warning · **Category:** correctness
+
+## What it checks
+
+Flags reads of browser-only globals (the same list as [CORRECT008](/svelte-vitals/rules/correct008)) at the **top level of a component's `<script>`** — that code runs on the server on every SSR render of the component. The same guards apply: `browser` from `$app/environment`, `typeof` checks, `onMount`/`$effect` bodies, your own bindings, and shadowed locals are never flagged.
+
+## Why it matters
+
+`const width = window.innerWidth;` at the top of a component works in the browser and in a client-only dev flow, then crashes the first SSR render with `ReferenceError: window is not defined`.
+
+This is a **warning**, not critical: a component that is only ever rendered behind a parent's `{#if browser}` (or dynamically imported on the client) legitimately never runs on the server — and that cannot be proven from the component file alone. If that is your case, add `// svelte-vitals-disable-next-line CORRECT009` above the line.
+
+## How to fix
+
+```svelte
+<script>
+  const width = window.innerWidth; // ❌ crashes SSR
+
+  let width2 = $state(0);
+  $effect(() => {
+    width2 = window.innerWidth; // ✅ client-only
+  });
+</script>
+```

--- a/docs/src/content/docs/rules/correct009.md
+++ b/docs/src/content/docs/rules/correct009.md
@@ -15,6 +15,8 @@ Flags reads of browser-only globals (the same list as [CORRECT008](/svelte-vital
 
 This is a **warning**, not critical: a component that is only ever rendered behind a parent's `{#if browser}` (or dynamically imported on the client) legitimately never runs on the server — and that cannot be proven from the component file alone. If that is your case, add `// svelte-vitals-disable-next-line CORRECT009` above the line.
 
+A browser global used only as a `$props()` destructuring default (`let { width = window.innerWidth } = $props()`) is not flagged either — the default only evaluates when the prop is absent, including during SSR, but the scanner doesn't visit destructuring defaults. This is a silent conservative miss, not a guard.
+
 ## How to fix
 
 ```svelte

--- a/docs/superpowers/plans/2026-07-16-correct008-009-browser-globals.md
+++ b/docs/superpowers/plans/2026-07-16-correct008-009-browser-globals.md
@@ -1,0 +1,1070 @@
+# CORRECT008/009 — Browser Globals Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add CORRECT008 (critical — browser globals in server-executed module code) and CORRECT009 (warning — browser globals at a component instance script's top level), catching the classic SSR `ReferenceError: window is not defined` before deploy.
+
+**Architecture:** One new position-aware scanner (`collectBrowserGlobalRefs`) in `component-parse.ts`, composed from existing machinery: eval-scope boundaries, shadow threading, plus new guard skipping (`browser` from `$app/environment`, `typeof X !== 'undefined'`) and top-level-binding disqualification. Facts land on both channels (`ComponentFacts.browserGlobalRefs` with `context: 'module' | 'instance'` — the instance script is scanned for the first time; `KitModuleFacts.browserGlobalRefs` with the CORRECT007 flag positions and a same-file `ssr = false` opt-out). CORRECT008 is a custom two-channel check (CORRECT007's shape); CORRECT009 is a plain `componentRule`.
+
+**Tech Stack:** TypeScript, Vitest, pnpm workspaces, `svelte/compiler` `parse`, Astro Starlight docs, Changesets.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-16-correct008-009-browser-globals-design.md`. Branch: `feat/correct008-009-browser-globals` (exists with the spec commit; work on it). Run `git fetch origin` first — rebase onto `origin/main` if it moved past `3cda63a`.
+- Tracked globals — exactly these 17, module constant `BROWSER_GLOBALS`: `window`, `document`, `localStorage`, `sessionStorage`, `navigator`, `location`, `history`, `screen`, `matchMedia`, `requestAnimationFrame`, `cancelAnimationFrame`, `IntersectionObserver`, `ResizeObserver`, `MutationObserver`, `alert`, `confirm`, `prompt`. No dynamic list, no Node-shared names.
+- Scanner semantics (spec §2): read positions only (never non-computed member property / non-computed object key / declaration id / import-export specifier / label); bare `typeof <global>` operand never matches; guard clauses (if/ternary/logical whose test references the `$app/environment` `browser` binding, alias-resolved, or contains `typeof <tracked-global> === | !== 'undefined'`) are skipped ENTIRELY including else branches; names imported or declared at the program's top level are disqualified program-wide; eval-scope boundaries + shadow threading as in CORRECT007.
+- `.svelte` instance scans use the UNION of both scripts' guard bindings and top-level bindings (module-script `const document = …` is visible in the instance script).
+- Kit flag positions identical to CORRECT007's `lifecycleCalls`: top level (`inHandler: false`), handler bodies (`true`), `init` (`false`); helper functions exempt; **closures nested inside handlers are NOT descended into** (they are typically client callbacks — a deliberate, documented difference from CORRECT007's nested-in-handler stance). Same-file `export const ssr = false` (incl. `satisfies` and alias-export forms) empties the kit facts; `csr = false` does not.
+- Rules: `CORRECT008` "Browser global in server module code", `critical`, custom `check(ctx)` over component `context === 'module'` facts + kit facts; `CORRECT009` "Browser global during component initialisation", `warning`, `componentRule` over `context === 'instance'`. Messages/recommendation verbatim from spec §4.
+- New facts are REQUIRED fields → literal fixups (lists in Tasks 1–2).
+- `packages/core/src`: no `node:` imports, no I/O. en/ja docs together; suppression range `CORRECT001–007` → `CORRECT001–009`. Changeset: core / `svelte-vitals` / vite / mcp — minor. cli tests need `pnpm --filter @svelte-vitals/core build` first. Root verify: `pnpm build && pnpm typecheck && pnpm test && pnpm lint` (2 pre-existing warnings in `packages/cli/test/meta-object.test.ts` are not yours). Final `chore(action)` dist commit if `pnpm build` changes it. Conventional commits.
+
+---
+
+## File Structure
+
+- Modify: `packages/core/src/component-parse.ts` — `BROWSER_GLOBALS`, `collectBrowserGuardImports`, `collectProgramBindings`, `isBrowserGuardTest`, `collectBrowserGlobalRefs` (exported for the Kit parser), wiring in `parseModuleFacts` + `parseComponentFacts` (Task 1).
+- Modify: `packages/core/src/component.ts` (`BrowserGlobalRefFact` + field), `packages/core/src/component-collect.ts` — Task 1.
+- Modify (ComponentFacts literal fixups, Task 1): `packages/core/test/component-collect.test.ts`, `component-rule.test.ts`, `security-rules.test.ts`, `bundle-rules.test.ts`, `correctness-rules.test.ts` (`comp()`), `architecture-rules.test.ts`, `security-kit-rules.test.ts` (`stateModule`), `packages/cli/test/malformed-svelte.test.ts`, `packages/cli/test/suppression-e2e.test.ts`.
+- Modify: `packages/core/src/kit-module.ts`, `packages/core/src/kit-module-parse.ts`, `packages/core/src/kit-module-collect.ts`; KitModuleFacts literal fixups: `packages/core/test/security-kit-rules.test.ts` (`kit()`), `packages/core/test/correctness-rules.test.ts` (`kitFacts()`) — Task 2.
+- Create: `packages/core/src/rules/correctness/correct008-browser-globals.ts`, `correct009-instance-browser-globals.ts`; Modify: `packages/core/src/rules/index.ts` (3 spots ×2), `packages/core/src/index.ts` (2 spots), `packages/core/test/correctness-rules.test.ts` — Task 3.
+- Create: `docs/src/content/docs/rules/correct008.md`, `correct009.md` + ja mirrors; Modify: guides `cli.md` en/ja; Create: `.changeset/correct008-009-browser-globals.md` — Task 4.
+
+---
+
+### Task 1: The scanner + `ComponentFacts.browserGlobalRefs`
+
+**Files:**
+
+- Modify: `packages/core/src/component-parse.ts` (new section after `collectOrphanLifecycleCalls`, ~line 815; wiring in `parseModuleFacts` ~line 899 and `parseComponentFacts` ~line 935)
+- Modify: `packages/core/src/component.ts` (interface after `OrphanLifecycleCallFact`; field after `orphanLifecycleCalls`)
+- Modify: `packages/core/src/component-collect.ts` (`emptyComponentFacts`)
+- Modify: `packages/core/test/component-parse.test.ts` (new describe)
+- Modify (add `browserGlobalRefs: []` next to `orphanLifecycleCalls: []`): the 7 core + 2 cli files in File Structure
+
+**Interfaces:**
+
+- Consumes: existing `EVAL_SCOPE_BOUNDARIES`, `WALK_IGNORED_KEYS`, `scopeIntroducedNames`, `addBoundNames`, `unwrapExport`, `walkEstree`, `lineOf`, `parseModuleProgram`.
+- Produces (Task 2 imports from `./component-parse.js`): `BROWSER_GLOBALS: Set<string>`, `collectBrowserGuardImports(program): Set<string>`, `collectProgramBindings(program): Set<string>`, `collectBrowserGlobalRefs(program, source, extra?: { guards?: Set<string>; bound?: Set<string> }): { name: string; line: number }[]`. Plus `ComponentFacts.browserGlobalRefs: BrowserGlobalRefFact[]` (Task 3 reads it).
+
+- [ ] **Step 1: Rebase check**
+
+```bash
+git switch feat/correct008-009-browser-globals
+git fetch origin
+git log --oneline origin/main -1   # if not 3cda63a, run: git rebase origin/main
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `packages/core/test/component-parse.test.ts`:
+
+```ts
+describe('parseComponentFacts — browser-global refs (CORRECT008/009)', () => {
+  const refs = (src: string, file = 'src/lib/store.svelte.ts') => parseComponentFacts(src, file).browserGlobalRefs;
+
+  it('flags bare and member-object reads at module scope', () => {
+    const src = 'const w = window.innerWidth;\nlocalStorage.setItem("k", "v");\ndocument.title = "x";';
+    expect(refs(src)).toEqual([
+      { name: 'window', line: 1, context: 'module' },
+      { name: 'localStorage', line: 2, context: 'module' },
+      { name: 'document', line: 3, context: 'module' }
+    ]);
+  });
+  it('does not flag typeof operands, property keys, or member property names', () => {
+    const src =
+      'const ok = typeof window;\nconst o = { window: 1, document: 2 };\nconst x = o.window;\napi.localStorage.get();';
+    expect(refs(src)).toEqual([]);
+  });
+  it('does not flag names imported or declared at top level', () => {
+    const src =
+      "import { window } from 'happy-dom';\nconst document = makeDoc();\nwindow.open();\ndocument.write('x');";
+    expect(refs(src)).toEqual([]);
+  });
+  it('skips browser-guarded clauses entirely (if / ternary / logical, alias included)', () => {
+    const src = [
+      "import { browser as isBrowser } from '$app/environment';",
+      'if (isBrowser) {',
+      '  window.scrollTo(0, 0);',
+      '} else {',
+      '  document.title;',
+      '}',
+      'const w = isBrowser ? window.innerWidth : 0;',
+      'isBrowser && localStorage.clear();'
+    ].join('\n');
+    expect(refs(src)).toEqual([]);
+  });
+  it('skips typeof-guarded clauses', () => {
+    const src =
+      "if (typeof window !== 'undefined') {\n  window.addEventListener('x', f);\n}\nconst s = typeof localStorage === 'undefined' ? null : localStorage.getItem('k');";
+    expect(refs(src)).toEqual([]);
+  });
+  it('does not flag reads inside functions, onMount, or $effect', () => {
+    const src = [
+      "import { onMount } from 'svelte';",
+      'export function width() {',
+      '  return window.innerWidth;',
+      '}',
+      'onMount(() => document.title);',
+      '$effect(() => {',
+      '  localStorage.setItem("a", "b");',
+      '});'
+    ].join('\n');
+    expect(refs(src)).toEqual([]);
+  });
+  it('splits module vs instance contexts in .svelte files', () => {
+    const src = [
+      '<script module>',
+      'const w = window.innerWidth;',
+      '</script>',
+      '<script>',
+      "  const stored = localStorage.getItem('k');",
+      '</script>'
+    ].join('\n');
+    expect(parseComponentFacts(src, 'C.svelte').browserGlobalRefs).toEqual([
+      { name: 'window', line: 2, context: 'module' },
+      { name: 'localStorage', line: 5, context: 'instance' }
+    ]);
+  });
+  it("shares the module script's guard and bindings with the instance scan", () => {
+    const src = [
+      '<script module>',
+      "import { browser } from '$app/environment';",
+      'const document = makeDoc();',
+      '</script>',
+      '<script>',
+      '  if (browser) {',
+      '    window.scrollTo(0, 0);',
+      '  }',
+      "  document.write('x');",
+      '</script>'
+    ].join('\n');
+    expect(parseComponentFacts(src, 'C.svelte').browserGlobalRefs).toEqual([]);
+  });
+  it('does not flag a shadowed name in a top-level block', () => {
+    const src = '{\n  const window = fake();\n  window.open();\n}';
+    expect(refs(src)).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 3: Run to verify they fail**
+
+Run: `pnpm --filter @svelte-vitals/core test -- component-parse`
+Expected: FAIL — `browserGlobalRefs` is `undefined`.
+
+- [ ] **Step 4: Add the fact type**
+
+In `packages/core/src/component.ts`, after `OrphanLifecycleCallFact`:
+
+```ts
+/** A browser-only global read in code that runs on the server — SSR crashes with "<name> is not defined" (CORRECT008/009). */
+export interface BrowserGlobalRefFact {
+  /** The global's name, e.g. 'window'. */
+  name: string;
+  /** 1-based source line, or 0 if unknown. */
+  line: number;
+  /** 'module' = module evaluation (script module / runes module — CORRECT008); 'instance' = component-init top level (runs on the server during SSR — CORRECT009). */
+  context: 'module' | 'instance';
+}
+```
+
+In `ComponentFacts`, after `orphanLifecycleCalls`:
+
+```ts
+/** Browser-global reads in server-executed positions of this file (CORRECT008/009). */
+browserGlobalRefs: BrowserGlobalRefFact[];
+```
+
+- [ ] **Step 5: Implement the scanner**
+
+In `packages/core/src/component-parse.ts`, add `BrowserGlobalRefFact` to the type import, and after `collectOrphanLifecycleCalls` (~line 815) add:
+
+```ts
+/** Browser-only globals worth flagging in server-executed code (CORRECT008/009) — curated high-signal names absent from Node; NOT the full `globals.browser` list, which would false-positive on generic identifiers without scope analysis. */
+export const BROWSER_GLOBALS = new Set([
+  'window',
+  'document',
+  'localStorage',
+  'sessionStorage',
+  'navigator',
+  'location',
+  'history',
+  'screen',
+  'matchMedia',
+  'requestAnimationFrame',
+  'cancelAnimationFrame',
+  'IntersectionObserver',
+  'ResizeObserver',
+  'MutationObserver',
+  'alert',
+  'confirm',
+  'prompt'
+]);
+
+/**
+ * Local names of `browser` value-imported from '$app/environment' (alias-resolved) —
+ * the guard binding recognised by the browser-global scanner (CORRECT008/009).
+ * Shared with the Kit-module parser.
+ */
+export function collectBrowserGuardImports(program: Node): Set<string> {
+  const out = new Set<string>();
+  for (const stmt of program.body ?? []) {
+    if (stmt?.type !== 'ImportDeclaration' || stmt.importKind === 'type' || stmt.source?.value !== '$app/environment')
+      continue;
+    for (const s of stmt.specifiers ?? []) {
+      if (s?.importKind === 'type' || s?.local?.type !== 'Identifier') continue;
+      if (s.type === 'ImportSpecifier' && s.imported?.type === 'Identifier' && s.imported.name === 'browser') {
+        out.add(s.local.name);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Names bound at the program's top level: every import's local name plus every
+ * export-unwrapped declaration name. A tracked global with such a binding is a real
+ * binding, not a global read (`const document = …`, `import { window } from …`) —
+ * disqualified program-wide by the browser-global scanner (CORRECT008/009).
+ * Shared with the Kit-module parser.
+ */
+export function collectProgramBindings(program: Node): Set<string> {
+  const bound = new Set<string>();
+  for (const stmt of program.body ?? []) {
+    if (stmt?.type === 'ImportDeclaration') {
+      for (const s of stmt.specifiers ?? []) if (s?.local?.type === 'Identifier') bound.add(s.local.name);
+      continue;
+    }
+    const decl = unwrapExport(stmt);
+    if (decl?.type === 'VariableDeclaration') {
+      for (const d of decl.declarations ?? []) addBoundNames(d?.id, bound);
+    } else if (
+      (decl?.type === 'FunctionDeclaration' || decl?.type === 'ClassDeclaration') &&
+      decl.id?.type === 'Identifier'
+    ) {
+      bound.add(decl.id.name);
+    }
+  }
+  return bound;
+}
+
+/**
+ * Whether a guard-clause test establishes a browser environment: it references the
+ * `$app/environment` `browser` binding, or contains a
+ * `typeof <tracked-global> === | !== 'undefined'` comparison (CORRECT008/009).
+ * Over-matching here only widens the skip — a conservative miss, never a false positive.
+ */
+function isBrowserGuardTest(test: Node, guardBindings: Set<string>): boolean {
+  let guarded = false;
+  walkEstree(test, (n) => {
+    if (n.type === 'Identifier' && guardBindings.has(n.name)) guarded = true;
+    if (n.type === 'BinaryExpression' && ['===', '!==', '==', '!='].includes(n.operator)) {
+      const sides = [n.left, n.right];
+      const hasTypeofGlobal = sides.some(
+        (s: Node) =>
+          s?.type === 'UnaryExpression' &&
+          s.operator === 'typeof' &&
+          s.argument?.type === 'Identifier' &&
+          BROWSER_GLOBALS.has(s.argument.name)
+      );
+      const hasUndefinedString = sides.some((s: Node) => s?.type === 'Literal' && s.value === 'undefined');
+      if (hasTypeofGlobal && hasUndefinedString) guarded = true;
+    }
+  });
+  return guarded;
+}
+
+/**
+ * Browser-global reads in code that executes when `program` (or a passed function body)
+ * is evaluated (CORRECT008/009). Position-aware — only read positions match: never a
+ * non-computed member property or object key, a declaration id, an import/export
+ * specifier, a label, or a bare `typeof` operand (that idiom never throws). Stops at
+ * eval-scope boundaries (function/class bodies), threads the shadow set, disqualifies
+ * names bound at the program's top level (`extra.bound` adds more, e.g. the other
+ * script's bindings or a handler's parameters), and skips guard clauses ENTIRELY —
+ * if/ternary/logical whose test passes `isBrowserGuardTest` — including their else
+ * branches (a documented conservative miss). `extra.guards` adds guard bindings beyond
+ * this program's own `$app/environment` import.
+ */
+export function collectBrowserGlobalRefs(
+  program: Node,
+  source: string,
+  extra?: { guards?: Set<string>; bound?: Set<string> }
+): { name: string; line: number }[] {
+  const out: { name: string; line: number }[] = [];
+  const bound = new Set([...collectProgramBindings(program), ...(extra?.bound ?? [])]);
+  const guards = new Set([...collectBrowserGuardImports(program), ...(extra?.guards ?? [])]);
+
+  const visit = (n: Node, shadowed: Set<string>): void => {
+    if (!n) return;
+    if (Array.isArray(n)) {
+      for (const c of n) visit(c, shadowed);
+      return;
+    }
+    if (typeof n !== 'object' || typeof n.type !== 'string') return;
+    if (EVAL_SCOPE_BOUNDARIES.has(n.type)) return;
+
+    if ((n.type === 'IfStatement' || n.type === 'ConditionalExpression') && isBrowserGuardTest(n.test, guards)) return;
+    if (n.type === 'LogicalExpression' && isBrowserGuardTest(n.left, guards)) return;
+
+    const introduced = scopeIntroducedNames(n);
+    const scope = introduced.size > 0 ? new Set([...shadowed, ...introduced]) : shadowed;
+
+    switch (n.type) {
+      case 'Identifier':
+        if (BROWSER_GLOBALS.has(n.name) && !bound.has(n.name) && !scope.has(n.name)) {
+          out.push({ name: n.name, line: lineOf(source, n.start) });
+        }
+        return;
+      case 'UnaryExpression':
+        if (n.operator === 'typeof' && n.argument?.type === 'Identifier') return; // guard idiom — never throws
+        break;
+      case 'MemberExpression':
+        visit(n.object, scope);
+        if (n.computed) visit(n.property, scope);
+        return;
+      case 'Property':
+        if (n.computed) visit(n.key, scope);
+        visit(n.value, scope);
+        return;
+      case 'VariableDeclarator':
+        visit(n.init, scope); // the id is a binding target, not a read
+        return;
+      case 'LabeledStatement':
+        visit(n.body, scope);
+        return;
+      case 'BreakStatement':
+      case 'ContinueStatement':
+      case 'ImportDeclaration':
+      case 'ExportAllDeclaration':
+        return;
+      case 'ExportNamedDeclaration':
+        if (!n.declaration) return; // bare specifiers aren't reads
+        break;
+    }
+    for (const key of Object.keys(n)) {
+      if (WALK_IGNORED_KEYS.has(key)) continue;
+      visit(n[key], scope);
+    }
+  };
+  visit(program, new Set());
+  return out;
+}
+```
+
+- [ ] **Step 6: Wire the facts**
+
+1. `parseModuleFacts`: alongside the other collectors add
+
+```ts
+const browserGlobalRefs: BrowserGlobalRefFact[] = program
+  ? collectBrowserGlobalRefs(program, wrapped).map((r) => ({ ...r, line: shift(r.line), context: 'module' as const }))
+  : [];
+```
+
+and include `browserGlobalRefs` in the return object. Extend the doc comment's populated-facts list.
+
+2. `parseComponentFacts` (`.svelte` path): after the `orphanLifecycleCalls` line add
+
+```ts
+const browserGlobalRefs: BrowserGlobalRefFact[] = [];
+const moduleProgram = ast.module?.content;
+if (moduleProgram) {
+  for (const r of collectBrowserGlobalRefs(moduleProgram, source)) {
+    browserGlobalRefs.push({ ...r, context: 'module' });
+  }
+}
+```
+
+and inside the existing `if (program) { … }` instance block (at its end, after the `constableStates` loop):
+
+```ts
+// Instance top level runs on the server during SSR (CORRECT009). The module
+// script's guard binding and top-level bindings are visible here — pass them in.
+const moduleExtra = moduleProgram
+  ? { guards: collectBrowserGuardImports(moduleProgram), bound: collectProgramBindings(moduleProgram) }
+  : undefined;
+for (const r of collectBrowserGlobalRefs(program, source, moduleExtra)) {
+  browserGlobalRefs.push({ ...r, context: 'instance' });
+}
+```
+
+Add `browserGlobalRefs` to the return object. NOTE: the existing code destructures `ast.module?.content` inline in two places — introduce the single `moduleProgram` const near the top of the `.svelte` path and reuse it for the existing `ast.module?.content` uses (pure refactor).
+
+3. `emptyComponentFacts` in `component-collect.ts`: add `browserGlobalRefs: [],`.
+
+- [ ] **Step 7: Literal fixups**
+
+Root `pnpm typecheck`; add `browserGlobalRefs: []` to every flagged `ComponentFacts` literal (the 7 core + 2 cli files listed in File Structure, next to `orphanLifecycleCalls: []`). Re-run until clean.
+
+- [ ] **Step 8: Run tests to verify pass**
+
+Run: `pnpm --filter @svelte-vitals/core test` then `pnpm --filter @svelte-vitals/core build && pnpm --filter svelte-vitals test`
+Expected: PASS, no existing assertion changed.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/core packages/cli
+git commit -m "feat(core): scan server-executed component code for browser-global reads"
+```
+
+---
+
+### Task 2: `KitModuleFacts.browserGlobalRefs` + `ssr = false` opt-out
+
+**Files:**
+
+- Modify: `packages/core/src/kit-module.ts` (field after `lifecycleCalls`)
+- Modify: `packages/core/src/kit-module-parse.ts`
+- Modify: `packages/core/src/kit-module-collect.ts` (`emptyKitModuleFacts`)
+- Modify: `packages/core/test/kit-module-parse.test.ts` (new describe); KitModuleFacts literal fixups: `packages/core/test/security-kit-rules.test.ts` (`kit()`), `packages/core/test/correctness-rules.test.ts` (`kitFacts()`)
+
+**Interfaces:**
+
+- Consumes (Task 1, from `./component-parse.js`): `collectBrowserGlobalRefs`, `collectBrowserGuardImports`, `collectProgramBindings`; existing kit internals `collectHandlerFunctions`, `collectStartupFunctions`, `collectTopLevelBindings`, `unwrapTs`, `unwrapExport`, `addBoundNames`, the `line()` shift helper.
+- Produces: `KitModuleFacts.browserGlobalRefs: { name: string; line: number; inHandler: boolean }[]` (Task 3 reads it).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/core/test/kit-module-parse.test.ts`:
+
+```ts
+describe('parseKitModuleFacts — browser-global refs (CORRECT008)', () => {
+  it('flags reads at top level and inside load with the right inHandler flags', () => {
+    const src = "const w = window.innerWidth;\nexport function load() {\n  return { s: localStorage.getItem('k') };\n}";
+    expect(facts(src, 'src/routes/+page.ts').browserGlobalRefs).toEqual([
+      { name: 'window', line: 1, inHandler: false },
+      { name: 'localStorage', line: 3, inHandler: true }
+    ]);
+  });
+  it('flags init-hook reads with inHandler false and exempts helper functions', () => {
+    const src = [
+      'export async function init() {',
+      '  document.title;',
+      '}',
+      'export function helper() {',
+      '  return window.innerWidth;',
+      '}'
+    ].join('\n');
+    expect(facts(src, 'src/hooks.server.ts').browserGlobalRefs).toEqual([
+      { name: 'document', line: 2, inHandler: false }
+    ]);
+  });
+  it('does not descend into closures nested inside a handler', () => {
+    const src = 'export function load() {\n  return { getWidth: () => window.innerWidth };\n}';
+    expect(facts(src, 'src/routes/+page.ts').browserGlobalRefs).toEqual([]);
+  });
+  it('respects browser/typeof guards and handler-parameter shadowing inside handlers', () => {
+    const src = [
+      "import { browser } from '$app/environment';",
+      'export function load({ window }) {',
+      '  if (browser) {',
+      '    document.title;',
+      '  }',
+      '  window.close();',
+      "  return typeof localStorage !== 'undefined' ? localStorage.getItem('k') : null;",
+      '}'
+    ].join('\n');
+    expect(facts(src, 'src/routes/+page.ts').browserGlobalRefs).toEqual([]);
+  });
+  it('empties the facts when the file itself exports ssr = false, but not for csr = false', () => {
+    const ssrOff =
+      'export const ssr = false;\nconst w = window.innerWidth;\nexport function load() {\n  return { t: document.title };\n}';
+    expect(facts(ssrOff, 'src/routes/+page.ts').browserGlobalRefs).toEqual([]);
+    const csrOff = 'export const csr = false;\nconst w = window.innerWidth;';
+    expect(facts(csrOff, 'src/routes/+page.ts').browserGlobalRefs).toEqual([
+      { name: 'window', line: 2, inHandler: false }
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pnpm --filter @svelte-vitals/core test -- kit-module-parse`
+Expected: FAIL — `browserGlobalRefs` is `undefined`.
+
+- [ ] **Step 3: Implement**
+
+1. `packages/core/src/kit-module.ts`, after `lifecycleCalls`:
+
+```ts
+/** Browser-global reads in server-executed positions — top level, handler bodies, the `init` hook (CORRECT008). Empty when the file itself exports `ssr = false`. */
+browserGlobalRefs: {
+  name: string;
+  line: number;
+  inHandler: boolean;
+}
+[];
+```
+
+2. `packages/core/src/kit-module-parse.ts`:
+   - Extend the import from `./component-parse.js` with `collectBrowserGlobalRefs, collectBrowserGuardImports, collectProgramBindings`.
+   - Add helper near `collectStartupFunctions`:
+
+```ts
+/**
+ * Whether this file opts out of the server entirely via `export const ssr = false`
+ * (satisfies-unwrapped; same-file alias export `export { ssr }` resolved). Such a file
+ * never runs on the server, so browser globals in it are legal (CORRECT008).
+ */
+function hasSsrFalseOptOut(program: Node): boolean {
+  const isFalse = (init: Node): boolean => {
+    const v = unwrapTs(init);
+    return v?.type === 'Literal' && v.value === false;
+  };
+  for (const stmt of program.body ?? []) {
+    const decl = unwrapExport(stmt);
+    if (decl?.type !== 'VariableDeclaration') continue;
+    for (const d of decl.declarations ?? []) {
+      if (d?.id?.type === 'Identifier' && d.id.name === 'ssr' && d.init && isFalse(d.init)) {
+        if (stmt.type === 'ExportNamedDeclaration') return true;
+      }
+    }
+  }
+  // Alias export: `const ssr = false; export { ssr };`
+  const bindings = collectTopLevelBindings(program);
+  for (const stmt of program.body ?? []) {
+    if (stmt?.type !== 'ExportNamedDeclaration' || !stmt.specifiers || stmt.source || stmt.exportKind === 'type')
+      continue;
+    for (const s of stmt.specifiers) {
+      if (s?.exportKind === 'type' || s?.exported?.type !== 'Identifier' || s?.local?.type !== 'Identifier') continue;
+      if (s.exported.name !== 'ssr') continue;
+      const resolved = bindings.get(s.local.name);
+      if (resolved?.type === 'Literal' && resolved.value === false) return true;
+    }
+  }
+  return false;
+}
+```
+
+- In `parseKitModuleFacts`: declare `const browserGlobalRefs: KitModuleFacts['browserGlobalRefs'] = [];` with the other arrays; include it in the early `!program` return and in the final return as `byLine(browserGlobalRefs)`.
+- After `startupFns` is computed, add the collection (NOT inside `walkKit` — the scanner has its own walk):
+
+```ts
+// CORRECT008 — browser-global reads in server-executed positions. The scanner stops
+// at function boundaries, so run it once over the program (top level) and once per
+// handler/init body; closures nested inside handlers are deliberately not entered
+// (they are typically client-side callbacks returned to components).
+if (!hasSsrFalseOptOut(program)) {
+  // The scanner returns line numbers computed against `wrapped` — subtract the
+  // 1-line wrap prefix (the local `line()` helper takes a byte OFFSET, not a line,
+  // so it must not be used here).
+  const shiftLine = (l: number) => Math.max(0, l - 1);
+  const guards = collectBrowserGuardImports(program);
+  const bound = collectProgramBindings(program);
+  for (const r of collectBrowserGlobalRefs(program, wrapped, { guards, bound })) {
+    browserGlobalRefs.push({ name: r.name, line: shiftLine(r.line), inHandler: false });
+  }
+  const scanFn = (fn: Node, inHandler: boolean) => {
+    if (!fn?.body) return;
+    const params = new Set<string>();
+    for (const p of fn.params ?? []) addBoundNames(p, params);
+    for (const r of collectBrowserGlobalRefs(fn.body, wrapped, { guards, bound: new Set([...bound, ...params]) })) {
+      browserGlobalRefs.push({ name: r.name, line: shiftLine(r.line), inHandler });
+    }
+  };
+  for (const fn of handlerFns) scanFn(fn, true);
+  for (const fn of startupFns) scanFn(fn, false);
+}
+```
+
+3. `emptyKitModuleFacts` in `kit-module-collect.ts`: add `browserGlobalRefs: [],`.
+4. Fixups: add `browserGlobalRefs: [],` to the `kit()` helper in `security-kit-rules.test.ts` and the `kitFacts()` helper in `correctness-rules.test.ts`; root typecheck for stragglers.
+
+- [ ] **Step 4: Run to verify pass, then commit**
+
+Run: `pnpm --filter @svelte-vitals/core test && pnpm --filter @svelte-vitals/core typecheck`
+Expected: PASS.
+
+```bash
+git add packages/core
+git commit -m "feat(core): collect browser-global reads in Kit route/hooks files with ssr=false opt-out"
+```
+
+---
+
+### Task 3: CORRECT008 + CORRECT009 rules
+
+**Files:**
+
+- Create: `packages/core/src/rules/correctness/correct008-browser-globals.ts`, `packages/core/src/rules/correctness/correct009-instance-browser-globals.ts`
+- Modify: `packages/core/src/rules/index.ts` (import/`allRules`/re-export, each after the `correct007OrphanLifecycle` entries), `packages/core/src/index.ts` (after `correct007OrphanLifecycle,`)
+- Modify: `packages/core/test/correctness-rules.test.ts`
+
+**Interfaces:**
+
+- Consumes: `ComponentFacts.browserGlobalRefs` (Task 1), `KitModuleFacts.browserGlobalRefs` (Task 2), `componentRule`, `docsUrlFor`.
+- Produces: exported `correct008BrowserGlobals: Rule`, `correct009InstanceBrowserGlobals: Rule`.
+
+- [ ] **Step 1: Write the failing rule tests**
+
+In `packages/core/test/correctness-rules.test.ts`, add both rule names to the `../src/index.js` import and append:
+
+```ts
+describe('CORRECT008 browser global in server module code', () => {
+  it('flags a module-context read as critical with the module message', async () => {
+    const rs = await correct008BrowserGlobals.check(
+      ctx([
+        comp({
+          file: 'src/lib/store.svelte.ts',
+          browserGlobalRefs: [{ name: 'window', line: 1, context: 'module' }]
+        })
+      ])
+    );
+    expect(fails(rs)).toHaveLength(1);
+    expect(rs[0]!.severity).toBe('critical');
+    expect(rs[0]!.message).toContain('window');
+    expect(rs[0]!.message).toContain('is not defined');
+  });
+  it('ignores instance-context refs (CORRECT009 territory) and reads the kit channel', async () => {
+    const rs = await correct008BrowserGlobals.check({
+      ...ctx([comp({ browserGlobalRefs: [{ name: 'window', line: 3, context: 'instance' }] })]),
+      kitModules: [kitFacts({ browserGlobalRefs: [{ name: 'localStorage', line: 3, inHandler: true }] })]
+    });
+    expect(fails(rs)).toHaveLength(1);
+    expect(fails(rs)[0]!.route).toBe('src/routes/+page.ts');
+    expect(fails(rs)[0]!.message).toContain('load/handler');
+  });
+  it('is silenced by suppressions and emits nothing in rendered mode', async () => {
+    const rs = await correct008BrowserGlobals.check(
+      ctx([
+        comp({
+          browserGlobalRefs: [{ name: 'window', line: 2, context: 'module' }],
+          suppressions: [{ line: 2, ruleIds: ['CORRECT008'] }]
+        })
+      ])
+    );
+    expect(fails(rs)).toHaveLength(0);
+    expect(await correct008BrowserGlobals.check(base as RuleContext)).toHaveLength(0);
+  });
+});
+
+describe('CORRECT009 browser global during component initialisation', () => {
+  it('flags an instance-context read as warning', async () => {
+    const rs = await correct009InstanceBrowserGlobals.check(
+      ctx([
+        comp({
+          file: 'src/lib/Widget.svelte',
+          browserGlobalRefs: [{ name: 'localStorage', line: 4, context: 'instance' }]
+        })
+      ])
+    );
+    expect(fails(rs)).toHaveLength(1);
+    expect(rs[0]!.severity).toBe('warning');
+    expect(rs[0]!.line).toBe(4);
+    expect(rs[0]!.message).toContain('localStorage');
+  });
+  it('ignores module-context refs and files without instance refs', async () => {
+    expect(
+      fails(
+        await correct009InstanceBrowserGlobals.check(
+          ctx([comp({ browserGlobalRefs: [{ name: 'window', line: 1, context: 'module' }] })])
+        )
+      )
+    ).toHaveLength(0);
+    expect(await correct009InstanceBrowserGlobals.check(ctx([comp({})]))).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pnpm --filter @svelte-vitals/core test -- correctness-rules`
+Expected: FAIL — rules not exported.
+
+- [ ] **Step 3: Implement CORRECT008**
+
+Create `packages/core/src/rules/correctness/correct008-browser-globals.ts`:
+
+```ts
+import type { Result } from '../../types.js';
+import { docsUrlFor, type Rule, type RuleContext } from '../../rule.js';
+import type { SuppressionDirective } from '../../component.js';
+
+const PENALIZED = { presence: 'none', value: 'absent' } as const;
+const PASS = { presence: 'own', value: 'static' } as const;
+
+const ID = 'CORRECT008';
+const DOCS_URL = docsUrlFor(ID);
+const LABEL = 'Server-safe module code';
+const RECOMMENDATION =
+  'Move browser-only code into onMount or $effect (they never run on the server), or guard it with browser from $app/environment (or a typeof check).';
+
+const moduleMessage = (name: string) =>
+  `${name} is accessed at module scope — it does not exist on the server, so importing this file crashes SSR with "${name} is not defined"`;
+
+function isSuppressed(suppressions: SuppressionDirective[] | undefined, line: number): boolean {
+  return (suppressions ?? []).some((s) => s.line === line && (!s.ruleIds || s.ruleIds.includes(ID)));
+}
+
+/** Emit one file's PASS/PENALIZED results — same shapes as componentRule/kitModuleRule. */
+function emitFile(
+  out: Result[],
+  file: string,
+  issues: { line: number; message: string }[],
+  suppressions: SuppressionDirective[] | undefined
+): void {
+  const bad = issues.filter((b) => !(b.line > 0 && isSuppressed(suppressions, b.line)));
+  if (bad.length === 0) {
+    out.push({
+      id: ID,
+      category: 'correctness',
+      severity: 'critical',
+      detection: PASS,
+      route: file,
+      message: LABEL,
+      recommendation: RECOMMENDATION,
+      docsUrl: DOCS_URL
+    });
+    return;
+  }
+  for (const b of bad) {
+    out.push({
+      id: ID,
+      category: 'correctness',
+      severity: 'critical',
+      detection: PENALIZED,
+      route: file,
+      location: file,
+      ...(b.line > 0 ? { line: b.line } : {}),
+      message: b.message,
+      recommendation: RECOMMENDATION,
+      docsUrl: DOCS_URL
+    });
+  }
+}
+
+/**
+ * CORRECT008 — browser globals read in server-executed MODULE code: module scope of
+ * runes modules / `<script module>`, and Kit route/hooks files (top level, handler
+ * bodies, the `init` hook). All of it runs on the server, where these globals do not
+ * exist — SSR crashes with a ReferenceError. Instance-script reads are CORRECT009's
+ * (warning) territory. A custom check because the facts live on both channels.
+ */
+export const correct008BrowserGlobals: Rule = {
+  id: ID,
+  title: 'Browser global in server module code',
+  category: 'correctness',
+  severity: 'critical',
+  scope: 'component',
+  rationale:
+    'window, document, localStorage and friends do not exist on the server; a read in module scope or a load/handler crashes SSR with a ReferenceError — the compiler does not catch it, and it surfaces as a production 500.',
+  async check(ctx: RuleContext): Promise<Result[]> {
+    const out: Result[] = [];
+    for (const c of ctx.components ?? []) {
+      const refs = (c.browserGlobalRefs ?? []).filter((r) => r.context === 'module');
+      if (refs.length === 0) continue;
+      emitFile(
+        out,
+        c.file,
+        refs.map((r) => ({ line: r.line, message: moduleMessage(r.name) })),
+        c.suppressions
+      );
+    }
+    for (const m of ctx.kitModules ?? []) {
+      const refs = m.browserGlobalRefs ?? [];
+      if (refs.length === 0) continue;
+      emitFile(
+        out,
+        m.file,
+        refs.map((r) => ({
+          line: r.line,
+          message: r.inHandler
+            ? `${r.name} is accessed in a load/handler — it runs on the server during SSR, where ${r.name} is not defined`
+            : moduleMessage(r.name)
+        })),
+        m.suppressions
+      );
+    }
+    return out;
+  }
+};
+```
+
+- [ ] **Step 4: Implement CORRECT009**
+
+Create `packages/core/src/rules/correctness/correct009-instance-browser-globals.ts`:
+
+```ts
+import { componentRule } from '../component-rule.js';
+
+export const correct009InstanceBrowserGlobals = componentRule({
+  id: 'CORRECT009',
+  title: 'Browser global during component initialisation',
+  category: 'correctness',
+  label: 'Server-safe component init',
+  recommendation:
+    'Move browser-only code into onMount or $effect (they never run on the server), or guard it with browser from $app/environment (or a typeof check).',
+  rationale:
+    'A component instance script runs on the server on every SSR render, where window/document/localStorage do not exist. Warning, not critical: a component rendered only behind a parent {#if browser} (or a client-only dynamic import) is a legitimate pattern that static analysis cannot prove cross-file.',
+  applies: (c) => (c.browserGlobalRefs ?? []).some((r) => r.context === 'instance'),
+  bad: (c) =>
+    (c.browserGlobalRefs ?? [])
+      .filter((r) => r.context === 'instance')
+      .map((r) => ({
+        line: r.line,
+        message: `${r.name} is accessed during component initialisation — during SSR this runs on the server, where ${r.name} is not defined`
+      }))
+});
+```
+
+- [ ] **Step 5: Register (four sites × 2 rules) and verify**
+
+`packages/core/src/rules/index.ts`: imports + `allRules` entries + re-exports for both rules, each directly after the `correct007OrphanLifecycle` line. `packages/core/src/index.ts`: both after `correct007OrphanLifecycle,`.
+
+Run: `grep -rn "correct008BrowserGlobals\|correct009InstanceBrowserGlobals" packages/core/src`
+Expected: 5 hits each.
+
+- [ ] **Step 6: Run to verify, then commit**
+
+Run: `pnpm --filter @svelte-vitals/core test`
+Expected: PASS (cli `docs-links` fails until Task 4 — expected).
+
+```bash
+git add packages/core
+git commit -m "feat(core): add CORRECT008/009 — flag browser globals in server-executed code"
+```
+
+---
+
+### Task 4: Docs (en/ja ×2), suppression range, changeset, full verification
+
+**Files:**
+
+- Create: `docs/src/content/docs/rules/correct008.md`, `correct009.md`, `docs/src/content/docs/ja/rules/correct008.md`, `correct009.md`
+- Modify: `docs/src/content/docs/guides/cli.md` (~line 217), `ja/guides/cli.md` (~line 215): `CORRECT001–007` → `CORRECT001–009`, nothing else, dash preserved
+- Create: `.changeset/correct008-009-browser-globals.md`
+
+- [ ] **Step 1: Write the four rule pages**
+
+`docs/src/content/docs/rules/correct008.md`:
+
+````md
+---
+title: CORRECT008 · Browser global in server module code
+description: window, document, localStorage accessed in module scope or a load/handler crash SSR with a ReferenceError.
+---
+
+**Severity:** critical · **Category:** correctness
+
+## What it checks
+
+Flags reads of browser-only globals (`window`, `document`, `localStorage`, `sessionStorage`, `navigator`, `location`, `history`, `screen`, `matchMedia`, `requestAnimationFrame`, `cancelAnimationFrame`, `IntersectionObserver`, `ResizeObserver`, `MutationObserver`, `alert`, `confirm`, `prompt`) in code that always runs on the server:
+
+- **module scope** of a `.svelte.ts`/`.svelte.js` runes module or a `.svelte` `<script module>` block (crashes when the module is imported on the server), and
+- **SvelteKit route/hooks files** — top level, `load`/action/endpoint handler bodies, and the `init` hook (crashes at import or on every request).
+
+Not flagged: code guarded by `browser` from `$app/environment` (aliases included) or a `typeof window !== 'undefined'` check; code inside `onMount`/`$effect`/ordinary functions (they don't run at module evaluation); a bare `typeof window` (never throws); names you imported or declared yourself (`const document = …`); closures nested inside handlers (typically client callbacks); and files that export `ssr = false` themselves.
+
+## Why it matters
+
+None of these globals exist in Node. A module-scope `window` read crashes the server the moment the file is imported; in a `load` it crashes every SSR request — `ReferenceError: window is not defined`, a production 500 the compiler never warns about.
+
+## How to fix
+
+```ts
+// +page.ts
+export function load() {
+  const stored = localStorage.getItem('filters'); // ❌ ReferenceError on the server
+
+  return {};
+}
+```
+
+Move the browser access to the client side:
+
+```svelte
+<!-- +page.svelte -->
+<script>
+  let stored = $state(null);
+  $effect(() => {
+    stored = localStorage.getItem('filters'); // ✅ effects never run on the server
+  });
+</script>
+```
+
+Or guard it explicitly:
+
+```ts
+import { browser } from '$app/environment';
+
+const stored = browser ? localStorage.getItem('filters') : null; // ✅
+```
+````
+
+`docs/src/content/docs/rules/correct009.md`:
+
+````md
+---
+title: CORRECT009 · Browser global during component initialisation
+description: A component's instance script runs on the server during SSR — window/document reads at its top level crash the render.
+---
+
+**Severity:** warning · **Category:** correctness
+
+## What it checks
+
+Flags reads of browser-only globals (the same list as [CORRECT008](/svelte-vitals/rules/correct008)) at the **top level of a component's `<script>`** — that code runs on the server on every SSR render of the component. The same guards apply: `browser` from `$app/environment`, `typeof` checks, `onMount`/`$effect` bodies, your own bindings, and shadowed locals are never flagged.
+
+## Why it matters
+
+`const width = window.innerWidth;` at the top of a component works in the browser and in a client-only dev flow, then crashes the first SSR render with `ReferenceError: window is not defined`.
+
+This is a **warning**, not critical: a component that is only ever rendered behind a parent's `{#if browser}` (or dynamically imported on the client) legitimately never runs on the server — and that cannot be proven from the component file alone. If that is your case, add `// svelte-vitals-disable-next-line CORRECT009` above the line.
+
+## How to fix
+
+```svelte
+<script>
+  const width = window.innerWidth; // ❌ crashes SSR
+
+  let width2 = $state(0);
+  $effect(() => {
+    width2 = window.innerWidth; // ✅ client-only
+  });
+</script>
+```
+````
+
+`docs/src/content/docs/ja/rules/correct008.md`:
+
+````md
+---
+title: CORRECT008 · サーバー実行モジュールコードでの browser global
+description: モジュールスコープや load/handler での window・document・localStorage 参照は SSR を ReferenceError でクラッシュさせます。
+---
+
+**重大度:** critical · **カテゴリ:** correctness
+
+## チェック内容
+
+**必ずサーバーで実行されるコード**での browser 専用 global(`window`、`document`、`localStorage`、`sessionStorage`、`navigator`、`location`、`history`、`screen`、`matchMedia`、`requestAnimationFrame`、`cancelAnimationFrame`、`IntersectionObserver`、`ResizeObserver`、`MutationObserver`、`alert`、`confirm`、`prompt`)の読み取りを検出します:
+
+- `.svelte.ts`/`.svelte.js` runes モジュールや `.svelte` の `<script module>` ブロックの**モジュールスコープ**(サーバーで import された瞬間にクラッシュ)
+- **SvelteKit のルート/フックファイル** — トップレベル、`load`/action/エンドポイント handler 本体、`init` フック(import 時またはリクエストごとにクラッシュ)
+
+検出対象外: `$app/environment` の `browser`(エイリアス込み)や `typeof window !== 'undefined'` チェックでガードされたコード、`onMount`/`$effect`/通常の関数内(モジュール評価時には実行されない)、裸の `typeof window`(throw しない)、自分で import/宣言した名前(`const document = …`)、handler 内にネストしたクロージャ(典型的にはクライアント側コールバック)、自身が `ssr = false` を export するファイル。
+
+## 重要な理由
+
+これらの global は Node に存在しません。モジュールスコープの `window` 参照はファイルがサーバーで import された瞬間に、`load` 内なら SSR リクエストのたびにクラッシュします — `ReferenceError: window is not defined`、コンパイラは一切警告しない本番 500 です。
+
+## 修正方法
+
+```ts
+// +page.ts
+export function load() {
+  const stored = localStorage.getItem('filters'); // ❌ サーバーで ReferenceError
+
+  return {};
+}
+```
+
+ブラウザアクセスをクライアント側へ移します:
+
+```svelte
+<!-- +page.svelte -->
+<script>
+  let stored = $state(null);
+  $effect(() => {
+    stored = localStorage.getItem('filters'); // ✅ effect はサーバーでは実行されない
+  });
+</script>
+```
+
+または明示的にガードします:
+
+```ts
+import { browser } from '$app/environment';
+
+const stored = browser ? localStorage.getItem('filters') : null; // ✅
+```
+````
+
+`docs/src/content/docs/ja/rules/correct009.md`:
+
+````md
+---
+title: CORRECT009 · コンポーネント初期化中の browser global
+description: コンポーネントの instance script は SSR 時にサーバーで実行されます — トップレベルの window/document 参照はレンダリングをクラッシュさせます。
+---
+
+**重大度:** warning · **カテゴリ:** correctness
+
+## チェック内容
+
+**コンポーネントの `<script>` トップレベル**での browser 専用 global([CORRECT008](/svelte-vitals/rules/correct008) と同じリスト)の読み取りを検出します — このコードはコンポーネントの SSR レンダリングのたびにサーバーで実行されます。ガードの扱いも同じです: `$app/environment` の `browser`、`typeof` チェック、`onMount`/`$effect` 本体、自前の binding、シャドーされたローカルは検出されません。
+
+## 重要な理由
+
+コンポーネント冒頭の `const width = window.innerWidth;` はブラウザ上とクライアント専用の開発フローでは動きますが、最初の SSR レンダリングで `ReferenceError: window is not defined` になります。
+
+これが critical ではなく **warning** なのは、親の `{#if browser}` の内側でのみレンダリングされる(またはクライアントで動的 import される)コンポーネントは正当にサーバーで実行されないためです — これはコンポーネントファイル単体からは証明できません。該当する場合は対象行の直前に `// svelte-vitals-disable-next-line CORRECT009` を書いてください。
+
+## 修正方法
+
+```svelte
+<script>
+  const width = window.innerWidth; // ❌ SSR がクラッシュ
+
+  let width2 = $state(0);
+  $effect(() => {
+    width2 = window.innerWidth; // ✅ クライアント専用
+  });
+</script>
+```
+````
+
+- [ ] **Step 2: Update the suppression range and verify docs-links**
+
+Both guide lines: `CORRECT001–007` → `CORRECT001–009`. Then:
+
+Run: `pnpm --filter @svelte-vitals/core build && pnpm --filter svelte-vitals test -- docs-links`
+Expected: PASS.
+
+- [ ] **Step 3: Add the changeset**
+
+Create `.changeset/correct008-009-browser-globals.md`:
+
+```md
+---
+'@svelte-vitals/core': minor
+'svelte-vitals': minor
+'@svelte-vitals/vite': minor
+'@svelte-vitals/mcp': minor
+---
+
+Add CORRECT008 (critical) and CORRECT009 (warning): flag browser-only globals (`window`, `document`, `localStorage`, …) read in server-executed code — module scope of runes modules and `<script module>`, SvelteKit load/handler/`init` bodies and file top levels (CORRECT008), and component instance-script top levels that run during SSR (CORRECT009). Recognises `browser`/`typeof` guards, respects same-file `export const ssr = false`, and never descends into `onMount`/`$effect`/function bodies.
+```
+
+- [ ] **Step 4: Full verification and commits**
+
+```bash
+pnpm build
+pnpm typecheck
+pnpm test
+pnpm lint
+```
+
+All green (`pnpm format` + re-run if formatting-only failure; fold reformats into the matching commit).
+
+```bash
+git add docs/src/content/docs .changeset
+git commit -m "docs: add CORRECT008/009 rule references (en/ja), extend suppression range, changeset"
+git add packages/action/dist/index.js
+git commit -m "chore(action): rebuild dist/ with the CORRECT008/009 core changes"
+```
+
+(Skip the second commit if no dist change.)
+
+---
+
+## Done criteria
+
+- `pnpm build && pnpm typecheck && pnpm test && pnpm lint` all green from the repo root.
+- 5 grep hits per rule export in `packages/core/src`.
+- Manual smoke (`/verify` before the PR): a fixture with `localStorage` in `load` reports critical CORRECT008; a component with top-level `window` reports warning CORRECT009; the same component with the access inside `$effect` reports nothing.
+- PR body in English.

--- a/docs/superpowers/specs/2026-07-16-correct008-009-browser-globals-design.md
+++ b/docs/superpowers/specs/2026-07-16-correct008-009-browser-globals-design.md
@@ -191,3 +191,8 @@ browser}`, dynamic import) — the reason CORRECT009 is a warning, with the
 window` at a guarded site then used elsewhere).
 - The curated list trades recall for precision — browser-only APIs outside
   the 17 names are not flagged.
+- **`$props()` destructuring defaults are not scanned** (`let { width =
+window.innerWidth } = $props()`) — the default only evaluates when the prop
+  is absent, including during SSR, but the scanner only visits a
+  `VariableDeclarator`'s `init`, never its `id` pattern's defaults — a
+  silent conservative miss.

--- a/docs/superpowers/specs/2026-07-16-correct008-009-browser-globals-design.md
+++ b/docs/superpowers/specs/2026-07-16-correct008-009-browser-globals-design.md
@@ -96,7 +96,11 @@ collision risk (`name`, `status`, `length`, …) are deliberately absent.
    generic key-walk. A guard binding derived from another guard, one level
    deep (`const canUse = browser && !!window.matchMedia;` then `if (canUse)
 {…}`), is also recognised via a one-pass pre-scan of the program's
-   top-level `const`/`let` declarators — no fixpoint chasing.
+   top-level `const`/`let` declarators (`collectDerivedGuardBindings`) — no
+   fixpoint chasing. The Kit parser and the `.svelte` instance scan run the
+   same pre-scan on the module program and pass the result through
+   `extra.guards`, so a module-level derived guard is recognised inside
+   handler bodies and the instance script.
 4. **TS type subtrees are never walked** — the generic key-walk stops at any
    `TS*` node (type aliases, interfaces, `TSTypeQuery`'s `typeof window`,
    generic type arguments, annotations), since none of that is runtime code.
@@ -196,3 +200,10 @@ window.innerWidth } = $props()`) — the default only evaluates when the prop
   is absent, including during SSR, but the scanner only visits a
   `VariableDeclarator`'s `init`, never its `id` pattern's defaults — a
   silent conservative miss.
+- **Nested-block early-return guards only stop their own block** — a
+  terminating guard inside a nested `{ … }` block ends the scan of that
+  block's remaining statements, but the guard's `return` actually exits the
+  whole function, so statements after the nested block are still scanned
+  and can false-positive. Contrived in practice (a bare nested block whose
+  guard returns for the enclosing function); a full control-flow
+  reachability analysis is out of scope for v1.

--- a/docs/superpowers/specs/2026-07-16-correct008-009-browser-globals-design.md
+++ b/docs/superpowers/specs/2026-07-16-correct008-009-browser-globals-design.md
@@ -87,7 +87,16 @@ collision risk (`name`, `status`, `length`, …) are deliberately absent.
    binding (`browser`) or (b) a `typeof <tracked-global> === | !==
 'undefined'` comparison is skipped **entirely, including the else
    branch** — a `window` access in the server branch of `if (browser) … else
-…` is a conservative miss, documented.
+…` is a conservative miss, documented. A **terminating early-return guard**
+   (`if (!browser) return {};` / `if (typeof window === 'undefined') throw
+…;`, any polarity) additionally stops the scan of the rest of its enclosing
+   `BlockStatement`/`Program` — the remaining statements never run in the
+   guarded environment, so the walk manually loops the container's
+   statement list and breaks after such a guard instead of relying on the
+   generic key-walk. A guard binding derived from another guard, one level
+   deep (`const canUse = browser && !!window.matchMedia;` then `if (canUse)
+{…}`), is also recognised via a one-pass pre-scan of the program's
+   top-level `const`/`let` declarators — no fixpoint chasing.
 4. **TS type subtrees are never walked** — the generic key-walk stops at any
    `TS*` node (type aliases, interfaces, `TSTypeQuery`'s `typeof window`,
    generic type arguments, annotations), since none of that is runtime code.
@@ -152,10 +161,13 @@ Changeset: core / `svelte-vitals` / vite / mcp — **minor**.
   function/`onMount`/`$effect` bodies excluded; module vs instance context
   split in `.svelte`; wrap −1 lines in `.svelte.ts`; TS type-position
   `typeof`/interface fields/generic type arguments never flagged, while
-  `as`/`satisfies` wrappers still scan their runtime expression.
+  `as`/`satisfies` wrappers still scan their runtime expression; a derived
+  guard binding (`const canUse = browser && …`) recognised one level deep.
 - **Kit**: access in `load` body (`inHandler: true`); top level and `init`
   (`false`); helper function exempt; `export const ssr = false` empties the
-  facts; `csr = false` does not.
+  facts; `csr = false` does not; a terminating early-return guard
+  (`if (!browser) return {};` / a `typeof` early return) stops scanning the
+  rest of the handler body, while code before the guard is still flagged.
 - **Rules**: severities and message variants; both channels for 008;
   suppression per channel; rendered-mode no-op; 009 via `componentRule`
   semantics.

--- a/docs/superpowers/specs/2026-07-16-correct008-009-browser-globals-design.md
+++ b/docs/superpowers/specs/2026-07-16-correct008-009-browser-globals-design.md
@@ -1,0 +1,172 @@
+# CORRECT008/009 — Browser globals in server-executed code
+
+**Date:** 2026-07-16
+**Status:** Approved design
+**Packages:** `@svelte-vitals/core` (facts + rules), `svelte-vitals` / `@svelte-vitals/vite` / `@svelte-vitals/mcp` (surface automatically)
+
+## Goal
+
+Add two rules catching `window` / `document` / `localStorage` (and friends)
+accessed in code that runs on the server, where those globals do not exist —
+the classic SSR `ReferenceError: window is not defined` 500:
+
+- **CORRECT008** (`critical`) — access in **server-executed module code**:
+  module scope of `.svelte.ts`/`.svelte.js` and `.svelte` `<script module>`
+  (crashes at import), and Kit route/hooks files (top level, load/handler
+  bodies, the `init` hook — crashes at import or per request).
+- **CORRECT009** (`warning`) — access at the **top level of a component's
+  instance script**: it runs on the server on every SSR render of the
+  component. Warning, not critical, because a component rendered only behind
+  a parent's `{#if browser}` (or a client-only dynamic import) is a
+  legitimate pattern that cannot be proven cross-file.
+
+Rule-selection criterion (maintainer, 2026-07-16): overlap with
+eslint-plugin-svelte's `no-top-level-browser-globals` is accepted — the
+deploy-blocker test dominates the duplication test.
+
+## Background (verified 2026-07-16)
+
+- eslint-plugin-svelte 3.20.0's `no-top-level-browser-globals` derives its
+  global list dynamically (`globals.browser` minus `globals.node` — hundreds
+  of names incl. generic words like `name`/`status`) and relies on eslint's
+  scope analysis to match only unresolved global references. svelte-vitals
+  has no scope-resolution engine, so adopting that list verbatim would
+  false-positive on ordinary identifiers. A **curated high-signal list** is
+  the correct adaptation.
+- Its recognised guards: `browser` from `$app/environment`, `typeof X !==
+'undefined'` checks, and `onMount` bodies. In svelte-vitals, function
+  bodies (incl. `onMount`/`$effect` callbacks and event handlers) are already
+  excluded by the eval-scope walk (`EVAL_SCOPE_BOUNDARIES`), so only the
+  `browser`/`typeof` guard skipping is new machinery.
+- Existing infrastructure reused: eval-scope walking with shadow tracking
+  (CORRECT006/007), the Kit channel with handler/`init` identification
+  (SEC003–005, CORRECT007), the wrap parser with −1 line shift.
+
+## Design
+
+### Approach decision
+
+**A (chosen): a dedicated position-aware scanner + facts on both channels.**
+Rejected: B — reusing `collectEvalScopeCalls` (it detects calls; identifier
+reads need parent/position awareness — forcing it would be a hack); C —
+eslint-style full scope analysis to unlock the complete `globals` list
+(an order-of-magnitude bigger engine for the ~10% tail; YAGNI).
+
+### 1. Tracked globals (curated, module-level constant `BROWSER_GLOBALS`)
+
+`window`, `document`, `localStorage`, `sessionStorage`, `navigator`,
+`location`, `history`, `screen`, `matchMedia`, `requestAnimationFrame`,
+`cancelAnimationFrame`, `IntersectionObserver`, `ResizeObserver`,
+`MutationObserver`, `alert`, `confirm`, `prompt` (17 names).
+
+Names available in Node (e.g. `fetch`, `setTimeout`, `console`,
+`URL`) are deliberately absent; generic browser-only names with high
+collision risk (`name`, `status`, `length`, …) are deliberately absent.
+
+### 2. Scanner — `collectBrowserGlobalRefs(program, source, …)` (component-parse.ts, shared with the Kit parser)
+
+1. **Pre-pass** — names that disqualify a candidate for the whole program:
+   every import's local name and every top-level declaration name
+   (export-unwrapped; `const document = …` / `import { window } from
+'happy-dom'` are real bindings, not global reads). Also collect the
+   **guard binding**: the local name(s) of `browser` value-imported from
+   `'$app/environment'` (alias-resolved).
+2. **Walk** — stops at eval-scope boundaries (functions/classes never run at
+   module evaluation / component init) and threads the shadow set
+   (CORRECT007's mechanism), so `onMount`/`$effect` callbacks, event
+   handlers, and locally shadowed names never match. **Position discipline**
+   (modeled on `bodyReadsReactive`): an `Identifier` matches only in read
+   positions — never as a non-computed `MemberExpression.property`, a
+   non-computed `Property.key`, a declaration id, a function/method name, an
+   import/export specifier, or a label. `window.innerWidth` matches via the
+   `window` object position. A bare `typeof window` operand does **not**
+   match — `typeof` on an undeclared name does not throw and is itself the
+   guard idiom.
+3. **Guard skipping** — an `IfStatement` / `ConditionalExpression` /
+   `LogicalExpression` whose test contains (a) a reference to a guard
+   binding (`browser`) or (b) a `typeof <tracked-global> === | !==
+'undefined'` comparison is skipped **entirely, including the else
+   branch** — a `window` access in the server branch of `if (browser) … else
+…` is a conservative miss, documented.
+4. Output `{ name: string; line: number }[]` in walk (source) order.
+
+### 3. Facts
+
+- `ComponentFacts.browserGlobalRefs: { name: string; line: number; context: 'module' | 'instance' }[]`
+  — `.svelte.ts`/`.svelte.js`: whole program as `'module'` (wrap −1 shift).
+  `.svelte`: `<script module>` as `'module'`, and — a first for this fact
+  family — the **instance script** as `'instance'` (its top level runs on
+  the server during SSR). Each script's own pre-pass runs on its own program
+  (imports may live in either script; the guard binding set is the union of
+  both scripts' imports).
+- `KitModuleFacts.browserGlobalRefs: { name: string; line: number; inHandler: boolean }[]`
+  — flag positions identical to CORRECT007's `lifecycleCalls`: top level,
+  handler bodies, the `init` hook; helper functions exempt. **Same-file
+  opt-out**: when the file itself has `export const ssr = false`
+  (satisfies-unwrapped, top-level or alias export), the whole fact array
+  stays empty — the file never runs on the server. `csr = false` does not
+  opt out (that declares server-only rendering; the globals still crash).
+
+### 4. Rules
+
+**CORRECT008 — `Browser global in server module code`** (`critical`,
+`category: 'correctness'`, `scope: 'component'`): custom `check(ctx)` (the
+CORRECT007 shape) reading `ComponentFacts.browserGlobalRefs` filtered to
+`context === 'module'` plus `KitModuleFacts.browserGlobalRefs`. Messages:
+
+- module: `` `${name} is accessed at module scope — it does not exist on the server, so importing this file crashes SSR with "${name} is not defined"` ``
+- kit `inHandler`: `` `${name} is accessed in a load/handler — it runs on the server during SSR, where ${name} is not defined` ``
+- kit top-level/`init`: the module message.
+
+**CORRECT009 — `Browser global during component initialisation`**
+(`warning`, built with the `componentRule` factory): flags
+`browserGlobalRefs` with `context === 'instance'`. Message:
+`` `${name} is accessed during component initialisation — during SSR this runs on the server, where ${name} is not defined` ``.
+
+Shared `recommendation`: `"Move browser-only code into onMount or $effect (they never run on the server), or guard it with browser from $app/environment (or a typeof check)."`
+
+Rationales state the crash class (008) and the warning reasoning — the
+unprovable client-only-component pattern (009).
+
+### 5. Registration, docs, changeset
+
+Four registration sites per rule + grep checks. Docs:
+`docs/src/content/docs/rules/correct008.md`, `correct009.md` + ja mirrors;
+CLI-guide suppression range (en/ja) `CORRECT001–007` → `CORRECT001–009`.
+Changeset: core / `svelte-vitals` / vite / mcp — **minor**.
+
+## Testing
+
+- **Scanner**: reads of representative globals (bare + member-object
+  position); `typeof window` operand not flagged; non-computed property
+  key/member-property not flagged; local declaration and import of a
+  tracked name excluded; nested shadowing excluded; `browser` guard
+  (plain + aliased) skips if/ternary/`&&`; `typeof` guard skips;
+  function/`onMount`/`$effect` bodies excluded; module vs instance context
+  split in `.svelte`; wrap −1 lines in `.svelte.ts`.
+- **Kit**: access in `load` body (`inHandler: true`); top level and `init`
+  (`false`); helper function exempt; `export const ssr = false` empties the
+  facts; `csr = false` does not.
+- **Rules**: severities and message variants; both channels for 008;
+  suppression per channel; rendered-mode no-op; 009 via `componentRule`
+  semantics.
+- Full existing suite unchanged; root `pnpm build` / `typecheck` / `test` /
+  `lint` green.
+
+## Known limitations / out of scope (v1, documented in the rule docs)
+
+- **Guard else-branches are skipped entirely** — a server-side branch of
+  `if (browser) … else …` that touches a browser global is a conservative
+  miss.
+- **Client-only components are unprovable cross-file** (parent `{#if
+browser}`, dynamic import) — the reason CORRECT009 is a warning, with the
+  inline suppression as the escape hatch.
+- **`ssr = false` opt-out is same-file only** — a root `+layout.ts` turning
+  SSR off app-wide is not detected.
+- **`import.meta.env.SSR` guards are not recognised** (v1).
+- **Template expressions are not scanned** (`{window.innerWidth}` in markup
+  also runs during SSR — future extension).
+- **Indirect access is not tracked** (`globalThis.window`, `const w =
+window` at a guarded site then used elsewhere).
+- The curated list trades recall for precision — browser-only APIs outside
+  the 17 names are not flagged.

--- a/docs/superpowers/specs/2026-07-16-correct008-009-browser-globals-design.md
+++ b/docs/superpowers/specs/2026-07-16-correct008-009-browser-globals-design.md
@@ -88,7 +88,14 @@ collision risk (`name`, `status`, `length`, …) are deliberately absent.
 'undefined'` comparison is skipped **entirely, including the else
    branch** — a `window` access in the server branch of `if (browser) … else
 …` is a conservative miss, documented.
-4. Output `{ name: string; line: number }[]` in walk (source) order.
+4. **TS type subtrees are never walked** — the generic key-walk stops at any
+   `TS*` node (type aliases, interfaces, `TSTypeQuery`'s `typeof window`,
+   generic type arguments, annotations), since none of that is runtime code.
+   The four TS _expression wrapper_ forms (`TSAsExpression`,
+   `TSSatisfiesExpression`, `TSNonNullExpression`, `TSInstantiationExpression`)
+   still have their runtime `.expression` visited — `foo as typeof window` is
+   not flagged, but `window.innerWidth as number` still is.
+5. Output `{ name: string; line: number }[]` in walk (source) order.
 
 ### 3. Facts
 
@@ -143,7 +150,9 @@ Changeset: core / `svelte-vitals` / vite / mcp — **minor**.
   tracked name excluded; nested shadowing excluded; `browser` guard
   (plain + aliased) skips if/ternary/`&&`; `typeof` guard skips;
   function/`onMount`/`$effect` bodies excluded; module vs instance context
-  split in `.svelte`; wrap −1 lines in `.svelte.ts`.
+  split in `.svelte`; wrap −1 lines in `.svelte.ts`; TS type-position
+  `typeof`/interface fields/generic type arguments never flagged, while
+  `as`/`satisfies` wrappers still scan their runtime expression.
 - **Kit**: access in `load` body (`inHandler: true`); top level and `init`
   (`false`); helper function exempt; `export const ssr = false` empties the
   facts; `csr = false` does not.

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -55202,19 +55202,24 @@ function isBrowserGuardTest(test, guardBindings) {
   });
   return guarded;
 }
-function collectBrowserGlobalRefs(program, source2, extra) {
-  const out = [];
-  const bound = /* @__PURE__ */ new Set([...collectProgramBindings(program), ...extra?.bound ?? []]);
-  const guards = /* @__PURE__ */ new Set([...collectBrowserGuardImports(program), ...extra?.guards ?? []]);
+function collectDerivedGuardBindings(program, guards) {
+  const derived = /* @__PURE__ */ new Set();
   for (const stmt2 of program.body ?? []) {
     const decl = unwrapExport(stmt2);
     if (decl?.type !== "VariableDeclaration" || decl.kind !== "const" && decl.kind !== "let") continue;
     for (const d of decl.declarations ?? []) {
       if (d?.id?.type === "Identifier" && d.init && isBrowserGuardTest(d.init, guards)) {
-        guards.add(d.id.name);
+        derived.add(d.id.name);
       }
     }
   }
+  return derived;
+}
+function collectBrowserGlobalRefs(program, source2, extra) {
+  const out = [];
+  const bound = /* @__PURE__ */ new Set([...collectProgramBindings(program), ...extra?.bound ?? []]);
+  const guards = /* @__PURE__ */ new Set([...collectBrowserGuardImports(program), ...extra?.guards ?? []]);
+  for (const name of collectDerivedGuardBindings(program, guards)) guards.add(name);
   const visit = (n, shadowed) => {
     if (!n) return;
     if (Array.isArray(n)) {
@@ -55421,7 +55426,14 @@ function parseComponentFacts(source2, filename2) {
     for (const d of stateDecls) {
       if (!writtenOrEscaped.has(d.name)) constableStates.push(d);
     }
-    const moduleExtra = moduleProgram ? { guards: collectBrowserGuardImports(moduleProgram), bound: collectProgramBindings(moduleProgram) } : void 0;
+    let moduleExtra;
+    if (moduleProgram) {
+      const moduleBrowserImports = collectBrowserGuardImports(moduleProgram);
+      moduleExtra = {
+        guards: /* @__PURE__ */ new Set([...moduleBrowserImports, ...collectDerivedGuardBindings(moduleProgram, moduleBrowserImports)]),
+        bound: collectProgramBindings(moduleProgram)
+      };
+    }
     for (const r of collectBrowserGlobalRefs(program, source2, moduleExtra)) {
       browserGlobalRefs.push({ ...r, context: "instance" });
     }
@@ -55717,7 +55729,8 @@ function parseKitModuleFacts(source2, filename2) {
   const svelteImports = collectSvelteLifecycleImports(program);
   if (!hasSsrFalseOptOut(program)) {
     const shiftLine = (l) => Math.max(0, l - 1);
-    const guards = collectBrowserGuardImports(program);
+    const browserImports = collectBrowserGuardImports(program);
+    const guards = /* @__PURE__ */ new Set([...browserImports, ...collectDerivedGuardBindings(program, browserImports)]);
     const bound = collectProgramBindings(program);
     for (const r of collectBrowserGlobalRefs(program, wrapped, { guards, bound })) {
       browserGlobalRefs.push({ name: r.name, line: shiftLine(r.line), inHandler: false });

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -55178,6 +55178,15 @@ function collectProgramBindings(program) {
   }
   return bound;
 }
+function guardTerminates(consequent) {
+  if (!consequent) return false;
+  if (consequent.type === "ReturnStatement" || consequent.type === "ThrowStatement") return true;
+  if (consequent.type === "BlockStatement") {
+    const last = (consequent.body ?? [])[consequent.body.length - 1];
+    return last?.type === "ReturnStatement" || last?.type === "ThrowStatement";
+  }
+  return false;
+}
 function isBrowserGuardTest(test, guardBindings) {
   let guarded = false;
   walkEstree(test, (n) => {
@@ -55197,6 +55206,15 @@ function collectBrowserGlobalRefs(program, source2, extra) {
   const out = [];
   const bound = /* @__PURE__ */ new Set([...collectProgramBindings(program), ...extra?.bound ?? []]);
   const guards = /* @__PURE__ */ new Set([...collectBrowserGuardImports(program), ...extra?.guards ?? []]);
+  for (const stmt2 of program.body ?? []) {
+    const decl = unwrapExport(stmt2);
+    if (decl?.type !== "VariableDeclaration" || decl.kind !== "const" && decl.kind !== "let") continue;
+    for (const d of decl.declarations ?? []) {
+      if (d?.id?.type === "Identifier" && d.init && isBrowserGuardTest(d.init, guards)) {
+        guards.add(d.id.name);
+      }
+    }
+  }
   const visit = (n, shadowed) => {
     if (!n) return;
     if (Array.isArray(n)) {
@@ -55240,6 +55258,22 @@ function collectBrowserGlobalRefs(program, source2, extra) {
       case "ExportNamedDeclaration":
         if (!n.declaration) return;
         break;
+      case "BlockStatement":
+      case "Program":
+        for (const stmt2 of n.body ?? []) {
+          visit(stmt2, scope);
+          if (stmt2?.type === "IfStatement" && isBrowserGuardTest(stmt2.test, guards) && guardTerminates(stmt2.consequent)) {
+            break;
+          }
+        }
+        return;
+      default:
+        if (n.type.startsWith("TS")) {
+          if (n.type === "TSAsExpression" || n.type === "TSSatisfiesExpression" || n.type === "TSNonNullExpression" || n.type === "TSInstantiationExpression") {
+            visit(n.expression, scope);
+          }
+          return;
+        }
     }
     for (const key2 of Object.keys(n)) {
       if (WALK_IGNORED_KEYS.has(key2)) continue;

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -55129,6 +55129,126 @@ function collectOrphanLifecycleCalls(program, source2) {
     return m && !shadowed.has(m.local) ? m.canonical : void 0;
   });
 }
+var BROWSER_GLOBALS = /* @__PURE__ */ new Set([
+  "window",
+  "document",
+  "localStorage",
+  "sessionStorage",
+  "navigator",
+  "location",
+  "history",
+  "screen",
+  "matchMedia",
+  "requestAnimationFrame",
+  "cancelAnimationFrame",
+  "IntersectionObserver",
+  "ResizeObserver",
+  "MutationObserver",
+  "alert",
+  "confirm",
+  "prompt"
+]);
+function collectBrowserGuardImports(program) {
+  const out = /* @__PURE__ */ new Set();
+  for (const stmt2 of program.body ?? []) {
+    if (stmt2?.type !== "ImportDeclaration" || stmt2.importKind === "type" || stmt2.source?.value !== "$app/environment")
+      continue;
+    for (const s of stmt2.specifiers ?? []) {
+      if (s?.importKind === "type" || s?.local?.type !== "Identifier") continue;
+      if (s.type === "ImportSpecifier" && s.imported?.type === "Identifier" && s.imported.name === "browser") {
+        out.add(s.local.name);
+      }
+    }
+  }
+  return out;
+}
+function collectProgramBindings(program) {
+  const bound = /* @__PURE__ */ new Set();
+  for (const stmt2 of program.body ?? []) {
+    if (stmt2?.type === "ImportDeclaration") {
+      for (const s of stmt2.specifiers ?? []) if (s?.local?.type === "Identifier") bound.add(s.local.name);
+      continue;
+    }
+    const decl = unwrapExport(stmt2);
+    if (decl?.type === "VariableDeclaration") {
+      for (const d of decl.declarations ?? []) addBoundNames(d?.id, bound);
+    } else if ((decl?.type === "FunctionDeclaration" || decl?.type === "ClassDeclaration") && decl.id?.type === "Identifier") {
+      bound.add(decl.id.name);
+    }
+  }
+  return bound;
+}
+function isBrowserGuardTest(test, guardBindings) {
+  let guarded = false;
+  walkEstree(test, (n) => {
+    if (n.type === "Identifier" && guardBindings.has(n.name)) guarded = true;
+    if (n.type === "BinaryExpression" && ["===", "!==", "==", "!="].includes(n.operator)) {
+      const sides = [n.left, n.right];
+      const hasTypeofGlobal = sides.some(
+        (s) => s?.type === "UnaryExpression" && s.operator === "typeof" && s.argument?.type === "Identifier" && BROWSER_GLOBALS.has(s.argument.name)
+      );
+      const hasUndefinedString = sides.some((s) => s?.type === "Literal" && s.value === "undefined");
+      if (hasTypeofGlobal && hasUndefinedString) guarded = true;
+    }
+  });
+  return guarded;
+}
+function collectBrowserGlobalRefs(program, source2, extra) {
+  const out = [];
+  const bound = /* @__PURE__ */ new Set([...collectProgramBindings(program), ...extra?.bound ?? []]);
+  const guards = /* @__PURE__ */ new Set([...collectBrowserGuardImports(program), ...extra?.guards ?? []]);
+  const visit = (n, shadowed) => {
+    if (!n) return;
+    if (Array.isArray(n)) {
+      for (const c of n) visit(c, shadowed);
+      return;
+    }
+    if (typeof n !== "object" || typeof n.type !== "string") return;
+    if (EVAL_SCOPE_BOUNDARIES.has(n.type)) return;
+    if ((n.type === "IfStatement" || n.type === "ConditionalExpression") && isBrowserGuardTest(n.test, guards)) return;
+    if (n.type === "LogicalExpression" && isBrowserGuardTest(n.left, guards)) return;
+    const introduced = scopeIntroducedNames(n);
+    const scope = introduced.size > 0 ? /* @__PURE__ */ new Set([...shadowed, ...introduced]) : shadowed;
+    switch (n.type) {
+      case "Identifier":
+        if (BROWSER_GLOBALS.has(n.name) && !bound.has(n.name) && !scope.has(n.name)) {
+          out.push({ name: n.name, line: lineOf(source2, n.start) });
+        }
+        return;
+      case "UnaryExpression":
+        if (n.operator === "typeof" && n.argument?.type === "Identifier") return;
+        break;
+      case "MemberExpression":
+        visit(n.object, scope);
+        if (n.computed) visit(n.property, scope);
+        return;
+      case "Property":
+        if (n.computed) visit(n.key, scope);
+        visit(n.value, scope);
+        return;
+      case "VariableDeclarator":
+        visit(n.init, scope);
+        return;
+      case "LabeledStatement":
+        visit(n.body, scope);
+        return;
+      case "BreakStatement":
+      case "ContinueStatement":
+      case "ImportDeclaration":
+      case "ExportAllDeclaration":
+        return;
+      case "ExportNamedDeclaration":
+        if (!n.declaration) return;
+        break;
+    }
+    for (const key2 of Object.keys(n)) {
+      if (WALK_IGNORED_KEYS.has(key2)) continue;
+      visit(n[key2], scope);
+    }
+  };
+  visit(program, /* @__PURE__ */ new Set());
+  return out;
+}
 var MODULE_FILE_RE = /\.svelte\.(ts|js)$/;
 function parseModuleProgram(source2, filename2) {
   const neutralized = source2.replace(/<\/script/gi, "<_script");
@@ -55178,6 +55298,7 @@ function parseModuleFacts(source2, filename2) {
   const shift = (line) => Math.max(0, line - 1);
   const orphanEffects = program ? collectOrphanEffects(program, wrapped).map((f) => ({ ...f, line: shift(f.line) })) : [];
   const orphanLifecycleCalls = program ? collectOrphanLifecycleCalls(program, wrapped).map((f) => ({ ...f, line: shift(f.line) })) : [];
+  const browserGlobalRefs = program ? collectBrowserGlobalRefs(program, wrapped).map((r) => ({ ...r, line: shift(r.line), context: "module" })) : [];
   const moduleStateDecls = program ? collectModuleStateDecls(program, wrapped).map((d) => ({ ...d, line: shift(d.line) })) : [];
   return {
     eachBlocks: [],
@@ -55194,6 +55315,7 @@ function parseModuleFacts(source2, filename2) {
     suppressions: collectSuppressions(source2),
     orphanEffects,
     orphanLifecycleCalls,
+    browserGlobalRefs,
     moduleStateDecls
   };
 }
@@ -55207,14 +55329,21 @@ function parseComponentFacts(source2, filename2) {
   collectSecurityFacts(ast.fragment ?? ast, source2, htmlTags, javascriptUrls);
   const loc = countLines(source2);
   const suppressions = collectSuppressions(source2);
+  const moduleProgram = ast.module?.content;
   const importSpans = [];
   const namespaceImports = [];
-  if (ast.module?.content) {
-    collectImportSources(ast.module.content, source2, importSpans);
-    collectNamespaceImports(ast.module.content, source2, namespaceImports);
+  if (moduleProgram) {
+    collectImportSources(moduleProgram, source2, importSpans);
+    collectNamespaceImports(moduleProgram, source2, namespaceImports);
   }
-  const orphanEffects = ast.module?.content ? collectOrphanEffects(ast.module.content, source2) : [];
-  const orphanLifecycleCalls = ast.module?.content ? collectOrphanLifecycleCalls(ast.module.content, source2) : [];
+  const orphanEffects = moduleProgram ? collectOrphanEffects(moduleProgram, source2) : [];
+  const orphanLifecycleCalls = moduleProgram ? collectOrphanLifecycleCalls(moduleProgram, source2) : [];
+  const browserGlobalRefs = [];
+  if (moduleProgram) {
+    for (const r of collectBrowserGlobalRefs(moduleProgram, source2)) {
+      browserGlobalRefs.push({ ...r, context: "module" });
+    }
+  }
   const effects = [];
   const constableStates = [];
   const mutatedProps = [];
@@ -55258,6 +55387,10 @@ function parseComponentFacts(source2, filename2) {
     for (const d of stateDecls) {
       if (!writtenOrEscaped.has(d.name)) constableStates.push(d);
     }
+    const moduleExtra = moduleProgram ? { guards: collectBrowserGuardImports(moduleProgram), bound: collectProgramBindings(moduleProgram) } : void 0;
+    for (const r of collectBrowserGlobalRefs(program, source2, moduleExtra)) {
+      browserGlobalRefs.push({ ...r, context: "instance" });
+    }
   }
   const imports2 = importSpans.map((s) => s.source);
   return {
@@ -55274,6 +55407,7 @@ function parseComponentFacts(source2, filename2) {
     mutatedProps,
     orphanEffects,
     orphanLifecycleCalls,
+    browserGlobalRefs,
     moduleStateDecls: [],
     suppressions
   };
@@ -55294,6 +55428,7 @@ function emptyComponentFacts(file) {
     mutatedProps: [],
     orphanEffects: [],
     orphanLifecycleCalls: [],
+    browserGlobalRefs: [],
     moduleStateDecls: [],
     suppressions: []
   };
@@ -55424,6 +55559,33 @@ function collectStartupFunctions(program) {
   resolveAliasStartupExports(program, collectTopLevelBindings(program), startup);
   return startup;
 }
+function hasSsrFalseOptOut(program) {
+  const isFalse = (init2) => {
+    const v = unwrapTs(init2);
+    return v?.type === "Literal" && v.value === false;
+  };
+  for (const stmt2 of program.body ?? []) {
+    const decl = unwrapExport(stmt2);
+    if (decl?.type !== "VariableDeclaration") continue;
+    for (const d of decl.declarations ?? []) {
+      if (d?.id?.type === "Identifier" && d.id.name === "ssr" && d.init && isFalse(d.init)) {
+        if (stmt2.type === "ExportNamedDeclaration") return true;
+      }
+    }
+  }
+  const bindings = collectTopLevelBindings(program);
+  for (const stmt2 of program.body ?? []) {
+    if (stmt2?.type !== "ExportNamedDeclaration" || !stmt2.specifiers || stmt2.source || stmt2.exportKind === "type")
+      continue;
+    for (const s of stmt2.specifiers) {
+      if (s?.exportKind === "type" || s?.exported?.type !== "Identifier" || s?.local?.type !== "Identifier") continue;
+      if (s.exported.name !== "ssr") continue;
+      const resolved = bindings.get(s.local.name);
+      if (resolved?.type === "Literal" && resolved.value === false) return true;
+    }
+  }
+  return false;
+}
 function walkKit(node, handlerFns, startupFns, visit, shadowed = /* @__PURE__ */ new Set(), inFunction = false, inHandler = false, inStartup = false) {
   if (Array.isArray(node)) {
     for (const child of node) walkKit(child, handlerFns, startupFns, visit, shadowed, inFunction, inHandler, inStartup);
@@ -55482,6 +55644,7 @@ function parseKitModuleFacts(source2, filename2) {
   const importedStateWritesOutsideHandlers = [];
   const runesModuleImports = [];
   const lifecycleCalls = [];
+  const browserGlobalRefs = [];
   if (!program) {
     return {
       moduleStateReassignments,
@@ -55489,6 +55652,7 @@ function parseKitModuleFacts(source2, filename2) {
       importedStateWritesOutsideHandlers,
       runesModuleImports,
       lifecycleCalls,
+      browserGlobalRefs,
       suppressions
     };
   }
@@ -55517,6 +55681,27 @@ function parseKitModuleFacts(source2, filename2) {
   const handlerFns = collectHandlerFunctions(program);
   const startupFns = collectStartupFunctions(program);
   const svelteImports = collectSvelteLifecycleImports(program);
+  if (!hasSsrFalseOptOut(program)) {
+    const shiftLine = (l) => Math.max(0, l - 1);
+    const guards = collectBrowserGuardImports(program);
+    const bound = collectProgramBindings(program);
+    for (const r of collectBrowserGlobalRefs(program, wrapped, { guards, bound })) {
+      browserGlobalRefs.push({ name: r.name, line: shiftLine(r.line), inHandler: false });
+    }
+    const scanFn = (fn, inHandler) => {
+      if (!fn?.body) return;
+      const params = /* @__PURE__ */ new Set();
+      for (const p of fn.params ?? []) addBoundNames(p, params);
+      for (const r of collectBrowserGlobalRefs(fn.body, wrapped, { guards, bound: /* @__PURE__ */ new Set([...bound, ...params]) })) {
+        browserGlobalRefs.push({ name: r.name, line: shiftLine(r.line), inHandler });
+      }
+    };
+    for (const fn of handlerFns) scanFn(fn, true);
+    for (const fn of startupFns) {
+      if (handlerFns.has(fn)) continue;
+      scanFn(fn, false);
+    }
+  }
   walkKit(program, handlerFns, startupFns, (n, shadowed, inFunction, inHandler, inStartup) => {
     if (inFunction && !inStartup) {
       const flagLet = (name) => {
@@ -55594,6 +55779,7 @@ function parseKitModuleFacts(source2, filename2) {
     importedStateWritesOutsideHandlers: byLine(importedStateWritesOutsideHandlers),
     runesModuleImports: byLine(runesModuleImports),
     lifecycleCalls: byLine(lifecycleCalls),
+    browserGlobalRefs: byLine(browserGlobalRefs),
     suppressions
   };
 }
@@ -55606,6 +55792,7 @@ function emptyKitModuleFacts(file, kind) {
     importedStateWritesOutsideHandlers: [],
     runesModuleImports: [],
     lifecycleCalls: [],
+    browserGlobalRefs: [],
     suppressions: []
   };
 }
@@ -57207,6 +57394,94 @@ var correct007OrphanLifecycle = {
     return out;
   }
 };
+var PENALIZED4 = { presence: "none", value: "absent" };
+var PASS4 = { presence: "own", value: "static" };
+var ID2 = "CORRECT008";
+var DOCS_URL2 = docsUrlFor(ID2);
+var LABEL2 = "Server-safe module code";
+var RECOMMENDATION2 = "Move browser-only code into onMount or $effect (they never run on the server), or guard it with browser from $app/environment (or a typeof check).";
+var moduleMessage = (name) => `${name} is accessed at module scope \u2014 it does not exist on the server, so importing this file crashes SSR with "${name} is not defined"`;
+function isSuppressed3(suppressions, line) {
+  return (suppressions ?? []).some((s) => s.line === line && (!s.ruleIds || s.ruleIds.includes(ID2)));
+}
+function emitFile2(out, file, issues, suppressions) {
+  const bad = issues.filter((b) => !(b.line > 0 && isSuppressed3(suppressions, b.line)));
+  if (bad.length === 0) {
+    out.push({
+      id: ID2,
+      category: "correctness",
+      severity: "critical",
+      detection: PASS4,
+      route: file,
+      message: LABEL2,
+      recommendation: RECOMMENDATION2,
+      docsUrl: DOCS_URL2
+    });
+    return;
+  }
+  for (const b of bad) {
+    out.push({
+      id: ID2,
+      category: "correctness",
+      severity: "critical",
+      detection: PENALIZED4,
+      route: file,
+      location: file,
+      ...b.line > 0 ? { line: b.line } : {},
+      message: b.message,
+      recommendation: RECOMMENDATION2,
+      docsUrl: DOCS_URL2
+    });
+  }
+}
+var correct008BrowserGlobals = {
+  id: ID2,
+  title: "Browser global in server module code",
+  category: "correctness",
+  severity: "critical",
+  scope: "component",
+  rationale: "window, document, localStorage and friends do not exist on the server; a read in module scope or a load/handler crashes SSR with a ReferenceError \u2014 the compiler does not catch it, and it surfaces as a production 500.",
+  async check(ctx) {
+    const out = [];
+    for (const c of ctx.components ?? []) {
+      const refs = (c.browserGlobalRefs ?? []).filter((r) => r.context === "module");
+      if (refs.length === 0) continue;
+      emitFile2(
+        out,
+        c.file,
+        refs.map((r) => ({ line: r.line, message: moduleMessage(r.name) })),
+        c.suppressions
+      );
+    }
+    for (const m of ctx.kitModules ?? []) {
+      const refs = m.browserGlobalRefs ?? [];
+      if (refs.length === 0) continue;
+      emitFile2(
+        out,
+        m.file,
+        refs.map((r) => ({
+          line: r.line,
+          message: r.inHandler ? `${r.name} is accessed in a load/handler \u2014 it runs on the server during SSR, where ${r.name} is not defined` : moduleMessage(r.name)
+        })),
+        m.suppressions
+      );
+    }
+    return out;
+  }
+};
+var correct009InstanceBrowserGlobals = componentRule({
+  id: "CORRECT009",
+  title: "Browser global during component initialisation",
+  category: "correctness",
+  label: "Server-safe component init",
+  recommendation: "Move browser-only code into onMount or $effect (they never run on the server), or guard it with browser from $app/environment (or a typeof check).",
+  rationale: "A component instance script runs on the server on every SSR render, where window/document/localStorage do not exist. Warning, not critical: a component rendered only behind a parent {#if browser} (or a client-only dynamic import) is a legitimate pattern that static analysis cannot prove cross-file.",
+  applies: (c) => (c.browserGlobalRefs ?? []).some((r) => r.context === "instance"),
+  bad: (c) => (c.browserGlobalRefs ?? []).filter((r) => r.context === "instance").map((r) => ({
+    line: r.line,
+    message: `${r.name} is accessed during component initialisation \u2014 during SSR this runs on the server, where ${r.name} is not defined`
+  }))
+});
 var sec001Html = componentRule({
   id: "SEC001",
   title: "Raw HTML render",
@@ -57227,9 +57502,9 @@ var sec002JavascriptUrl = componentRule({
   applies: (c) => c.javascriptUrls.length > 0,
   bad: (c) => c.javascriptUrls.map((u) => ({ line: u.line, message: "javascript: URL in an attribute" }))
 });
-var PENALIZED4 = { presence: "none", value: "absent" };
-var PASS4 = { presence: "own", value: "static" };
-function isSuppressed3(m, ruleId, line) {
+var PENALIZED5 = { presence: "none", value: "absent" };
+var PASS5 = { presence: "own", value: "static" };
+function isSuppressed4(m, ruleId, line) {
   return (m.suppressions ?? []).some((s) => s.line === line && (!s.ruleIds || s.ruleIds.includes(ruleId)));
 }
 function kitModuleRule(opts) {
@@ -57246,13 +57521,13 @@ function kitModuleRule(opts) {
       const out = [];
       for (const m of ctx.kitModules ?? []) {
         if (!opts.applies(m, ctx)) continue;
-        const bad = opts.bad(m, ctx).filter((b) => !(b.line > 0 && isSuppressed3(m, opts.id, b.line)));
+        const bad = opts.bad(m, ctx).filter((b) => !(b.line > 0 && isSuppressed4(m, opts.id, b.line)));
         if (bad.length === 0) {
           out.push({
             id: opts.id,
             category: opts.category,
             severity,
-            detection: PASS4,
+            detection: PASS5,
             route: m.file,
             message: opts.label,
             recommendation: opts.recommendation,
@@ -57265,7 +57540,7 @@ function kitModuleRule(opts) {
             id: opts.id,
             category: opts.category,
             severity,
-            detection: PENALIZED4,
+            detection: PENALIZED5,
             route: m.file,
             location: m.file,
             ...b.line > 0 ? { line: b.line } : {},
@@ -57456,6 +57731,8 @@ var allRules = [
   correct005PropMutation,
   correct006OrphanEffect,
   correct007OrphanLifecycle,
+  correct008BrowserGlobals,
+  correct009InstanceBrowserGlobals,
   sec001Html,
   sec002JavascriptUrl,
   sec003LoadStateWrite,

--- a/packages/cli/test/malformed-svelte.test.ts
+++ b/packages/cli/test/malformed-svelte.test.ts
@@ -50,6 +50,7 @@ describe('collectComponentFacts: malformed .svelte files (component path)', () =
       mutatedProps: [],
       orphanEffects: [],
       orphanLifecycleCalls: [],
+      browserGlobalRefs: [],
       moduleStateDecls: [],
       suppressions: []
     });
@@ -111,6 +112,7 @@ describe('collectComponentFacts: malformed .svelte files (component path)', () =
       mutatedProps: [],
       orphanEffects: [],
       orphanLifecycleCalls: [],
+      browserGlobalRefs: [],
       moduleStateDecls: [],
       suppressions: []
     });

--- a/packages/cli/test/suppression-e2e.test.ts
+++ b/packages/cli/test/suppression-e2e.test.ts
@@ -28,6 +28,7 @@ const comp = (over: Partial<ComponentFacts>): ComponentFacts => ({
   mutatedProps: [],
   orphanEffects: [],
   orphanLifecycleCalls: [],
+  browserGlobalRefs: [],
   moduleStateDecls: [],
   suppressions: [],
   ...over

--- a/packages/core/src/component-collect.ts
+++ b/packages/core/src/component-collect.ts
@@ -24,6 +24,7 @@ export function emptyComponentFacts(file: string): ComponentFacts {
     mutatedProps: [],
     orphanEffects: [],
     orphanLifecycleCalls: [],
+    browserGlobalRefs: [],
     moduleStateDecls: [],
     suppressions: []
   };

--- a/packages/core/src/component-parse.ts
+++ b/packages/core/src/component-parse.ts
@@ -887,12 +887,6 @@ export function collectProgramBindings(program: Node): Set<string> {
   return bound;
 }
 
-/**
- * Whether a guard-clause test establishes a browser environment: it references the
- * `$app/environment` `browser` binding, or contains a
- * `typeof <tracked-global> === | !== 'undefined'` comparison (CORRECT008/009).
- * Over-matching here only widens the skip — a conservative miss, never a false positive.
- */
 /** Whether a guard's consequent unconditionally exits (return/throw) — code after it never runs in the guarded environment (CORRECT008/009). */
 function guardTerminates(consequent: Node): boolean {
   if (!consequent) return false;
@@ -904,6 +898,12 @@ function guardTerminates(consequent: Node): boolean {
   return false;
 }
 
+/**
+ * Whether a guard-clause test establishes a browser environment: it references the
+ * `$app/environment` `browser` binding, or contains a
+ * `typeof <tracked-global> === | !== 'undefined'` comparison (CORRECT008/009).
+ * Over-matching here only widens the skip — a conservative miss, never a false positive.
+ */
 function isBrowserGuardTest(test: Node, guardBindings: Set<string>): boolean {
   let guarded = false;
   walkEstree(test, (n) => {
@@ -922,6 +922,30 @@ function isBrowserGuardTest(test: Node, guardBindings: Set<string>): boolean {
     }
   });
   return guarded;
+}
+
+/**
+ * Names of derived guard bindings (one level, no fixpoint chasing): a top-level
+ * (export-unwrapped) `const`/`let` declarator whose init passes `isBrowserGuardTest` —
+ * `const canUse = browser && !!window.matchMedia;` makes `canUse` itself a guard for a
+ * later `if (canUse) { … }`. Over-matching here only widens the skip (conservative
+ * miss). The scanner runs this on its own program; the Kit parser and the `.svelte`
+ * instance scan also run it on the module program so a module-level derived guard is
+ * recognised inside handlers / the instance script (CORRECT008/009).
+ * Shared with the Kit-module parser.
+ */
+export function collectDerivedGuardBindings(program: Node, guards: Set<string>): Set<string> {
+  const derived = new Set<string>();
+  for (const stmt of program.body ?? []) {
+    const decl = unwrapExport(stmt);
+    if (decl?.type !== 'VariableDeclaration' || (decl.kind !== 'const' && decl.kind !== 'let')) continue;
+    for (const d of decl.declarations ?? []) {
+      if (d?.id?.type === 'Identifier' && d.init && isBrowserGuardTest(d.init, guards)) {
+        derived.add(d.id.name);
+      }
+    }
+  }
+  return derived;
 }
 
 /**
@@ -952,19 +976,7 @@ export function collectBrowserGlobalRefs(
   const out: { name: string; line: number }[] = [];
   const bound = new Set([...collectProgramBindings(program), ...(extra?.bound ?? [])]);
   const guards = new Set([...collectBrowserGuardImports(program), ...(extra?.guards ?? [])]);
-
-  // Derived guard bindings (one level, no fixpoint chasing): `const canUse = browser
-  // && !!window.matchMedia;` makes `canUse` itself recognised as a guard for a later
-  // `if (canUse) { … }`. Over-matching here only widens the skip (conservative miss).
-  for (const stmt of program.body ?? []) {
-    const decl = unwrapExport(stmt);
-    if (decl?.type !== 'VariableDeclaration' || (decl.kind !== 'const' && decl.kind !== 'let')) continue;
-    for (const d of decl.declarations ?? []) {
-      if (d?.id?.type === 'Identifier' && d.init && isBrowserGuardTest(d.init, guards)) {
-        guards.add(d.id.name);
-      }
-    }
-  }
+  for (const name of collectDerivedGuardBindings(program, guards)) guards.add(name);
 
   const visit = (n: Node, shadowed: Set<string>): void => {
     if (!n) return;
@@ -1253,10 +1265,16 @@ export function parseComponentFacts(source: string, filename: string): ParsedFac
       if (!writtenOrEscaped.has(d.name)) constableStates.push(d);
     }
     // Instance top level runs on the server during SSR (CORRECT009). The module
-    // script's guard binding and top-level bindings are visible here — pass them in.
-    const moduleExtra = moduleProgram
-      ? { guards: collectBrowserGuardImports(moduleProgram), bound: collectProgramBindings(moduleProgram) }
-      : undefined;
+    // script's guard bindings (raw browser imports + module-level derived guards)
+    // and top-level bindings are visible here — pass them in.
+    let moduleExtra: { guards: Set<string>; bound: Set<string> } | undefined;
+    if (moduleProgram) {
+      const moduleBrowserImports = collectBrowserGuardImports(moduleProgram);
+      moduleExtra = {
+        guards: new Set([...moduleBrowserImports, ...collectDerivedGuardBindings(moduleProgram, moduleBrowserImports)]),
+        bound: collectProgramBindings(moduleProgram)
+      };
+    }
     for (const r of collectBrowserGlobalRefs(program, source, moduleExtra)) {
       browserGlobalRefs.push({ ...r, context: 'instance' });
     }

--- a/packages/core/src/component-parse.ts
+++ b/packages/core/src/component-parse.ts
@@ -893,6 +893,17 @@ export function collectProgramBindings(program: Node): Set<string> {
  * `typeof <tracked-global> === | !== 'undefined'` comparison (CORRECT008/009).
  * Over-matching here only widens the skip — a conservative miss, never a false positive.
  */
+/** Whether a guard's consequent unconditionally exits (return/throw) — code after it never runs in the guarded environment (CORRECT008/009). */
+function guardTerminates(consequent: Node): boolean {
+  if (!consequent) return false;
+  if (consequent.type === 'ReturnStatement' || consequent.type === 'ThrowStatement') return true;
+  if (consequent.type === 'BlockStatement') {
+    const last = (consequent.body ?? [])[consequent.body.length - 1];
+    return last?.type === 'ReturnStatement' || last?.type === 'ThrowStatement';
+  }
+  return false;
+}
+
 function isBrowserGuardTest(test: Node, guardBindings: Set<string>): boolean {
   let guarded = false;
   walkEstree(test, (n) => {
@@ -926,8 +937,12 @@ function isBrowserGuardTest(test: Node, guardBindings: Set<string>): boolean {
  * program's top level (`extra.bound` adds more, e.g. the other script's bindings or a
  * handler's parameters), and skips guard clauses ENTIRELY — if/ternary/logical whose
  * test passes `isBrowserGuardTest` — including their else branches (a documented
- * conservative miss). `extra.guards` adds guard bindings beyond this program's own
- * `$app/environment` import.
+ * conservative miss). A guard binding derived from another guard, one level deep
+ * (`const canUse = browser && !!window.matchMedia;`), is recognised too. Within a
+ * `BlockStatement`/`Program`, a terminating early-return guard (`if (!browser) return
+ * {};`) stops the scan of the remaining statements in that container — they are
+ * server-unreachable in the guarded environment. `extra.guards` adds guard bindings
+ * beyond this program's own `$app/environment` import.
  */
 export function collectBrowserGlobalRefs(
   program: Node,
@@ -937,6 +952,19 @@ export function collectBrowserGlobalRefs(
   const out: { name: string; line: number }[] = [];
   const bound = new Set([...collectProgramBindings(program), ...(extra?.bound ?? [])]);
   const guards = new Set([...collectBrowserGuardImports(program), ...(extra?.guards ?? [])]);
+
+  // Derived guard bindings (one level, no fixpoint chasing): `const canUse = browser
+  // && !!window.matchMedia;` makes `canUse` itself recognised as a guard for a later
+  // `if (canUse) { … }`. Over-matching here only widens the skip (conservative miss).
+  for (const stmt of program.body ?? []) {
+    const decl = unwrapExport(stmt);
+    if (decl?.type !== 'VariableDeclaration' || (decl.kind !== 'const' && decl.kind !== 'let')) continue;
+    for (const d of decl.declarations ?? []) {
+      if (d?.id?.type === 'Identifier' && d.init && isBrowserGuardTest(d.init, guards)) {
+        guards.add(d.id.name);
+      }
+    }
+  }
 
   const visit = (n: Node, shadowed: Set<string>): void => {
     if (!n) return;
@@ -984,6 +1012,26 @@ export function collectBrowserGlobalRefs(
       case 'ExportNamedDeclaration':
         if (!n.declaration) return; // bare specifiers aren't reads
         break;
+      case 'BlockStatement':
+      case 'Program':
+        // Statement-list containers get a manual loop (rather than the generic
+        // key-walk) so a terminating early-return guard (`if (!browser) return
+        // {};`) can stop scanning the rest of the container — the remaining
+        // statements are server-unreachable in the guarded environment
+        // (CORRECT008/009). The guard statement itself is still skipped by the
+        // IfStatement check above; `Program` can't contain a `return`, so its
+        // early-break only ever triggers on a `throw`-terminated guard.
+        for (const stmt of n.body ?? []) {
+          visit(stmt, scope);
+          if (
+            stmt?.type === 'IfStatement' &&
+            isBrowserGuardTest(stmt.test, guards) &&
+            guardTerminates(stmt.consequent)
+          ) {
+            break;
+          }
+        }
+        return;
       default:
         if (n.type.startsWith('TS')) {
           // TS wrapper expressions carry a runtime expression — visit only that.

--- a/packages/core/src/component-parse.ts
+++ b/packages/core/src/component-parse.ts
@@ -917,13 +917,17 @@ function isBrowserGuardTest(test: Node, guardBindings: Set<string>): boolean {
  * Browser-global reads in code that executes when `program` (or a passed function body)
  * is evaluated (CORRECT008/009). Position-aware — only read positions match: never a
  * non-computed member property or object key, a declaration id, an import/export
- * specifier, a label, or a bare `typeof` operand (that idiom never throws). Stops at
- * eval-scope boundaries (function/class bodies), threads the shadow set, disqualifies
- * names bound at the program's top level (`extra.bound` adds more, e.g. the other
- * script's bindings or a handler's parameters), and skips guard clauses ENTIRELY —
- * if/ternary/logical whose test passes `isBrowserGuardTest` — including their else
- * branches (a documented conservative miss). `extra.guards` adds guard bindings beyond
- * this program's own `$app/environment` import.
+ * specifier, a label, or a bare `typeof` operand (that idiom never throws). Never
+ * descends into TS type-only subtrees (type aliases, interfaces, `TSTypeQuery`'s
+ * `typeof window`, generic type arguments, annotations) — a `TSAsExpression` /
+ * `TSSatisfiesExpression` / `TSNonNullExpression` / `TSInstantiationExpression`
+ * wrapper still has its runtime `.expression` visited. Stops at eval-scope boundaries
+ * (function/class bodies), threads the shadow set, disqualifies names bound at the
+ * program's top level (`extra.bound` adds more, e.g. the other script's bindings or a
+ * handler's parameters), and skips guard clauses ENTIRELY — if/ternary/logical whose
+ * test passes `isBrowserGuardTest` — including their else branches (a documented
+ * conservative miss). `extra.guards` adds guard bindings beyond this program's own
+ * `$app/environment` import.
  */
 export function collectBrowserGlobalRefs(
   program: Node,
@@ -980,6 +984,24 @@ export function collectBrowserGlobalRefs(
       case 'ExportNamedDeclaration':
         if (!n.declaration) return; // bare specifiers aren't reads
         break;
+      default:
+        if (n.type.startsWith('TS')) {
+          // TS wrapper expressions carry a runtime expression — visit only that.
+          // Everything else under a TS* node is erased type-level code (type
+          // aliases, interfaces, TSTypeQuery's `typeof window`, generic args,
+          // annotations) and can never throw at runtime. Skipping the rare
+          // runtime-bearing TS constructs (enum initializers, namespaces) is a
+          // conservative miss, aligned with the no-false-positive contract.
+          if (
+            n.type === 'TSAsExpression' ||
+            n.type === 'TSSatisfiesExpression' ||
+            n.type === 'TSNonNullExpression' ||
+            n.type === 'TSInstantiationExpression'
+          ) {
+            visit(n.expression, scope);
+          }
+          return;
+        }
     }
     for (const key of Object.keys(n)) {
       if (WALK_IGNORED_KEYS.has(key)) continue;

--- a/packages/core/src/component-parse.ts
+++ b/packages/core/src/component-parse.ts
@@ -1,5 +1,6 @@
 import { parse } from 'svelte/compiler';
 import type {
+  BrowserGlobalRefFact,
   ComponentFacts,
   EachBlockFact,
   EffectFact,
@@ -818,6 +819,177 @@ function collectOrphanLifecycleCalls(program: Node, source: string): OrphanLifec
   });
 }
 
+/** Browser-only globals worth flagging in server-executed code (CORRECT008/009) — curated high-signal names absent from Node; NOT the full `globals.browser` list, which would false-positive on generic identifiers without scope analysis. */
+export const BROWSER_GLOBALS = new Set([
+  'window',
+  'document',
+  'localStorage',
+  'sessionStorage',
+  'navigator',
+  'location',
+  'history',
+  'screen',
+  'matchMedia',
+  'requestAnimationFrame',
+  'cancelAnimationFrame',
+  'IntersectionObserver',
+  'ResizeObserver',
+  'MutationObserver',
+  'alert',
+  'confirm',
+  'prompt'
+]);
+
+/**
+ * Local names of `browser` value-imported from '$app/environment' (alias-resolved) —
+ * the guard binding recognised by the browser-global scanner (CORRECT008/009).
+ * Shared with the Kit-module parser.
+ */
+export function collectBrowserGuardImports(program: Node): Set<string> {
+  const out = new Set<string>();
+  for (const stmt of program.body ?? []) {
+    if (stmt?.type !== 'ImportDeclaration' || stmt.importKind === 'type' || stmt.source?.value !== '$app/environment')
+      continue;
+    for (const s of stmt.specifiers ?? []) {
+      if (s?.importKind === 'type' || s?.local?.type !== 'Identifier') continue;
+      if (s.type === 'ImportSpecifier' && s.imported?.type === 'Identifier' && s.imported.name === 'browser') {
+        out.add(s.local.name);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Names bound at the program's top level: every import's local name plus every
+ * export-unwrapped declaration name. A tracked global with such a binding is a real
+ * binding, not a global read (`const document = …`, `import { window } from …`) —
+ * disqualified program-wide by the browser-global scanner (CORRECT008/009).
+ * Shared with the Kit-module parser.
+ */
+export function collectProgramBindings(program: Node): Set<string> {
+  const bound = new Set<string>();
+  for (const stmt of program.body ?? []) {
+    if (stmt?.type === 'ImportDeclaration') {
+      for (const s of stmt.specifiers ?? []) if (s?.local?.type === 'Identifier') bound.add(s.local.name);
+      continue;
+    }
+    const decl = unwrapExport(stmt);
+    if (decl?.type === 'VariableDeclaration') {
+      for (const d of decl.declarations ?? []) addBoundNames(d?.id, bound);
+    } else if (
+      (decl?.type === 'FunctionDeclaration' || decl?.type === 'ClassDeclaration') &&
+      decl.id?.type === 'Identifier'
+    ) {
+      bound.add(decl.id.name);
+    }
+  }
+  return bound;
+}
+
+/**
+ * Whether a guard-clause test establishes a browser environment: it references the
+ * `$app/environment` `browser` binding, or contains a
+ * `typeof <tracked-global> === | !== 'undefined'` comparison (CORRECT008/009).
+ * Over-matching here only widens the skip — a conservative miss, never a false positive.
+ */
+function isBrowserGuardTest(test: Node, guardBindings: Set<string>): boolean {
+  let guarded = false;
+  walkEstree(test, (n) => {
+    if (n.type === 'Identifier' && guardBindings.has(n.name)) guarded = true;
+    if (n.type === 'BinaryExpression' && ['===', '!==', '==', '!='].includes(n.operator)) {
+      const sides = [n.left, n.right];
+      const hasTypeofGlobal = sides.some(
+        (s: Node) =>
+          s?.type === 'UnaryExpression' &&
+          s.operator === 'typeof' &&
+          s.argument?.type === 'Identifier' &&
+          BROWSER_GLOBALS.has(s.argument.name)
+      );
+      const hasUndefinedString = sides.some((s: Node) => s?.type === 'Literal' && s.value === 'undefined');
+      if (hasTypeofGlobal && hasUndefinedString) guarded = true;
+    }
+  });
+  return guarded;
+}
+
+/**
+ * Browser-global reads in code that executes when `program` (or a passed function body)
+ * is evaluated (CORRECT008/009). Position-aware — only read positions match: never a
+ * non-computed member property or object key, a declaration id, an import/export
+ * specifier, a label, or a bare `typeof` operand (that idiom never throws). Stops at
+ * eval-scope boundaries (function/class bodies), threads the shadow set, disqualifies
+ * names bound at the program's top level (`extra.bound` adds more, e.g. the other
+ * script's bindings or a handler's parameters), and skips guard clauses ENTIRELY —
+ * if/ternary/logical whose test passes `isBrowserGuardTest` — including their else
+ * branches (a documented conservative miss). `extra.guards` adds guard bindings beyond
+ * this program's own `$app/environment` import.
+ */
+export function collectBrowserGlobalRefs(
+  program: Node,
+  source: string,
+  extra?: { guards?: Set<string>; bound?: Set<string> }
+): { name: string; line: number }[] {
+  const out: { name: string; line: number }[] = [];
+  const bound = new Set([...collectProgramBindings(program), ...(extra?.bound ?? [])]);
+  const guards = new Set([...collectBrowserGuardImports(program), ...(extra?.guards ?? [])]);
+
+  const visit = (n: Node, shadowed: Set<string>): void => {
+    if (!n) return;
+    if (Array.isArray(n)) {
+      for (const c of n) visit(c, shadowed);
+      return;
+    }
+    if (typeof n !== 'object' || typeof n.type !== 'string') return;
+    if (EVAL_SCOPE_BOUNDARIES.has(n.type)) return;
+
+    if ((n.type === 'IfStatement' || n.type === 'ConditionalExpression') && isBrowserGuardTest(n.test, guards)) return;
+    if (n.type === 'LogicalExpression' && isBrowserGuardTest(n.left, guards)) return;
+
+    const introduced = scopeIntroducedNames(n);
+    const scope = introduced.size > 0 ? new Set([...shadowed, ...introduced]) : shadowed;
+
+    switch (n.type) {
+      case 'Identifier':
+        if (BROWSER_GLOBALS.has(n.name) && !bound.has(n.name) && !scope.has(n.name)) {
+          out.push({ name: n.name, line: lineOf(source, n.start) });
+        }
+        return;
+      case 'UnaryExpression':
+        if (n.operator === 'typeof' && n.argument?.type === 'Identifier') return; // guard idiom — never throws
+        break;
+      case 'MemberExpression':
+        visit(n.object, scope);
+        if (n.computed) visit(n.property, scope);
+        return;
+      case 'Property':
+        if (n.computed) visit(n.key, scope);
+        visit(n.value, scope);
+        return;
+      case 'VariableDeclarator':
+        visit(n.init, scope); // the id is a binding target, not a read
+        return;
+      case 'LabeledStatement':
+        visit(n.body, scope);
+        return;
+      case 'BreakStatement':
+      case 'ContinueStatement':
+      case 'ImportDeclaration':
+      case 'ExportAllDeclaration':
+        return;
+      case 'ExportNamedDeclaration':
+        if (!n.declaration) return; // bare specifiers aren't reads
+        break;
+    }
+    for (const key of Object.keys(n)) {
+      if (WALK_IGNORED_KEYS.has(key)) continue;
+      visit(n[key], scope);
+    }
+  };
+  visit(program, new Set());
+  return out;
+}
+
 /** A Svelte runes module file — the whole file is one module-scope program (CORRECT006). */
 const MODULE_FILE_RE = /\.svelte\.(ts|js)$/;
 
@@ -889,11 +1061,11 @@ function collectModuleStateDecls(program: Node, source: string): { name: string;
 }
 
 /**
- * Facts for a `.svelte.ts`/`.svelte.js` runes module (CORRECT006/007). The whole file runs
- * at import time, so only `orphanEffects`, `orphanLifecycleCalls`, `moduleStateDecls`, and
- * `suppressions` are populated — component-only facts stay empty and `loc` is 0 so
- * ARCH001/PERF009 don't fire on module files. Uses `parseModuleProgram` to get the ESTree
- * program from the wrapped source; the 1-line wrap prefix is subtracted from every
+ * Facts for a `.svelte.ts`/`.svelte.js` runes module (CORRECT006/007/008). The whole file runs
+ * at import time, so only `orphanEffects`, `orphanLifecycleCalls`, `browserGlobalRefs`,
+ * `moduleStateDecls`, and `suppressions` are populated — component-only facts stay empty and
+ * `loc` is 0 so ARCH001/PERF009 don't fire on module files. Uses `parseModuleProgram` to get
+ * the ESTree program from the wrapped source; the 1-line wrap prefix is subtracted from every
  * reported line.
  */
 function parseModuleFacts(source: string, filename: string): ParsedFacts {
@@ -904,6 +1076,9 @@ function parseModuleFacts(source: string, filename: string): ParsedFacts {
     : [];
   const orphanLifecycleCalls = program
     ? collectOrphanLifecycleCalls(program, wrapped).map((f) => ({ ...f, line: shift(f.line) }))
+    : [];
+  const browserGlobalRefs: BrowserGlobalRefFact[] = program
+    ? collectBrowserGlobalRefs(program, wrapped).map((r) => ({ ...r, line: shift(r.line), context: 'module' as const }))
     : [];
   const moduleStateDecls = program
     ? collectModuleStateDecls(program, wrapped).map((d) => ({ ...d, line: shift(d.line) }))
@@ -923,6 +1098,7 @@ function parseModuleFacts(source: string, filename: string): ParsedFacts {
     suppressions: collectSuppressions(source),
     orphanEffects,
     orphanLifecycleCalls,
+    browserGlobalRefs,
     moduleStateDecls
   };
 }
@@ -945,16 +1121,23 @@ export function parseComponentFacts(source: string, filename: string): ParsedFac
   const suppressions = collectSuppressions(source);
 
   // Imports live in either the instance (<script>) or module (<script module>) program.
+  const moduleProgram = ast.module?.content;
   const importSpans: { source: string; line: number }[] = [];
   const namespaceImports: { source: string; line: number }[] = [];
-  if (ast.module?.content) {
-    collectImportSources(ast.module.content, source, importSpans);
-    collectNamespaceImports(ast.module.content, source, namespaceImports);
+  if (moduleProgram) {
+    collectImportSources(moduleProgram, source, importSpans);
+    collectNamespaceImports(moduleProgram, source, namespaceImports);
   }
-  const orphanEffects: OrphanEffectFact[] = ast.module?.content ? collectOrphanEffects(ast.module.content, source) : [];
-  const orphanLifecycleCalls: OrphanLifecycleCallFact[] = ast.module?.content
-    ? collectOrphanLifecycleCalls(ast.module.content, source)
+  const orphanEffects: OrphanEffectFact[] = moduleProgram ? collectOrphanEffects(moduleProgram, source) : [];
+  const orphanLifecycleCalls: OrphanLifecycleCallFact[] = moduleProgram
+    ? collectOrphanLifecycleCalls(moduleProgram, source)
     : [];
+  const browserGlobalRefs: BrowserGlobalRefFact[] = [];
+  if (moduleProgram) {
+    for (const r of collectBrowserGlobalRefs(moduleProgram, source)) {
+      browserGlobalRefs.push({ ...r, context: 'module' });
+    }
+  }
 
   const effects: EffectFact[] = [];
   const constableStates: { name: string; line: number }[] = [];
@@ -999,6 +1182,14 @@ export function parseComponentFacts(source: string, filename: string): ParsedFac
     for (const d of stateDecls) {
       if (!writtenOrEscaped.has(d.name)) constableStates.push(d);
     }
+    // Instance top level runs on the server during SSR (CORRECT009). The module
+    // script's guard binding and top-level bindings are visible here — pass them in.
+    const moduleExtra = moduleProgram
+      ? { guards: collectBrowserGuardImports(moduleProgram), bound: collectProgramBindings(moduleProgram) }
+      : undefined;
+    for (const r of collectBrowserGlobalRefs(program, source, moduleExtra)) {
+      browserGlobalRefs.push({ ...r, context: 'instance' });
+    }
   }
   const imports = importSpans.map((s) => s.source);
   return {
@@ -1015,6 +1206,7 @@ export function parseComponentFacts(source: string, filename: string): ParsedFac
     mutatedProps,
     orphanEffects,
     orphanLifecycleCalls,
+    browserGlobalRefs,
     moduleStateDecls: [],
     suppressions
   };

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -44,6 +44,16 @@ export interface OrphanLifecycleCallFact {
   className?: string;
 }
 
+/** A browser-only global read in code that runs on the server — SSR crashes with "<name> is not defined" (CORRECT008/009). */
+export interface BrowserGlobalRefFact {
+  /** The global's name, e.g. 'window'. */
+  name: string;
+  /** 1-based source line, or 0 if unknown. */
+  line: number;
+  /** 'module' = module evaluation (script module / runes module — CORRECT008); 'instance' = component-init top level (runs on the server during SSR — CORRECT009). */
+  context: 'module' | 'instance';
+}
+
 /** A flagged source position in a component (e.g. an `{@html}` tag or a `javascript:` URL). */
 export interface SourceSpan {
   /** 1-based source line, or 0 if unknown. */
@@ -86,6 +96,8 @@ export interface ComponentFacts {
   orphanEffects: OrphanEffectFact[];
   /** Svelte lifecycle/context calls guaranteed to run outside component initialisation — module scope in `.svelte.ts`/`.svelte.js` or `<script module>` (CORRECT007). */
   orphanLifecycleCalls: OrphanLifecycleCallFact[];
+  /** Browser-global reads in server-executed positions of this file (CORRECT008/009). */
+  browserGlobalRefs: BrowserGlobalRefFact[];
   /** Module-scope `$state` declarations in a `.svelte.ts`/`.svelte.js` runes module — on a server, one instance shared by every request (SEC005). Always empty for `.svelte` files. */
   moduleStateDecls: { name: string; line: number }[];
   /** Inline `svelte-vitals-disable-next-line` directives found in this file's source — component-rule escape hatch (issue #92). Optional: absent is equivalent to no directives, so existing external constructors of `ComponentFacts` are unaffected. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -98,6 +98,8 @@ export {
   correct005PropMutation,
   correct006OrphanEffect,
   correct007OrphanLifecycle,
+  correct008BrowserGlobals,
+  correct009InstanceBrowserGlobals,
   sec001Html,
   sec002JavascriptUrl,
   sec003LoadStateWrite,

--- a/packages/core/src/kit-module-collect.ts
+++ b/packages/core/src/kit-module-collect.ts
@@ -12,6 +12,7 @@ export function emptyKitModuleFacts(file: string, kind: KitModuleFacts['kind']):
     importedStateWritesOutsideHandlers: [],
     runesModuleImports: [],
     lifecycleCalls: [],
+    browserGlobalRefs: [],
     suppressions: []
   };
 }

--- a/packages/core/src/kit-module-parse.ts
+++ b/packages/core/src/kit-module-parse.ts
@@ -10,6 +10,7 @@ import {
   matchLifecycleCall,
   collectBrowserGlobalRefs,
   collectBrowserGuardImports,
+  collectDerivedGuardBindings,
   collectProgramBindings
 } from './component-parse.js';
 import { lineOf } from './svelte-ast.js';
@@ -388,7 +389,11 @@ export function parseKitModuleFacts(source: string, filename: string): Omit<KitM
     // 1-line wrap prefix (the local `line()` helper takes a byte OFFSET, not a line,
     // so it must not be used here).
     const shiftLine = (l: number) => Math.max(0, l - 1);
-    const guards = collectBrowserGuardImports(program);
+    // Union of the raw `$app/environment` browser imports and module-level derived
+    // guard bindings, so per-handler scans (whose own pre-pass only sees the handler
+    // body) still recognise `const canUse = browser;` declared at module level.
+    const browserImports = collectBrowserGuardImports(program);
+    const guards = new Set([...browserImports, ...collectDerivedGuardBindings(program, browserImports)]);
     const bound = collectProgramBindings(program);
     for (const r of collectBrowserGlobalRefs(program, wrapped, { guards, bound })) {
       browserGlobalRefs.push({ name: r.name, line: shiftLine(r.line), inHandler: false });

--- a/packages/core/src/kit-module-parse.ts
+++ b/packages/core/src/kit-module-parse.ts
@@ -402,7 +402,13 @@ export function parseKitModuleFacts(source: string, filename: string): Omit<KitM
       }
     };
     for (const fn of handlerFns) scanFn(fn, true);
-    for (const fn of startupFns) scanFn(fn, false);
+    for (const fn of startupFns) {
+      // A function aliased to BOTH a handler and `init` was already scanned above —
+      // scanning it again would duplicate the facts with a conflicting inHandler
+      // flag. Handler classification wins.
+      if (handlerFns.has(fn)) continue;
+      scanFn(fn, false);
+    }
   }
 
   walkKit(program, handlerFns, startupFns, (n, shadowed, inFunction, inHandler, inStartup) => {

--- a/packages/core/src/kit-module-parse.ts
+++ b/packages/core/src/kit-module-parse.ts
@@ -7,7 +7,10 @@ import {
   rootObjectName,
   WALK_IGNORED_KEYS,
   collectSvelteLifecycleImports,
-  matchLifecycleCall
+  matchLifecycleCall,
+  collectBrowserGlobalRefs,
+  collectBrowserGuardImports,
+  collectProgramBindings
 } from './component-parse.js';
 import { lineOf } from './svelte-ast.js';
 import type { KitModuleFacts } from './kit-module.js';
@@ -175,6 +178,40 @@ function collectStartupFunctions(program: Node): Set<Node> {
 }
 
 /**
+ * Whether this file opts out of the server entirely via `export const ssr = false`
+ * (satisfies-unwrapped; same-file alias export `export { ssr }` resolved). Such a file
+ * never runs on the server, so browser globals in it are legal (CORRECT008).
+ */
+function hasSsrFalseOptOut(program: Node): boolean {
+  const isFalse = (init: Node): boolean => {
+    const v = unwrapTs(init);
+    return v?.type === 'Literal' && v.value === false;
+  };
+  for (const stmt of program.body ?? []) {
+    const decl = unwrapExport(stmt);
+    if (decl?.type !== 'VariableDeclaration') continue;
+    for (const d of decl.declarations ?? []) {
+      if (d?.id?.type === 'Identifier' && d.id.name === 'ssr' && d.init && isFalse(d.init)) {
+        if (stmt.type === 'ExportNamedDeclaration') return true;
+      }
+    }
+  }
+  // Alias export: `const ssr = false; export { ssr };`
+  const bindings = collectTopLevelBindings(program);
+  for (const stmt of program.body ?? []) {
+    if (stmt?.type !== 'ExportNamedDeclaration' || !stmt.specifiers || stmt.source || stmt.exportKind === 'type')
+      continue;
+    for (const s of stmt.specifiers) {
+      if (s?.exportKind === 'type' || s?.exported?.type !== 'Identifier' || s?.local?.type !== 'Identifier') continue;
+      if (s.exported.name !== 'ssr') continue;
+      const resolved = bindings.get(s.local.name);
+      if (resolved?.type === 'Literal' && resolved.value === false) return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Walk the whole program threading (1) shadowed names (like component-parse's
  * `walkScoped`), (2) whether the CURRENT node sits inside any function body, (3)
  * whether that function chain includes a server handler, and (4) whether it
@@ -298,6 +335,7 @@ export function parseKitModuleFacts(source: string, filename: string): Omit<KitM
   const importedStateWritesOutsideHandlers: KitModuleFacts['importedStateWritesOutsideHandlers'] = [];
   const runesModuleImports: KitModuleFacts['runesModuleImports'] = [];
   const lifecycleCalls: KitModuleFacts['lifecycleCalls'] = [];
+  const browserGlobalRefs: KitModuleFacts['browserGlobalRefs'] = [];
   if (!program) {
     return {
       moduleStateReassignments,
@@ -305,6 +343,7 @@ export function parseKitModuleFacts(source: string, filename: string): Omit<KitM
       importedStateWritesOutsideHandlers,
       runesModuleImports,
       lifecycleCalls,
+      browserGlobalRefs,
       suppressions
     };
   }
@@ -339,6 +378,33 @@ export function parseKitModuleFacts(source: string, filename: string): Omit<KitM
   const handlerFns = collectHandlerFunctions(program);
   const startupFns = collectStartupFunctions(program);
   const svelteImports = collectSvelteLifecycleImports(program);
+
+  // CORRECT008 — browser-global reads in server-executed positions. The scanner stops
+  // at function boundaries, so run it once over the program (top level) and once per
+  // handler/init body; closures nested inside handlers are deliberately not entered
+  // (they are typically client-side callbacks returned to components).
+  if (!hasSsrFalseOptOut(program)) {
+    // The scanner returns line numbers computed against `wrapped` — subtract the
+    // 1-line wrap prefix (the local `line()` helper takes a byte OFFSET, not a line,
+    // so it must not be used here).
+    const shiftLine = (l: number) => Math.max(0, l - 1);
+    const guards = collectBrowserGuardImports(program);
+    const bound = collectProgramBindings(program);
+    for (const r of collectBrowserGlobalRefs(program, wrapped, { guards, bound })) {
+      browserGlobalRefs.push({ name: r.name, line: shiftLine(r.line), inHandler: false });
+    }
+    const scanFn = (fn: Node, inHandler: boolean) => {
+      if (!fn?.body) return;
+      const params = new Set<string>();
+      for (const p of fn.params ?? []) addBoundNames(p, params);
+      for (const r of collectBrowserGlobalRefs(fn.body, wrapped, { guards, bound: new Set([...bound, ...params]) })) {
+        browserGlobalRefs.push({ name: r.name, line: shiftLine(r.line), inHandler });
+      }
+    };
+    for (const fn of handlerFns) scanFn(fn, true);
+    for (const fn of startupFns) scanFn(fn, false);
+  }
+
   walkKit(program, handlerFns, startupFns, (n, shadowed, inFunction, inHandler, inStartup) => {
     if (inFunction && !inStartup) {
       // SEC004 — module-scope let/var reassigned from inside a function body.
@@ -435,6 +501,7 @@ export function parseKitModuleFacts(source: string, filename: string): Omit<KitM
     importedStateWritesOutsideHandlers: byLine(importedStateWritesOutsideHandlers),
     runesModuleImports: byLine(runesModuleImports),
     lifecycleCalls: byLine(lifecycleCalls),
+    browserGlobalRefs: byLine(browserGlobalRefs),
     suppressions
   };
 }

--- a/packages/core/src/kit-module.ts
+++ b/packages/core/src/kit-module.ts
@@ -23,6 +23,12 @@ export interface KitModuleFacts {
     line: number;
     inHandler: boolean;
   }[];
+  /** Browser-global reads in server-executed positions — top level, handler bodies, the `init` hook (CORRECT008). Empty when the file itself exports `ssr = false`. */
+  browserGlobalRefs: {
+    name: string;
+    line: number;
+    inHandler: boolean;
+  }[];
   /** Inline `svelte-vitals-disable-next-line` directives in this file. */
   suppressions: SuppressionDirective[];
 }

--- a/packages/core/src/rules/correctness/correct008-browser-globals.ts
+++ b/packages/core/src/rules/correctness/correct008-browser-globals.ts
@@ -1,0 +1,102 @@
+import type { Result } from '../../types.js';
+import { docsUrlFor, type Rule, type RuleContext } from '../../rule.js';
+import type { SuppressionDirective } from '../../component.js';
+
+const PENALIZED = { presence: 'none', value: 'absent' } as const;
+const PASS = { presence: 'own', value: 'static' } as const;
+
+const ID = 'CORRECT008';
+const DOCS_URL = docsUrlFor(ID);
+const LABEL = 'Server-safe module code';
+const RECOMMENDATION =
+  'Move browser-only code into onMount or $effect (they never run on the server), or guard it with browser from $app/environment (or a typeof check).';
+
+const moduleMessage = (name: string) =>
+  `${name} is accessed at module scope — it does not exist on the server, so importing this file crashes SSR with "${name} is not defined"`;
+
+function isSuppressed(suppressions: SuppressionDirective[] | undefined, line: number): boolean {
+  return (suppressions ?? []).some((s) => s.line === line && (!s.ruleIds || s.ruleIds.includes(ID)));
+}
+
+/** Emit one file's PASS/PENALIZED results — same shapes as componentRule/kitModuleRule. */
+function emitFile(
+  out: Result[],
+  file: string,
+  issues: { line: number; message: string }[],
+  suppressions: SuppressionDirective[] | undefined
+): void {
+  const bad = issues.filter((b) => !(b.line > 0 && isSuppressed(suppressions, b.line)));
+  if (bad.length === 0) {
+    out.push({
+      id: ID,
+      category: 'correctness',
+      severity: 'critical',
+      detection: PASS,
+      route: file,
+      message: LABEL,
+      recommendation: RECOMMENDATION,
+      docsUrl: DOCS_URL
+    });
+    return;
+  }
+  for (const b of bad) {
+    out.push({
+      id: ID,
+      category: 'correctness',
+      severity: 'critical',
+      detection: PENALIZED,
+      route: file,
+      location: file,
+      ...(b.line > 0 ? { line: b.line } : {}),
+      message: b.message,
+      recommendation: RECOMMENDATION,
+      docsUrl: DOCS_URL
+    });
+  }
+}
+
+/**
+ * CORRECT008 — browser globals read in server-executed MODULE code: module scope of
+ * runes modules / `<script module>`, and Kit route/hooks files (top level, handler
+ * bodies, the `init` hook). All of it runs on the server, where these globals do not
+ * exist — SSR crashes with a ReferenceError. Instance-script reads are CORRECT009's
+ * (warning) territory. A custom check because the facts live on both channels.
+ */
+export const correct008BrowserGlobals: Rule = {
+  id: ID,
+  title: 'Browser global in server module code',
+  category: 'correctness',
+  severity: 'critical',
+  scope: 'component',
+  rationale:
+    'window, document, localStorage and friends do not exist on the server; a read in module scope or a load/handler crashes SSR with a ReferenceError — the compiler does not catch it, and it surfaces as a production 500.',
+  async check(ctx: RuleContext): Promise<Result[]> {
+    const out: Result[] = [];
+    for (const c of ctx.components ?? []) {
+      const refs = (c.browserGlobalRefs ?? []).filter((r) => r.context === 'module');
+      if (refs.length === 0) continue;
+      emitFile(
+        out,
+        c.file,
+        refs.map((r) => ({ line: r.line, message: moduleMessage(r.name) })),
+        c.suppressions
+      );
+    }
+    for (const m of ctx.kitModules ?? []) {
+      const refs = m.browserGlobalRefs ?? [];
+      if (refs.length === 0) continue;
+      emitFile(
+        out,
+        m.file,
+        refs.map((r) => ({
+          line: r.line,
+          message: r.inHandler
+            ? `${r.name} is accessed in a load/handler — it runs on the server during SSR, where ${r.name} is not defined`
+            : moduleMessage(r.name)
+        })),
+        m.suppressions
+      );
+    }
+    return out;
+  }
+};

--- a/packages/core/src/rules/correctness/correct009-instance-browser-globals.ts
+++ b/packages/core/src/rules/correctness/correct009-instance-browser-globals.ts
@@ -1,0 +1,20 @@
+import { componentRule } from '../component-rule.js';
+
+export const correct009InstanceBrowserGlobals = componentRule({
+  id: 'CORRECT009',
+  title: 'Browser global during component initialisation',
+  category: 'correctness',
+  label: 'Server-safe component init',
+  recommendation:
+    'Move browser-only code into onMount or $effect (they never run on the server), or guard it with browser from $app/environment (or a typeof check).',
+  rationale:
+    'A component instance script runs on the server on every SSR render, where window/document/localStorage do not exist. Warning, not critical: a component rendered only behind a parent {#if browser} (or a client-only dynamic import) is a legitimate pattern that static analysis cannot prove cross-file.',
+  applies: (c) => (c.browserGlobalRefs ?? []).some((r) => r.context === 'instance'),
+  bad: (c) =>
+    (c.browserGlobalRefs ?? [])
+      .filter((r) => r.context === 'instance')
+      .map((r) => ({
+        line: r.line,
+        message: `${r.name} is accessed during component initialisation — during SSR this runs on the server, where ${r.name} is not defined`
+      }))
+});

--- a/packages/core/src/rules/index.ts
+++ b/packages/core/src/rules/index.ts
@@ -42,6 +42,8 @@ import { correct004UnmutatedState } from './correctness/correct004-unmutated-sta
 import { correct005PropMutation } from './correctness/correct005-prop-mutation.js';
 import { correct006OrphanEffect } from './correctness/correct006-orphan-effect.js';
 import { correct007OrphanLifecycle } from './correctness/correct007-orphan-lifecycle.js';
+import { correct008BrowserGlobals } from './correctness/correct008-browser-globals.js';
+import { correct009InstanceBrowserGlobals } from './correctness/correct009-instance-browser-globals.js';
 import { sec001Html, sec002JavascriptUrl } from './security/sec001-002.js';
 import { sec003LoadStateWrite } from './security/sec003-load-state-write.js';
 import { sec004ServerModuleState } from './security/sec004-server-module-state.js';
@@ -96,6 +98,8 @@ export const allRules: Rule[] = [
   correct005PropMutation,
   correct006OrphanEffect,
   correct007OrphanLifecycle,
+  correct008BrowserGlobals,
+  correct009InstanceBrowserGlobals,
   sec001Html,
   sec002JavascriptUrl,
   sec003LoadStateWrite,
@@ -153,6 +157,8 @@ export {
   correct005PropMutation,
   correct006OrphanEffect,
   correct007OrphanLifecycle,
+  correct008BrowserGlobals,
+  correct009InstanceBrowserGlobals,
   sec001Html,
   sec002JavascriptUrl,
   sec003LoadStateWrite,

--- a/packages/core/test/architecture-rules.test.ts
+++ b/packages/core/test/architecture-rules.test.ts
@@ -24,6 +24,7 @@ const comp = (over: Partial<ComponentFacts>): ComponentFacts => ({
   mutatedProps: [],
   orphanEffects: [],
   orphanLifecycleCalls: [],
+  browserGlobalRefs: [],
   moduleStateDecls: [],
   suppressions: [],
   ...over

--- a/packages/core/test/bundle-rules.test.ts
+++ b/packages/core/test/bundle-rules.test.ts
@@ -27,6 +27,7 @@ const comp = (
   mutatedProps: [],
   orphanEffects: [],
   orphanLifecycleCalls: [],
+  browserGlobalRefs: [],
   moduleStateDecls: [],
   suppressions
 });

--- a/packages/core/test/component-collect.test.ts
+++ b/packages/core/test/component-collect.test.ts
@@ -44,6 +44,7 @@ describe('emptyComponentFacts', () => {
       mutatedProps: [],
       orphanEffects: [],
       orphanLifecycleCalls: [],
+      browserGlobalRefs: [],
       moduleStateDecls: [],
       suppressions: []
     });

--- a/packages/core/test/component-parse.test.ts
+++ b/packages/core/test/component-parse.test.ts
@@ -832,4 +832,14 @@ describe('parseComponentFacts — browser-global refs (CORRECT008/009)', () => {
     expect(refs('const w = window.innerWidth as number;')).toEqual([{ name: 'window', line: 1, context: 'module' }]);
     expect(refs('const x = foo as typeof window;')).toEqual([]);
   });
+  it('recognises a derived guard binding (one level)', () => {
+    const src = [
+      "import { browser } from '$app/environment';",
+      'const canUse = browser && !!window.matchMedia;',
+      'if (canUse) {',
+      '  window.scrollTo(0, 0);',
+      '}'
+    ].join('\n');
+    expect(refs(src)).toEqual([]);
+  });
 });

--- a/packages/core/test/component-parse.test.ts
+++ b/packages/core/test/component-parse.test.ts
@@ -823,4 +823,13 @@ describe('parseComponentFacts — browser-global refs (CORRECT008/009)', () => {
     const src = '{\n  const window = fake();\n  window.open();\n}';
     expect(refs(src)).toEqual([]);
   });
+  it('never flags TS type-position typeof or type annotations', () => {
+    expect(refs('type W = typeof window;\nexport type { W };')).toEqual([]);
+    expect(refs('interface Foo {\n  d: typeof document;\n}\nexport const x: Foo | null = null;')).toEqual([]);
+    expect(refs('const m = new Map<string, typeof localStorage>();')).toEqual([]);
+  });
+  it('still scans the runtime expression inside as/satisfies wrappers', () => {
+    expect(refs('const w = window.innerWidth as number;')).toEqual([{ name: 'window', line: 1, context: 'module' }]);
+    expect(refs('const x = foo as typeof window;')).toEqual([]);
+  });
 });

--- a/packages/core/test/component-parse.test.ts
+++ b/packages/core/test/component-parse.test.ts
@@ -737,3 +737,90 @@ describe('parseComponentFacts — orphan lifecycle calls (CORRECT007)', () => {
     expect(calls("import { type onMount, tick } from 'svelte';\ntick();")).toEqual([]);
   });
 });
+
+describe('parseComponentFacts — browser-global refs (CORRECT008/009)', () => {
+  const refs = (src: string, file = 'src/lib/store.svelte.ts') => parseComponentFacts(src, file).browserGlobalRefs;
+
+  it('flags bare and member-object reads at module scope', () => {
+    const src = 'const w = window.innerWidth;\nlocalStorage.setItem("k", "v");\ndocument.title = "x";';
+    expect(refs(src)).toEqual([
+      { name: 'window', line: 1, context: 'module' },
+      { name: 'localStorage', line: 2, context: 'module' },
+      { name: 'document', line: 3, context: 'module' }
+    ]);
+  });
+  it('does not flag typeof operands, property keys, or member property names', () => {
+    const src =
+      'const ok = typeof window;\nconst o = { window: 1, document: 2 };\nconst x = o.window;\napi.localStorage.get();';
+    expect(refs(src)).toEqual([]);
+  });
+  it('does not flag names imported or declared at top level', () => {
+    const src =
+      "import { window } from 'happy-dom';\nconst document = makeDoc();\nwindow.open();\ndocument.write('x');";
+    expect(refs(src)).toEqual([]);
+  });
+  it('skips browser-guarded clauses entirely (if / ternary / logical, alias included)', () => {
+    const src = [
+      "import { browser as isBrowser } from '$app/environment';",
+      'if (isBrowser) {',
+      '  window.scrollTo(0, 0);',
+      '} else {',
+      '  document.title;',
+      '}',
+      'const w = isBrowser ? window.innerWidth : 0;',
+      'isBrowser && localStorage.clear();'
+    ].join('\n');
+    expect(refs(src)).toEqual([]);
+  });
+  it('skips typeof-guarded clauses', () => {
+    const src =
+      "if (typeof window !== 'undefined') {\n  window.addEventListener('x', f);\n}\nconst s = typeof localStorage === 'undefined' ? null : localStorage.getItem('k');";
+    expect(refs(src)).toEqual([]);
+  });
+  it('does not flag reads inside functions, onMount, or $effect', () => {
+    const src = [
+      "import { onMount } from 'svelte';",
+      'export function width() {',
+      '  return window.innerWidth;',
+      '}',
+      'onMount(() => document.title);',
+      '$effect(() => {',
+      '  localStorage.setItem("a", "b");',
+      '});'
+    ].join('\n');
+    expect(refs(src)).toEqual([]);
+  });
+  it('splits module vs instance contexts in .svelte files', () => {
+    const src = [
+      '<script module>',
+      'const w = window.innerWidth;',
+      '</script>',
+      '<script>',
+      "  const stored = localStorage.getItem('k');",
+      '</script>'
+    ].join('\n');
+    expect(parseComponentFacts(src, 'C.svelte').browserGlobalRefs).toEqual([
+      { name: 'window', line: 2, context: 'module' },
+      { name: 'localStorage', line: 5, context: 'instance' }
+    ]);
+  });
+  it("shares the module script's guard and bindings with the instance scan", () => {
+    const src = [
+      '<script module>',
+      "import { browser } from '$app/environment';",
+      'const document = makeDoc();',
+      '</script>',
+      '<script>',
+      '  if (browser) {',
+      '    window.scrollTo(0, 0);',
+      '  }',
+      "  document.write('x');",
+      '</script>'
+    ].join('\n');
+    expect(parseComponentFacts(src, 'C.svelte').browserGlobalRefs).toEqual([]);
+  });
+  it('does not flag a shadowed name in a top-level block', () => {
+    const src = '{\n  const window = fake();\n  window.open();\n}';
+    expect(refs(src)).toEqual([]);
+  });
+});

--- a/packages/core/test/component-parse.test.ts
+++ b/packages/core/test/component-parse.test.ts
@@ -842,4 +842,18 @@ describe('parseComponentFacts — browser-global refs (CORRECT008/009)', () => {
     ].join('\n');
     expect(refs(src)).toEqual([]);
   });
+  it('recognises a <script module>-derived guard used in the instance script', () => {
+    const src = [
+      '<script module>',
+      "import { browser } from '$app/environment';",
+      'export const canUse = browser;',
+      '</script>',
+      '<script>',
+      '  if (canUse) {',
+      '    window.scrollTo(0, 0);',
+      '  }',
+      '</script>'
+    ].join('\n');
+    expect(parseComponentFacts(src, 'C.svelte').browserGlobalRefs).toEqual([]);
+  });
 });

--- a/packages/core/test/component-rule.test.ts
+++ b/packages/core/test/component-rule.test.ts
@@ -24,6 +24,7 @@ const comp = (over: Partial<ComponentFacts>): ComponentFacts => ({
   mutatedProps: [],
   orphanEffects: [],
   orphanLifecycleCalls: [],
+  browserGlobalRefs: [],
   moduleStateDecls: [],
   suppressions: [],
   ...over

--- a/packages/core/test/correctness-rules.test.ts
+++ b/packages/core/test/correctness-rules.test.ts
@@ -33,6 +33,7 @@ const comp = (over: Partial<ComponentFacts>): ComponentFacts => ({
   mutatedProps: [],
   orphanEffects: [],
   orphanLifecycleCalls: [],
+  browserGlobalRefs: [],
   moduleStateDecls: [],
   suppressions: [],
   ...over

--- a/packages/core/test/correctness-rules.test.ts
+++ b/packages/core/test/correctness-rules.test.ts
@@ -6,7 +6,9 @@ import {
   correct004UnmutatedState,
   correct005PropMutation,
   correct006OrphanEffect,
-  correct007OrphanLifecycle
+  correct007OrphanLifecycle,
+  correct008BrowserGlobals,
+  correct009InstanceBrowserGlobals
 } from '../src/index.js';
 import { defineConfig, defaultProject, type Result } from '../src/types.js';
 import type { ComponentFacts } from '../src/component.js';
@@ -286,5 +288,70 @@ describe('CORRECT007 lifecycle call outside component initialisation', () => {
   it('emits nothing without signal or in rendered mode', async () => {
     expect(await correct007OrphanLifecycle.check(ctx([comp({})]))).toHaveLength(0);
     expect(await correct007OrphanLifecycle.check(base as RuleContext)).toHaveLength(0);
+  });
+});
+
+describe('CORRECT008 browser global in server module code', () => {
+  it('flags a module-context read as critical with the module message', async () => {
+    const rs = await correct008BrowserGlobals.check(
+      ctx([
+        comp({
+          file: 'src/lib/store.svelte.ts',
+          browserGlobalRefs: [{ name: 'window', line: 1, context: 'module' }]
+        })
+      ])
+    );
+    expect(fails(rs)).toHaveLength(1);
+    expect(rs[0]!.severity).toBe('critical');
+    expect(rs[0]!.message).toContain('window');
+    expect(rs[0]!.message).toContain('is not defined');
+  });
+  it('ignores instance-context refs (CORRECT009 territory) and reads the kit channel', async () => {
+    const rs = await correct008BrowserGlobals.check({
+      ...ctx([comp({ browserGlobalRefs: [{ name: 'window', line: 3, context: 'instance' }] })]),
+      kitModules: [kitFacts({ browserGlobalRefs: [{ name: 'localStorage', line: 3, inHandler: true }] })]
+    });
+    expect(fails(rs)).toHaveLength(1);
+    expect(fails(rs)[0]!.route).toBe('src/routes/+page.ts');
+    expect(fails(rs)[0]!.message).toContain('load/handler');
+  });
+  it('is silenced by suppressions and emits nothing in rendered mode', async () => {
+    const rs = await correct008BrowserGlobals.check(
+      ctx([
+        comp({
+          browserGlobalRefs: [{ name: 'window', line: 2, context: 'module' }],
+          suppressions: [{ line: 2, ruleIds: ['CORRECT008'] }]
+        })
+      ])
+    );
+    expect(fails(rs)).toHaveLength(0);
+    expect(await correct008BrowserGlobals.check(base as RuleContext)).toHaveLength(0);
+  });
+});
+
+describe('CORRECT009 browser global during component initialisation', () => {
+  it('flags an instance-context read as warning', async () => {
+    const rs = await correct009InstanceBrowserGlobals.check(
+      ctx([
+        comp({
+          file: 'src/lib/Widget.svelte',
+          browserGlobalRefs: [{ name: 'localStorage', line: 4, context: 'instance' }]
+        })
+      ])
+    );
+    expect(fails(rs)).toHaveLength(1);
+    expect(rs[0]!.severity).toBe('warning');
+    expect(rs[0]!.line).toBe(4);
+    expect(rs[0]!.message).toContain('localStorage');
+  });
+  it('ignores module-context refs and files without instance refs', async () => {
+    expect(
+      fails(
+        await correct009InstanceBrowserGlobals.check(
+          ctx([comp({ browserGlobalRefs: [{ name: 'window', line: 1, context: 'module' }] })])
+        )
+      )
+    ).toHaveLength(0);
+    expect(await correct009InstanceBrowserGlobals.check(ctx([comp({})]))).toHaveLength(0);
   });
 });

--- a/packages/core/test/correctness-rules.test.ts
+++ b/packages/core/test/correctness-rules.test.ts
@@ -47,6 +47,7 @@ const kitFacts = (over: Partial<KitModuleFacts>): KitModuleFacts => ({
   importedStateWritesOutsideHandlers: [],
   runesModuleImports: [],
   lifecycleCalls: [],
+  browserGlobalRefs: [],
   suppressions: [],
   ...over
 });

--- a/packages/core/test/kit-module-parse.test.ts
+++ b/packages/core/test/kit-module-parse.test.ts
@@ -317,4 +317,14 @@ describe('parseKitModuleFacts — browser-global refs (CORRECT008)', () => {
       { name: 'window', line: 2, inHandler: false }
     ]);
   });
+  it('scans a function aliased to both a handler and init exactly once (handler wins)', () => {
+    const src = 'function foo() {\n  document.title;\n}\nexport { foo as load, foo as init };';
+    expect(facts(src, 'src/routes/+page.ts').browserGlobalRefs).toEqual([
+      { name: 'document', line: 2, inHandler: true }
+    ]);
+  });
+  it('honours the alias-exported ssr = false form', () => {
+    const src = 'const ssr = false;\nexport { ssr };\nconst w = window.innerWidth;';
+    expect(facts(src, 'src/routes/+page.ts').browserGlobalRefs).toEqual([]);
+  });
 });

--- a/packages/core/test/kit-module-parse.test.ts
+++ b/packages/core/test/kit-module-parse.test.ts
@@ -327,4 +327,26 @@ describe('parseKitModuleFacts — browser-global refs (CORRECT008)', () => {
     const src = 'const ssr = false;\nexport { ssr };\nconst w = window.innerWidth;';
     expect(facts(src, 'src/routes/+page.ts').browserGlobalRefs).toEqual([]);
   });
+  it('stops scanning a handler after an early-return browser guard', () => {
+    const src = [
+      "import { browser } from '$app/environment';",
+      'export function load() {',
+      '  if (!browser) return {};',
+      '  return { w: window.innerWidth };',
+      '}'
+    ].join('\n');
+    expect(facts(src, 'src/routes/+page.ts').browserGlobalRefs).toEqual([]);
+  });
+  it('stops after a typeof early-return guard but still flags before it', () => {
+    const src = [
+      'export function load() {',
+      '  const before = navigator.language;',
+      "  if (typeof window === 'undefined') return {};",
+      '  return { w: window.innerWidth };',
+      '}'
+    ].join('\n');
+    expect(facts(src, 'src/routes/+page.ts').browserGlobalRefs).toEqual([
+      { name: 'navigator', line: 2, inHandler: true }
+    ]);
+  });
 });

--- a/packages/core/test/kit-module-parse.test.ts
+++ b/packages/core/test/kit-module-parse.test.ts
@@ -337,6 +337,19 @@ describe('parseKitModuleFacts — browser-global refs (CORRECT008)', () => {
     ].join('\n');
     expect(facts(src, 'src/routes/+page.ts').browserGlobalRefs).toEqual([]);
   });
+  it('recognises a module-level derived guard used inside a handler', () => {
+    const src = [
+      "import { browser } from '$app/environment';",
+      'const canUse = browser;',
+      'export function load() {',
+      '  if (canUse) {',
+      '    return { w: window.innerWidth };',
+      '  }',
+      '  return {};',
+      '}'
+    ].join('\n');
+    expect(facts(src, 'src/routes/+page.ts').browserGlobalRefs).toEqual([]);
+  });
   it('stops after a typeof early-return guard but still flags before it', () => {
     const src = [
       'export function load() {',

--- a/packages/core/test/kit-module-parse.test.ts
+++ b/packages/core/test/kit-module-parse.test.ts
@@ -269,3 +269,52 @@ describe('parseKitModuleFacts — lifecycle calls (CORRECT007)', () => {
     expect(facts(src).lifecycleCalls).toEqual([{ name: 'getContext', line: 3, inHandler: true }]);
   });
 });
+
+describe('parseKitModuleFacts — browser-global refs (CORRECT008)', () => {
+  it('flags reads at top level and inside load with the right inHandler flags', () => {
+    const src = "const w = window.innerWidth;\nexport function load() {\n  return { s: localStorage.getItem('k') };\n}";
+    expect(facts(src, 'src/routes/+page.ts').browserGlobalRefs).toEqual([
+      { name: 'window', line: 1, inHandler: false },
+      { name: 'localStorage', line: 3, inHandler: true }
+    ]);
+  });
+  it('flags init-hook reads with inHandler false and exempts helper functions', () => {
+    const src = [
+      'export async function init() {',
+      '  document.title;',
+      '}',
+      'export function helper() {',
+      '  return window.innerWidth;',
+      '}'
+    ].join('\n');
+    expect(facts(src, 'src/hooks.server.ts').browserGlobalRefs).toEqual([
+      { name: 'document', line: 2, inHandler: false }
+    ]);
+  });
+  it('does not descend into closures nested inside a handler', () => {
+    const src = 'export function load() {\n  return { getWidth: () => window.innerWidth };\n}';
+    expect(facts(src, 'src/routes/+page.ts').browserGlobalRefs).toEqual([]);
+  });
+  it('respects browser/typeof guards and handler-parameter shadowing inside handlers', () => {
+    const src = [
+      "import { browser } from '$app/environment';",
+      'export function load({ window }) {',
+      '  if (browser) {',
+      '    document.title;',
+      '  }',
+      '  window.close();',
+      "  return typeof localStorage !== 'undefined' ? localStorage.getItem('k') : null;",
+      '}'
+    ].join('\n');
+    expect(facts(src, 'src/routes/+page.ts').browserGlobalRefs).toEqual([]);
+  });
+  it('empties the facts when the file itself exports ssr = false, but not for csr = false', () => {
+    const ssrOff =
+      'export const ssr = false;\nconst w = window.innerWidth;\nexport function load() {\n  return { t: document.title };\n}';
+    expect(facts(ssrOff, 'src/routes/+page.ts').browserGlobalRefs).toEqual([]);
+    const csrOff = 'export const csr = false;\nconst w = window.innerWidth;';
+    expect(facts(csrOff, 'src/routes/+page.ts').browserGlobalRefs).toEqual([
+      { name: 'window', line: 2, inHandler: false }
+    ]);
+  });
+});

--- a/packages/core/test/security-kit-rules.test.ts
+++ b/packages/core/test/security-kit-rules.test.ts
@@ -22,6 +22,7 @@ const kit = (over: Partial<KitModuleFacts>): KitModuleFacts => ({
   importedStateWritesOutsideHandlers: [],
   runesModuleImports: [],
   lifecycleCalls: [],
+  browserGlobalRefs: [],
   suppressions: [],
   ...over
 });

--- a/packages/core/test/security-kit-rules.test.ts
+++ b/packages/core/test/security-kit-rules.test.ts
@@ -87,6 +87,7 @@ const stateModule = (file: string): ComponentFacts => ({
   mutatedProps: [],
   orphanEffects: [],
   orphanLifecycleCalls: [],
+  browserGlobalRefs: [],
   moduleStateDecls: [{ name: 'user', line: 1 }],
   suppressions: []
 });

--- a/packages/core/test/security-rules.test.ts
+++ b/packages/core/test/security-rules.test.ts
@@ -24,6 +24,7 @@ const comp = (over: Partial<ComponentFacts>): ComponentFacts => ({
   mutatedProps: [],
   orphanEffects: [],
   orphanLifecycleCalls: [],
+  browserGlobalRefs: [],
   moduleStateDecls: [],
   suppressions: [],
   ...over


### PR DESCRIPTION
## Summary

Adds two rules catching the classic SSR `ReferenceError: window is not defined` 500 before deploy (the eslint-plugin-svelte `no-top-level-browser-globals` gap in svelte-vitals's CI-gating context, adapted rather than copied):

- **CORRECT008 (critical)** — browser-only globals read in **server-executed module code**: module scope of `.svelte.ts`/`.svelte.js` and `.svelte` `<script module>` (crashes at import), and SvelteKit route/hooks files — top level, load/action/endpoint handler bodies, the `init` hook. Same-file `export const ssr = false` (incl. `satisfies` and alias-export forms) opts the file out; `csr = false` does not. Functions aliased to both a handler and `init` are scanned once (handler wins).
- **CORRECT009 (warning)** — browser globals at the **top level of a component's instance script**, which runs on the server on every SSR render. Warning, not critical: a component rendered only behind a parent's `{#if browser}` (or a client-only dynamic import) is a legitimate pattern that cannot be proven cross-file — the docs point at the inline suppression for that case.

Detection is a new position-aware scanner over a **curated 17-name list** (`window`, `document`, `localStorage`, …; the eslint rule's dynamic `globals.browser − node` list would false-positive on generic identifiers without scope analysis). It recognises `browser` from `$app/environment` (aliases and one-level derived guard bindings, shared across `<script module>`/instance and into handler scans), `typeof X !== 'undefined'` checks, and **terminating early-return guards** (`if (!browser) return {};`); never scans `onMount`/`$effect`/function bodies, TS type subtrees, property keys, your own bindings, or shadowed locals.

Design doc: `docs/superpowers/specs/2026-07-16-correct008-009-browser-globals-design.md`
Plan: `docs/superpowers/plans/2026-07-16-correct008-009-browser-globals.md`

## Test plan

- 25+ new tests across the scanner (position discipline, guard forms incl. aliased/derived/early-return, TS type-position negatives, shadowing, module/instance context split), the Kit channel (handler/`init`/top-level flags, nested-closure exemption, `ssr = false` opt-out both forms, handler/init alias dedupe), and both rules (severities, messages, suppression, rendered no-op)
- Root `pnpm build` / `pnpm typecheck` / `pnpm test` (1,384 tests) / `pnpm lint` all green
- Final whole-branch review ran a hostile false-positive probe battery against the built dist (`svelte/reactivity/window`, `$derived` initializers, `prerender` files, `satisfies`/`as` wrappers, derived guards, param shadowing) — the TS-type-subtree and early-return-guard false positives it found were fixed with regression tests across two fix loops; final verdict "Ready to merge"

Known conservative misses are documented in the spec and rule docs (guard else-branches, cross-file client-only components, root-layout `ssr = false`, `import.meta.env.SSR`, template expressions, `$props()` defaults, nested-block early returns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CORRECT008 and CORRECT009 rules to detect browser-only globals used in server-rendered code.
  * Added safeguards for common browser checks and client-only execution patterns.
* **Documentation**
  * Added English and Japanese guidance for both rules, including remediation examples.
  * Updated suppression guidance to include the new rule range.
* **Tests**
  * Added coverage for detection, exemptions, SSR behavior, suppression, and server route handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->