### PR TITLE
chore(oxlint): re-enable unicorn/oxc plugins, restore correctness category

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,9 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["typescript"],
-  "categories": {
-    "correctness": "off"
-  },
+  "plugins": ["typescript", "unicorn", "oxc"],
   "env": {
     "builtin": true,
     "node": true
@@ -11,6 +8,10 @@
   "ignorePatterns": [
     "**/node_modules/",
     "**/dist/",
+    // packages/action/dist is negated in .gitignore (committed so GitHub Actions can
+    // consume it directly), which un-ignores it from **/dist/ above — the final entry
+    // below re-excludes it from lint explicitly, since it's a machine-generated esbuild
+    // bundle, not hand-written source.
     "!packages/action/dist/",
     "**/*.log",
     "**/.DS_Store",

--- a/packages/vite/src/analyze.ts
+++ b/packages/vite/src/analyze.ts
@@ -65,7 +65,7 @@ export async function analyze(
   const { heads, headings, images, htmlLang } = await collectRenderedHeads(prerenderPagesDir);
   const project = {
     ...(await collectRenderedProject(cwd, htmlLang)),
-    ...(extraProjectFacts ?? {})
+    ...extraProjectFacts
   };
   const components = await collectComponentFacts(cwd);
   const kitModules = await collectKitModuleFacts(cwd);


### PR DESCRIPTION
## Why

Audited the `@oxlint/migrate`-generated `.oxlintrc.json` for gaps, per a request to make sure this config actually earns its keep rather than being a rote port of the old ESLint setup.

Found: `"plugins": ["typescript"]` and `"categories": { "correctness": "off" }` (with ~65 individual rules re-listed by hand to replicate the old ESLint behavior). Both `unicorn` and `oxc` (oxlint's own native rules) are **enabled by default** upstream — specifying `plugins` in config *replaces* the defaults rather than adding to them, so this was silently dropping both plugins entirely, and the whole `correctness` category was capped at exactly the hand-picked list (no automatic pickup of new correctness rules on oxlint upgrades).

## What changed

- `plugins`: `["typescript"]` → `["typescript", "unicorn", "oxc"]`
- Removed the `categories.correctness: "off"` override, restoring it to oxlint's default.
- Verified via `oxlint --print-config` + manual diffing (not guessed) that this surfaces exactly **one** real finding across the whole source tree: `unicorn/no-useless-fallback-in-spread` in `packages/vite/src/analyze.ts:68` — fixed here (`...(extraProjectFacts ?? {})` → `...extraProjectFacts`; spreading `undefined` is already a no-op).
- Added a comment documenting why `packages/action/dist/` appears both un-ignored and re-ignored in `ignorePatterns` — this is intentional (see the equivalent comment that lived next to it in the old `eslint.config.js`, lost in the migration), not a mistake, but was undocumented.

## Also investigated, not included here

- **`vitest` plugin**: has genuinely useful rules (`expect-expect`, `no-conditional-expect`, `valid-expect`, `no-disabled-tests`, `no-focused-tests`), but enabling the whole plugin surfaces ~90 warnings, almost all `require-mock-type-parameters` (a stylistic demand for explicit generics on every `vi.fn()`). Recommend hand-picking the valuable subset rather than the whole plugin.
- **`import/no-cycle`**: not in the old ESLint config at all (genuinely new capability). Flags a cycle between `packages/core/src/reporter/app-shell.ts` and `html.ts` — but `html.ts` has zero imports, so this looks like it may be a false positive from oxlint's cycle detection rather than a real cycle; needs verification before enabling as an error.
- **Type-aware TypeScript rules** (`no-floating-promises`, `no-misused-promises`, `no-unsafe-*`): would meaningfully lock in this session's `any`-removal work, but requires a new `oxlint-tsgolint` dependency, adds CI time, and would immediately flag the two files (`component-parse.ts`, `kit-module-parse.ts`) intentionally left partially-typed for cost/benefit reasons.

Happy to follow up on any of these in a separate PR if wanted.

## Test plan
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm lint`

No changeset — internal tooling config only, no user-facing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)