### PR TITLE
ci(release): auto-create a GitHub Release for @svelte-vitals/action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,12 +116,17 @@ jobs:
               echo "release for $tag already exists, skipping"
             else
               # Extract this version's own section from CHANGELOG.md (between its
-              # "## <version>" heading and the next "## " heading, or EOF) as the release body.
-              notes=$(awk -v ver="$version" '
+              # "## <version>" heading and the next "## " heading, or EOF) as the release
+              # body. Fail closed (not an empty-body release) if the heading is missing.
+              if ! notes="$(awk -v ver="$version" '
                 $0 == "## " ver { found=1; next }
                 found && /^## / { exit }
                 found { print }
-              ' "$pkg_dir/CHANGELOG.md")
+                END { if (!found) exit 1 }
+              ' "$pkg_dir/CHANGELOG.md")"; then
+                echo "::error::No changelog section found for $name@$version"
+                exit 1
+              fi
               gh release create "$tag" --title "$name@$version" --notes "$notes"
               echo "created release for $tag"
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,28 +75,54 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
-      - name: Tag private package releases
+      - name: Tag and release private packages
         # @changesets/cli@2.31.0 (latest stable; the tag-only-for-private-packages behavior
-        # only exists in the unreleased 3.0 line) only tags packages it publishes to npm, so
-        # our private, changesets-versioned packages (currently just @svelte-vitals/action,
-        # distributed via git tag/SHA instead of npm) never get tagged by the step above.
+        # only exists in the unreleased 3.0 line) only tags (and creates a GitHub Release for)
+        # packages it publishes to npm, so our private, changesets-versioned packages
+        # (currently just @svelte-vitals/action, distributed via git tag/SHA instead of npm)
+        # get neither from the step above — version bump and CHANGELOG.md still happen
+        # normally (changesets doesn't skip private packages for those), only the publish+tag+
+        # release trio is skipped. This step fills in the tag and the Release so a private
+        # package still gets equivalent visibility, without actually publishing to npm.
+        #
         # Tag as <dir-basename>-v<version> (e.g. action-v0.3.5), not the npm-scoped
-        # `$name@$version` form used pre-fix — Renovate's github-actions manager parses a
-        # version out of the SHA-pinned `uses:` line's trailing comment (packages/cli/src/ci/
-        # action-pin-comment.ts writes the same format there) and its regex doesn't recognize
-        # npm scope syntax, so the old tag shape made this action invisible to Renovate.
-        # Idempotent: skips any package whose tag already exists on origin.
+        # `$name@$version` form changesets itself would use — Renovate's github-actions
+        # manager parses a version out of the SHA-pinned `uses:` line's trailing comment
+        # (packages/cli/src/ci/action-pin-comment.ts writes the same format there) and its
+        # regex doesn't recognize npm scope syntax, so that shape would make the action
+        # invisible to Renovate.
+        # Idempotent: the tag and the Release are checked (and created) independently, so a
+        # prior partial failure (e.g. tag pushed but release creation dropped) is retried
+        # rather than permanently skipped just because the tag already exists.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           for pkg_dir in packages/action; do
+            name=$(node -p "require('./$pkg_dir/package.json').name")
             version=$(node -p "require('./$pkg_dir/package.json').version")
             tag="$(basename "$pkg_dir")-v$version"
+
             if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
-              echo "$tag already exists on origin, skipping"
+              echo "$tag already exists on origin"
             else
               git config user.name "github-actions[bot]"
               git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
               git tag "$tag"
               git push origin "$tag"
               echo "created and pushed $tag"
+            fi
+
+            if gh release view "$tag" >/dev/null 2>&1; then
+              echo "release for $tag already exists, skipping"
+            else
+              # Extract this version's own section from CHANGELOG.md (between its
+              # "## <version>" heading and the next "## " heading, or EOF) as the release body.
+              notes=$(awk -v ver="$version" '
+                $0 == "## " ver { found=1; next }
+                found && /^## / { exit }
+                found { print }
+              ' "$pkg_dir/CHANGELOG.md")
+              gh release create "$tag" --title "$name@$version" --notes "$notes"
+              echo "created release for $tag"
             fi
           done


### PR DESCRIPTION
## Why

`@svelte-vitals/action` is `"private": true` (by design — it's consumed via a SHA-pinned `uses:` reference, never `npm install`), so `changesets/action`'s publish step skips it entirely: no npm publish, no tag, no GitHub Release. Version bump and `CHANGELOG.md` entries still happen normally (changesets doesn't skip private packages for those), so the existing "Tag private package releases" step already fills in the missing tag — but the package still ends up as the only one in the repo with no GitHub Release, unlike every npm-published package.

## What changed

- Renamed the step to "Tag and release private packages".
- After the tag is created (unchanged logic), it now also creates a GitHub Release for that tag via `gh release create`, using the release's own section of `CHANGELOG.md` (extracted with `awk`, between its `## <version>` heading and the next) as the release notes — matching the format `changesets/action` itself uses for every other package.
- Tag existence and Release existence are now checked independently (`git ls-remote` / `gh release view`), so a partial prior failure (tag pushed, release creation dropped for some reason) gets retried on the next run instead of being silently skipped forever just because the tag already exists.
- npm publishing is deliberately left alone. Publishing it would add no real consumer benefit (nobody `npm install`s a GitHub Action's bundled entry point) and would reopen the tag-format problem already fixed for Renovate: changesets would tag it as `@svelte-vitals/action@X.Y.Z` (npm-scoped), which Renovate's github-actions manager can't parse as a version — the whole reason `action-vX.Y.Z` exists (`packages/cli/src/ci/action-pin-comment.ts`).

## Test plan
- [x] YAML parses cleanly
- [x] `pnpm lint`
- [x] Manually verified the `awk` extraction against the current `packages/action/CHANGELOG.md` — correctly isolates just the current version's section
- Can't fully simulate a real release run locally; worth watching the next release to confirm `gh release create` succeeds with `GITHUB_TOKEN` (release creation isn't a protected-branch push, so unlike the dist self-heal step this shouldn't need `ACTION_DIST_PAT`, but flagging for visibility)

No changeset — internal release-workflow config only, no user-facing package behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic GitHub Release creation during package releases.
  * Release titles now include the package name and version.
  * Release notes are populated from the corresponding changelog section.
  * Existing tags and releases are detected to prevent duplicate creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->