### PR TITLE
feat: route-/file-scoped rule overrides + make exclusions discoverable from CI

### DIFF
--- a/.changeset/report-footer-exclusion-link.md
+++ b/.changeset/report-footer-exclusion-link.md
@@ -1,0 +1,5 @@
+---
+'@svelte-vitals/core': patch
+---
+
+The Markdown report (GitHub Actions job summary / sticky PR comment) now ends with a one-line pointer to the "Excluding routes or rules" docs whenever findings are shown, so adopters blocked by expected findings (e.g. auth-only routes flagged by SEO rules) can find `overrides` / the suppressions file from the report itself.

--- a/.changeset/report-footer-exclusion-link.md
+++ b/.changeset/report-footer-exclusion-link.md
@@ -1,5 +1,5 @@
 ---
-'@svelte-vitals/core': patch
+'@svelte-vitals/core': minor
 ---
 
 The Markdown report (GitHub Actions job summary / sticky PR comment) now ends with a one-line pointer to the "Excluding routes or rules" docs whenever findings are shown, so adopters blocked by expected findings (e.g. auth-only routes flagged by SEO rules) can find `overrides` / the suppressions file from the report itself.

--- a/.changeset/route-file-scoped-overrides.md
+++ b/.changeset/route-file-scoped-overrides.md
@@ -1,0 +1,7 @@
+---
+'@svelte-vitals/core': minor
+'svelte-vitals': minor
+'@svelte-vitals/vite': minor
+---
+
+Add route-/file-scoped rule overrides via a new `overrides` option in `svelte-vitals.config.*` (also available as a Vite plugin option). Each entry scopes rule settings with `route` globs (matched against route ids) and/or `files` globs (matched against source paths — the way to target a `(group)` directory, since group segments are dropped from route ids): `overrides: [{ files: 'src/routes/(app)/**', rules: { seo: 'off' } }]` turns all SEO rules off for an auth-only route group, durably — routes added under the glob later are excluded too, unlike the snapshot-style suppressions file. Keys in an entry's `rules` may be rule ids or category names; values are `'off'` (the finding is removed entirely) or a severity. Applied in `analyzeProject`, so the CLI, MCP server, GitHub Action, and Vite build gate all honor it.

