### PR TITLE
refactor(cli): replace any with estree/svelte AST types in source adapters

### DIFF
--- a/packages/action/dist/index.js
+++ b/packages/action/dist/index.js
@@ -58540,7 +58540,7 @@ function applyOverrides(results, config) {
   return out;
 }
 
-// ../cli/dist/chunk-DY7THW6C.js
+// ../cli/dist/chunk-YRLO56SA.js
 import { readFile, access as access2 } from "fs/promises";
 import { join } from "path";
 
@@ -59318,7 +59318,7 @@ async function glob(globInput, options) {
   return crawler ? formatPaths(await crawler.withPromise(), relative2) : [];
 }
 
-// ../cli/dist/chunk-DY7THW6C.js
+// ../cli/dist/chunk-YRLO56SA.js
 import { readFileSync as readFileSync2 } from "fs";
 import { execFileSync } from "child_process";
 import { execFileSync as execFileSync2 } from "child_process";
@@ -59451,16 +59451,16 @@ function exprValue(node) {
 }
 function resolveMetaObject(attr, keyMap) {
   if (!attr) return { tags: [], opaque: false };
-  const expr = attr.value?.type === "ExpressionTag" ? attr.value.expression : void 0;
+  const expr = attr.value !== true && !Array.isArray(attr.value) ? attr.value.expression : void 0;
   if (!expr || expr.type !== "ObjectExpression") return { tags: [], opaque: true };
   const tags = [];
   let opaque = false;
-  for (const prop2 of expr.properties ?? []) {
-    if (prop2?.type !== "Property" || prop2.computed) {
+  for (const prop2 of expr.properties) {
+    if (prop2.type !== "Property" || prop2.computed) {
       opaque = true;
       continue;
     }
-    const key2 = prop2.key?.name ?? prop2.key?.value;
+    const key2 = prop2.key.type === "Identifier" ? prop2.key.name : prop2.key.type === "Literal" ? prop2.key.value : void 0;
     const make = typeof key2 === "string" ? keyMap[key2] : void 0;
     if (make) tags.push(make(exprValue(prop2.value)));
   }
@@ -59562,24 +59562,24 @@ function findAdapter(info2) {
 }
 function addImportsFromProgram(program, map) {
   for (const node of program?.body ?? []) {
-    if (node?.type !== "ImportDeclaration") continue;
-    const source2 = String(node.source?.value ?? "");
-    for (const spec of node.specifiers ?? []) {
-      const local = spec?.local?.name;
+    if (node.type !== "ImportDeclaration") continue;
+    const source2 = String(node.source.value ?? "");
+    for (const spec of node.specifiers) {
+      const local = spec.local?.name;
       if (!local) continue;
       if (spec.type === "ImportDefaultSpecifier") {
         map.set(local, { source: source2, imported: "default" });
       } else if (spec.type === "ImportSpecifier") {
-        map.set(local, { source: source2, imported: spec.imported?.name ?? spec.imported?.value ?? local });
+        const imported = spec.imported.type === "Identifier" ? spec.imported.name : spec.imported.value;
+        map.set(local, { source: source2, imported: typeof imported === "string" ? imported : local });
       }
     }
   }
 }
 function collectImports(ast) {
-  const root = ast;
   const map = /* @__PURE__ */ new Map();
-  addImportsFromProgram(root?.instance?.content, map);
-  addImportsFromProgram(root?.module?.content, map);
+  addImportsFromProgram(ast.instance?.content, map);
+  addImportsFromProgram(ast.module?.content, map);
   return map;
 }
 function collectSvelteHeads(node, acc) {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,6 +54,7 @@
     "tinyglobby": "catalog:"
   },
   "devDependencies": {
+    "@types/estree": "catalog:",
     "@types/node": "catalog:"
   }
 }

--- a/packages/cli/src/providers/source/adapters/meta-object.ts
+++ b/packages/cli/src/providers/source/adapters/meta-object.ts
@@ -1,11 +1,10 @@
-/* oxlint-disable @typescript-eslint/no-explicit-any */
+import type { Expression, Pattern } from 'estree';
+import type { AST } from 'svelte/compiler';
 import type { Value } from '@svelte-vitals/core';
 import type { ParsedTag } from '../parse.js';
 
-type Node = any;
-
 /** Value kind of an ESTree expression used as a prop or object-property value. */
-export function exprValue(node: Node): Value {
+export function exprValue(node: Expression | Pattern | null | undefined): Value {
   if (!node) return 'absent';
   if (node.type === 'Literal') {
     // A non-empty string literal is a concrete static value; other literals
@@ -35,24 +34,25 @@ export interface MetaObjectResult {
  * reported opaque for the caller to broaden.
  */
 export function resolveMetaObject(
-  attr: Node | undefined,
+  attr: AST.Attribute | undefined,
   keyMap: Record<string, (value: Value) => ParsedTag>
 ): MetaObjectResult {
   if (!attr) return { tags: [], opaque: false };
-  const expr = attr.value?.type === 'ExpressionTag' ? attr.value.expression : undefined;
+  const expr = attr.value !== true && !Array.isArray(attr.value) ? attr.value.expression : undefined;
   if (!expr || expr.type !== 'ObjectExpression') return { tags: [], opaque: true };
 
   const tags: ParsedTag[] = [];
   let opaque = false;
-  for (const prop of expr.properties ?? []) {
+  for (const prop of expr.properties) {
     // A SpreadElement (`{...d}`) or a computed key (`{ [k]: v }`) can't be
     // enumerated statically — fall back to broad coverage rather than silently
     // under-reporting a key we can't resolve.
-    if (prop?.type !== 'Property' || prop.computed) {
+    if (prop.type !== 'Property' || prop.computed) {
       opaque = true;
       continue;
     }
-    const key = prop.key?.name ?? prop.key?.value;
+    const key =
+      prop.key.type === 'Identifier' ? prop.key.name : prop.key.type === 'Literal' ? prop.key.value : undefined;
     const make = typeof key === 'string' ? keyMap[key] : undefined;
     if (make) tags.push(make(exprValue(prop.value)));
   }

--- a/packages/cli/src/providers/source/adapters/svelte-meta-tags.ts
+++ b/packages/cli/src/providers/source/adapters/svelte-meta-tags.ts
@@ -1,13 +1,11 @@
-/* oxlint-disable @typescript-eslint/no-explicit-any */
+import type { AST } from 'svelte/compiler';
 import type { ImportInfo } from '../imports.js';
 import type { ComponentUse, ParsedTag } from '../parse.js';
 import { attrValueOf, attrTextOf } from '@svelte-vitals/core';
 import { resolveMetaObject, OPEN_GRAPH_KEYS, TWITTER_KEYS } from './meta-object.js';
 import type { Adapter, AdapterResult } from './types.js';
 
-type Node = any;
-
-function findAttr(attributes: Node[], name: string): Node | undefined {
+function findAttr(attributes: AST.Attribute[], name: string): AST.Attribute | undefined {
   return attributes.find((a) => a?.type === 'Attribute' && a.name === name);
 }
 

--- a/packages/cli/src/providers/source/adapters/svelte-seo.ts
+++ b/packages/cli/src/providers/source/adapters/svelte-seo.ts
@@ -1,13 +1,11 @@
-/* oxlint-disable @typescript-eslint/no-explicit-any */
+import type { AST } from 'svelte/compiler';
 import type { ImportInfo } from '../imports.js';
 import type { ComponentUse, ParsedTag } from '../parse.js';
 import { attrValueOf, attrTextOf } from '@svelte-vitals/core';
 import { resolveMetaObject, OPEN_GRAPH_KEYS, TWITTER_KEYS } from './meta-object.js';
 import type { Adapter, AdapterResult } from './types.js';
 
-type Node = any;
-
-function findAttr(attributes: Node[], name: string): Node | undefined {
+function findAttr(attributes: AST.Attribute[], name: string): AST.Attribute | undefined {
   return attributes.find((a) => a?.type === 'Attribute' && a.name === name);
 }
 

--- a/packages/cli/src/providers/source/imports.ts
+++ b/packages/cli/src/providers/source/imports.ts
@@ -1,5 +1,5 @@
-/* oxlint-disable @typescript-eslint/no-explicit-any */
-type Node = any;
+import type { Program } from 'estree';
+import type { AST } from 'svelte/compiler';
 
 /** A resolved import binding: which module, and which export ('default' for default imports). */
 export interface ImportInfo {
@@ -10,12 +10,12 @@ export interface ImportInfo {
 /** local identifier -> import binding. */
 export type ImportMap = Map<string, ImportInfo>;
 
-function addImportsFromProgram(program: Node, map: ImportMap): void {
+function addImportsFromProgram(program: Program | null | undefined, map: ImportMap): void {
   for (const node of program?.body ?? []) {
-    if (node?.type !== 'ImportDeclaration') continue;
-    const source = String(node.source?.value ?? '');
-    for (const spec of node.specifiers ?? []) {
-      const local = spec?.local?.name;
+    if (node.type !== 'ImportDeclaration') continue;
+    const source = String(node.source.value ?? '');
+    for (const spec of node.specifiers) {
+      const local = spec.local?.name;
       if (!local) continue;
       if (spec.type === 'ImportDefaultSpecifier') {
         map.set(local, { source, imported: 'default' });
@@ -23,17 +23,17 @@ function addImportsFromProgram(program: Node, map: ImportMap): void {
         // `imported` is an Identifier (`.name`) for normal specifiers, or a string
         // Literal (`.value`) for string-literal specifiers (`import { 'a-b' as c }`).
         // Falling back to `local` would mislabel the latter (`c` instead of `a-b`).
-        map.set(local, { source, imported: spec.imported?.name ?? spec.imported?.value ?? local });
+        const imported = spec.imported.type === 'Identifier' ? spec.imported.name : spec.imported.value;
+        map.set(local, { source, imported: typeof imported === 'string' ? imported : local });
       }
     }
   }
 }
 
 /** Collect import bindings from both the instance and module `<script>` blocks. */
-export function collectImports(ast: unknown): ImportMap {
-  const root = ast as Node;
+export function collectImports(ast: AST.Root): ImportMap {
   const map: ImportMap = new Map();
-  addImportsFromProgram(root?.instance?.content, map);
-  addImportsFromProgram(root?.module?.content, map);
+  addImportsFromProgram(ast.instance?.content, map);
+  addImportsFromProgram(ast.module?.content, map);
   return map;
 }

--- a/packages/cli/test/meta-object.test.ts
+++ b/packages/cli/test/meta-object.test.ts
@@ -1,6 +1,7 @@
-/* oxlint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect } from 'vitest';
 import { parse } from 'svelte/compiler';
+import type { AST } from 'svelte/compiler';
+import type { ObjectExpression, Property } from 'estree';
 import {
   exprValue,
   resolveMetaObject,
@@ -8,11 +9,16 @@ import {
   TWITTER_KEYS
 } from '../src/providers/source/adapters/meta-object.js';
 
-// The Svelte AST is only partially typed for our needs, so this test helper traverses with `any`.
-function attrOf(tag: string, name: string): any {
-  const ast = parse(`<script></script>${tag}`, { modern: true, filename: 'x.svelte' }) as any;
-  const component = ast.fragment.nodes.find((n: any) => n.type === 'Component');
-  return component.attributes.find((a: any) => a.type === 'Attribute' && a.name === name);
+function attrOf(tag: string, name: string): AST.Attribute | undefined {
+  const ast = parse(`<script></script>${tag}`, { modern: true, filename: 'x.svelte' });
+  const component = ast.fragment.nodes.find((n): n is AST.Component => n.type === 'Component');
+  return component?.attributes.find((a): a is AST.Attribute => a.type === 'Attribute' && a.name === name);
+}
+
+/** The first property of an attribute's inline object-literal value, e.g. `openGraph={{ url: … }}`. */
+function firstObjectProp(attr: AST.Attribute): Property {
+  const expr = (attr.value as AST.ExpressionTag).expression as ObjectExpression;
+  return expr.properties[0] as Property;
 }
 
 describe('resolveMetaObject', () => {
@@ -67,16 +73,12 @@ describe('resolveMetaObject', () => {
 
 describe('exprValue', () => {
   it('classifies a non-empty string literal as static', () => {
-    const attr = attrOf('<MetaTags openGraph={{ url: "https://x" }} />', 'openGraph');
-    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-    const prop = (attr.value.expression.properties as any[])[0];
-    expect(exprValue(prop.value)).toBe('static');
+    const attr = attrOf('<MetaTags openGraph={{ url: "https://x" }} />', 'openGraph')!;
+    expect(exprValue(firstObjectProp(attr).value)).toBe('static');
   });
 
   it('classifies an identifier as dynamic', () => {
-    const attr = attrOf('<MetaTags openGraph={{ url: SITE }} />', 'openGraph');
-    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-    const prop = (attr.value.expression.properties as any[])[0];
-    expect(exprValue(prop.value)).toBe('dynamic');
+    const attr = attrOf('<MetaTags openGraph={{ url: SITE }} />', 'openGraph')!;
+    expect(exprValue(firstObjectProp(attr).value)).toBe('dynamic');
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ catalogs:
     '@sveltejs/kit':
       specifier: ^2.70.1
       version: 2.70.1
+    '@types/estree':
+      specifier: ^1.0.9
+      version: 1.0.9
     '@types/node':
       specifier: ^24.13.3
       version: 24.13.3
@@ -211,6 +214,9 @@ importers:
         specifier: 'catalog:'
         version: 0.2.17
     devDependencies:
+      '@types/estree':
+        specifier: 'catalog:'
+        version: 1.0.9
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,7 @@ catalog:
   '@modelcontextprotocol/sdk': ^1.29.0
   astro: ^7.1.1
   '@sveltejs/kit': ^2.70.1
+  '@types/estree': ^1.0.9
   '@types/node': ^24.13.3
   esm-env: ^1.2.2
   jsdom: ^29.1.1


### PR DESCRIPTION
## Summary

Second in the `any`-removal series started by [#270](https://github.com/oekazuma/svelte-vitals/pull/270) (`svelte-ast.ts`). This one covers the group of files that only touch **estree-standard** AST nodes — plain JS constructs like `ObjectExpression`, `Property`, `ImportDeclaration` — with no TypeScript-only syntax (`TSSatisfiesExpression` etc., which needs separate handling and is deferred to a later PR for `component-parse.ts`/`kit-module-parse.ts`/`vite-config-parse.ts`).

- **`meta-object.ts`**: `exprValue` now takes `Expression | Pattern` (estree); `resolveMetaObject` takes `AST.Attribute` (svelte/compiler). The Identifier-name-or-Literal-value key resolution is now an explicit type check instead of relying on optional chaining to silently no-op on the wrong union member.
- **`imports.ts`**: `addImportsFromProgram` takes estree's `Program`; `collectImports` takes `AST.Root` — svelte's `parse(src, { modern: true })` overload already returns `AST.Root` directly, so no caller needs a cast.
- **`svelte-meta-tags.ts` / `svelte-seo.ts`**: local `findAttr` helpers now take `AST.Attribute[]` and return `AST.Attribute | undefined`.

Added `@types/estree` (via the pnpm catalog) to `packages/cli`, since `estree`'s types aren't resolvable as a direct import in this workspace — only available as a transitive devDependency of `svelte`.

`meta-object.test.ts`'s fixtures now build `attrOf`/`firstObjectProp` against real `svelte/compiler` `parse()` output (already fully typed) instead of loose `any` traversal.

**No behavior change.** The `packages/action/dist` rebuild diff is the same logic expressed via explicit type checks instead of optional-chaining fallthrough — verified equivalent by inspection line-by-line.

## Test plan

- [x] `pnpm build && pnpm typecheck` — clean
- [x] `pnpm test` — core 622, cli 694, action 15, mcp 21, vite 162, all passing (assertions unmodified)
- [x] `pnpm lint` — clean
- [x] `pnpm check:publish` — clean
- [x] Manually diffed `packages/action/dist/index.js` to confirm the rebuild is logic-equivalent, not a behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Svelte metadata, SEO attributes, object literals, and import declarations.
  * Correctly preserves imported names, including string-literal imports.
  * Maintains existing behavior for dynamic values, spreads, and computed keys.

* **Refactor**
  * Strengthened AST type safety across source analysis and metadata processing.
  * Added supporting type definitions for more reliable development and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->