### PR TITLE
feat(core): add SEO031 — flag routes that disable server-side rendering

### DIFF
--- a/.changeset/seo031-ssr-disabled.md
+++ b/.changeset/seo031-ssr-disabled.md
@@ -1,0 +1,8 @@
+---
+'@svelte-vitals/core': minor
+'svelte-vitals': minor
+'@svelte-vitals/vite': minor
+'@svelte-vitals/mcp': minor
+---
+
+Add SEO031 (warning): flag SvelteKit route files that disable server-side rendering with `export const ssr = false` — per the official SEO guidance, server-rendered content indexes more reliably, and SPA mode adds a round trip before first paint. The root-layout (app-wide) case gets a dedicated message; deliberate SPAs can turn the rule off or suppress inline.

--- a/docs/src/content/docs/ja/rules/seo031.md
+++ b/docs/src/content/docs/ja/rules/seo031.md
@@ -7,7 +7,7 @@ description: export const ssr = false は、JS を実行しないクローラー
 
 ## チェック内容
 
-`export const ssr = false` でサーバーサイドレンダリングを無効化している SvelteKit のルートファイルを検出します(`satisfies` 形式や同一ファイル内のエイリアス export も対象)。ルートの `+layout` での無効化 — アプリ全体が SPA になる — には、より強いアプリ全体向けのメッセージを出します。
+`export const ssr = false` でサーバーサイドレンダリングを無効化している SvelteKit のルートファイルを検出します(`satisfies`/`as` 形式や同一ファイル内のエイリアス export も対象)。ルートの `+layout` での無効化 — アプリ全体が SPA になる — には、より強いアプリ全体向けのメッセージを出します。
 
 検出対象外: `csr = false`(サーバー専用レンダリング — SEO にはむしろ良い)、`export const ssr = dev` のような非リテラル値(静的に評価不能)、export されていない `const ssr = false`(SvelteKit では効果がない)。
 

--- a/docs/src/content/docs/ja/rules/seo031.md
+++ b/docs/src/content/docs/ja/rules/seo031.md
@@ -1,0 +1,38 @@
+---
+title: SEO031 · SSR の無効化
+description: export const ssr = false は、JS を実行しないクローラーからコンテンツを見えなくし、初回描画も遅くします。
+---
+
+**重大度:** warning · **カテゴリ:** seo
+
+## チェック内容
+
+`export const ssr = false` でサーバーサイドレンダリングを無効化している SvelteKit のルートファイルを検出します(`satisfies` 形式や同一ファイル内のエイリアス export も対象)。ルートの `+layout` での無効化 — アプリ全体が SPA になる — には、より強いアプリ全体向けのメッセージを出します。
+
+検出対象外: `csr = false`(サーバー専用レンダリング — SEO にはむしろ良い)、`export const ssr = dev` のような非リテラル値(静的に評価不能)、export されていない `const ssr = false`(SvelteKit では効果がない)。
+
+## 重要な理由
+
+SvelteKit 公式の SEO ガイダンスいわく: サーバーレンダリングされたコンテンツはより頻繁に・確実にインデックスされる — 正当な理由がない限り SSR は有効のままにすべきです。インデックスのリスクに加えて、SPA モードは空のページを配信して JavaScript の取得・実行を待つため、何かが描画されるまでにネットワークラウンドトリップが1回増えます。
+
+`prerender = true` を併用してもこの問題は解消されません: `ssr = false` では事前レンダリングの出力も空のシェルになります。
+
+## 修正方法
+
+`ssr = false` は SEO が本当に不要なルートに限定します:
+
+```ts
+// src/routes/(app)/dashboard/+page.ts — 認証必須、インデックス不要
+export const ssr = false; // これが意図的なら suppression するかルールを off に
+```
+
+意図的な完全 SPA の場合は、config でルールを無効化します:
+
+```js
+// svelte-vitals config
+rules: {
+  SEO031: 'off';
+}
+```
+
+または宣言の直前に `// svelte-vitals-disable-next-line SEO031` を書いてください。

--- a/docs/src/content/docs/ja/rules/seo031.md
+++ b/docs/src/content/docs/ja/rules/seo031.md
@@ -29,10 +29,12 @@ export const ssr = false; // これが意図的なら suppression するかル�
 意図的な完全 SPA の場合は、config でルールを無効化します:
 
 ```js
-// svelte-vitals config
-rules: {
-  SEO031: 'off';
-}
+// svelte-vitals.config.mjs
+export default {
+  rules: {
+    SEO031: 'off'
+  }
+};
 ```
 
 または宣言の直前に `// svelte-vitals-disable-next-line SEO031` を書いてください。

--- a/docs/src/content/docs/rules/seo031.md
+++ b/docs/src/content/docs/rules/seo031.md
@@ -1,0 +1,38 @@
+---
+title: SEO031 · SSR disabled
+description: export const ssr = false makes a route's content invisible to non-JS crawlers and slower to first paint.
+---
+
+**Severity:** warning · **Category:** seo
+
+## What it checks
+
+Flags SvelteKit route files that disable server-side rendering with `export const ssr = false` (the `satisfies` and same-file alias-export forms included). Disabling it in the root `+layout` — which turns the whole app into an SPA — gets a stronger, app-wide message.
+
+Not flagged: `csr = false` (server-only rendering — fine for SEO), non-literal values like `export const ssr = dev` (not statically evaluable), and non-exported `const ssr = false` (has no effect in SvelteKit).
+
+## Why it matters
+
+SvelteKit's own SEO guidance: server-side rendered content is indexed more frequently and reliably — leave SSR on unless you have a good reason not to. On top of the indexing risk, SPA mode ships an empty page that must fetch and run JavaScript before anything renders, adding a network round trip before first paint.
+
+Note that `prerender = true` does not neutralise this: with `ssr = false` the prerendered output is still an empty shell.
+
+## How to fix
+
+Scope `ssr = false` to routes that genuinely don't need SEO:
+
+```ts
+// src/routes/(app)/dashboard/+page.ts — authenticated, not indexable
+export const ssr = false; // fine — suppress or turn the rule off if this is deliberate
+```
+
+For a deliberate full SPA, disable the rule in your config:
+
+```js
+// svelte-vitals config
+rules: {
+  SEO031: 'off';
+}
+```
+
+or add `// svelte-vitals-disable-next-line SEO031` above the declaration.

--- a/docs/src/content/docs/rules/seo031.md
+++ b/docs/src/content/docs/rules/seo031.md
@@ -7,7 +7,7 @@ description: export const ssr = false makes a route's content invisible to non-J
 
 ## What it checks
 
-Flags SvelteKit route files that disable server-side rendering with `export const ssr = false` (the `satisfies` and same-file alias-export forms included). Disabling it in the root `+layout` — which turns the whole app into an SPA — gets a stronger, app-wide message.
+Flags SvelteKit route files that disable server-side rendering with `export const ssr = false` (the `satisfies`/`as` and same-file alias-export forms included). Disabling it in the root `+layout` — which turns the whole app into an SPA — gets a stronger, app-wide message.
 
 Not flagged: `csr = false` (server-only rendering — fine for SEO), non-literal values like `export const ssr = dev` (not statically evaluable), and non-exported `const ssr = false` (has no effect in SvelteKit).
 

--- a/docs/src/content/docs/rules/seo031.md
+++ b/docs/src/content/docs/rules/seo031.md
@@ -29,10 +29,12 @@ export const ssr = false; // fine — suppress or turn the rule off if this is d
 For a deliberate full SPA, disable the rule in your config:
 
 ```js
-// svelte-vitals config
-rules: {
-  SEO031: 'off';
-}
+// svelte-vitals.config.mjs
+export default {
+  rules: {
+    SEO031: 'off'
+  }
+};
 ```
 
 or add `// svelte-vitals-disable-next-line SEO031` above the declaration.

--- a/docs/superpowers/plans/2026-07-21-seo031-ssr-disabled.md
+++ b/docs/superpowers/plans/2026-07-21-seo031-ssr-disabled.md
@@ -311,10 +311,12 @@ export const ssr = false; // fine — suppress or turn the rule off if this is d
 For a deliberate full SPA, disable the rule in your config:
 
 ```js
-// svelte-vitals config
-rules: {
-  SEO031: 'off';
-}
+// svelte-vitals.config.mjs
+export default {
+  rules: {
+    SEO031: 'off'
+  }
+};
 ```
 
 or add `// svelte-vitals-disable-next-line SEO031` above the declaration.
