### PR TITLE
ci: auto-rebuild packages/action/dist on Renovate PRs

### DIFF
--- a/.github/workflows/rebuild-action-dist.yml
+++ b/.github/workflows/rebuild-action-dist.yml
@@ -1,0 +1,60 @@
+# packages/action/dist is a committed bundle that embeds the CLI and its
+# dependencies (svelte included), so every Renovate bump that touches the
+# bundle graph leaves dist stale and fails CI's "Verify action dist is up to
+# date" step. This workflow rebuilds dist on Renovate PRs and pushes the
+# refreshed bundle back to the branch, so those PRs go green without a human.
+#
+# The push uses the ACTION_DIST_PAT secret (fine-grained PAT, Contents:
+# read/write on this repo) instead of GITHUB_TOKEN — pushes made with
+# GITHUB_TOKEN do not trigger workflows, which would leave the new commit
+# without CI runs. The PAT push re-triggers CI (and this workflow, which then
+# finds no diff and exits — no loop).
+name: Rebuild action dist
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  rebuild:
+    # Same-repo Renovate branches only: never forks, never human PRs.
+    if: github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'renovate/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.head_ref }}
+          # The default GITHUB_TOKEN stays out of .git/config; the push below
+          # authenticates explicitly with the PAT.
+          persist-credentials: false
+      - name: Setup Node.js and dependencies
+        uses: ./.github/workflows/setup-node
+      - name: Rebuild packages
+        run: pnpm build
+      - name: Commit refreshed dist if stale
+        env:
+          PAT: ${{ secrets.ACTION_DIST_PAT }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if git diff --quiet -- packages/action/dist; then
+            echo "packages/action/dist is up to date — nothing to do."
+            exit 0
+          fi
+          if [ -z "$PAT" ]; then
+            echo "::error::packages/action/dist is stale but the ACTION_DIST_PAT secret is not set. Rebuild manually (pnpm build) and commit packages/action/dist, or add the secret."
+            exit 1
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add packages/action/dist
+          git commit -m "chore(action): rebuild dist for updated dependencies"
+          git push "https://x-access-token:${PAT}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${HEAD_REF}"


### PR DESCRIPTION
## Summary

Renovate bumps that land in the action's bundle graph (svelte, magicast, …) leave the committed `packages/action/dist` stale, fail the "Verify action dist is up to date" CI step, and require a manual `pnpm build` + commit every time (most recently on #242). This adds a workflow that removes the manual step:

- Triggers on `pull_request` for **same-repo `renovate/*` branches only** (never forks, never human PRs).
- Runs `pnpm build`; if `packages/action/dist` differs, commits it as `chore(action): rebuild dist for updated dependencies` and pushes back to the PR branch.
- Pushes with the **`ACTION_DIST_PAT`** secret instead of `GITHUB_TOKEN`: GITHUB_TOKEN pushes don't trigger workflows, which would leave the new commit with no CI runs. The PAT push re-triggers CI (and this workflow, which then finds no diff and exits — no loop).
- `persist-credentials: false` on checkout, so the build never runs with the token in `.git/config`; the PAT is used only for the final push.
- If the secret is missing, the workflow fails with an error that points back to the manual procedure — same net behavior as today, just with a clearer message.

## Required setup (maintainer, one-time)

1. Create a **fine-grained PAT**: GitHub → Settings → Developer settings → Fine-grained tokens, repository access limited to `oekazuma/svelte-vitals`, permission **Contents: Read and write**.
2. Add it as a repository secret named **`ACTION_DIST_PAT`** (repo Settings → Secrets and variables → Actions).

## Notes

- Renovate stops rebasing a branch once someone else has pushed to it; ticking the PR's rebase checkbox discards the bot commit, after which this workflow simply re-adds it on the next run.
- Workflow-only change, so no changeset.
- Verified: prettier check passes; the `if:` guard and push mechanics follow the existing pinned-action conventions in `ci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated checks to keep generated action distribution files up to date on eligible pull requests.
  * Automatically rebuilds and commits updated distribution files when the required credentials are available.
  * Prevents concurrent rebuilds for the same pull request and reports when manual updates are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->