--- a/docs/src/content/docs/guides/ci.md
+++ b/docs/src/content/docs/guides/ci.md
@@ -151,7 +151,7 @@ Vite plugin, and this action. Pick by intent:
 - **The findings are real, you just can't fix them all now** — accept the current backlog
   one-shot with `svelte-vitals --update-suppressions` and commit the file (see
   [Adopting on an existing project](#adopting-on-an-existing-project) above). Unlike `overrides`,
-  this is a snapshot: a *new* route with the same problem fails again, which is exactly what you
+  this is a snapshot: a _new_ route with the same problem fails again, which is exactly what you
   want for a backlog.
 
 All three are committed files — no workflow inputs involved, and a change to them is reviewed

--- a/docs/src/content/docs/guides/ci.md
+++ b/docs/src/content/docs/guides/ci.md
@@ -113,6 +113,50 @@ A few things worth knowing before you see the real thing:
 There's no `reporter` input — the action always produces annotations, the job summary, and the
 sticky comment together in one pass; that fan-out isn't something you configure separately.
 
+The inputs above are **not** the whole configuration surface: the action runs the same analysis
+as the CLI, so it automatically picks up your committed
+[`svelte-vitals.config.*`](/svelte-vitals/guides/configuration/) and
+[`svelte-vitals-suppressions.json`](/svelte-vitals/guides/cli/#svelte-vitals-suppressionsjson----update-suppressions----no-suppressions)
+— see the next section.
+
+## Excluding routes or rules
+
+A common wall when adopting in CI: routes that are intentionally not public (behind auth, admin
+areas) get flagged by SEO rules, and there's no action input to exclude them — because exclusions
+live in files the action already reads, so they apply identically to the CLI, the MCP server, the
+Vite plugin, and this action. Pick by intent:
+
+- **Never want a rule at all** — turn it off globally in
+  [`svelte-vitals.config.*`](/svelte-vitals/guides/configuration/):
+
+  ```js
+  // svelte-vitals.config.mjs
+  export default {
+    rules: { SEO008: 'off' }
+  };
+  ```
+
+- **A rule or category doesn't apply to part of the app** (the auth-only case) — scope it with
+  [`overrides`](/svelte-vitals/guides/configuration/#scoping-rules-to-routes-or-files-overrides).
+  This is durable policy: routes added under the glob later are excluded too.
+
+  ```js
+  // svelte-vitals.config.mjs
+  export default {
+    // No SEO checks for anything in the (app) route group.
+    overrides: [{ files: 'src/routes/(app)/**', rules: { seo: 'off' } }]
+  };
+  ```
+
+- **The findings are real, you just can't fix them all now** — accept the current backlog
+  one-shot with `svelte-vitals --update-suppressions` and commit the file (see
+  [Adopting on an existing project](#adopting-on-an-existing-project) above). Unlike `overrides`,
+  this is a snapshot: a *new* route with the same problem fails again, which is exactly what you
+  want for a backlog.
+
+All three are committed files — no workflow inputs involved, and a change to them is reviewed
+like any other PR.
+
 ## Permissions
 
 The generated workflow requests:

--- a/docs/src/content/docs/guides/configuration.mdx
+++ b/docs/src/content/docs/guides/configuration.mdx
@@ -70,13 +70,13 @@ The `defineConfig` import in a `.ts` config is a **runtime** import — it resol
 
 ## Available options
 
-| Option           | Type                                                         | Default            | Description                                                                                |
-| ---------------- | ------------------------------------------------------------ | ------------------ | ------------------------------------------------------------------------------------------ |
-| `treatDynamicAs` | `'pass' \| 'warn' \| 'fail'`                                 | `'pass'`           | How to score routes where a metadata value is set dynamically                              |
-| `metaComponents` | `string[]`                                                   | `[]`               | Custom component names that emit `<head>` metadata                                         |
-| `rules`          | `Record<string, 'off' \| 'critical' \| 'warning' \| 'info'>` | `{}`               | Per-rule overrides — disable a rule or change its severity                                 |
-| `failOn`         | `'critical' \| 'warning' \| 'info'`                          | `'critical'`       | Minimum severity that fails the run (exit code `1`)                                        |
-| `weights`        | `Partial<Record<Category, number>>`                          | every category `1` | Per-category weights for the combined [Health score](/svelte-vitals/guides/health-report/) |
+| Option           | Type                                                         | Default            | Description                                                                                  |
+| ---------------- | ------------------------------------------------------------ | ------------------ | -------------------------------------------------------------------------------------------- |
+| `treatDynamicAs` | `'pass' \| 'warn' \| 'fail'`                                 | `'pass'`           | How to score routes where a metadata value is set dynamically                                |
+| `metaComponents` | `string[]`                                                   | `[]`               | Custom component names that emit `<head>` metadata                                           |
+| `rules`          | `Record<string, 'off' \| 'critical' \| 'warning' \| 'info'>` | `{}`               | Per-rule overrides — disable a rule or change its severity                                   |
+| `failOn`         | `'critical' \| 'warning' \| 'info'`                          | `'critical'`       | Minimum severity that fails the run (exit code `1`)                                          |
+| `weights`        | `Partial<Record<Category, number>>`                          | every category `1` | Per-category weights for the combined [Health score](/svelte-vitals/guides/health-report/)   |
 | `overrides`      | `RuleOverride[]`                                             | (none)             | Route-/file-scoped rule overrides — see [below](#scoping-rules-to-routes-or-files-overrides) |
 
 `Category` is `'seo' | 'performance' | 'correctness' | 'security' | 'architecture'`.

--- a/docs/src/content/docs/guides/configuration.mdx
+++ b/docs/src/content/docs/guides/configuration.mdx
@@ -77,10 +77,56 @@ The `defineConfig` import in a `.ts` config is a **runtime** import — it resol
 | `rules`          | `Record<string, 'off' \| 'critical' \| 'warning' \| 'info'>` | `{}`               | Per-rule overrides — disable a rule or change its severity                                 |
 | `failOn`         | `'critical' \| 'warning' \| 'info'`                          | `'critical'`       | Minimum severity that fails the run (exit code `1`)                                        |
 | `weights`        | `Partial<Record<Category, number>>`                          | every category `1` | Per-category weights for the combined [Health score](/svelte-vitals/guides/health-report/) |
+| `overrides`      | `RuleOverride[]`                                             | (none)             | Route-/file-scoped rule overrides — see [below](#scoping-rules-to-routes-or-files-overrides) |
 
 `Category` is `'seo' | 'performance' | 'correctness' | 'security' | 'architecture'`.
 
 A weight of `0` is valid — it excludes that category from the Health average entirely (the category's own score still appears in the output, and findings / exit-code behavior are unaffected). Setting **every** present category to `0` is an error, though: there is nothing left to average, so the run stops with exit `2`.
+
+## Scoping rules to routes or files (overrides)
+
+`rules` applies everywhere. `overrides` applies rule settings only where they match — the typical
+case being routes that are intentionally not public (behind auth) and shouldn't be held to SEO
+metadata rules:
+
+```js
+// svelte-vitals.config.mjs
+export default {
+  overrides: [
+    // Everything in the (app) route group: no SEO checks at all.
+    { files: 'src/routes/(app)/**', rules: { seo: 'off' } },
+    // /admin and everything under it: keep SEO001, but only as info.
+    { route: '/admin/**', rules: { SEO001: 'info' } }
+  ]
+};
+```
+
+Each entry has `rules` (keys are **rule ids or category names**, values are
+`'off' | 'critical' | 'warning' | 'info'`) plus at least one scope:
+
+- **`route`** — glob(s) matched against the finding's route id as shown in reports (e.g.
+  `/blog/[slug]`). Note that SvelteKit `(group)` segments are **not** part of the route id
+  (`src/routes/(app)/dashboard` reports as `/dashboard`) — to target a group, use `files`.
+- **`files`** — glob(s) matched against the finding's source path (e.g.
+  `src/routes/(app)/dashboard/+page.svelte`).
+
+Glob syntax is deliberately small: `*` matches within a path segment, `**` matches across
+segments, and a trailing `/**` also matches the bare prefix (`/admin/**` matches `/admin`
+itself). Everything else — including `(`, `)`, `[`, `]` — is literal. An entry matches when
+_any_ of its `route` or `files` globs match.
+
+Semantics worth knowing:
+
+- `'off'` removes matching findings entirely — they don't fail the run and don't drag the
+  score, as if the rule hadn't run there. A severity value re-classifies instead.
+- Entries are evaluated in order and **later entries win**; within one entry, a rule-id key
+  beats a category key. Overrides always win over the global `rules` setting where they match.
+- Findings that aren't attached to a route or file (project-wide checks like robots.txt) are
+  never affected — use `rules` for those.
+- For a permanent "this part of the app is exempt" policy, prefer `overrides` over the
+  [suppressions file](/svelte-vitals/guides/cli/#svelte-vitals-suppressionsjson----update-suppressions----no-suppressions):
+  suppressions accept only the findings that existed when the file was written, so newly added
+  routes fail again; overrides keep matching new routes under the same glob.
 
 ## Precedence
 
@@ -88,9 +134,11 @@ For each field, the first of these that is set wins: **CLI flag > config file > 
 
 One exception: `rules` is replaced as a whole, not merged key-by-key. If you pass `--rules` or `--ignore` on the command line, the flag-built rule set replaces the config file's `rules` entirely for that run — it does not merge with it.
 
+`overrides` has no CLI flag — route policy belongs in a committed file. The config file is its only source for the CLI/MCP/action; the Vite plugin additionally accepts it as a plugin option (option > file, as usual).
+
 ## Validation
 
-- **Invalid and svelte-vitals stops (exit `2`)**: the file can't be loaded (syntax error, no default export, or a `.ts` file on a Node version that can't load it — see below); an unknown rule id inside `rules`; an unknown category or a negative/non-numeric value inside `weights`.
+- **Invalid and svelte-vitals stops (exit `2`)**: the file can't be loaded (syntax error, no default export, or a `.ts` file on a Node version that can't load it — see below); an unknown rule id inside `rules`; an unknown category or a negative/non-numeric value inside `weights`; a malformed `overrides` entry (not `{ route/files, rules }`-shaped, a scope that isn't a string / non-empty string array, a key in its `rules` that is neither a known rule id nor a category, or a setting other than `off`/`critical`/`warning`/`info`).
 - **Invalid but ignored, with a warning (analysis still runs)**: an unrecognized `treatDynamicAs` or `failOn` value (falls back to flag/default); an unrecognized top-level key (forward-compatible with future config fields).
 
 ## TypeScript configs
@@ -115,4 +163,4 @@ export default {
 };
 ```
 
-With a `svelte-vitals.config` file (any of the three supported extensions) in the project root, the plugin above picks up its `treatDynamicAs` / `metaComponents` / `rules` / `failOn` / `weights` automatically — no need to import the file yourself in `vite.config.ts`. Non-fatal config-file warnings (unknown top-level keys, invalid enum values) are logged to the console with a `svelte-vitals:` prefix, the same wording the CLI uses.
+With a `svelte-vitals.config` file (any of the three supported extensions) in the project root, the plugin above picks up its `treatDynamicAs` / `metaComponents` / `rules` / `failOn` / `weights` / `overrides` automatically — no need to import the file yourself in `vite.config.ts`. Non-fatal config-file warnings (unknown top-level keys, invalid enum values) are logged to the console with a `svelte-vitals:` prefix, the same wording the CLI uses.

--- a/docs/src/content/docs/ja/guides/ci.md
+++ b/docs/src/content/docs/ja/guides/ci.md
@@ -110,6 +110,49 @@ svelte-vitals が生成したワークフローが既にある場合は、`--for
 スティッキーコメントを1回のパスでまとめて生成します。この出力の振り分けは個別に
 設定するものではなくなりました。
 
+上記の入力が設定のすべてでは**ありません**。Action は CLI と同じ解析を実行するため、コミット済みの
+[`svelte-vitals.config.*`](/svelte-vitals/ja/guides/configuration/) と
+[`svelte-vitals-suppressions.json`](/svelte-vitals/ja/guides/cli/#svelte-vitals-suppressionsjson----update-suppressions----no-suppressions)
+を自動的に読み取ります — 次のセクションを参照してください。
+
+## ルートやルールを除外する
+
+CI 導入時によくぶつかる壁：意図的に公開していないルート（認証必須のページや管理画面）が SEO
+ルールに大量に引っかかるのに、それを除外する Action の入力が見当たらない — 除外の仕組みは
+Action がすでに読み取っているファイル側にあるからです。そのため同じ設定が CLI・MCP サーバー・
+Vite プラグイン・この Action すべてに同一に適用されます。意図に応じて選んでください：
+
+- **そのルールが一切不要** — [`svelte-vitals.config.*`](/svelte-vitals/ja/guides/configuration/)
+  でグローバルに無効化します：
+
+  ```js
+  // svelte-vitals.config.mjs
+  export default {
+    rules: { SEO008: 'off' }
+  };
+  ```
+
+- **アプリの一部にだけルールやカテゴリが当てはまらない**（認証必須ルートのケース）—
+  [`overrides`](/svelte-vitals/ja/guides/configuration/#ルールをルートやファイルにスコープする-overrides)
+  でスコープします。これは恒久的なポリシーです：あとから glob 配下に追加したルートも除外されます。
+
+  ```js
+  // svelte-vitals.config.mjs
+  export default {
+    // (app) ルートグループ配下では SEO チェックを行わない。
+    overrides: [{ files: 'src/routes/(app)/**', rules: { seo: 'off' } }]
+  };
+  ```
+
+- **検出結果自体は正しいが、今すぐ全部は直せない** — `svelte-vitals --update-suppressions` で
+  現在の蓄積分を一括で受け入れてファイルをコミットします（上の
+  [既存プロジェクトへの導入](#既存プロジェクトへの導入) を参照）。`overrides` と違いこちらは
+  スナップショットです：同じ問題を持つ*新しい*ルートは再び失敗します — 蓄積分の管理には
+  まさにそれが望ましい挙動です。
+
+3つともコミットされるファイルです — ワークフローの入力は関与せず、変更は他の PR と同じように
+レビューされます。
+
 ## 権限
 
 生成されるワークフローは以下を要求します：

--- a/docs/src/content/docs/ja/guides/configuration.mdx
+++ b/docs/src/content/docs/ja/guides/configuration.mdx
@@ -77,10 +77,59 @@ svelte-vitals は次のファイルを、この優先順で**分析対象ディ�
 | `rules`          | `Record<string, 'off' \| 'critical' \| 'warning' \| 'info'>` | `{}`           | ルールごとの上書き — ルールを無効化するか重大度を変更する                                  |
 | `failOn`         | `'critical' \| 'warning' \| 'info'`                          | `'critical'`   | 実行を失敗させる(終了コード `1`)最低重大度                                                 |
 | `weights`        | `Partial<Record<Category, number>>`                          | 各カテゴリ `1` | 組み合わせた [Health スコア](/svelte-vitals/ja/guides/health-report/) のカテゴリごとの重み |
+| `overrides`      | `RuleOverride[]`                                             | (なし)         | ルート/ファイル単位のルール上書き — [下記](#ルールをルートやファイルにスコープする-overrides)を参照 |
 
 `Category` は `'seo' | 'performance' | 'correctness' | 'security' | 'architecture'` です。
 
 重み `0` は正当な値で、そのカテゴリを Health の平均から完全に除外します(カテゴリ自体のスコアは引き続き出力され、検出結果や終了コードの挙動にも影響しません)。ただし、結果に存在する**すべて**のカテゴリを `0` にすると平均の取りようがなくなるため、実行はエラー(終了コード `2`)になります。
+
+## ルールをルートやファイルにスコープする (overrides)
+
+`rules` は全体に適用されます。`overrides` はマッチした箇所にだけルール設定を適用します —
+典型的なのは、意図的に非公開のルート(認証必須のページ)を SEO メタデータルールの対象外に
+したいケースです：
+
+```js
+// svelte-vitals.config.mjs
+export default {
+  overrides: [
+    // (app) ルートグループ配下：SEO チェックを一切行わない。
+    { files: 'src/routes/(app)/**', rules: { seo: 'off' } },
+    // /admin とその配下：SEO001 は残すが info に格下げ。
+    { route: '/admin/**', rules: { SEO001: 'info' } }
+  ]
+};
+```
+
+各エントリは `rules`(キーは**ルール ID またはカテゴリ名**、値は
+`'off' | 'critical' | 'warning' | 'info'`)と、少なくとも1つのスコープを持ちます：
+
+- **`route`** — レポートに表示されるルート ID(例: `/blog/[slug]`)にマッチする glob。
+  SvelteKit の `(group)` セグメントはルート ID に**含まれない**点に注意してください
+  (`src/routes/(app)/dashboard` は `/dashboard` として報告されます) — グループを対象に
+  するには `files` を使います。
+- **`files`** — 検出結果のソースパス(例: `src/routes/(app)/dashboard/+page.svelte`)に
+  マッチする glob。
+
+glob の構文は意図的に小さくしてあります：`*` はパスセグメント内にマッチ、`**` はセグメントを
+またいでマッチ、末尾の `/**` はプレフィックス自体にもマッチします(`/admin/**` は `/admin`
+そのものにもマッチ)。それ以外 — `(`、`)`、`[`、`]` を含む — はすべてリテラルです。エントリは
+`route` / `files` の glob の*いずれか*がマッチしたときにマッチします。
+
+知っておくべきセマンティクス：
+
+- `'off'` はマッチした検出結果を完全に取り除きます — 実行を失敗させず、スコアも下げません。
+  そのルールがそこでは実行されなかったのと同じ扱いです。重大度の値を指定すると再分類になります。
+- エントリは順に評価され、**後のエントリが勝ちます**。1つのエントリ内ではルール ID のキーが
+  カテゴリのキーに勝ちます。マッチした箇所ではオーバーライドが常にグローバルの `rules` 設定に
+  勝ちます。
+- ルートにもファイルにも紐付かない検出結果(robots.txt などプロジェクト全体のチェック)には
+  一切影響しません — そちらは `rules` を使ってください。
+- 「アプリのこの部分は恒久的に対象外」というポリシーには、
+  [suppressions ファイル](/svelte-vitals/ja/guides/cli/#svelte-vitals-suppressionsjson----update-suppressions----no-suppressions)
+  より `overrides` を選んでください：suppressions はファイルを書き出した時点で存在した検出結果
+  だけを受け入れるため、あとから追加したルートは再び失敗します。overrides は同じ glob 配下の
+  新しいルートにもマッチし続けます。
 
 ## 優先順位
 
@@ -88,9 +137,11 @@ svelte-vitals は次のファイルを、この優先順で**分析対象ディ�
 
 一つ例外があります。`rules` はキー単位でマージされるのではなく、全体が丸ごと置き換わります。コマンドラインで `--rules` または `--ignore` を指定した場合、フラグから構築されたルールセットがその実行では設定ファイルの `rules` を完全に置き換えます — マージはされません。
 
+`overrides` に対応する CLI フラグはありません — ルートのポリシーはコミットされるファイルに置くべきものだからです。CLI/MCP/Action にとっては設定ファイルが唯一のソースで、Vite プラグインだけは追加でプラグインオプションとしても受け取ります(いつも通り、オプション > ファイル)。
+
 ## バリデーション
 
-- **無効で svelte-vitals が停止する(終了コード `2`)**:ファイルを読み込めない(構文エラー、default export がない、または後述する Node のバージョンで `.ts` ファイルを読み込めない場合)、`rules` 内に未知のルール ID がある、`weights` 内に未知のカテゴリまたは負の値・数値でない値がある場合。
+- **無効で svelte-vitals が停止する(終了コード `2`)**:ファイルを読み込めない(構文エラー、default export がない、または後述する Node のバージョンで `.ts` ファイルを読み込めない場合)、`rules` 内に未知のルール ID がある、`weights` 内に未知のカテゴリまたは負の値・数値でない値がある場合、`overrides` のエントリが不正な場合(`{ route/files, rules }` の形でない、スコープが文字列でも空でない文字列配列でもない、`rules` 内のキーが既知のルール ID でもカテゴリ名でもない、設定値が `off`/`critical`/`warning`/`info` 以外)。
 - **無効だが無視され、警告が出る(分析は続行される)**:認識できない `treatDynamicAs` または `failOn` の値(フラグ／デフォルトにフォールバック)、認識できないトップレベルキー(将来の設定フィールドとの前方互換性のため)。
 
 ## TypeScript の設定ファイル
@@ -115,4 +166,4 @@ export default {
 };
 ```
 
-プロジェクトルートに `svelte-vitals.config` ファイル(サポートされる3つの拡張子のいずれか)を置くだけで、上記のプラグインはその `treatDynamicAs` / `metaComponents` / `rules` / `failOn` / `weights` を自動的に読み込みます — `vite.config.ts` 側で自分でファイルを import する必要はありません。設定ファイルの非致命的な警告(未知のトップレベルキー、無効な列挙値など)は、CLI と同じ `svelte-vitals:` というプレフィックス付きの文言でコンソールに出力されます。
+プロジェクトルートに `svelte-vitals.config` ファイル(サポートされる3つの拡張子のいずれか)を置くだけで、上記のプラグインはその `treatDynamicAs` / `metaComponents` / `rules` / `failOn` / `weights` / `overrides` を自動的に読み込みます — `vite.config.ts` 側で自分でファイルを import する必要はありません。設定ファイルの非致命的な警告(未知のトップレベルキー、無効な列挙値など)は、CLI と同じ `svelte-vitals:` というプレフィックス付きの文言でコンソールに出力されます。

--- a/docs/src/content/docs/ja/guides/configuration.mdx
+++ b/docs/src/content/docs/ja/guides/configuration.mdx
@@ -70,13 +70,13 @@ svelte-vitals は次のファイルを、この優先順で**分析対象ディ�
 
 ## 利用可能なオプション
 
-| オプション       | 型                                                           | デフォルト     | 説明                                                                                       |
-| ---------------- | ------------------------------------------------------------ | -------------- | ------------------------------------------------------------------------------------------ |
-| `treatDynamicAs` | `'pass' \| 'warn' \| 'fail'`                                 | `'pass'`       | メタデータの値が動的に設定されているルートをどう採点するか                                 |
-| `metaComponents` | `string[]`                                                   | `[]`           | `<head>` メタデータを出力するカスタムコンポーネント名                                      |
-| `rules`          | `Record<string, 'off' \| 'critical' \| 'warning' \| 'info'>` | `{}`           | ルールごとの上書き — ルールを無効化するか重大度を変更する                                  |
-| `failOn`         | `'critical' \| 'warning' \| 'info'`                          | `'critical'`   | 実行を失敗させる(終了コード `1`)最低重大度                                                 |
-| `weights`        | `Partial<Record<Category, number>>`                          | 各カテゴリ `1` | 組み合わせた [Health スコア](/svelte-vitals/ja/guides/health-report/) のカテゴリごとの重み |
+| オプション       | 型                                                           | デフォルト     | 説明                                                                                                |
+| ---------------- | ------------------------------------------------------------ | -------------- | --------------------------------------------------------------------------------------------------- |
+| `treatDynamicAs` | `'pass' \| 'warn' \| 'fail'`                                 | `'pass'`       | メタデータの値が動的に設定されているルートをどう採点するか                                          |
+| `metaComponents` | `string[]`                                                   | `[]`           | `<head>` メタデータを出力するカスタムコンポーネント名                                               |
+| `rules`          | `Record<string, 'off' \| 'critical' \| 'warning' \| 'info'>` | `{}`           | ルールごとの上書き — ルールを無効化するか重大度を変更する                                           |
+| `failOn`         | `'critical' \| 'warning' \| 'info'`                          | `'critical'`   | 実行を失敗させる(終了コード `1`)最低重大度                                                          |
+| `weights`        | `Partial<Record<Category, number>>`                          | 各カテゴリ `1` | 組み合わせた [Health スコア](/svelte-vitals/ja/guides/health-report/) のカテゴリごとの重み          |
 | `overrides`      | `RuleOverride[]`                                             | (なし)         | ルート/ファイル単位のルール上書き — [下記](#ルールをルートやファイルにスコープする-overrides)を参照 |
 
 `Category` は `'seo' | 'performance' | 'correctness' | 'security' | 'architecture'` です。

--- a/docs/superpowers/specs/2026-07-18-route-overrides-and-exclusion-discoverability-design.md
+++ b/docs/superpowers/specs/2026-07-18-route-overrides-and-exclusion-discoverability-design.md
@@ -1,0 +1,164 @@
+# Route-scoped rule overrides + exclusion discoverability
+
+Date: 2026-07-18
+Status: approved (user-confirmed direction from CI-adoption feedback on X)
+
+## Motivation
+
+A CI adopter hit a wall: authenticated-only routes were flagged en masse by SEO
+meta rules, and they could not find a way to exclude "these rules on these
+routes" when running through `@svelte-vitals/action`. Two real problems:
+
+1. **Discoverability** — the mechanism that solves the immediate case already
+   exists (`svelte-vitals-suppressions.json` is applied automatically by the
+   action, and `svelte-vitals.config.*` is loaded by `analyzeProject`), but
+   nothing near the action's docs says so, and `packages/action` has no README
+   at all. The action's inputs table reads as "this is all the configuration
+   there is".
+2. **A real feature gap** — the suppressions file is a snapshot amnesty keyed on
+   exact `(id, route, location)`. Adding a *new* authenticated route later fails
+   CI again until `--update-suppressions` is re-run. There is no way to express
+   the durable policy "routes under `/(app)` are not public; don't run SEO
+   rules there".
+
+Three deliverables, in this design:
+
+- **A. Docs**: action README + an "Excluding routes or rules" section in the CI
+  guide + `overrides` in the config-file guide (en/ja).
+- **B. Report hint**: a one-line footer in the Markdown report (job summary /
+  sticky PR comment) linking to the exclusion docs whenever findings exist.
+- **C. Feature**: declarative route-scoped rule overrides in the config file.
+
+## C. Route-scoped overrides
+
+### Config shape
+
+```ts
+export interface RouteOverride {
+  /** Route glob(s) matched against a finding's `route` (e.g. '/(app)/**'). */
+  route: string | string[];
+  /** Keys are rule ids ('SEO001') or category names ('seo'). */
+  rules: Record<string, RuleSetting>; // 'off' | 'critical' | 'warning' | 'info'
+}
+
+interface Config {
+  // ...existing fields
+  /** Route-scoped rule overrides, applied to results after analysis. */
+  overrides?: RouteOverride[];
+}
+```
+
+Rationale for ESLint-style entries (chosen over per-rule `exclude` lists or a
+category-only knob): one entry expresses the motivating case in one line
+(`{ route: '/(app)/**', rules: { seo: 'off' } }`), scales to per-rule and
+per-severity tweaks for free by reusing `RuleSetting`, and is the shape users
+already know.
+
+### Matching semantics
+
+- Overrides match against `Result.route` (`'/blog/[slug]'`-style route ids).
+  Project-scoped findings (no `route`) are never matched — global `rules` config
+  already covers those.
+- Glob support is deliberately minimal, implemented in core with no new
+  dependency (core stays runtime-agnostic; `(`, `)`, `[`, `]` are escaped as
+  literals since SvelteKit route ids use them):
+  - `*` matches within a segment (no `/`),
+  - `**` matches across segments,
+  - a trailing `/**` also matches the bare prefix (`'/admin/**'` matches
+    `/admin` itself — the intuitive reading of "everything under /admin").
+  - anything else is literal; matching is case-sensitive and anchored
+    (full-route match).
+- Precedence: entries are evaluated in array order, **later entries win**;
+  within one entry, a rule-id key beats a category key. Overrides are applied
+  after global `rules` severities, so an override always wins over the global
+  setting for matched routes.
+
+### Application point
+
+New pure function in `packages/core/src/config-apply.ts`:
+
+```ts
+applyRouteOverrides(results: Result[], config: Config): Result[]
+```
+
+- `'off'` **removes the result entirely** — both penalized and passing entries —
+  as if the rule had not run for that route. (Keeping passing seeds while
+  dropping failures would inflate the score; symmetric removal keeps
+  scoring/`passed` counts honest.)
+- A severity value rewrites `result.severity` (same shape as
+  `applyRuleSeverities`).
+- Called immediately after `applyRuleSeverities` at all three call sites:
+  `packages/cli/src/index.ts` (`analyzeProject` — CLI, MCP, and the action all
+  inherit it), `packages/vite/src/analyze.ts`, and
+  `packages/vite/src/hooks/handle.ts`. It cannot be folded into `selectRules`
+  because that operates pre-run on rules, not per-route.
+
+### Validation (config file)
+
+`packages/cli/src/config-file.ts` learns the `overrides` key (added to
+`KNOWN_TOP_LEVEL_KEYS`). Fatal errors (same philosophy as `rules` — a silently
+dropped override would un-gate or over-gate CI):
+
+- `overrides` not an array of plain objects,
+- an entry missing `route` (string or non-empty string array) or `rules`
+  (plain object),
+- a `rules` key that is neither a known rule id nor a category name,
+- a `rules` value that is not `'off' | 'critical' | 'warning' | 'info'`.
+
+`analyzeProject`'s per-field precedence merge passes `file.overrides` through;
+no CLI flag is added (config-file only, like `metaComponents` in spirit —
+route policy belongs in a committed file, not a flag).
+
+### Out of scope
+
+- Matching on `location`/file globs (component-scoped findings). The motivating
+  case is route-keyed; file matching can be added later without schema changes
+  (a `files` key on the same entry shape).
+- Auto-relaxing SEO rules on routes that declare `noindex` (idea #4 from the
+  discussion) — separate design if pursued.
+
+## B. Report footer hint
+
+`formatMarkdownReport` (core) appends, only when at least one finding row is
+rendered, a final line:
+
+> _Expected findings (e.g. routes behind auth)? See [Excluding routes or rules](https://oekazuma.github.io/svelte-vitals/guides/ci/#excluding-routes-or-rules)._
+
+This lands in both the job summary and the sticky PR comment via the action
+with no action change (dist rebuild only). Not added to console/HTML reporters:
+the CI comment is where a blocked adopter is actually standing when they need
+the pointer.
+
+## A. Docs
+
+- **`packages/action/README.md`** (new; shipped to npm): what the action does,
+  the inputs table, and a Configuration section stating explicitly that the
+  action loads the project's `svelte-vitals.config.*` and applies
+  `svelte-vitals-suppressions.json` automatically — inputs are *not* the whole
+  configuration surface. Links to the CI guide.
+- **CI guide** (`guides/ci.md`, en/ja): new `## Excluding routes or rules`
+  section near the inputs table covering the three mechanisms and when to use
+  which: global `rules: { X: 'off' }` (never want the rule), `overrides`
+  (rule/category off for a route subtree — durable policy), suppressions file
+  (accept existing findings one-shot, gate only new ones).
+- **Config guide** (`guides/configuration.mdx`, en/ja): `overrides` row in the
+  options table + example.
+
+## Testing
+
+- Core unit tests (`packages/core/test`): glob matcher edge cases (`*` vs `**`,
+  trailing `/**` matching the bare prefix, literal `(`/`[` in routes,
+  anchoring), `'off'` removal of passing + failing entries, severity rewrite,
+  entry-order precedence, rule-id-over-category precedence, no-`route` findings
+  untouched, empty/absent `overrides` is a no-op identity.
+- CLI config-file tests: valid shapes accepted, each fatal-validation case
+  throws with an actionable message, unknown-key warning unaffected.
+- Reporter test: footer present with findings, absent on a clean report.
+- `packages/cli/test/docs-links.test.ts` guards rule docs only — unaffected.
+
+## Release
+
+Two changesets: (1) minor — `overrides` feature (core, cli, vite, action);
+(2) minor — report footer hint (core, action). `packages/action/dist` is
+committed, so it is rebuilt in the same PR (repo convention:
+`chore(action): rebuild dist/`).

--- a/docs/superpowers/specs/2026-07-18-route-overrides-and-exclusion-discoverability-design.md
+++ b/docs/superpowers/specs/2026-07-18-route-overrides-and-exclusion-discoverability-design.md
@@ -34,40 +34,56 @@ Three deliverables, in this design:
 ### Config shape
 
 ```ts
-export interface RouteOverride {
-  /** Route glob(s) matched against a finding's `route` (e.g. '/(app)/**'). */
-  route: string | string[];
+export interface RuleOverride {
+  /** Route-id glob(s), e.g. '/admin/**'. Route ids drop (group) segments. */
+  route?: string | string[];
+  /** Source-path glob(s) matched against a finding's location, e.g. 'src/routes/(app)/**'. */
+  files?: string | string[];
   /** Keys are rule ids ('SEO001') or category names ('seo'). */
   rules: Record<string, RuleSetting>; // 'off' | 'critical' | 'warning' | 'info'
 }
 
 interface Config {
   // ...existing fields
-  /** Route-scoped rule overrides, applied to results after analysis. */
-  overrides?: RouteOverride[];
+  /** Route-/file-scoped rule overrides, applied to results after analysis. */
+  overrides?: RuleOverride[];
 }
 ```
 
+At least one of `route` / `files` is required per entry (validated fatally).
+
 Rationale for ESLint-style entries (chosen over per-rule `exclude` lists or a
 category-only knob): one entry expresses the motivating case in one line
-(`{ route: '/(app)/**', rules: { seo: 'off' } }`), scales to per-rule and
-per-severity tweaks for free by reusing `RuleSetting`, and is the shape users
-already know.
+(`{ files: 'src/routes/(app)/**', rules: { seo: 'off' } }`), scales to per-rule
+and per-severity tweaks for free by reusing `RuleSetting`, and is the shape
+users already know.
+
+**Why `files` exists (found during implementation):** `deriveRoute` drops
+`(group)` segments from route ids (`src/routes/(app)/dashboard/+page.svelte`
+reports as `/dashboard`), so a route glob cannot target "everything in the
+`(app)` group" — the exact shape the motivating auth-routes case takes. `files`
+globs match the finding's `location` (source path), where the group directory
+is visible.
 
 ### Matching semantics
 
-- Overrides match against `Result.route` (`'/blog/[slug]'`-style route ids).
-  Project-scoped findings (no `route`) are never matched — global `rules` config
-  already covers those.
+- An entry matches a finding when **any `route` glob matches `Result.route` OR
+  any `files` glob matches `Result.location`**. Findings with neither field
+  (some project-scoped findings) never match — global `rules` config already
+  covers those.
+- Caveat: passing seeds generally carry no `location`, so a `files`-only entry
+  removes penalized findings but leaves passing seeds of the same rule. Gating
+  and scores behave correctly (passing seeds are inert); only the
+  "checks passed" count retains them.
 - Glob support is deliberately minimal, implemented in core with no new
   dependency (core stays runtime-agnostic; `(`, `)`, `[`, `]` are escaped as
-  literals since SvelteKit route ids use them):
+  literals since SvelteKit paths use them):
   - `*` matches within a segment (no `/`),
   - `**` matches across segments,
   - a trailing `/**` also matches the bare prefix (`'/admin/**'` matches
     `/admin` itself — the intuitive reading of "everything under /admin").
   - anything else is literal; matching is case-sensitive and anchored
-    (full-route match).
+    (full-string match).
 - Precedence: entries are evaluated in array order, **later entries win**;
   within one entry, a rule-id key beats a category key. Overrides are applied
   after global `rules` severities, so an override always wins over the global
@@ -78,7 +94,7 @@ already know.
 New pure function in `packages/core/src/config-apply.ts`:
 
 ```ts
-applyRouteOverrides(results: Result[], config: Config): Result[]
+applyOverrides(results: Result[], config: Config): Result[]
 ```
 
 - `'off'` **removes the result entirely** — both penalized and passing entries —
@@ -87,11 +103,14 @@ applyRouteOverrides(results: Result[], config: Config): Result[]
   scoring/`passed` counts honest.)
 - A severity value rewrites `result.severity` (same shape as
   `applyRuleSeverities`).
-- Called immediately after `applyRuleSeverities` at all three call sites:
+- Called immediately after `applyRuleSeverities` in
   `packages/cli/src/index.ts` (`analyzeProject` — CLI, MCP, and the action all
-  inherit it), `packages/vite/src/analyze.ts`, and
-  `packages/vite/src/hooks/handle.ts`. It cannot be folded into `selectRules`
-  because that operates pre-run on rules, not per-route.
+  inherit it) and `packages/vite/src/analyze.ts` (build gate; also gains an
+  `overrides` plugin option with the usual option > file precedence). The dev
+  `svelteVitalsHandle` (`packages/vite/src/hooks/handle.ts`) is deliberately
+  unchanged: it is observe-only, never gates, and reads no config file. It
+  cannot be folded into `selectRules` because that operates pre-run on rules,
+  not per-route.
 
 ### Validation (config file)
 
@@ -100,8 +119,9 @@ applyRouteOverrides(results: Result[], config: Config): Result[]
 dropped override would un-gate or over-gate CI):
 
 - `overrides` not an array of plain objects,
-- an entry missing `route` (string or non-empty string array) or `rules`
-  (plain object),
+- an entry whose `route`/`files` is present but not a string or non-empty
+  string array, or an entry with neither; `rules` missing or not a plain
+  object,
 - a `rules` key that is neither a known rule id nor a category name,
 - a `rules` value that is not `'off' | 'critical' | 'warning' | 'info'`.
 
@@ -111,9 +131,6 @@ route policy belongs in a committed file, not a flag).
 
 ### Out of scope
 
-- Matching on `location`/file globs (component-scoped findings). The motivating
-  case is route-keyed; file matching can be added later without schema changes
-  (a `files` key on the same entry shape).
 - Auto-relaxing SEO rules on routes that declare `noindex` (idea #4 from the
   discussion) — separate design if pursued.
 

--- a/docs/superpowers/specs/2026-07-18-route-overrides-and-exclusion-discoverability-design.md
+++ b/docs/superpowers/specs/2026-07-18-route-overrides-and-exclusion-discoverability-design.md
@@ -16,7 +16,7 @@ routes" when running through `@svelte-vitals/action`. Two real problems:
    at all. The action's inputs table reads as "this is all the configuration
    there is".
 2. **A real feature gap** — the suppressions file is a snapshot amnesty keyed on
-   exact `(id, route, location)`. Adding a *new* authenticated route later fails
+   exact `(id, route, location)`. Adding a _new_ authenticated route later fails
    CI again until `--update-suppressions` is re-run. There is no way to express
    the durable policy "routes under `/(app)` are not public; don't run SEO
    rules there".
@@ -151,7 +151,7 @@ the pointer.
 - **`packages/action/README.md`** (new; shipped to npm): what the action does,
   the inputs table, and a Configuration section stating explicitly that the
   action loads the project's `svelte-vitals.config.*` and applies
-  `svelte-vitals-suppressions.json` automatically — inputs are *not* the whole
+  `svelte-vitals-suppressions.json` automatically — inputs are _not_ the whole
   configuration surface. Links to the CI guide.
 - **CI guide** (`guides/ci.md`, en/ja): new `## Excluding routes or rules`
   section near the inputs table covering the three mechanisms and when to use

--- a/docs/superpowers/specs/2026-07-18-route-overrides-and-exclusion-discoverability-design.md
+++ b/docs/superpowers/specs/2026-07-18-route-overrides-and-exclusion-discoverability-design.md
@@ -175,7 +175,9 @@ the pointer.
 
 ## Release
 
-Two changesets: (1) minor — `overrides` feature (core, cli, vite, action);
-(2) minor — report footer hint (core, action). `packages/action/dist` is
-committed, so it is rebuilt in the same PR (repo convention:
-`chore(action): rebuild dist/`).
+Two changesets: (1) minor — `overrides` feature (core, cli, vite);
+(2) minor — report footer hint (core). `@svelte-vitals/action` is private
+and is never listed explicitly — it gets its bump automatically as a
+dependent (`updateInternalDependencies: patch`), matching every previous
+release in its CHANGELOG. `packages/action/dist` is committed, so it is
+rebuilt in the same PR (repo convention: `chore(action): rebuild dist/`).

--- a/packages/action/README.md
+++ b/packages/action/README.md
@@ -1,0 +1,56 @@
+# @svelte-vitals/action
+
+First-party GitHub Action for [svelte-vitals](https://github.com/oekazuma/svelte-vitals): static SvelteKit code-health checks (SEO, Performance, Correctness, Security, Architecture) on every pull request — inline annotations on the diff, a job summary, and a single sticky PR comment that updates in place on each push.
+
+The easiest way to set it up is the generator (no YAML to hand-write, and it pins a working commit SHA for you):
+
+```bash
+npx svelte-vitals@latest ci install
+```
+
+Or by hand:
+
+```yaml
+name: svelte-vitals
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  svelte-vitals:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0 # full history, so diff/baseline can resolve the base ref
+      - uses: oekazuma/svelte-vitals/packages/action@<sha> # @svelte-vitals/action@<version>
+        with:
+          diff: origin/${{ github.base_ref }}
+          baseline: origin/${{ github.base_ref }}
+```
+
+Pin `<sha>`/`<version>` from the latest `@svelte-vitals/action@X.Y.Z` [release tag](https://github.com/oekazuma/svelte-vitals/releases); `npx svelte-vitals ci upgrade` rewrites the pin in an existing workflow.
+
+## Inputs
+
+| Input          | Description                                                          | Default               |
+| -------------- | -------------------------------------------------------------------- | --------------------- |
+| `path`         | Project directory to analyze                                         | `.`                   |
+| `diff`         | Scope findings to files changed vs this git ref (e.g. `origin/main`) | (unset)               |
+| `baseline`     | Report only findings not already present at this git ref             | (unset)               |
+| `github-token` | Token used to read/post/update the sticky PR comment                 | `${{ github.token }}` |
+
+The job fails when the scan finds gating findings (per the resolved `failOn`, default `critical`) — after the summary/comment are written, so you always get the report. On fork PRs the sticky comment is skipped (GitHub downgrades the token); annotations and the job summary still work.
+
+## Configuration — the inputs are not the whole story
+
+The action runs the **same analysis as the `svelte-vitals` CLI**, so everything you configure in committed files applies here automatically, with no action input involved:
+
+- **[`svelte-vitals.config.*`](https://oekazuma.github.io/svelte-vitals/guides/configuration/)** — disable rules or change their severity (`rules`), scope rules/categories to specific routes or files (`overrides` — e.g. turn SEO rules off for auth-only routes: `overrides: [{ files: 'src/routes/(app)/**', rules: { seo: 'off' } }]`), `failOn`, `weights`, and the rest.
+- **[`svelte-vitals-suppressions.json`](https://oekazuma.github.io/svelte-vitals/guides/cli/#svelte-vitals-suppressionsjson----update-suppressions----no-suppressions)** — a committed one-shot acceptance of the existing backlog (`svelte-vitals --update-suppressions`); the action applies it whenever it's present in the repo.
+
+See [Excluding routes or rules](https://oekazuma.github.io/svelte-vitals/guides/ci/#excluding-routes-or-rules) in the CI guide for which mechanism fits which situation, and the [CI integration guide](https://oekazuma.github.io/svelte-vitals/guides/ci/) for the full workflow reference.

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -58054,7 +58054,7 @@ function applyRuleSeverities(results, config) {
   });
 }
 function routeGlobToRegExp(pattern) {
-  const body = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*\*/g, "\0").replace(/\*/g, "[^/]*").replace(/\u0000/g, ".*");
+  const body = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*\*/g, "\0").replace(/\*/g, "[^/]*").split("\0").join(".*");
   const source2 = body.endsWith("/.*") ? `${body.slice(0, -3)}(/.*)?` : body;
   return new RegExp(`^${source2}$`);
 }
@@ -58086,7 +58086,7 @@ function applyOverrides(results, config) {
   return out;
 }
 
-// ../cli/dist/chunk-I2XGFPE7.js
+// ../cli/dist/chunk-BGC45D76.js
 import { readFile, access as access2 } from "fs/promises";
 import { join } from "path";
 
@@ -58864,7 +58864,7 @@ async function glob(globInput, options) {
   return crawler ? formatPaths(await crawler.withPromise(), relative2) : [];
 }
 
-// ../cli/dist/chunk-I2XGFPE7.js
+// ../cli/dist/chunk-BGC45D76.js
 import { readFileSync as readFileSync2 } from "fs";
 import { execFileSync } from "child_process";
 import { execFileSync as execFileSync2 } from "child_process";
@@ -59778,7 +59778,10 @@ async function analyzeProject(opts = {}) {
   const selected = selectRules(allRules, config);
   const rules = opts.categories ? selected.filter((r) => opts.categories.includes(r.category)) : selected;
   const results = applyOverrides(
-    applyRuleSeverities(await runRules(rules, { heads, images, headings, components, project, config, kitModules }), config),
+    applyRuleSeverities(
+      await runRules(rules, { heads, images, headings, components, project, config, kitModules }),
+      config
+    ),
     config
   );
   return { results, config, version: readPackageVersion(), warnings: warnings2 };

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -58037,6 +58037,10 @@ function formatMarkdownReport(results, config, meta) {
       lines.push("");
       lines.push(`\u2026and ${findings.length - MAX_FINDINGS} more (run \`npx svelte-vitals\` locally for the full report)`);
     }
+    lines.push("");
+    lines.push(
+      "_Expected findings (e.g. routes behind auth)? See [Excluding routes or rules](https://oekazuma.github.io/svelte-vitals/guides/ci/#excluding-routes-or-rules)._"
+    );
   }
   return lines.join("\n");
 }
@@ -58049,8 +58053,40 @@ function applyRuleSeverities(results, config) {
     return setting && setting !== "off" ? { ...result, severity: setting } : result;
   });
 }
+function routeGlobToRegExp(pattern) {
+  const body = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*\*/g, "\0").replace(/\*/g, "[^/]*").replace(/\u0000/g, ".*");
+  const source2 = body.endsWith("/.*") ? `${body.slice(0, -3)}(/.*)?` : body;
+  return new RegExp(`^${source2}$`);
+}
+function toPatterns(globs) {
+  if (globs === void 0) return [];
+  return (Array.isArray(globs) ? globs : [globs]).map(routeGlobToRegExp);
+}
+function applyOverrides(results, config) {
+  const overrides = config.overrides;
+  if (!overrides || overrides.length === 0) return results;
+  const compiled = overrides.map((o) => ({
+    routes: toPatterns(o.route),
+    files: toPatterns(o.files),
+    rules: o.rules
+  }));
+  const out = [];
+  for (const result of results) {
+    const { route, location } = result;
+    let setting;
+    for (const o of compiled) {
+      const matched = route !== void 0 && o.routes.some((p) => p.test(route)) || location !== void 0 && o.files.some((p) => p.test(location));
+      if (!matched) continue;
+      const s = o.rules[result.id] ?? o.rules[result.category ?? "seo"];
+      if (s !== void 0) setting = s;
+    }
+    if (setting === void 0) out.push(result);
+    else if (setting !== "off") out.push({ ...result, severity: setting });
+  }
+  return out;
+}
 
-// ../cli/dist/chunk-AAUZ37EW.js
+// ../cli/dist/chunk-I2XGFPE7.js
 import { readFile, access as access2 } from "fs/promises";
 import { join } from "path";
 
@@ -58828,7 +58864,7 @@ async function glob(globInput, options) {
   return crawler ? formatPaths(await crawler.withPromise(), relative2) : [];
 }
 
-// ../cli/dist/chunk-AAUZ37EW.js
+// ../cli/dist/chunk-I2XGFPE7.js
 import { readFileSync as readFileSync2 } from "fs";
 import { execFileSync } from "child_process";
 import { execFileSync as execFileSync2 } from "child_process";
@@ -59572,7 +59608,8 @@ var CONFIG_FILENAMES = ["svelte-vitals.config.mjs", "svelte-vitals.config.js", "
 var CATEGORIES = ["seo", "performance", "correctness", "security", "architecture"];
 var TREAT_DYNAMIC_AS_VALUES = ["pass", "warn", "fail"];
 var FAIL_ON_VALUES = ["critical", "warning", "info"];
-var KNOWN_TOP_LEVEL_KEYS = /* @__PURE__ */ new Set(["treatDynamicAs", "metaComponents", "rules", "failOn", "weights"]);
+var KNOWN_TOP_LEVEL_KEYS = /* @__PURE__ */ new Set(["treatDynamicAs", "metaComponents", "rules", "failOn", "weights", "overrides"]);
+var RULE_SETTING_VALUES = ["off", "critical", "warning", "info"];
 function isPlainObject22(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -59622,6 +59659,50 @@ function validateConfigFile(raw, path) {
       );
     }
     config.rules = rules;
+  }
+  if (raw.overrides !== void 0) {
+    if (!Array.isArray(raw.overrides)) {
+      throw new Error(`${path}: overrides must be an array of { route/files, rules } entries.`);
+    }
+    const isGlobs = (v) => typeof v === "string" || Array.isArray(v) && v.length > 0 && v.every((g) => typeof g === "string");
+    const overrides = [];
+    raw.overrides.forEach((entry, i) => {
+      if (!isPlainObject22(entry)) {
+        throw new Error(`${path}: overrides[${i}] must be an object with 'route' and/or 'files', and 'rules'.`);
+      }
+      if (entry.route !== void 0 && !isGlobs(entry.route)) {
+        throw new Error(`${path}: overrides[${i}].route must be a string or a non-empty array of strings.`);
+      }
+      if (entry.files !== void 0 && !isGlobs(entry.files)) {
+        throw new Error(`${path}: overrides[${i}].files must be a string or a non-empty array of strings.`);
+      }
+      if (entry.route === void 0 && entry.files === void 0) {
+        throw new Error(`${path}: overrides[${i}] must set 'route' and/or 'files' to scope the override.`);
+      }
+      if (!isPlainObject22(entry.rules)) {
+        throw new Error(`${path}: overrides[${i}].rules must be an object of rule-id/category \u2192 setting.`);
+      }
+      const nonCategoryKeys = Object.keys(entry.rules).filter((k) => !CATEGORIES.includes(k));
+      const unknown = findUnknownRuleIds(nonCategoryKeys);
+      if (unknown.length > 0) {
+        throw new Error(
+          `${path}: unknown rule id(s) or categories in overrides[${i}].rules: ${unknown.join(", ")}. Known categories: ${CATEGORIES.join(", ")}. Known rule ids: ${knownRuleIds().join(", ")}`
+        );
+      }
+      for (const [key2, setting] of Object.entries(entry.rules)) {
+        if (!RULE_SETTING_VALUES.includes(setting)) {
+          throw new Error(
+            `${path}: overrides[${i}].rules.${key2}: invalid setting '${String(setting)}'; expected ${RULE_SETTING_VALUES.join("|")}.`
+          );
+        }
+      }
+      overrides.push({
+        ...entry.route !== void 0 ? { route: entry.route } : {},
+        ...entry.files !== void 0 ? { files: entry.files } : {},
+        rules: entry.rules
+      });
+    });
+    config.overrides = overrides;
   }
   if (raw.weights !== void 0) {
     if (!isPlainObject22(raw.weights)) {
@@ -59682,7 +59763,8 @@ async function analyzeProject(opts = {}) {
     metaComponents: opts.metaComponents ?? file?.metaComponents ?? [],
     rules: opts.rules ?? file?.rules ?? {},
     failOn: opts.failOn ?? file?.failOn ?? "critical",
-    ...weights !== void 0 ? { weights } : {}
+    ...weights !== void 0 ? { weights } : {},
+    ...file?.overrides !== void 0 ? { overrides: file.overrides } : {}
   });
   await detectProject(rt, cwd);
   const matches = routeMatcher(opts.route);
@@ -59695,8 +59777,8 @@ async function analyzeProject(opts = {}) {
   const kitModules = opts.route ? [] : await collectKitModuleFacts(rt, cwd);
   const selected = selectRules(allRules, config);
   const rules = opts.categories ? selected.filter((r) => opts.categories.includes(r.category)) : selected;
-  const results = applyRuleSeverities(
-    await runRules(rules, { heads, images, headings, components, project, config, kitModules }),
+  const results = applyOverrides(
+    applyRuleSeverities(await runRules(rules, { heads, images, headings, components, project, config, kitModules }), config),
     config
   );
   return { results, config, version: readPackageVersion(), warnings: warnings2 };

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -58086,7 +58086,7 @@ function applyOverrides(results, config) {
   return out;
 }
 
-// ../cli/dist/chunk-BGC45D76.js
+// ../cli/dist/chunk-QBXO46PU.js
 import { readFile, access as access2 } from "fs/promises";
 import { join } from "path";
 
@@ -58864,7 +58864,7 @@ async function glob(globInput, options) {
   return crawler ? formatPaths(await crawler.withPromise(), relative2) : [];
 }
 
-// ../cli/dist/chunk-BGC45D76.js
+// ../cli/dist/chunk-QBXO46PU.js
 import { readFileSync as readFileSync2 } from "fs";
 import { execFileSync } from "child_process";
 import { execFileSync as execFileSync2 } from "child_process";
@@ -59664,23 +59664,31 @@ function validateConfigFile(raw, path) {
     if (!Array.isArray(raw.overrides)) {
       throw new Error(`${path}: overrides must be an array of { route/files, rules } entries.`);
     }
-    const isGlobs = (v) => typeof v === "string" || Array.isArray(v) && v.length > 0 && v.every((g) => typeof g === "string");
+    const isGlob = (v) => typeof v === "string" && v.length > 0;
+    const isGlobs = (v) => isGlob(v) || Array.isArray(v) && v.length > 0 && v.every(isGlob);
     const overrides = [];
     raw.overrides.forEach((entry, i) => {
       if (!isPlainObject22(entry)) {
         throw new Error(`${path}: overrides[${i}] must be an object with 'route' and/or 'files', and 'rules'.`);
       }
       if (entry.route !== void 0 && !isGlobs(entry.route)) {
-        throw new Error(`${path}: overrides[${i}].route must be a string or a non-empty array of strings.`);
+        throw new Error(
+          `${path}: overrides[${i}].route must be a non-empty string or a non-empty array of non-empty strings.`
+        );
       }
       if (entry.files !== void 0 && !isGlobs(entry.files)) {
-        throw new Error(`${path}: overrides[${i}].files must be a string or a non-empty array of strings.`);
+        throw new Error(
+          `${path}: overrides[${i}].files must be a non-empty string or a non-empty array of non-empty strings.`
+        );
       }
       if (entry.route === void 0 && entry.files === void 0) {
         throw new Error(`${path}: overrides[${i}] must set 'route' and/or 'files' to scope the override.`);
       }
       if (!isPlainObject22(entry.rules)) {
         throw new Error(`${path}: overrides[${i}].rules must be an object of rule-id/category \u2192 setting.`);
+      }
+      if (Object.keys(entry.rules).length === 0) {
+        throw new Error(`${path}: overrides[${i}].rules must contain at least one rule id or category.`);
       }
       const nonCategoryKeys = Object.keys(entry.rules).filter((k) => !CATEGORIES.includes(k));
       const unknown = findUnknownRuleIds(nonCategoryKeys);

--- a/packages/cli/src/config-file.ts
+++ b/packages/cli/src/config-file.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import type { Category, Config } from '@svelte-vitals/core';
+import type { Category, Config, RuleOverride } from '@svelte-vitals/core';
 import { findUnknownRuleIds, knownRuleIds } from './rules-config.js';
 
 /**
@@ -22,7 +22,8 @@ export const CONFIG_FILENAMES = ['svelte-vitals.config.mjs', 'svelte-vitals.conf
 const CATEGORIES: Category[] = ['seo', 'performance', 'correctness', 'security', 'architecture'];
 const TREAT_DYNAMIC_AS_VALUES = ['pass', 'warn', 'fail'];
 const FAIL_ON_VALUES = ['critical', 'warning', 'info'];
-const KNOWN_TOP_LEVEL_KEYS = new Set(['treatDynamicAs', 'metaComponents', 'rules', 'failOn', 'weights']);
+const KNOWN_TOP_LEVEL_KEYS = new Set(['treatDynamicAs', 'metaComponents', 'rules', 'failOn', 'weights', 'overrides']);
+const RULE_SETTING_VALUES = ['off', 'critical', 'warning', 'info'];
 
 /** Whether `value` is a plain object (not null, not an array) — usable with Object.keys/entries. */
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -102,6 +103,56 @@ function validateConfigFile(raw: Record<string, unknown>, path: string): LoadedC
       );
     }
     config.rules = rules;
+  }
+
+  if (raw.overrides !== undefined) {
+    if (!Array.isArray(raw.overrides)) {
+      throw new Error(`${path}: overrides must be an array of { route/files, rules } entries.`);
+    }
+    const isGlobs = (v: unknown): v is RuleOverride['route'] =>
+      typeof v === 'string' || (Array.isArray(v) && v.length > 0 && v.every((g) => typeof g === 'string'));
+    const overrides: RuleOverride[] = [];
+    raw.overrides.forEach((entry: unknown, i: number) => {
+      if (!isPlainObject(entry)) {
+        throw new Error(`${path}: overrides[${i}] must be an object with 'route' and/or 'files', and 'rules'.`);
+      }
+      if (entry.route !== undefined && !isGlobs(entry.route)) {
+        throw new Error(`${path}: overrides[${i}].route must be a string or a non-empty array of strings.`);
+      }
+      if (entry.files !== undefined && !isGlobs(entry.files)) {
+        throw new Error(`${path}: overrides[${i}].files must be a string or a non-empty array of strings.`);
+      }
+      if (entry.route === undefined && entry.files === undefined) {
+        throw new Error(`${path}: overrides[${i}] must set 'route' and/or 'files' to scope the override.`);
+      }
+      if (!isPlainObject(entry.rules)) {
+        throw new Error(`${path}: overrides[${i}].rules must be an object of rule-id/category → setting.`);
+      }
+      // Keys may be rule ids or category names; reject anything else so a typo
+      // can't silently leave a route gated (or un-gated) — same stance as `rules`.
+      const nonCategoryKeys = Object.keys(entry.rules).filter((k) => !CATEGORIES.includes(k as Category));
+      const unknown = findUnknownRuleIds(nonCategoryKeys);
+      if (unknown.length > 0) {
+        throw new Error(
+          `${path}: unknown rule id(s) or categories in overrides[${i}].rules: ${unknown.join(', ')}. ` +
+            `Known categories: ${CATEGORIES.join(', ')}. Known rule ids: ${knownRuleIds().join(', ')}`
+        );
+      }
+      for (const [key, setting] of Object.entries(entry.rules)) {
+        if (!RULE_SETTING_VALUES.includes(setting as string)) {
+          throw new Error(
+            `${path}: overrides[${i}].rules.${key}: invalid setting '${String(setting)}'; ` +
+              `expected ${RULE_SETTING_VALUES.join('|')}.`
+          );
+        }
+      }
+      overrides.push({
+        ...(entry.route !== undefined ? { route: entry.route as RuleOverride['route'] } : {}),
+        ...(entry.files !== undefined ? { files: entry.files as RuleOverride['files'] } : {}),
+        rules: entry.rules as RuleOverride['rules']
+      });
+    });
+    config.overrides = overrides;
   }
 
   if (raw.weights !== undefined) {

--- a/packages/cli/src/config-file.ts
+++ b/packages/cli/src/config-file.ts
@@ -109,24 +109,34 @@ function validateConfigFile(raw: Record<string, unknown>, path: string): LoadedC
     if (!Array.isArray(raw.overrides)) {
       throw new Error(`${path}: overrides must be an array of { route/files, rules } entries.`);
     }
+    // Empty globs compile to a never-matching pattern, so an entry carrying one
+    // would silently do nothing — reject alongside the other shape errors.
+    const isGlob = (v: unknown): v is string => typeof v === 'string' && v.length > 0;
     const isGlobs = (v: unknown): v is RuleOverride['route'] =>
-      typeof v === 'string' || (Array.isArray(v) && v.length > 0 && v.every((g) => typeof g === 'string'));
+      isGlob(v) || (Array.isArray(v) && v.length > 0 && v.every(isGlob));
     const overrides: RuleOverride[] = [];
     raw.overrides.forEach((entry: unknown, i: number) => {
       if (!isPlainObject(entry)) {
         throw new Error(`${path}: overrides[${i}] must be an object with 'route' and/or 'files', and 'rules'.`);
       }
       if (entry.route !== undefined && !isGlobs(entry.route)) {
-        throw new Error(`${path}: overrides[${i}].route must be a string or a non-empty array of strings.`);
+        throw new Error(
+          `${path}: overrides[${i}].route must be a non-empty string or a non-empty array of non-empty strings.`
+        );
       }
       if (entry.files !== undefined && !isGlobs(entry.files)) {
-        throw new Error(`${path}: overrides[${i}].files must be a string or a non-empty array of strings.`);
+        throw new Error(
+          `${path}: overrides[${i}].files must be a non-empty string or a non-empty array of non-empty strings.`
+        );
       }
       if (entry.route === undefined && entry.files === undefined) {
         throw new Error(`${path}: overrides[${i}] must set 'route' and/or 'files' to scope the override.`);
       }
       if (!isPlainObject(entry.rules)) {
         throw new Error(`${path}: overrides[${i}].rules must be an object of rule-id/category → setting.`);
+      }
+      if (Object.keys(entry.rules).length === 0) {
+        throw new Error(`${path}: overrides[${i}].rules must contain at least one rule id or category.`);
       }
       // Keys may be rule ids or category names; reject anything else so a typo
       // can't silently leave a route gated (or un-gated) — same stance as `rules`.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,6 +16,7 @@ import {
   defineConfig,
   selectRules,
   applyRuleSeverities,
+  applyOverrides,
   collectKitModuleFacts,
   type Severity,
   type RuleSetting,
@@ -197,7 +198,8 @@ export async function analyzeProject(opts: AnalyzeOptions = {}): Promise<Analyze
     metaComponents: opts.metaComponents ?? file?.metaComponents ?? [],
     rules: opts.rules ?? file?.rules ?? {},
     failOn: opts.failOn ?? file?.failOn ?? 'critical',
-    ...(weights !== undefined ? { weights } : {})
+    ...(weights !== undefined ? { weights } : {}),
+    ...(file?.overrides !== undefined ? { overrides: file.overrides } : {})
   });
 
   await detectProject(rt, cwd); // throws ProjectError if not a SvelteKit project
@@ -215,8 +217,8 @@ export async function analyzeProject(opts: AnalyzeOptions = {}): Promise<Analyze
   const kitModules = opts.route ? [] : await collectKitModuleFacts(rt, cwd);
   const selected = selectRules(allRules, config);
   const rules = opts.categories ? selected.filter((r) => opts.categories!.includes(r.category)) : selected;
-  const results = applyRuleSeverities(
-    await runRules(rules, { heads, images, headings, components, project, config, kitModules }),
+  const results = applyOverrides(
+    applyRuleSeverities(await runRules(rules, { heads, images, headings, components, project, config, kitModules }), config),
     config
   );
   return { results, config, version: readPackageVersion(), warnings };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -218,7 +218,10 @@ export async function analyzeProject(opts: AnalyzeOptions = {}): Promise<Analyze
   const selected = selectRules(allRules, config);
   const rules = opts.categories ? selected.filter((r) => opts.categories!.includes(r.category)) : selected;
   const results = applyOverrides(
-    applyRuleSeverities(await runRules(rules, { heads, images, headings, components, project, config, kitModules }), config),
+    applyRuleSeverities(
+      await runRules(rules, { heads, images, headings, components, project, config, kitModules }),
+      config
+    ),
     config
   );
   return { results, config, version: readPackageVersion(), warnings };

--- a/packages/cli/test/analyze-project.test.ts
+++ b/packages/cli/test/analyze-project.test.ts
@@ -31,6 +31,19 @@ describe('analyzeProject', () => {
   it('throws ProjectError for a non-SvelteKit directory', async () => {
     await expect(analyzeProject({ cwd: here })).rejects.toBeInstanceOf(ProjectError);
   });
+
+  it('applies config-file overrides: seo off under src/routes/(app)/** only (design 2026-07-18)', async () => {
+    const { results, config } = await analyzeProject({ cwd: join(here, 'fixtures', 'overrides-project') });
+    expect(config.overrides).toEqual([{ files: 'src/routes/(app)/**', rules: { seo: 'off' } }]);
+    const seoOf = (route: string) => results.filter((r) => r.route === route && (r.category ?? 'seo') === 'seo');
+    // (group) segments are dropped from route ids, so the dashboard reports as '/dashboard'.
+    // Passing seeds carry no location and so survive a files glob — only penalized
+    // findings must be gone (they are what gates CI and drags the score).
+    const penalized = (r: { detection: { presence: string; value: string } }) =>
+      r.detection.presence === 'none' || r.detection.value === 'absent';
+    expect(seoOf('/dashboard').filter(penalized)).toEqual([]);
+    expect(seoOf('/public').some((r) => r.id === 'SEO001' && penalized(r))).toBe(true);
+  });
 });
 
 describe('analyzeProject config-file precedence (design doc 2026-07-05-config-file-design.md §3)', () => {

--- a/packages/cli/test/config-file.test.ts
+++ b/packages/cli/test/config-file.test.ts
@@ -115,9 +115,27 @@ describe('loadConfigFile', () => {
     );
   });
 
-  it('rejects an overrides entry whose route is not a string or non-empty string array', async () => {
+  it('rejects an overrides entry whose route is not a non-empty string or non-empty string array', async () => {
     await expect(loadConfigFile(fixture('config-file-overrides-bad-route'))).rejects.toThrow(
-      /overrides\[0\]\.route must be a string or a non-empty array of strings/
+      /overrides\[0\]\.route must be a non-empty string or a non-empty array of non-empty strings/
+    );
+  });
+
+  it('rejects an empty route glob (it would silently never match)', async () => {
+    await expect(loadConfigFile(fixture('config-file-overrides-empty-route'))).rejects.toThrow(
+      /overrides\[0\]\.route must be a non-empty string or a non-empty array of non-empty strings/
+    );
+  });
+
+  it('rejects an empty string inside a files glob array', async () => {
+    await expect(loadConfigFile(fixture('config-file-overrides-empty-files'))).rejects.toThrow(
+      /overrides\[0\]\.files must be a non-empty string or a non-empty array of non-empty strings/
+    );
+  });
+
+  it('rejects an overrides entry with an empty rules object (it would change nothing)', async () => {
+    await expect(loadConfigFile(fixture('config-file-overrides-empty-rules'))).rejects.toThrow(
+      /overrides\[0\]\.rules must contain at least one rule id or category/
     );
   });
 

--- a/packages/cli/test/config-file.test.ts
+++ b/packages/cli/test/config-file.test.ts
@@ -100,6 +100,45 @@ describe('loadConfigFile', () => {
     expect(loaded?.config.weights).toEqual({ seo: 2 });
   });
 
+  it('loads valid scoped overrides through to config.overrides', async () => {
+    const loaded = await loadConfigFile(fixture('config-file-overrides'));
+    expect(loaded?.warnings).toEqual([]);
+    expect(loaded?.config.overrides).toEqual([
+      { files: 'src/routes/(app)/**', rules: { seo: 'off' } },
+      { route: ['/admin', '/admin/**'], rules: { SEO001: 'warning' } }
+    ]);
+  });
+
+  it('rejects an overrides value that is not an array', async () => {
+    await expect(loadConfigFile(fixture('config-file-overrides-not-array'))).rejects.toThrow(
+      /overrides must be an array/
+    );
+  });
+
+  it('rejects an overrides entry whose route is not a string or non-empty string array', async () => {
+    await expect(loadConfigFile(fixture('config-file-overrides-bad-route'))).rejects.toThrow(
+      /overrides\[0\]\.route must be a string or a non-empty array of strings/
+    );
+  });
+
+  it('rejects an overrides entry that sets neither route nor files', async () => {
+    await expect(loadConfigFile(fixture('config-file-overrides-no-scope'))).rejects.toThrow(
+      /overrides\[0\] must set 'route' and\/or 'files'/
+    );
+  });
+
+  it('rejects an overrides rules key that is neither a known rule id nor a category', async () => {
+    await expect(loadConfigFile(fixture('config-file-overrides-unknown-rule'))).rejects.toThrow(
+      /unknown rule id\(s\) or categor(y|ies) in overrides\[0\]\.rules: SEO999/
+    );
+  });
+
+  it('rejects an overrides rules value that is not off or a severity', async () => {
+    await expect(loadConfigFile(fixture('config-file-overrides-bad-value'))).rejects.toThrow(
+      /overrides\[0\]\.rules\.SEO001: invalid setting 'nope'/
+    );
+  });
+
   it('warns (without rejecting) on a metaComponents value that is not an array of strings, dropping the field', async () => {
     const loaded = await loadConfigFile(fixture('config-file-bad-metacomponents'));
     expect(loaded?.config.metaComponents).toBeUndefined();

--- a/packages/cli/test/fixtures/config-file-overrides-bad-route/svelte-vitals.config.mjs
+++ b/packages/cli/test/fixtures/config-file-overrides-bad-route/svelte-vitals.config.mjs
@@ -1,0 +1,4 @@
+/** route must be a string or a non-empty array of strings. */
+export default {
+  overrides: [{ route: 42, rules: { SEO001: 'off' } }]
+};

--- a/packages/cli/test/fixtures/config-file-overrides-bad-value/svelte-vitals.config.mjs
+++ b/packages/cli/test/fixtures/config-file-overrides-bad-value/svelte-vitals.config.mjs
@@ -1,0 +1,4 @@
+/** rules values must be 'off' or a severity. */
+export default {
+  overrides: [{ route: '/(app)/**', rules: { SEO001: 'nope' } }]
+};

--- a/packages/cli/test/fixtures/config-file-overrides-empty-files/svelte-vitals.config.mjs
+++ b/packages/cli/test/fixtures/config-file-overrides-empty-files/svelte-vitals.config.mjs
@@ -1,0 +1,4 @@
+/** An empty string inside a files array is a never-matching glob — reject it. */
+export default {
+  overrides: [{ files: [''], rules: { SEO001: 'off' } }]
+};

--- a/packages/cli/test/fixtures/config-file-overrides-empty-route/svelte-vitals.config.mjs
+++ b/packages/cli/test/fixtures/config-file-overrides-empty-route/svelte-vitals.config.mjs
@@ -1,0 +1,4 @@
+/** An empty route glob compiles to a never-matching pattern — reject it. */
+export default {
+  overrides: [{ route: '', rules: { SEO001: 'off' } }]
+};

--- a/packages/cli/test/fixtures/config-file-overrides-empty-rules/svelte-vitals.config.mjs
+++ b/packages/cli/test/fixtures/config-file-overrides-empty-rules/svelte-vitals.config.mjs
@@ -1,0 +1,4 @@
+/** An override with no rules changes nothing — reject it. */
+export default {
+  overrides: [{ route: '/admin/**', rules: {} }]
+};

--- a/packages/cli/test/fixtures/config-file-overrides-no-scope/svelte-vitals.config.mjs
+++ b/packages/cli/test/fixtures/config-file-overrides-no-scope/svelte-vitals.config.mjs
@@ -1,0 +1,4 @@
+/** An override entry must set route and/or files. */
+export default {
+  overrides: [{ rules: { SEO001: 'off' } }]
+};

--- a/packages/cli/test/fixtures/config-file-overrides-not-array/svelte-vitals.config.mjs
+++ b/packages/cli/test/fixtures/config-file-overrides-not-array/svelte-vitals.config.mjs
@@ -1,0 +1,4 @@
+/** overrides must be an array, not an object. */
+export default {
+  overrides: { route: '/(app)/**', rules: { seo: 'off' } }
+};

--- a/packages/cli/test/fixtures/config-file-overrides-unknown-rule/svelte-vitals.config.mjs
+++ b/packages/cli/test/fixtures/config-file-overrides-unknown-rule/svelte-vitals.config.mjs
@@ -1,0 +1,4 @@
+/** rules keys must be known rule ids or category names. */
+export default {
+  overrides: [{ route: '/(app)/**', rules: { SEO999: 'off' } }]
+};

--- a/packages/cli/test/fixtures/config-file-overrides/svelte-vitals.config.mjs
+++ b/packages/cli/test/fixtures/config-file-overrides/svelte-vitals.config.mjs
@@ -1,0 +1,7 @@
+/** Valid scoped overrides: category key, rule-id key, route and files globs. */
+export default {
+  overrides: [
+    { files: 'src/routes/(app)/**', rules: { seo: 'off' } },
+    { route: ['/admin', '/admin/**'], rules: { SEO001: 'warning' } }
+  ]
+};

--- a/packages/cli/test/fixtures/overrides-project/package.json
+++ b/packages/cli/test/fixtures/overrides-project/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "overrides-project-fixture",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@sveltejs/kit": "^2.0.0",
+    "svelte": "^5.0.0"
+  }
+}

--- a/packages/cli/test/fixtures/overrides-project/src/app.html
+++ b/packages/cli/test/fixtures/overrides-project/src/app.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    %sveltekit.head%
+  </head>
+  <body>
+    %sveltekit.body%
+  </body>
+</html>

--- a/packages/cli/test/fixtures/overrides-project/src/routes/(app)/dashboard/+page.svelte
+++ b/packages/cli/test/fixtures/overrides-project/src/routes/(app)/dashboard/+page.svelte
@@ -1,0 +1,1 @@
+<h1>Auth-only dashboard, deliberately without head metadata</h1>

--- a/packages/cli/test/fixtures/overrides-project/src/routes/public/+page.svelte
+++ b/packages/cli/test/fixtures/overrides-project/src/routes/public/+page.svelte
@@ -1,0 +1,1 @@
+<h1>Public page, also without head metadata</h1>

--- a/packages/cli/test/fixtures/overrides-project/svelte-vitals.config.mjs
+++ b/packages/cli/test/fixtures/overrides-project/svelte-vitals.config.mjs
@@ -1,0 +1,4 @@
+/** Fixture config file for analyzeProject scoped overrides (design 2026-07-18). */
+export default {
+  overrides: [{ files: 'src/routes/(app)/**', rules: { seo: 'off' } }]
+};

--- a/packages/core/src/config-apply.ts
+++ b/packages/core/src/config-apply.ts
@@ -20,12 +20,15 @@ export function applyRuleSeverities(results: Result[], config: Config): Result[]
  * everything else — including SvelteKit's `(`, `)`, `[`, `]` — is literal
  * (design 2026-07-18).
  */
+// '\u0000' below is a placeholder for '**' so the single-'*' pass can't see it;
+// it cannot occur in a route id or path, and split/join avoids a control-char regex.
 function routeGlobToRegExp(pattern: string): RegExp {
   const body = pattern
     .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
     .replace(/\*\*/g, '\u0000')
     .replace(/\*/g, '[^/]*')
-    .replace(/\u0000/g, '.*');
+    .split('\u0000')
+    .join('.*');
   const source = body.endsWith('/.*') ? `${body.slice(0, -3)}(/.*)?` : body;
   return new RegExp(`^${source}$`);
 }

--- a/packages/core/src/config-apply.ts
+++ b/packages/core/src/config-apply.ts
@@ -1,4 +1,4 @@
-import type { Config, Result } from './types.js';
+import type { Config, Result, RuleSetting } from './types.js';
 import type { Rule } from './rule.js';
 
 /** Drop rules disabled via config (design §6). */
@@ -12,4 +12,62 @@ export function applyRuleSeverities(results: Result[], config: Config): Result[]
     const setting = config.rules[result.id];
     return setting && setting !== 'off' ? { ...result, severity: setting } : result;
   });
+}
+
+/**
+ * Compile a route glob to an anchored RegExp: `*` matches within a segment,
+ * `**` across segments, a trailing `/**` also matches the bare prefix, and
+ * everything else — including SvelteKit's `(`, `)`, `[`, `]` — is literal
+ * (design 2026-07-18).
+ */
+function routeGlobToRegExp(pattern: string): RegExp {
+  const body = pattern
+    .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*\*/g, '\u0000')
+    .replace(/\*/g, '[^/]*')
+    .replace(/\u0000/g, '.*');
+  const source = body.endsWith('/.*') ? `${body.slice(0, -3)}(/.*)?` : body;
+  return new RegExp(`^${source}$`);
+}
+
+function toPatterns(globs: string | string[] | undefined): RegExp[] {
+  if (globs === undefined) return [];
+  return (Array.isArray(globs) ? globs : [globs]).map(routeGlobToRegExp);
+}
+
+/**
+ * Apply route-/file-scoped overrides to results (design 2026-07-18). An entry
+ * matches when any `route` glob matches the finding's route id or any `files`
+ * glob matches its location (OR). `'off'` removes a matched result entirely —
+ * passing seeds included, so scoring and "checks passed" counts behave as if
+ * the rule never ran there. A severity value rewrites the result's severity.
+ * Entries are evaluated in order (later entries win); within one entry a
+ * rule-id key beats a category key.
+ */
+export function applyOverrides(results: Result[], config: Config): Result[] {
+  const overrides = config.overrides;
+  if (!overrides || overrides.length === 0) return results;
+
+  const compiled = overrides.map((o) => ({
+    routes: toPatterns(o.route),
+    files: toPatterns(o.files),
+    rules: o.rules
+  }));
+
+  const out: Result[] = [];
+  for (const result of results) {
+    const { route, location } = result;
+    let setting: RuleSetting | undefined;
+    for (const o of compiled) {
+      const matched =
+        (route !== undefined && o.routes.some((p) => p.test(route))) ||
+        (location !== undefined && o.files.some((p) => p.test(location)));
+      if (!matched) continue;
+      const s = o.rules[result.id] ?? o.rules[result.category ?? 'seo'];
+      if (s !== undefined) setting = s;
+    }
+    if (setting === undefined) out.push(result);
+    else if (setting !== 'off') out.push({ ...result, severity: setting });
+  }
+  return out;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export type {
   Category,
   TreatDynamicAs,
   RuleSetting,
+  RuleOverride,
   Config
 } from './types.js';
 export { defaultConfig, defineConfig, defaultProject } from './types.js';
@@ -132,7 +133,7 @@ export { buildHtmlDocument, formatHtmlReport, escapeHtml, safeHref, scoreBand, B
 export { renderAppShell, APP_SCRIPT, APP_STYLE } from './reporter/app-shell.js';
 export type { AppSnapshot, RouteBadge } from './reporter/app-shell.js';
 
-export { selectRules, applyRuleSeverities } from './config-apply.js';
+export { selectRules, applyRuleSeverities, applyOverrides } from './config-apply.js';
 
 export type { ScoreModel, ScoreResult, ScoreOptions, HealthResult } from './scoring/score.js';
 export { computeScore, scoresByCategory, computeHealth } from './scoring/score.js';

--- a/packages/core/src/reporter/markdown.ts
+++ b/packages/core/src/reporter/markdown.ts
@@ -112,6 +112,12 @@ export function formatMarkdownReport(results: Result[], config: Config, meta: { 
       lines.push('');
       lines.push(`…and ${findings.length - MAX_FINDINGS} more (run \`npx svelte-vitals\` locally for the full report)`);
     }
+    // A blocked adopter reading this comment in CI is exactly who needs the exclusion
+    // mechanisms (config overrides / suppressions file) — point there, once, at the end.
+    lines.push('');
+    lines.push(
+      '_Expected findings (e.g. routes behind auth)? See [Excluding routes or rules](https://oekazuma.github.io/svelte-vitals/guides/ci/#excluding-routes-or-rules)._'
+    );
   }
 
   return lines.join('\n');

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -77,6 +77,27 @@ export type TreatDynamicAs = 'pass' | 'warn' | 'fail';
 /** Per-rule override: disable, or change severity. */
 export type RuleSetting = 'off' | Severity;
 
+/**
+ * Scoped rule override (design 2026-07-18), applied to results after analysis.
+ * An entry matches a finding when any `route` glob matches its route id or any
+ * `files` glob matches its source location; at least one of the two must be
+ * set. Glob syntax: `*` matches within a segment, `**` across segments, a
+ * trailing `/**` also matches the bare prefix, and all other characters
+ * (including SvelteKit's `(`, `)`, `[`, `]`) are literal.
+ */
+export interface RuleOverride {
+  /**
+   * Route-id glob(s), e.g. '/admin/**'. Note route ids drop `(group)` segments
+   * (`src/routes/(app)/dashboard` reports as '/dashboard') — target a group
+   * via `files` instead.
+   */
+  route?: string | string[];
+  /** Source-path glob(s) matched against a finding's location, e.g. 'src/routes/(app)/**'. */
+  files?: string | string[];
+  /** Keys are rule ids ('SEO001') or category names ('seo'). Rule id beats category within an entry. */
+  rules: Record<string, RuleSetting>;
+}
+
 export interface Config {
   treatDynamicAs: TreatDynamicAs;
   /** Component names treated as meta sources of unknown content (design §11 layer 4). */
@@ -87,6 +108,8 @@ export interface Config {
   failOn: Severity;
   /** Per-category weights for the combined Health score (default: equal, 1 each) (#10). */
   weights?: Partial<Record<Category, number>>;
+  /** Route-/file-scoped rule overrides, applied to results after analysis (later entries win). */
+  overrides?: RuleOverride[];
 }
 
 export const defaultConfig: Config = {

--- a/packages/core/test/markdown-report.test.ts
+++ b/packages/core/test/markdown-report.test.ts
@@ -87,6 +87,24 @@ describe('formatMarkdownReport', () => {
     expect(out).toContain('**0 critical · 0 warning · 0 info**');
   });
 
+  it('appends an exclusion-docs footer when findings exist, and omits it on a clean run', () => {
+    const failing: Result[] = [
+      {
+        id: 'SEO001',
+        severity: 'critical',
+        detection: { presence: 'none', value: 'absent' },
+        route: '/none',
+        message: 'Missing <title>'
+      }
+    ];
+    const out = formatMarkdownReport(failing, config, { version: '1.0.0' });
+    expect(out).toContain('routes behind auth');
+    expect(out).toContain('https://oekazuma.github.io/svelte-vitals/guides/ci/#excluding-routes-or-rules');
+
+    const clean: Result[] = [{ ...failing[0]!, detection: { presence: 'own', value: 'static' } }];
+    expect(formatMarkdownReport(clean, config, { version: '1.0.0' })).not.toContain('#excluding-routes-or-rules');
+  });
+
   it('truncates to 50 findings and appends a "…and N more" note', () => {
     const results: Result[] = Array.from({ length: 60 }, (_, i) => ({
       id: 'SEO006',

--- a/packages/core/test/route-overrides.test.ts
+++ b/packages/core/test/route-overrides.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { applyOverrides, defineConfig, type Result } from '../src/index.js';
+
+function finding(overrides: Partial<Result> = {}): Result {
+  return {
+    id: 'SEO001',
+    severity: 'critical',
+    detection: { presence: 'none', value: 'absent' },
+    route: '/dashboard',
+    location: 'src/routes/(app)/dashboard/+page.svelte',
+    message: 'x',
+    category: 'seo',
+    ...overrides
+  };
+}
+
+describe('applyOverrides', () => {
+  it('is an identity when overrides is absent or empty', () => {
+    const results = [finding()];
+    expect(applyOverrides(results, defineConfig({}))).toEqual(results);
+    expect(applyOverrides(results, defineConfig({ overrides: [] }))).toEqual(results);
+  });
+
+  it("removes matched results entirely on 'off' — failing and passing entries alike", () => {
+    const failing = finding();
+    const passing = finding({ detection: { presence: 'own', value: 'static' } });
+    const otherRoute = finding({ route: '/blog', location: 'src/routes/blog/+page.svelte' });
+    const config = defineConfig({ overrides: [{ route: '/dashboard/**', rules: { SEO001: 'off' } }] });
+    expect(applyOverrides([failing, passing, otherRoute], config)).toEqual([otherRoute]);
+  });
+
+  it('rewrites severity for matched results', () => {
+    const config = defineConfig({ overrides: [{ route: '/dashboard', rules: { SEO001: 'info' } }] });
+    const out = applyOverrides([finding()], config);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.severity).toBe('info');
+  });
+
+  it('applies category keys to every rule in that category, defaulting absent category to seo', () => {
+    const seo = finding({ category: undefined });
+    const perf = finding({ id: 'PERF001', category: 'performance' });
+    const config = defineConfig({ overrides: [{ route: '/dashboard', rules: { seo: 'off' } }] });
+    expect(applyOverrides([seo, perf], config)).toEqual([perf]);
+  });
+
+  it('lets a rule-id key beat a category key within one entry', () => {
+    const config = defineConfig({
+      overrides: [{ route: '/dashboard', rules: { seo: 'off', SEO001: 'warning' } }]
+    });
+    const out = applyOverrides([finding()], config);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.severity).toBe('warning');
+  });
+
+  it('lets later entries win over earlier ones', () => {
+    const config = defineConfig({
+      overrides: [
+        { route: '/dashboard/**', rules: { SEO001: 'off' } },
+        { route: '/dashboard', rules: { SEO001: 'info' } }
+      ]
+    });
+    const out = applyOverrides([finding()], config);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.severity).toBe('info');
+  });
+
+  it('accepts an array of route globs on one entry', () => {
+    const config = defineConfig({ overrides: [{ route: ['/admin', '/account/**'], rules: { SEO001: 'off' } }] });
+    const results = [finding({ route: '/admin' }), finding({ route: '/account/settings' }), finding({ route: '/blog' })];
+    expect(applyOverrides(results, config).map((r) => r.route)).toEqual(['/blog']);
+  });
+
+  it('matches on files globs against a finding location — the way to target a (group)', () => {
+    const grouped = finding();
+    const outside = finding({ route: '/blog', location: 'src/routes/blog/+page.svelte' });
+    const config = defineConfig({ overrides: [{ files: 'src/routes/(app)/**', rules: { seo: 'off' } }] });
+    expect(applyOverrides([grouped, outside], config)).toEqual([outside]);
+  });
+
+  it('matches when either route or files matches (OR semantics)', () => {
+    const byRoute = finding({ location: undefined });
+    const byFile = finding({ route: '/elsewhere' });
+    const neither = finding({ route: '/blog', location: 'src/routes/blog/+page.svelte' });
+    const config = defineConfig({
+      overrides: [{ route: '/dashboard', files: 'src/routes/(app)/**', rules: { SEO001: 'off' } }]
+    });
+    expect(applyOverrides([byRoute, byFile, neither], config)).toEqual([neither]);
+  });
+
+  it('never matches findings that lack both route and location', () => {
+    const project = finding({ route: undefined, location: undefined });
+    const config = defineConfig({ overrides: [{ route: '**', files: '**', rules: { SEO001: 'off' } }] });
+    expect(applyOverrides([project], config)).toEqual([project]);
+  });
+
+  describe('glob matching', () => {
+    function matches(pattern: string, route: string): boolean {
+      const config = defineConfig({ overrides: [{ route: pattern, rules: { SEO001: 'off' } }] });
+      return applyOverrides([finding({ route, location: undefined })], config).length === 0;
+    }
+
+    it('matches exact routes literally, anchored at both ends', () => {
+      expect(matches('/admin', '/admin')).toBe(true);
+      expect(matches('/admin', '/admin/users')).toBe(false);
+      expect(matches('/admin', '/blog/admin')).toBe(false);
+    });
+
+    it('treats SvelteKit route characters ( ) [ ] as literals', () => {
+      expect(matches('/blog/[slug]', '/blog/[slug]')).toBe(true);
+      expect(matches('/blog/[slug]', '/blog/s')).toBe(false);
+      expect(matches('/(app)/dashboard', '/(app)/dashboard')).toBe(true);
+    });
+
+    it('* matches within a segment but never across /', () => {
+      expect(matches('/blog/*', '/blog/[slug]')).toBe(true);
+      expect(matches('/blog/*', '/blog/a/b')).toBe(false);
+      expect(matches('/(*)/dashboard', '/(app)/dashboard')).toBe(true);
+    });
+
+    it('** matches across segments', () => {
+      expect(matches('/admin/**', '/admin/users/[id]')).toBe(true);
+      expect(matches('**', '/anything/at/all')).toBe(true);
+    });
+
+    it('a trailing /** also matches the bare prefix', () => {
+      expect(matches('/admin/**', '/admin')).toBe(true);
+      expect(matches('/admin/**', '/administrator')).toBe(false);
+    });
+  });
+});

--- a/packages/core/test/route-overrides.test.ts
+++ b/packages/core/test/route-overrides.test.ts
@@ -66,7 +66,11 @@ describe('applyOverrides', () => {
 
   it('accepts an array of route globs on one entry', () => {
     const config = defineConfig({ overrides: [{ route: ['/admin', '/account/**'], rules: { SEO001: 'off' } }] });
-    const results = [finding({ route: '/admin' }), finding({ route: '/account/settings' }), finding({ route: '/blog' })];
+    const results = [
+      finding({ route: '/admin' }),
+      finding({ route: '/account/settings' }),
+      finding({ route: '/blog' })
+    ];
     expect(applyOverrides(results, config).map((r) => r.route)).toEqual(['/blog']);
   });
 

--- a/packages/vite/src/analyze.ts
+++ b/packages/vite/src/analyze.ts
@@ -66,7 +66,15 @@ export async function analyze(
   const kitModules = await collectKitModuleFacts(cwd);
   const results = applyOverrides(
     applyRuleSeverities(
-      await runRules(selectRules(allRules, config), { heads, headings, images, project, components, config, kitModules }),
+      await runRules(selectRules(allRules, config), {
+        heads,
+        headings,
+        images,
+        project,
+        components,
+        config,
+        kitModules
+      }),
       config
     ),
     config

--- a/packages/vite/src/analyze.ts
+++ b/packages/vite/src/analyze.ts
@@ -2,6 +2,7 @@ import {
   allRules,
   selectRules,
   applyRuleSeverities,
+  applyOverrides,
   runRules,
   computeScore,
   summarize,
@@ -49,20 +50,25 @@ export async function analyze(
   const warnings = loaded?.warnings ?? [];
 
   const weights = options.weights ?? fileConfig?.weights;
+  const overrides = options.overrides ?? fileConfig?.overrides;
   const config = defineConfig({
     treatDynamicAs: options.treatDynamicAs ?? fileConfig?.treatDynamicAs ?? 'pass',
     metaComponents: options.metaComponents ?? fileConfig?.metaComponents ?? [],
     rules: options.rules ?? fileConfig?.rules ?? {},
     failOn: options.failOn ?? fileConfig?.failOn ?? 'critical',
-    ...(weights !== undefined ? { weights } : {})
+    ...(weights !== undefined ? { weights } : {}),
+    ...(overrides !== undefined ? { overrides } : {})
   });
 
   const { heads, headings, images, htmlLang } = await collectRenderedHeads(prerenderPagesDir);
   const project = await collectRenderedProject(cwd, htmlLang);
   const components = await collectComponentFacts(cwd);
   const kitModules = await collectKitModuleFacts(cwd);
-  const results = applyRuleSeverities(
-    await runRules(selectRules(allRules, config), { heads, headings, images, project, components, config, kitModules }),
+  const results = applyOverrides(
+    applyRuleSeverities(
+      await runRules(selectRules(allRules, config), { heads, headings, images, project, components, config, kitModules }),
+      config
+    ),
     config
   );
 

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs';
 import { writeFile, mkdir } from 'node:fs/promises';
 import { join, isAbsolute, dirname, relative, basename, sep } from 'node:path';
 import type { Plugin, ViteDevServer } from 'vite';
-import type { Category, RuleSetting, Severity, TreatDynamicAs } from '@svelte-vitals/core';
+import type { Category, RuleOverride, RuleSetting, Severity, TreatDynamicAs } from '@svelte-vitals/core';
 import { defineConfig } from '@svelte-vitals/core';
 import { loadConfigFile } from 'svelte-vitals';
 import { analyze } from './analyze.js';
@@ -42,6 +42,8 @@ export interface SvelteVitalsOptions {
   treatDynamicAs?: TreatDynamicAs;
   metaComponents?: string[];
   rules?: Record<string, RuleSetting>;
+  /** Route-/file-scoped rule overrides applied to build-gate results (option > config file). */
+  overrides?: RuleOverride[];
   /** Minimum severity that fails the build (default: 'critical'). */
   failOn?: Severity;
   /** Per-category weights for the combined Health score shown in the JSON/console report (flag > config file > default 1 each). */

--- a/packages/vite/test/analyze.test.ts
+++ b/packages/vite/test/analyze.test.ts
@@ -109,6 +109,16 @@ describe('analyze — svelte-vitals.config.*', () => {
     }
   });
 
+  it('applies route-scoped overrides from the config file to rendered results (design 2026-07-18)', async () => {
+    const { cwd, pages } = await makeProject(`export default { overrides: [{ route: '/', rules: { seo: 'off' } }] };\n`);
+    try {
+      const r = await analyze(pages, cwd, { report: false });
+      expect(r.results.some((x) => x.id === 'SEO001')).toBe(false);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
   it('surfaces non-fatal config-file warnings (e.g. an unrecognized failOn value)', async () => {
     const { cwd, pages } = await makeProject(`export default { failOn: 'nope' };\n`);
     try {

--- a/packages/vite/test/analyze.test.ts
+++ b/packages/vite/test/analyze.test.ts
@@ -110,7 +110,9 @@ describe('analyze — svelte-vitals.config.*', () => {
   });
 
   it('applies route-scoped overrides from the config file to rendered results (design 2026-07-18)', async () => {
-    const { cwd, pages } = await makeProject(`export default { overrides: [{ route: '/', rules: { seo: 'off' } }] };\n`);
+    const { cwd, pages } = await makeProject(
+      `export default { overrides: [{ route: '/', rules: { seo: 'off' } }] };\n`
+    );
     try {
       const r = await analyze(pages, cwd, { report: false });
       expect(r.results.some((x) => x.id === 'SEO001')).toBe(false);


### PR DESCRIPTION
## Why

Feedback from a CI adopter on X: auth-only routes were mass-flagged by SEO rules, and they couldn't find a way to exclude specific rules on specific routes from the GitHub Action. Two real problems: the existing mechanisms (config file, suppressions file — both applied by the action automatically) were undiscoverable, and there was no *durable* way to say "this part of the app is exempt from these rules".

Design doc: `docs/superpowers/specs/2026-07-18-route-overrides-and-exclusion-discoverability-design.md`

## What

**1. `overrides` in `svelte-vitals.config.*` (feat)**

```js
export default {
  overrides: [
    { files: 'src/routes/(app)/**', rules: { seo: 'off' } },
    { route: '/admin/**', rules: { SEO001: 'info' } }
  ]
};
```

- Entries scope rule settings by `route` globs (route ids) and/or `files` globs (source paths). `files` exists because route ids drop `(group)` segments — the only way to target "the whole `(app)` auth group".
- `rules` keys are rule ids or category names; `'off'` removes matching findings entirely (no gate, no score drag), a severity value re-classifies. Later entries win; rule-id beats category within an entry.
- Applied post-analysis in `applyOverrides` (core, pure) via `analyzeProject`, so CLI, MCP, the action, and the Vite build gate all honor it. Vite also accepts it as a plugin option. Config-file validation rejects malformed entries fatally (exit 2), same stance as `rules`.
- Unlike the snapshot-style suppressions file, this is durable policy: routes added under the glob later are excluded too.

**2. Report footer pointer (feat)**

The Markdown report (job summary / sticky PR comment) now ends with a one-line link to the exclusion docs whenever findings are shown — the person blocked in CI is exactly who needs it.

**3. Discoverability docs**

- New `packages/action/README.md`: the four inputs are *not* the whole configuration surface; the action reads `svelte-vitals.config.*` and `svelte-vitals-suppressions.json` from the repo.
- CI guide (en/ja): new "Excluding routes or rules" section mapping the three mechanisms (global `rules` off / scoped `overrides` / suppressions) to intents.
- Config guide (en/ja): full `overrides` reference.

## Verification

- `pnpm build` / `pnpm typecheck` / `pnpm test` (1408 tests, incl. 23 new) / `pnpm lint` / `pnpm run check:publint` / docs `astro build` all pass locally (`attw` needs npm, absent locally — CI covers it).
- E2E: built CLI run against a fixture project — `/dashboard` under `(app)` reports zero issues, `/public` keeps its SEO findings.
- Generated doc anchors verified against the built HTML (en/ja).
- Changesets: minor (core/cli/vite) + patch (core); `packages/action/dist` rebuilt and committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4tV2bQj9u2xztovZfnrXH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added route- and file-scoped rule overrides to disable findings or adjust their severity.
  * Overrides are supported across CLI, Vite builds, CI workflows, and other analysis entry points.
  * Added documentation for configuration, validation, CI usage, and the GitHub Action.
  * Reports with findings now link directly to exclusion guidance.

* **Bug Fixes**
  * Improved configuration validation and clearer handling of invalid override settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->