@@ -356,10 +358,12 @@ export const ssr = false; // これが意図的なら suppression するかル�
 意図的な完全 SPA の場合は、config でルールを無効化します:
 
 ```js
-// svelte-vitals config
-rules: {
-  SEO031: 'off';
-}
+// svelte-vitals.config.mjs
+export default {
+  rules: {
+    SEO031: 'off'
+  }
+};
 ```
 
 または宣言の直前に `// svelte-vitals-disable-next-line SEO031` を書いてください。

--- a/docs/superpowers/plans/2026-07-21-seo031-ssr-disabled.md
+++ b/docs/superpowers/plans/2026-07-21-seo031-ssr-disabled.md
@@ -1,0 +1,414 @@
+# SEO031 — SSR Disabled Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add SEO031 — a `warning` SEO rule flagging SvelteKit route files that disable server-side rendering (`export const ssr = false`), the official SEO best-practices doc's headline risk.
+
+**Architecture:** Promote the existing CORRECT008 opt-out detector (`hasSsrFalseOptOut` in `kit-module-parse.ts`) to a line-reporting `findSsrFalseOptOut`, record it as the OPTIONAL fact `KitModuleFacts.ssrDisabled` (no literal churn), and build the rule with the `kitModuleRule` factory after widening its `category` type to `'security' | 'seo'`. Root-layout files get an app-wide message variant.
+
+**Tech Stack:** TypeScript, Vitest, pnpm workspaces, Astro Starlight docs, Changesets.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-21-seo031-ssr-disabled-design.md`. Branch: `feat/seo031-ssr-disabled` (exists with the spec commit). Run `git fetch origin` first — rebase onto `origin/main` if it moved past `4dae3da6`.
+- Rule identity: `id 'SEO031'`, `title 'SSR disabled'`, `category 'seo'`, `severity 'warning'`, `scope 'component'`; message/recommendation/rationale strings verbatim from spec §2.
+- `ssrDisabled` is OPTIONAL on `KitModuleFacts` — absent means SSR on; existing test-helper literals need no changes.
+- CORRECT008's opt-out behavior is unchanged (truthiness of the renamed helper) — every existing `ssr = false` opt-out test passes untouched.
+- NOT flagged: `csr = false`, `ssr = true`, non-literal values (`ssr = dev`), non-exported `const ssr = false`.
+- `packages/core/src`: no `node:` imports, no I/O. en/ja docs together. No suppression-range doc edits exist anymore (removed in PR #240). Changeset: core / `svelte-vitals` / vite / mcp — minor. cli tests need `pnpm --filter @svelte-vitals/core build` first. Root verify: `pnpm build && pnpm typecheck && pnpm test && pnpm lint` (2 pre-existing warnings in `packages/cli/test/meta-object.test.ts` are not yours). Final `chore(action)` dist commit if `pnpm build` changes it. Conventional commits.
+
+---
+
+## File Structure
+
+- Modify: `packages/core/src/kit-module-parse.ts` (`hasSsrFalseOptOut` → `findSsrFalseOptOut` + `ssrDisabled` wiring), `packages/core/src/kit-module.ts` (field) — Task 1.
+- Modify: `packages/core/test/kit-module-parse.test.ts` (new describe) — Task 1.
+- Create: `packages/core/src/rules/seo/seo031-ssr-disabled.ts`; Modify: `packages/core/src/rules/kit-module-rule.ts` (category type), `packages/core/src/rules/index.ts` (3 spots), `packages/core/src/index.ts` (1 spot), `packages/core/test/security-kit-rules.test.ts` (rule tests — the `kit()` helper lives here) — Task 2.
+- Create: `docs/src/content/docs/rules/seo031.md` + `ja/rules/seo031.md`, `.changeset/seo031-ssr-disabled.md` — Task 3.
+
+---
+
+### Task 1: The `ssrDisabled` fact
+
+**Files:**
+
+- Modify: `packages/core/src/kit-module.ts` (after the `browserGlobalRefs` field)
+- Modify: `packages/core/src/kit-module-parse.ts` (`hasSsrFalseOptOut` ~line 186; its call site ~line 387; the final return ~line 515)
+- Modify: `packages/core/test/kit-module-parse.test.ts` (new describe at end)
+
+**Interfaces:**
+
+- Consumes: existing `unwrapExport`, `unwrapTs`, `collectTopLevelBindings`, `lineOf`, the `wrapped` source and the file's `Math.max(0, l - 1)` shift convention.
+- Produces (Task 2 reads it): `KitModuleFacts.ssrDisabled?: { line: number }` — set (with the declaration's unwrapped line) when the file disables SSR via either detection form.
+
+- [ ] **Step 1: Rebase check**
+
+```bash
+git switch feat/seo031-ssr-disabled
+git fetch origin
+git log --oneline origin/main -1   # if not 4dae3da6, run: git rebase origin/main
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `packages/core/test/kit-module-parse.test.ts`:
+
+```ts
+describe('parseKitModuleFacts — ssrDisabled (SEO031)', () => {
+  it('records the declaration line for an inline export const ssr = false', () => {
+    const src = 'export const prerender = true;\nexport const ssr = false;';
+    expect(facts(src, 'src/routes/+page.ts').ssrDisabled).toEqual({ line: 2 });
+  });
+  it('handles satisfies and the alias-export form', () => {
+    expect(facts('export const ssr = false satisfies boolean;', 'src/routes/+page.ts').ssrDisabled).toEqual({
+      line: 1
+    });
+    expect(facts('const ssr = false;\nexport { ssr };', 'src/routes/+page.ts').ssrDisabled).toEqual({ line: 1 });
+  });
+  it('is absent for csr = false, ssr = true, non-literal, and non-exported forms', () => {
+    expect(facts('export const csr = false;', 'src/routes/+page.ts').ssrDisabled).toBeUndefined();
+    expect(facts('export const ssr = true;', 'src/routes/+page.ts').ssrDisabled).toBeUndefined();
+    expect(
+      facts("import { dev } from '$app/environment';\nexport const ssr = dev;", 'src/routes/+page.ts').ssrDisabled
+    ).toBeUndefined();
+    expect(facts('const ssr = false;', 'src/routes/+page.ts').ssrDisabled).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 3: Run to verify they fail**
+
+Run: `pnpm --filter @svelte-vitals/core test -- kit-module-parse`
+Expected: FAIL — `ssrDisabled` is always `undefined`.
+
+- [ ] **Step 4: Implement**
+
+1. `packages/core/src/kit-module.ts`, after the `browserGlobalRefs` field:
+
+```ts
+/** Set when this file disables SSR via `export const ssr = false` (inline or same-file alias export) — the declaration's line (SEO031). */
+ssrDisabled?: { line: number };
+```
+
+2. `packages/core/src/kit-module-parse.ts` — replace `hasSsrFalseOptOut` with a line-reporting version (same detection logic; note it now takes the wrapped source to compute the line):
+
+```ts
+/**
+ * The `export const ssr = false` opt-out, when present: inline form
+ * (`satisfies`/`as` unwrapped) or same-file alias export (`const ssr = false;
+ * export { ssr };`). Returns the declaration's line in the WRAPPED source (the
+ * caller applies the −1 shift). Such a file never runs on the server — CORRECT008
+ * skips its browser-global scan, and SEO031 reports the flag itself.
+ */
+function findSsrFalseOptOut(program: Node, source: string): { line: number } | undefined {
+  const isFalse = (init: Node): boolean => {
+    const v = unwrapTs(init);
+    return v?.type === 'Literal' && v.value === false;
+  };
+  for (const stmt of program.body ?? []) {
+    const decl = unwrapExport(stmt);
+    if (decl?.type !== 'VariableDeclaration') continue;
+    for (const d of decl.declarations ?? []) {
+      if (d?.id?.type === 'Identifier' && d.id.name === 'ssr' && d.init && isFalse(d.init)) {
+        if (stmt.type === 'ExportNamedDeclaration') return { line: lineOf(source, d.start) };
+      }
+    }
+  }
+  // Alias export: `const ssr = false; export { ssr };`
+  const bindings = collectTopLevelBindings(program);
+  for (const stmt of program.body ?? []) {
+    if (stmt?.type !== 'ExportNamedDeclaration' || !stmt.specifiers || stmt.source || stmt.exportKind === 'type')
+      continue;
+    for (const s of stmt.specifiers) {
+      if (s?.exportKind === 'type' || s?.exported?.type !== 'Identifier' || s?.local?.type !== 'Identifier') continue;
+      if (s.exported.name !== 'ssr') continue;
+      const resolved = bindings.get(s.local.name);
+      if (resolved?.type === 'Literal' && resolved.value === false) return { line: lineOf(source, resolved.start) };
+    }
+  }
+  return undefined;
+}
+```
+
+3. In `parseKitModuleFacts`: where the browser-global scan currently does `if (!hasSsrFalseOptOut(program)) {`, compute once above it:
+
+```ts
+const ssrOptOut = findSsrFalseOptOut(program, wrapped);
+```
+
+and change the guard to `if (!ssrOptOut) {`. In the FINAL return object add:
+
+```ts
+    ...(ssrOptOut ? { ssrDisabled: { line: Math.max(0, ssrOptOut.line - 1) } } : {})
+```
+
+(The early `!program` return needs no change — the field is optional.)
+
+- [ ] **Step 5: Run to verify pass (incl. CORRECT008 regression)**
+
+Run: `pnpm --filter @svelte-vitals/core test`
+Expected: PASS — every existing `ssr = false` opt-out test unchanged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core
+git commit -m "feat(core): record the ssr=false opt-out as KitModuleFacts.ssrDisabled"
+```
+
+---
+
+### Task 2: The SEO031 rule
+
+**Files:**
+
+- Modify: `packages/core/src/rules/kit-module-rule.ts` (the `category` option type, currently line ~18: `category: 'security';`)
+- Create: `packages/core/src/rules/seo/seo031-ssr-disabled.ts`
+- Modify: `packages/core/src/rules/index.ts` (import after the `seo030HeadingOrder` import ~line 39; `allRules` after ~line 93; re-export after ~line 152), `packages/core/src/index.ts` (after `seo030HeadingOrder,` ~line 94)
+- Modify: `packages/core/test/security-kit-rules.test.ts` (new describe — the `kit()` helper lives here)
+
+**Interfaces:**
+
+- Consumes: `KitModuleFacts.ssrDisabled` (Task 1), `kitModuleRule`.
+- Produces: exported `seo031SsrDisabled: Rule`.
+
+- [ ] **Step 1: Write the failing rule tests**
+
+In `packages/core/test/security-kit-rules.test.ts`: add `seo031SsrDisabled` to the `../src/index.js` import and append:
+
+```ts
+describe('SEO031 SSR disabled', () => {
+  it('flags a leaf route with the per-route message as an seo warning', async () => {
+    const rs = await seo031SsrDisabled.check(
+      ctx([kit({ file: 'src/routes/dash/+page.ts', kind: 'universal', ssrDisabled: { line: 1 } })])
+    );
+    expect(fails(rs)).toHaveLength(1);
+    expect(rs[0]!.severity).toBe('warning');
+    expect(rs[0]!.category).toBe('seo');
+    expect(rs[0]!.line).toBe(1);
+    expect(rs[0]!.message).toContain('this route');
+  });
+  it('uses the app-wide message for the root layout', async () => {
+    const rs = await seo031SsrDisabled.check(
+      ctx([kit({ file: 'src/routes/+layout.ts', kind: 'universal', ssrDisabled: { line: 2 } })])
+    );
+    expect(fails(rs)[0]!.message).toContain('whole app');
+  });
+  it('emits nothing without the flag, honours suppression, and no-ops in rendered mode', async () => {
+    expect(await seo031SsrDisabled.check(ctx([kit({})]))).toHaveLength(0);
+    const suppressed = await seo031SsrDisabled.check(
+      ctx([kit({ ssrDisabled: { line: 3 }, suppressions: [{ line: 3, ruleIds: ['SEO031'] }] })])
+    );
+    expect(fails(suppressed)).toHaveLength(0);
+    expect(await seo031SsrDisabled.check(base as RuleContext)).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pnpm --filter @svelte-vitals/core test -- security-kit-rules`
+Expected: FAIL — `seo031SsrDisabled` not exported.
+
+- [ ] **Step 3: Widen the factory's category type**
+
+In `packages/core/src/rules/kit-module-rule.ts`, change the option:
+
+```ts
+/** Kit-file rules report as Security (SEC003–005) or SEO (SEO031). */
+category: 'security' | 'seo';
+```
+
+- [ ] **Step 4: Implement the rule**
+
+Create `packages/core/src/rules/seo/seo031-ssr-disabled.ts`:
+
+```ts
+import { kitModuleRule } from '../kit-module-rule.js';
+
+/** The root layout — disabling SSR there turns the whole app into an SPA. */
+const ROOT_LAYOUT_RE = /^src\/routes\/\+layout(\.server)?\.(ts|js)$/;
+
+export const seo031SsrDisabled = kitModuleRule({
+  id: 'SEO031',
+  title: 'SSR disabled',
+  category: 'seo',
+  label: 'SSR enabled',
+  recommendation:
+    "Keep SSR on for indexable pages; restrict ssr = false to routes that don't need SEO (authenticated dashboards, app-only views). For a deliberate SPA, turn this rule off in the config or add an inline suppression.",
+  rationale:
+    "SvelteKit's SEO guidance is to leave SSR on unless there is a good reason not to: server-rendered content is indexed more frequently and reliably, and SPA mode costs an extra network round trip before anything renders.",
+  applies: (m) => m.ssrDisabled !== undefined,
+  bad: (m) => [
+    {
+      line: m.ssrDisabled!.line,
+      message: ROOT_LAYOUT_RE.test(m.file)
+        ? 'SSR is disabled for the whole app — search engines index server-rendered content more reliably, and SPA mode adds a network round trip before first paint'
+        : "SSR is disabled for this route — its content is invisible to crawlers that don't execute JavaScript and indexes less reliably"
+    }
+  ]
+});
+```
+
+- [ ] **Step 5: Register (four sites) and verify**
+
+`packages/core/src/rules/index.ts`: `import { seo031SsrDisabled } from './seo/seo031-ssr-disabled.js';` after the `seo030HeadingOrder` import; `seo031SsrDisabled,` after `seo030HeadingOrder,` in `allRules` and in the re-export block. `packages/core/src/index.ts`: `seo031SsrDisabled,` after `seo030HeadingOrder,`.
+
+Run: `grep -rn "seo031SsrDisabled" packages/core/src`
+Expected: 5 hits.
+
+- [ ] **Step 6: Run to verify, then commit**
+
+Run: `pnpm --filter @svelte-vitals/core test`
+Expected: PASS (cli `docs-links` fails until Task 3 — expected).
+
+```bash
+git add packages/core
+git commit -m "feat(core): add SEO031 — flag routes that disable server-side rendering"
+```
+
+---
+
+### Task 3: Docs (en/ja), changeset, full verification
+
+**Files:**
+
+- Create: `docs/src/content/docs/rules/seo031.md`, `docs/src/content/docs/ja/rules/seo031.md`, `.changeset/seo031-ssr-disabled.md`
+
+- [ ] **Step 1: Write the English rule page**
+
+Create `docs/src/content/docs/rules/seo031.md`:
+
+````md
+---
+title: SEO031 · SSR disabled
+description: export const ssr = false makes a route's content invisible to non-JS crawlers and slower to first paint.
+---
+
+**Severity:** warning · **Category:** seo
+
+## What it checks
+
+Flags SvelteKit route files that disable server-side rendering with `export const ssr = false` (the `satisfies` and same-file alias-export forms included). Disabling it in the root `+layout` — which turns the whole app into an SPA — gets a stronger, app-wide message.
+
+Not flagged: `csr = false` (server-only rendering — fine for SEO), non-literal values like `export const ssr = dev` (not statically evaluable), and non-exported `const ssr = false` (has no effect in SvelteKit).
+
+## Why it matters
+
+SvelteKit's own SEO guidance: server-side rendered content is indexed more frequently and reliably — leave SSR on unless you have a good reason not to. On top of the indexing risk, SPA mode ships an empty page that must fetch and run JavaScript before anything renders, adding a network round trip before first paint.
+
+Note that `prerender = true` does not neutralise this: with `ssr = false` the prerendered output is still an empty shell.
+
+## How to fix
+
+Scope `ssr = false` to routes that genuinely don't need SEO:
+
+```ts
+// src/routes/(app)/dashboard/+page.ts — authenticated, not indexable
+export const ssr = false; // fine — suppress or turn the rule off if this is deliberate
+```
+
+For a deliberate full SPA, disable the rule in your config:
+
+```js
+// svelte-vitals config
+rules: {
+  SEO031: 'off';
+}
+```
+
+or add `// svelte-vitals-disable-next-line SEO031` above the declaration.
+````
+
+- [ ] **Step 2: Write the Japanese rule page**
+
+Create `docs/src/content/docs/ja/rules/seo031.md`:
+
+````md
+---
+title: SEO031 · SSR の無効化
+description: export const ssr = false は、JS を実行しないクローラーからコンテンツを見えなくし、初回描画も遅くします。
+---
+
+**重大度:** warning · **カテゴリ:** seo
+
+## チェック内容
+
+`export const ssr = false` でサーバーサイドレンダリングを無効化している SvelteKit のルートファイルを検出します(`satisfies` 形式や同一ファイル内のエイリアス export も対象)。ルートの `+layout` での無効化 — アプリ全体が SPA になる — には、より強いアプリ全体向けのメッセージを出します。
+
+検出対象外: `csr = false`(サーバー専用レンダリング — SEO にはむしろ良い)、`export const ssr = dev` のような非リテラル値(静的に評価不能)、export されていない `const ssr = false`(SvelteKit では効果がない)。
+
+## 重要な理由
+
+SvelteKit 公式の SEO ガイダンスいわく: サーバーレンダリングされたコンテンツはより頻繁に・確実にインデックスされる — 正当な理由がない限り SSR は有効のままにすべきです。インデックスのリスクに加えて、SPA モードは空のページを配信して JavaScript の取得・実行を待つため、何かが描画されるまでにネットワークラウンドトリップが1回増えます。
+
+`prerender = true` を併用してもこの問題は解消されません: `ssr = false` では事前レンダリングの出力も空のシェルになります。
+
+## 修正方法
+
+`ssr = false` は SEO が本当に不要なルートに限定します:
+
+```ts
+// src/routes/(app)/dashboard/+page.ts — 認証必須、インデックス不要
+export const ssr = false; // これが意図的なら suppression するかルールを off に
+```
+
+意図的な完全 SPA の場合は、config でルールを無効化します:
+
+```js
+// svelte-vitals config
+rules: {
+  SEO031: 'off';
+}
+```
+
+または宣言の直前に `// svelte-vitals-disable-next-line SEO031` を書いてください。
+````
+
+- [ ] **Step 3: Verify docs-links, add the changeset**
+
+Run: `pnpm --filter @svelte-vitals/core build && pnpm --filter svelte-vitals test -- docs-links`
+Expected: PASS.
+
+Create `.changeset/seo031-ssr-disabled.md`:
+
+```md
+---
+'@svelte-vitals/core': minor
+'svelte-vitals': minor
+'@svelte-vitals/vite': minor
+'@svelte-vitals/mcp': minor
+---
+
+Add SEO031 (warning): flag SvelteKit route files that disable server-side rendering with `export const ssr = false` — per the official SEO guidance, server-rendered content indexes more reliably, and SPA mode adds a round trip before first paint. The root-layout (app-wide) case gets a dedicated message; deliberate SPAs can turn the rule off or suppress inline.
+```
+
+- [ ] **Step 4: Full verification and commits**
+
+```bash
+pnpm build
+pnpm typecheck
+pnpm test
+pnpm lint
+```
+
+All green (`pnpm format` + fold in if formatting-only failure).
+
+```bash
+git add docs/src/content/docs .changeset
+git commit -m "docs: add SEO031 rule reference (en/ja) and changeset"
+git add packages/action/dist/index.js
+git commit -m "chore(action): rebuild dist/ with the SEO031 core changes"
+```
+
+(Skip the second commit if no dist change.)
+
+---
+
+## Done criteria
+
+- `pnpm build && pnpm typecheck && pnpm test && pnpm lint` all green from the repo root.
+- `grep -rn "seo031SsrDisabled" packages/core/src` → 5 hits.
+- Every existing CORRECT008 `ssr = false` opt-out test passes unchanged.
+- Manual smoke: a fixture `+page.ts` with `export const ssr = false` reports a warning SEO031 at the declaration line; the root-layout fixture gets the app-wide message.
+- PR body in English.

--- a/docs/superpowers/specs/2026-07-21-seo031-ssr-disabled-design.md
+++ b/docs/superpowers/specs/2026-07-21-seo031-ssr-disabled-design.md
@@ -1,0 +1,108 @@
+# SEO031 — SSR disabled
+
+**Date:** 2026-07-21
+**Status:** Approved design
+**Packages:** `@svelte-vitals/core` (fact + rule), `svelte-vitals` / `@svelte-vitals/vite` / `@svelte-vitals/mcp` (surface automatically)
+
+## Goal
+
+Add **SEO031**: flag SvelteKit route files that disable server-side rendering
+(`export const ssr = false`). The official SEO best-practices doc's headline
+risk — "server-side rendered content is indexed more frequently and
+reliably… you should leave it on unless you have a good reason not to" — and
+the performance doc's SPA-mode warning ("an empty page is generated, which
+fetches JavaScript… extra network round trips before a single pixel can be
+displayed") both point at the same flag.
+
+`warning` severity, `category: 'seo'`, `scope: 'component'` (file = scoring
+unit). A deliberate SPA is a legitimate architecture — the escape hatches are
+the standard ones (rule config `SEO031: 'off'`, inline suppression).
+
+Sourced from the best-practices survey (2026-07-21) of
+`sveltejs/kit/documentation/docs/40-best-practices` — candidate B of three
+(PERF012 `minify: false` and PERF011 load waterfalls follow on separate
+branches).
+
+## Background
+
+- Detection already exists: `hasSsrFalseOptOut(program)` in
+  `packages/core/src/kit-module-parse.ts` (built for CORRECT008's opt-out)
+  handles the inline form (`export const ssr = false`, `satisfies`/`as`
+  unwrapped) and the same-file alias-export form
+  (`const ssr = false; export { ssr };`). This design promotes it from an
+  internal boolean guard to a recorded fact.
+- The Kit channel (`KitModuleFacts`, collectors, `kitModuleRule` factory,
+  suppressions) is in place from SEC003–005 / CORRECT007–008.
+- `kitModuleRule`'s `category` is currently typed as the literal `'security'`
+  — widened to `'security' | 'seo'` (one-line type change; runtime already
+  passes the option through).
+
+## Design
+
+### 1. Fact — `KitModuleFacts.ssrDisabled`
+
+```ts
+/** Set when this file disables SSR via `export const ssr = false` (inline or same-file alias export) — the declaration's line (SEO031). */
+ssrDisabled?: { line: number };
+```
+
+Optional (absent = SSR on) — no literal churn in existing fixtures/tests.
+Implementation: `hasSsrFalseOptOut` becomes `findSsrFalseOptOut(program):
+{ line: number } | undefined` returning the `ssr` declarator's line
+(wrap-shifted −1 like every other kit fact); the CORRECT008 browser-global
+opt-out keeps using its truthiness — behavior unchanged, existing tests are
+the regression bar. Both detection forms (inline export incl.
+`satisfies`/`as`; alias export) report the **declaration** line.
+
+### 2. Rule — SEO031
+
+`packages/core/src/rules/seo/seo031-ssr-disabled.ts`, built with
+`kitModuleRule` (category type widened):
+
+- `id: 'SEO031'`, `title: 'SSR disabled'`, `category: 'seo'`,
+  `severity: 'warning'`, `scope: 'component'`.
+- `label` (PASS): `'SSR enabled'`.
+- `applies`: `(m) => m.ssrDisabled !== undefined`.
+- Message variants (root layout = the flag applies app-wide):
+  - file is `src/routes/+layout.ts|js` or `src/routes/+layout.server.ts|js`:
+    `` `SSR is disabled for the whole app — search engines index server-rendered content more reliably, and SPA mode adds a network round trip before first paint` ``
+  - any other route file:
+    `` `SSR is disabled for this route — its content is invisible to crawlers that don't execute JavaScript and indexes less reliably` ``
+- `recommendation`: `"Keep SSR on for indexable pages; restrict ssr = false to routes that don't need SEO (authenticated dashboards, app-only views). For a deliberate SPA, turn this rule off in the config or add an inline suppression."`
+- `rationale`: `"SvelteKit's SEO guidance is to leave SSR on unless there is a good reason not to: server-rendered content is indexed more frequently and reliably, and SPA mode costs an extra network round trip before anything renders."`
+
+Not flagged: `csr = false` (server-only rendering — good for SEO),
+`ssr = true`, non-literal values (`ssr = dev` — unknowable statically,
+conservative miss). `prerender = true` alongside `ssr = false` is still
+flagged (the prerendered output is an empty shell).
+
+### 3. Registration, docs, changeset
+
+- Usual four sites + grep check (SEO031 lands next to the other SEO rules'
+  entries).
+- Docs: `docs/src/content/docs/rules/seo031.md` + ja mirror (en/ja together).
+  No suppression-range edits exist anymore (removed in PR #240).
+- Changeset: core / `svelte-vitals` / vite / mcp — **minor**.
+
+## Testing
+
+- **Fact** (kit-module-parse tests): inline `export const ssr = false` →
+  `{ line }`; `satisfies` form; alias-export form; NOT set for `csr = false`,
+  `ssr = true`, non-exported `const ssr = false`, `ssr = dev`; line numbers
+  wrap-shifted.
+- **Rule**: root-layout variant message; leaf-route variant message; warning
+  severity; suppression on the declaration line; rendered-mode no-op; PASS
+  unit absent when `ssrDisabled` is absent (applies false).
+- **Regression bar**: every existing CORRECT008 `ssr = false` opt-out test
+  passes unchanged through the renamed helper.
+- Root `pnpm build` / `typecheck` / `test` / `lint` green.
+
+## Known limitations (v1, documented in the rule docs)
+
+- **Non-literal `ssr` values** (`export const ssr = dev`) are not evaluated —
+  conservative miss.
+- **Layout inheritance is not modeled**: a group layout
+  (`src/routes/(app)/+layout.ts`) disabling SSR flags that one file, not
+  every descendant route; only the root layout gets the app-wide message.
+- A deliberate SPA will see one warning per `ssr = false` file — the intended
+  remedies are the rule config or suppressions, not detection heuristics.

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -57292,6 +57292,7 @@ function kitModuleRule(opts) {
   };
 }
 var ROOT_LAYOUT_RE = /^src\/routes\/\+layout(\.server)?\.(ts|js)$/;
+var PAGE_OPTION_FILE_RE = /\+(page|layout)(\.server)?\.(ts|js)$/;
 var seo031SsrDisabled = kitModuleRule({
   id: "SEO031",
   title: "SSR disabled",
@@ -57299,7 +57300,7 @@ var seo031SsrDisabled = kitModuleRule({
   label: "SSR enabled",
   recommendation: "Keep SSR on for indexable pages; restrict ssr = false to routes that don't need SEO (authenticated dashboards, app-only views). For a deliberate SPA, turn this rule off in the config or add an inline suppression.",
   rationale: "SvelteKit's SEO guidance is to leave SSR on unless there is a good reason not to: server-rendered content is indexed more frequently and reliably, and SPA mode costs an extra network round trip before anything renders.",
-  applies: (m) => m.ssrDisabled !== void 0,
+  applies: (m) => m.ssrDisabled !== void 0 && PAGE_OPTION_FILE_RE.test(m.file),
   bad: (m) => [
     {
       line: m.ssrDisabled.line,

--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -55605,7 +55605,7 @@ function collectStartupFunctions(program) {
   resolveAliasStartupExports(program, collectTopLevelBindings(program), startup);
   return startup;
 }
-function hasSsrFalseOptOut(program) {
+function findSsrFalseOptOut(program, source2) {
   const isFalse = (init2) => {
     const v = unwrapTs(init2);
     return v?.type === "Literal" && v.value === false;
@@ -55615,7 +55615,7 @@ function hasSsrFalseOptOut(program) {
     if (decl?.type !== "VariableDeclaration") continue;
     for (const d of decl.declarations ?? []) {
       if (d?.id?.type === "Identifier" && d.id.name === "ssr" && d.init && isFalse(d.init)) {
-        if (stmt2.type === "ExportNamedDeclaration") return true;
+        if (stmt2.type === "ExportNamedDeclaration") return { line: lineOf(source2, d.start) };
       }
     }
   }
@@ -55627,10 +55627,10 @@ function hasSsrFalseOptOut(program) {
       if (s?.exportKind === "type" || s?.exported?.type !== "Identifier" || s?.local?.type !== "Identifier") continue;
       if (s.exported.name !== "ssr") continue;
       const resolved = bindings.get(s.local.name);
-      if (resolved?.type === "Literal" && resolved.value === false) return true;
+      if (resolved?.type === "Literal" && resolved.value === false) return { line: lineOf(source2, resolved.start) };
     }
   }
-  return false;
+  return void 0;
 }
 function walkKit(node, handlerFns, startupFns, visit, shadowed = /* @__PURE__ */ new Set(), inFunction = false, inHandler = false, inStartup = false) {
   if (Array.isArray(node)) {
@@ -55727,7 +55727,8 @@ function parseKitModuleFacts(source2, filename2) {
   const handlerFns = collectHandlerFunctions(program);
   const startupFns = collectStartupFunctions(program);
   const svelteImports = collectSvelteLifecycleImports(program);
-  if (!hasSsrFalseOptOut(program)) {
+  const ssrOptOut = findSsrFalseOptOut(program, wrapped);
+  if (!ssrOptOut) {
     const shiftLine = (l) => Math.max(0, l - 1);
     const browserImports = collectBrowserGuardImports(program);
     const guards = /* @__PURE__ */ new Set([...browserImports, ...collectDerivedGuardBindings(program, browserImports)]);
@@ -55827,6 +55828,7 @@ function parseKitModuleFacts(source2, filename2) {
     runesModuleImports: byLine(runesModuleImports),
     lifecycleCalls: byLine(lifecycleCalls),
     browserGlobalRefs: byLine(browserGlobalRefs),
+    ...ssrOptOut ? { ssrDisabled: { line: Math.max(0, ssrOptOut.line - 1) } } : {},
     suppressions
   };
 }
@@ -57239,7 +57241,75 @@ var seo030HeadingOrder = {
 };
 var PENALIZED2 = { presence: "none", value: "absent" };
 var PASS2 = { presence: "own", value: "static" };
-function isSuppressed(c, ruleId, line) {
+function isSuppressed(m, ruleId, line) {
+  return (m.suppressions ?? []).some((s) => s.line === line && (!s.ruleIds || s.ruleIds.includes(ruleId)));
+}
+function kitModuleRule(opts) {
+  const docsUrl7 = docsUrlFor(opts.id);
+  const severity = opts.severity ?? "warning";
+  return {
+    id: opts.id,
+    title: opts.title,
+    category: opts.category,
+    severity,
+    scope: "component",
+    rationale: opts.rationale,
+    async check(ctx) {
+      const out = [];
+      for (const m of ctx.kitModules ?? []) {
+        if (!opts.applies(m, ctx)) continue;
+        const bad = opts.bad(m, ctx).filter((b) => !(b.line > 0 && isSuppressed(m, opts.id, b.line)));
+        if (bad.length === 0) {
+          out.push({
+            id: opts.id,
+            category: opts.category,
+            severity,
+            detection: PASS2,
+            route: m.file,
+            message: opts.label,
+            recommendation: opts.recommendation,
+            docsUrl: docsUrl7
+          });
+          continue;
+        }
+        for (const b of bad) {
+          out.push({
+            id: opts.id,
+            category: opts.category,
+            severity,
+            detection: PENALIZED2,
+            route: m.file,
+            location: m.file,
+            ...b.line > 0 ? { line: b.line } : {},
+            message: b.message,
+            recommendation: opts.recommendation,
+            docsUrl: docsUrl7
+          });
+        }
+      }
+      return out;
+    }
+  };
+}
+var ROOT_LAYOUT_RE = /^src\/routes\/\+layout(\.server)?\.(ts|js)$/;
+var seo031SsrDisabled = kitModuleRule({
+  id: "SEO031",
+  title: "SSR disabled",
+  category: "seo",
+  label: "SSR enabled",
+  recommendation: "Keep SSR on for indexable pages; restrict ssr = false to routes that don't need SEO (authenticated dashboards, app-only views). For a deliberate SPA, turn this rule off in the config or add an inline suppression.",
+  rationale: "SvelteKit's SEO guidance is to leave SSR on unless there is a good reason not to: server-rendered content is indexed more frequently and reliably, and SPA mode costs an extra network round trip before anything renders.",
+  applies: (m) => m.ssrDisabled !== void 0,
+  bad: (m) => [
+    {
+      line: m.ssrDisabled.line,
+      message: ROOT_LAYOUT_RE.test(m.file) ? "SSR is disabled for the whole app \u2014 search engines index server-rendered content more reliably, and SPA mode adds a network round trip before first paint" : "SSR is disabled for this route \u2014 its content is invisible to crawlers that don't execute JavaScript and indexes less reliably"
+    }
+  ]
+});
+var PENALIZED3 = { presence: "none", value: "absent" };
+var PASS3 = { presence: "own", value: "static" };
+function isSuppressed2(c, ruleId, line) {
   return (c.suppressions ?? []).some((s) => s.line === line && (!s.ruleIds || s.ruleIds.includes(ruleId)));
 }
 function componentRule(opts) {
@@ -57256,13 +57326,13 @@ function componentRule(opts) {
       const out = [];
       for (const c of ctx.components ?? []) {
         if (!opts.applies(c)) continue;
-        const bad = opts.bad(c).filter((b) => !(b.line > 0 && isSuppressed(c, opts.id, b.line)));
+        const bad = opts.bad(c).filter((b) => !(b.line > 0 && isSuppressed2(c, opts.id, b.line)));
         if (bad.length === 0) {
           out.push({
             id: opts.id,
             category: opts.category,
             severity,
-            detection: PASS2,
+            detection: PASS3,
             route: c.file,
             message: opts.label,
             recommendation: opts.recommendation,
@@ -57275,7 +57345,7 @@ function componentRule(opts) {
             id: opts.id,
             category: opts.category,
             severity,
-            detection: PENALIZED2,
+            detection: PENALIZED3,
             route: c.file,
             location: c.file,
             ...b.line > 0 ? { line: b.line } : {},
@@ -57363,24 +57433,24 @@ var correct006OrphanEffect = componentRule({
     message: o.kind === "top-level" ? "$effect at module scope runs outside component initialisation \u2014 it throws effect_orphan at runtime" : `class "${o.className}" runs $effect in its constructor and is instantiated at module scope \u2014 it throws effect_orphan at runtime`
   }))
 });
-var PENALIZED3 = { presence: "none", value: "absent" };
-var PASS3 = { presence: "own", value: "static" };
+var PENALIZED4 = { presence: "none", value: "absent" };
+var PASS4 = { presence: "own", value: "static" };
 var ID = "CORRECT007";
 var DOCS_URL = docsUrlFor(ID);
 var LABEL = "Lifecycle-call context";
 var RECOMMENDATION = "Call lifecycle/context functions during component initialisation (the top level of a component's <script>). In load, return the data and call setContext in a layout/page component; in shared modules, expose a setup function that components call during init.";
 var topLevelMessage = (name) => `${name}() runs at module evaluation, outside component initialisation \u2014 it throws lifecycle_outside_component at runtime`;
-function isSuppressed2(suppressions, line) {
+function isSuppressed3(suppressions, line) {
   return (suppressions ?? []).some((s) => s.line === line && (!s.ruleIds || s.ruleIds.includes(ID)));
 }
 function emitFile(out, file, issues, suppressions) {
-  const bad = issues.filter((b) => !(b.line > 0 && isSuppressed2(suppressions, b.line)));
+  const bad = issues.filter((b) => !(b.line > 0 && isSuppressed3(suppressions, b.line)));
   if (bad.length === 0) {
     out.push({
       id: ID,
       category: "correctness",
       severity: "critical",
-      detection: PASS3,
+      detection: PASS4,
       route: file,
       message: LABEL,
       recommendation: RECOMMENDATION,
@@ -57393,7 +57463,7 @@ function emitFile(out, file, issues, suppressions) {
       id: ID,
       category: "correctness",
       severity: "critical",
-      detection: PENALIZED3,
+      detection: PENALIZED4,
       route: file,
       location: file,
       ...b.line > 0 ? { line: b.line } : {},
@@ -57441,24 +57511,24 @@ var correct007OrphanLifecycle = {
     return out;
   }
 };
-var PENALIZED4 = { presence: "none", value: "absent" };
-var PASS4 = { presence: "own", value: "static" };
+var PENALIZED5 = { presence: "none", value: "absent" };
+var PASS5 = { presence: "own", value: "static" };
 var ID2 = "CORRECT008";
 var DOCS_URL2 = docsUrlFor(ID2);
 var LABEL2 = "Server-safe module code";
 var RECOMMENDATION2 = "Move browser-only code into onMount or $effect (they never run on the server), or guard it with browser from $app/environment (or a typeof check).";
 var moduleMessage = (name) => `${name} is accessed at module scope \u2014 it does not exist on the server, so importing this file crashes SSR with "${name} is not defined"`;
-function isSuppressed3(suppressions, line) {
+function isSuppressed4(suppressions, line) {
   return (suppressions ?? []).some((s) => s.line === line && (!s.ruleIds || s.ruleIds.includes(ID2)));
 }
 function emitFile2(out, file, issues, suppressions) {
-  const bad = issues.filter((b) => !(b.line > 0 && isSuppressed3(suppressions, b.line)));
+  const bad = issues.filter((b) => !(b.line > 0 && isSuppressed4(suppressions, b.line)));
   if (bad.length === 0) {
     out.push({
       id: ID2,
       category: "correctness",
       severity: "critical",
-      detection: PASS4,
+      detection: PASS5,
       route: file,
       message: LABEL2,
       recommendation: RECOMMENDATION2,
@@ -57471,7 +57541,7 @@ function emitFile2(out, file, issues, suppressions) {
       id: ID2,
       category: "correctness",
       severity: "critical",
-      detection: PENALIZED4,
+      detection: PENALIZED5,
       route: file,
       location: file,
       ...b.line > 0 ? { line: b.line } : {},
@@ -57549,58 +57619,6 @@ var sec002JavascriptUrl = componentRule({
   applies: (c) => c.javascriptUrls.length > 0,
   bad: (c) => c.javascriptUrls.map((u) => ({ line: u.line, message: "javascript: URL in an attribute" }))
 });
-var PENALIZED5 = { presence: "none", value: "absent" };
-var PASS5 = { presence: "own", value: "static" };
-function isSuppressed4(m, ruleId, line) {
-  return (m.suppressions ?? []).some((s) => s.line === line && (!s.ruleIds || s.ruleIds.includes(ruleId)));
-}
-function kitModuleRule(opts) {
-  const docsUrl7 = docsUrlFor(opts.id);
-  const severity = opts.severity ?? "warning";
-  return {
-    id: opts.id,
-    title: opts.title,
-    category: opts.category,
-    severity,
-    scope: "component",
-    rationale: opts.rationale,
-    async check(ctx) {
-      const out = [];
-      for (const m of ctx.kitModules ?? []) {
-        if (!opts.applies(m, ctx)) continue;
-        const bad = opts.bad(m, ctx).filter((b) => !(b.line > 0 && isSuppressed4(m, opts.id, b.line)));
-        if (bad.length === 0) {
-          out.push({
-            id: opts.id,
-            category: opts.category,
-            severity,
-            detection: PASS5,
-            route: m.file,
-            message: opts.label,
-            recommendation: opts.recommendation,
-            docsUrl: docsUrl7
-          });
-          continue;
-        }
-        for (const b of bad) {
-          out.push({
-            id: opts.id,
-            category: opts.category,
-            severity,
-            detection: PENALIZED5,
-            route: m.file,
-            location: m.file,
-            ...b.line > 0 ? { line: b.line } : {},
-            message: b.message,
-            recommendation: opts.recommendation,
-            docsUrl: docsUrl7
-          });
-        }
-      }
-      return out;
-    }
-  };
-}
 var sec003LoadStateWrite = kitModuleRule({
   id: "SEC003",
   title: "Handler writes imported state",
@@ -57771,6 +57789,7 @@ var allRules = [
   seo028TitleUnique,
   seo029DescriptionUnique,
   seo030HeadingOrder,
+  seo031SsrDisabled,
   correct001EachKey,
   correct002EffectDerived,
   correct003EffectAsOnMount,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -92,6 +92,7 @@ export {
   seo028TitleUnique,
   seo029DescriptionUnique,
   seo030HeadingOrder,
+  seo031SsrDisabled,
   correct001EachKey,
   correct002EffectDerived,
   correct003EffectAsOnMount,

--- a/packages/core/src/kit-module-parse.ts
+++ b/packages/core/src/kit-module-parse.ts
@@ -179,11 +179,13 @@ function collectStartupFunctions(program: Node): Set<Node> {
 }
 
 /**
- * Whether this file opts out of the server entirely via `export const ssr = false`
- * (satisfies-unwrapped; same-file alias export `export { ssr }` resolved). Such a file
- * never runs on the server, so browser globals in it are legal (CORRECT008).
+ * The `export const ssr = false` opt-out, when present: inline form
+ * (`satisfies`/`as` unwrapped) or same-file alias export (`const ssr = false;
+ * export { ssr };`). Returns the declaration's line in the WRAPPED source (the
+ * caller applies the −1 shift). Such a file never runs on the server — CORRECT008
+ * skips its browser-global scan, and SEO031 reports the flag itself.
  */
-function hasSsrFalseOptOut(program: Node): boolean {
+function findSsrFalseOptOut(program: Node, source: string): { line: number } | undefined {
   const isFalse = (init: Node): boolean => {
     const v = unwrapTs(init);
     return v?.type === 'Literal' && v.value === false;
@@ -193,7 +195,7 @@ function hasSsrFalseOptOut(program: Node): boolean {
     if (decl?.type !== 'VariableDeclaration') continue;
     for (const d of decl.declarations ?? []) {
       if (d?.id?.type === 'Identifier' && d.id.name === 'ssr' && d.init && isFalse(d.init)) {
-        if (stmt.type === 'ExportNamedDeclaration') return true;
+        if (stmt.type === 'ExportNamedDeclaration') return { line: lineOf(source, d.start) };
       }
     }
   }
@@ -206,10 +208,10 @@ function hasSsrFalseOptOut(program: Node): boolean {
       if (s?.exportKind === 'type' || s?.exported?.type !== 'Identifier' || s?.local?.type !== 'Identifier') continue;
       if (s.exported.name !== 'ssr') continue;
       const resolved = bindings.get(s.local.name);
-      if (resolved?.type === 'Literal' && resolved.value === false) return true;
+      if (resolved?.type === 'Literal' && resolved.value === false) return { line: lineOf(source, resolved.start) };
     }
   }
-  return false;
+  return undefined;
 }
 
 /**
@@ -384,7 +386,8 @@ export function parseKitModuleFacts(source: string, filename: string): Omit<KitM
   // at function boundaries, so run it once over the program (top level) and once per
   // handler/init body; closures nested inside handlers are deliberately not entered
   // (they are typically client-side callbacks returned to components).
-  if (!hasSsrFalseOptOut(program)) {
+  const ssrOptOut = findSsrFalseOptOut(program, wrapped);
+  if (!ssrOptOut) {
     // The scanner returns line numbers computed against `wrapped` — subtract the
     // 1-line wrap prefix (the local `line()` helper takes a byte OFFSET, not a line,
     // so it must not be used here).
@@ -513,6 +516,7 @@ export function parseKitModuleFacts(source: string, filename: string): Omit<KitM
     runesModuleImports: byLine(runesModuleImports),
     lifecycleCalls: byLine(lifecycleCalls),
     browserGlobalRefs: byLine(browserGlobalRefs),
+    ...(ssrOptOut ? { ssrDisabled: { line: Math.max(0, ssrOptOut.line - 1) } } : {}),
     suppressions
   };
 }

--- a/packages/core/src/kit-module.ts
+++ b/packages/core/src/kit-module.ts
@@ -29,6 +29,8 @@ export interface KitModuleFacts {
     line: number;
     inHandler: boolean;
   }[];
+  /** Set when this file disables SSR via `export const ssr = false` (inline or same-file alias export) — the declaration's line (SEO031). */
+  ssrDisabled?: { line: number };
   /** Inline `svelte-vitals-disable-next-line` directives in this file. */
   suppressions: SuppressionDirective[];
 }

--- a/packages/core/src/rules/index.ts
+++ b/packages/core/src/rules/index.ts
@@ -37,6 +37,7 @@ import { seo026Hreflang } from './seo/seo026-hreflang.js';
 import { seo027Heading } from './seo/seo027-heading.js';
 import { seo028TitleUnique, seo029DescriptionUnique } from './seo/seo028-029-uniqueness.js';
 import { seo030HeadingOrder } from './seo/seo030-heading-order.js';
+import { seo031SsrDisabled } from './seo/seo031-ssr-disabled.js';
 import { correct001EachKey, correct002EffectDerived, correct003EffectAsOnMount } from './correctness/correct001-002.js';
 import { correct004UnmutatedState } from './correctness/correct004-unmutated-state.js';
 import { correct005PropMutation } from './correctness/correct005-prop-mutation.js';
@@ -91,6 +92,7 @@ export const allRules: Rule[] = [
   seo028TitleUnique,
   seo029DescriptionUnique,
   seo030HeadingOrder,
+  seo031SsrDisabled,
   correct001EachKey,
   correct002EffectDerived,
   correct003EffectAsOnMount,
@@ -150,6 +152,7 @@ export {
   seo028TitleUnique,
   seo029DescriptionUnique,
   seo030HeadingOrder,
+  seo031SsrDisabled,
   correct001EachKey,
   correct002EffectDerived,
   correct003EffectAsOnMount,

--- a/packages/core/src/rules/kit-module-rule.ts
+++ b/packages/core/src/rules/kit-module-rule.ts
@@ -14,8 +14,8 @@ export interface KitModuleIssue {
 export interface KitModuleRuleOptions {
   id: string;
   title: string;
-  /** The SSR shared-state rules are Security rules. */
-  category: 'security';
+  /** Kit-file rules report as Security (SEC003–005) or SEO (SEO031). */
+  category: 'security' | 'seo';
   /** Default 'warning'. */
   severity?: Severity;
   /** Pass message / category label. */

--- a/packages/core/src/rules/kit-module-rule.ts
+++ b/packages/core/src/rules/kit-module-rule.ts
@@ -34,7 +34,7 @@ function isSuppressed(m: KitModuleFacts, ruleId: string, line: number): boolean 
 }
 
 /**
- * Build a Kit-module-scoped rule (SEC003–005) over `ctx.kitModules`. Static/CLI and
+ * Build a Kit-module-scoped rule (SEC003–005, SEO031) over `ctx.kitModules`. Static/CLI and
  * vite build mode only — `ctx.kitModules` is unset in rendered mode, so it emits
  * nothing there. Findings use the source file as the scoring unit.
  */

--- a/packages/core/src/rules/seo/seo031-ssr-disabled.ts
+++ b/packages/core/src/rules/seo/seo031-ssr-disabled.ts
@@ -1,0 +1,24 @@
+import { kitModuleRule } from '../kit-module-rule.js';
+
+/** The root layout — disabling SSR there turns the whole app into an SPA. */
+const ROOT_LAYOUT_RE = /^src\/routes\/\+layout(\.server)?\.(ts|js)$/;
+
+export const seo031SsrDisabled = kitModuleRule({
+  id: 'SEO031',
+  title: 'SSR disabled',
+  category: 'seo',
+  label: 'SSR enabled',
+  recommendation:
+    "Keep SSR on for indexable pages; restrict ssr = false to routes that don't need SEO (authenticated dashboards, app-only views). For a deliberate SPA, turn this rule off in the config or add an inline suppression.",
+  rationale:
+    "SvelteKit's SEO guidance is to leave SSR on unless there is a good reason not to: server-rendered content is indexed more frequently and reliably, and SPA mode costs an extra network round trip before anything renders.",
+  applies: (m) => m.ssrDisabled !== undefined,
+  bad: (m) => [
+    {
+      line: m.ssrDisabled!.line,
+      message: ROOT_LAYOUT_RE.test(m.file)
+        ? 'SSR is disabled for the whole app — search engines index server-rendered content more reliably, and SPA mode adds a network round trip before first paint'
+        : "SSR is disabled for this route — its content is invisible to crawlers that don't execute JavaScript and indexes less reliably"
+    }
+  ]
+});

--- a/packages/core/src/rules/seo/seo031-ssr-disabled.ts
+++ b/packages/core/src/rules/seo/seo031-ssr-disabled.ts
@@ -3,6 +3,9 @@ import { kitModuleRule } from '../kit-module-rule.js';
 /** The root layout — disabling SSR there turns the whole app into an SPA. */
 const ROOT_LAYOUT_RE = /^src\/routes\/\+layout(\.server)?\.(ts|js)$/;
 
+/** `ssr` is a page option — it has no effect in `+server` endpoints or hooks files. */
+const PAGE_OPTION_FILE_RE = /\+(page|layout)(\.server)?\.(ts|js)$/;
+
 export const seo031SsrDisabled = kitModuleRule({
   id: 'SEO031',
   title: 'SSR disabled',
@@ -12,7 +15,7 @@ export const seo031SsrDisabled = kitModuleRule({
     "Keep SSR on for indexable pages; restrict ssr = false to routes that don't need SEO (authenticated dashboards, app-only views). For a deliberate SPA, turn this rule off in the config or add an inline suppression.",
   rationale:
     "SvelteKit's SEO guidance is to leave SSR on unless there is a good reason not to: server-rendered content is indexed more frequently and reliably, and SPA mode costs an extra network round trip before anything renders.",
-  applies: (m) => m.ssrDisabled !== undefined,
+  applies: (m) => m.ssrDisabled !== undefined && PAGE_OPTION_FILE_RE.test(m.file),
   bad: (m) => [
     {
       line: m.ssrDisabled!.line,

--- a/packages/core/test/kit-module-parse.test.ts
+++ b/packages/core/test/kit-module-parse.test.ts
@@ -363,3 +363,24 @@ describe('parseKitModuleFacts — browser-global refs (CORRECT008)', () => {
     ]);
   });
 });
+
+describe('parseKitModuleFacts — ssrDisabled (SEO031)', () => {
+  it('records the declaration line for an inline export const ssr = false', () => {
+    const src = 'export const prerender = true;\nexport const ssr = false;';
+    expect(facts(src, 'src/routes/+page.ts').ssrDisabled).toEqual({ line: 2 });
+  });
+  it('handles satisfies and the alias-export form', () => {
+    expect(facts('export const ssr = false satisfies boolean;', 'src/routes/+page.ts').ssrDisabled).toEqual({
+      line: 1
+    });
+    expect(facts('const ssr = false;\nexport { ssr };', 'src/routes/+page.ts').ssrDisabled).toEqual({ line: 1 });
+  });
+  it('is absent for csr = false, ssr = true, non-literal, and non-exported forms', () => {
+    expect(facts('export const csr = false;', 'src/routes/+page.ts').ssrDisabled).toBeUndefined();
+    expect(facts('export const ssr = true;', 'src/routes/+page.ts').ssrDisabled).toBeUndefined();
+    expect(
+      facts("import { dev } from '$app/environment';\nexport const ssr = dev;", 'src/routes/+page.ts').ssrDisabled
+    ).toBeUndefined();
+    expect(facts('const ssr = false;', 'src/routes/+page.ts').ssrDisabled).toBeUndefined();
+  });
+});

--- a/packages/core/test/security-kit-rules.test.ts
+++ b/packages/core/test/security-kit-rules.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { sec003LoadStateWrite, sec004ServerModuleState, sec005SharedStateImport, seo031SsrDisabled } from '../src/index.js';
+import {
+  sec003LoadStateWrite,
+  sec004ServerModuleState,
+  sec005SharedStateImport,
+  seo031SsrDisabled
+} from '../src/index.js';
 import { defineConfig, defaultProject } from '../src/types.js';
 import type { ComponentFacts } from '../src/component.js';
 import type { KitModuleFacts } from '../src/kit-module.js';

--- a/packages/core/test/security-kit-rules.test.ts
+++ b/packages/core/test/security-kit-rules.test.ts
@@ -169,6 +169,15 @@ describe('SEO031 SSR disabled', () => {
     );
     expect(fails(rs)[0]!.message).toContain('whole app');
   });
+  it('does not fire for hooks.server or +server files (ssr is a page option)', async () => {
+    const rs = await seo031SsrDisabled.check(
+      ctx([
+        kit({ file: 'src/hooks.server.ts', kind: 'server', ssrDisabled: { line: 1 } }),
+        kit({ file: 'src/routes/api/+server.ts', kind: 'server', ssrDisabled: { line: 1 } })
+      ])
+    );
+    expect(rs).toHaveLength(0);
+  });
   it('emits nothing without the flag, honours suppression, and no-ops in rendered mode', async () => {
     expect(await seo031SsrDisabled.check(ctx([kit({})]))).toHaveLength(0);
     const suppressed = await seo031SsrDisabled.check(

--- a/packages/core/test/security-kit-rules.test.ts
+++ b/packages/core/test/security-kit-rules.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { sec003LoadStateWrite, sec004ServerModuleState, sec005SharedStateImport } from '../src/index.js';
+import { sec003LoadStateWrite, sec004ServerModuleState, sec005SharedStateImport, seo031SsrDisabled } from '../src/index.js';
 import { defineConfig, defaultProject } from '../src/types.js';
 import type { ComponentFacts } from '../src/component.js';
 import type { KitModuleFacts } from '../src/kit-module.js';
@@ -144,5 +144,32 @@ describe('SEC005 shared runes-state import on the server', () => {
       })
     );
     expect(fails(noState)).toHaveLength(0);
+  });
+});
+
+describe('SEO031 SSR disabled', () => {
+  it('flags a leaf route with the per-route message as an seo warning', async () => {
+    const rs = await seo031SsrDisabled.check(
+      ctx([kit({ file: 'src/routes/dash/+page.ts', kind: 'universal', ssrDisabled: { line: 1 } })])
+    );
+    expect(fails(rs)).toHaveLength(1);
+    expect(rs[0]!.severity).toBe('warning');
+    expect(rs[0]!.category).toBe('seo');
+    expect(rs[0]!.line).toBe(1);
+    expect(rs[0]!.message).toContain('this route');
+  });
+  it('uses the app-wide message for the root layout', async () => {
+    const rs = await seo031SsrDisabled.check(
+      ctx([kit({ file: 'src/routes/+layout.ts', kind: 'universal', ssrDisabled: { line: 2 } })])
+    );
+    expect(fails(rs)[0]!.message).toContain('whole app');
+  });
+  it('emits nothing without the flag, honours suppression, and no-ops in rendered mode', async () => {
+    expect(await seo031SsrDisabled.check(ctx([kit({})]))).toHaveLength(0);
+    const suppressed = await seo031SsrDisabled.check(
+      ctx([kit({ ssrDisabled: { line: 3 }, suppressions: [{ line: 3, ruleIds: ['SEO031'] }] })])
+    );
+    expect(fails(suppressed)).toHaveLength(0);
+    expect(await seo031SsrDisabled.check(base as RuleContext)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

Adds **SEO031** (`warning`, category `seo`), the first of three rules sourced from a survey of SvelteKit's official best-practices docs (`documentation/docs/40-best-practices`): flag route files that disable server-side rendering with `export const ssr = false` — the SEO doc's headline risk ("server-side rendered content is indexed more frequently and reliably… leave it on unless you have a good reason not to"), compounded by the performance doc's SPA-mode warning (an extra network round trip before first paint).

- Detects the inline form (`satisfies`/`as` unwrapped) and the same-file alias export (`const ssr = false; export { ssr };`); the **root `+layout`** gets a dedicated app-wide message. Gated to `+page`/`+layout` files — `ssr` is a page option, so `+server`/`hooks.server` never fire.
- Not flagged: `csr = false` (server-only rendering — fine for SEO), non-literal values (`ssr = dev`), non-exported declarations.
- A deliberate SPA is a legitimate architecture — hence `warning`, with `rules: { SEO031: 'off' }` or an inline suppression as the documented escape hatches.
- Implementation promotes CORRECT008's existing opt-out detector to a line-reporting fact (`KitModuleFacts.ssrDisabled`, optional — no fixture churn); CORRECT008's behavior is byte-unchanged (empirically re-verified). The `kitModuleRule` factory's category option widened to `'security' | 'seo'`.

Design doc: `docs/superpowers/specs/2026-07-21-seo031-ssr-disabled-design.md`
Plan: `docs/superpowers/plans/2026-07-21-seo031-ssr-disabled.md`

## Test plan

- 7 new tests: fact detection (inline/satisfies/alias forms, line numbers, the four negatives), rule (message variants, seo/warning, suppression, rendered no-op, hooks/+server gate pin)
- Root `pnpm build` / `pnpm typecheck` / `pnpm test` (1,418 tests) / `pnpm lint` all green
- Final whole-branch review probed the detection matrix against the built dist (satisfies/as/as-const, reverse aliasing, cross-file re-exports, group/nested layouts, runes-module isolation, CORRECT008 interplay) — verdict "Ready to merge"; the one reachable false positive it found (hooks.server) was gated with a regression test

Follow-ups on separate branches per the survey: PERF012 (`minify: false` left in vite config) and PERF011 (load-function waterfalls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added **SEO031 (warning)** to detect SvelteKit routes where SSR is disabled via `export const ssr = false`.
  - Provides different messaging for disabling SSR in the root `+layout` vs. individual route files, reflecting broader SPA/SEO impact.
  - Supports inline suppression and configuration-based disabling for intentional SPA scenarios.
- **Documentation**
  - Added/updated English and Japanese rule documentation with detection scope, exclusions, and remediation guidance.
- **Tests**
  - Added coverage for SSR-disabled detection and rule messaging variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->