### PR TITLE
feat(cli): warn when the analyzed project is below the Svelte/Kit floor

### DIFF
--- a/.changeset/svelte-version-floor-warning.md
+++ b/.changeset/svelte-version-floor-warning.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': minor
+---
+
+Warn (stderr, non-blocking) when the analyzed project declares a `svelte` or `@sveltejs/kit` version below what rules assume (Svelte 5+ runes, SvelteKit 2+) — rules that key off runes syntax can't recognize the legacy (`export let` / `$:`) equivalent of the same bugs, so findings may be incomplete for components that haven't migrated to runes yet.

--- a/docs/src/content/docs/guides/cli.md
+++ b/docs/src/content/docs/guides/cli.md
@@ -269,6 +269,16 @@ Print the help text and exit.
 
 Print the CLI's own version and the resolved `@svelte-vitals/core` version, e.g. `0.20.0 (core 0.21.0)`. `svelte-vitals` and `@svelte-vitals/vite` are versioned independently and can end up depending on different `@svelte-vitals/core` releases — compare this `core` version against the one shown in the [live dashboard](/svelte-vitals/guides/dev-dashboard/#version-drift) topbar if the two surfaces ever disagree on findings.
 
+## Supported Svelte/SvelteKit versions
+
+Rules assume **Svelte 5+ (runes)** and **SvelteKit 2+**. If the analyzed project declares an
+older `svelte` or `@sveltejs/kit` version in `package.json`, a warning is printed to stderr —
+the analysis still runs normally, but rules that key off runes syntax (e.g.
+[correctness/stale-prop-derivation](/svelte-vitals/rules/correctness/stale-prop-derivation/),
+[correctness/prop-mutation](/svelte-vitals/rules/correctness/prop-mutation/)) can't recognize
+the legacy (`export let` / `$:`) equivalent of the same bugs, so findings may be incomplete for
+components that haven't migrated to runes yet.
+
 ## Exit codes
 
 | Code | Meaning                                                                     |

--- a/docs/src/content/docs/ja/guides/cli.md
+++ b/docs/src/content/docs/ja/guides/cli.md
@@ -262,6 +262,16 @@ svelte-vitals --meta-components "SeoHead,PageMeta"
 
 CLI 自身のバージョンと、解決された `@svelte-vitals/core` のバージョンを表示して終了します（例：`0.20.0 (core 0.21.0)`）。`svelte-vitals` と `@svelte-vitals/vite` はそれぞれ独立してバージョン管理されており、異なる `@svelte-vitals/core` リリースに依存する状態になり得ます。CLI と[ライブダッシュボード](/svelte-vitals/ja/guides/dev-dashboard/#バージョンのずれ)で検出結果が食い違う場合は、この `core` バージョンをダッシュボードのトップバーに表示される値と比較してください。
 
+## 対応する Svelte/SvelteKit バージョン
+
+ルールは **Svelte 5+（runes）** と **SvelteKit 2+** を前提としています。解析対象プロジェクトの
+`package.json` がそれより古い `svelte`/`@sveltejs/kit` バージョンを宣言している場合、stderr に
+警告が表示されます — 解析自体は通常どおり実行されますが、
+[correctness/stale-prop-derivation](/svelte-vitals/ja/rules/correctness/stale-prop-derivation/)や
+[correctness/prop-mutation](/svelte-vitals/ja/rules/correctness/prop-mutation/)のように runes
+構文を手がかりにするルールは、同じバグの legacy 構文（`export let` / `$:`）版を認識できないため、
+runes へまだ移行していないコンポーネントでは検出結果が不完全になる場合があります。
+
 ## 終了コード
 
 | コード | 意味                                                                                 |

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,7 +28,7 @@ import { createNodeRuntime } from './runtime/node.js';
 import { collectRoutes } from './providers/source/routes.js';
 import type { ParseCache } from './providers/source/resolve.js';
 import { collectComponentFacts } from './providers/source/components.js';
-import { detectProject, ProjectError, collectProjectFacts } from './providers/source/project.js';
+import { detectProject, ProjectError, collectProjectFacts, checkVersionFloor } from './providers/source/project.js';
 import { discoverApps } from './discover-apps.js';
 import { readPackageVersion, readCoreVersion } from './version.js';
 import { resolveReporter, isAutoDetectedAgent, isAutoDetectedGithub, type ReporterName } from './reporter-resolve.js';
@@ -190,7 +190,6 @@ export async function analyzeProject(opts: AnalyzeOptions = {}): Promise<Analyze
 
   const loaded = await loadConfigFile(cwd);
   const file = loaded?.config;
-  const warnings = loaded?.warnings ?? [];
 
   const weights = opts.weights ?? file?.weights;
   const config = defineConfig({
@@ -203,6 +202,7 @@ export async function analyzeProject(opts: AnalyzeOptions = {}): Promise<Analyze
   });
 
   await detectProject(rt, cwd); // throws ProjectError if not a SvelteKit project
+  const warnings = [...(loaded?.warnings ?? []), ...(await checkVersionFloor(rt, cwd))];
 
   const matches = routeMatcher(opts.route);
   const collected = await collectRoutes(rt, cwd, config, opts.parseCache);

--- a/packages/cli/src/providers/source/project.ts
+++ b/packages/cli/src/providers/source/project.ts
@@ -27,10 +27,16 @@ const ROUTES_DIR = 'src/routes';
 const MIN_SVELTE_MAJOR = 5;
 const MIN_KIT_MAJOR = 2;
 
-/** The leading integer in a semver range specifier (`^5.56.6` → 5, `>=4.0.0` → 4); undefined for an empty/unparsable string (`*`, `latest`, `workspace:*`, …) — never guessed. */
+/**
+ * The leading integer in a semver range specifier (`^5.56.6` → 5, `>=4.0.0` → 4); undefined
+ * for an empty/unparsable string (`*`, `latest`, `workspace:*`, …) — never guessed. Anchored
+ * to the start of the (optionally operator-prefixed) string, not a bare digit search — a
+ * `file:../svelte-4` path or a `github:sveltejs/svelte#v4` git specifier contains a `4` too,
+ * but isn't a version declaration at all, so it must not be read as "major 4".
+ */
 function leadingMajor(range: string | undefined): number | undefined {
-  const m = range ? /\d+/.exec(range) : null;
-  return m ? Number(m[0]) : undefined;
+  const m = range ? /^(?:[\^~]|>=|<=|>|<|=)?\s*(\d+)/.exec(range.trim()) : null;
+  return m ? Number(m[1]) : undefined;
 }
 
 /**

--- a/packages/cli/src/providers/source/project.ts
+++ b/packages/cli/src/providers/source/project.ts
@@ -18,6 +18,58 @@ export class ProjectError extends Error {
 const ROUTES_DIR = 'src/routes';
 
 /**
+ * Minimum Svelte/SvelteKit major versions this tool's rules assume (Svelte 5 runes —
+ * `$props()`/`$state()`/`$derived()` — and SvelteKit 2 APIs). Advisory only: an older
+ * project still gets analyzed normally, but rules that key off runes syntax (e.g.
+ * correctness/stale-prop-derivation, correctness/prop-mutation) can't recognize the
+ * legacy (`export let`, `$:`) equivalent of the same bugs, so findings may be incomplete.
+ */
+const MIN_SVELTE_MAJOR = 5;
+const MIN_KIT_MAJOR = 2;
+
+/** The leading integer in a semver range specifier (`^5.56.6` → 5, `>=4.0.0` → 4); undefined for an empty/unparsable string (`*`, `latest`, `workspace:*`, …) — never guessed. */
+function leadingMajor(range: string | undefined): number | undefined {
+  const m = range ? /\d+/.exec(range) : null;
+  return m ? Number(m[0]) : undefined;
+}
+
+/**
+ * Warn (never block) when the analyzed project declares a Svelte or SvelteKit version
+ * below the floor rules assume — read from package.json's declared range, same source
+ * `detectProject` already uses for the `@sveltejs/kit` presence check. A missing/
+ * unparsable package.json or an unparsable version range yields no warning (silent,
+ * consistent with `detectProject`'s own conservative fallbacks) rather than guessing.
+ */
+export async function checkVersionFloor(rt: Runtime, cwd: string): Promise<string[]> {
+  const pkgPath = rt.join(cwd, 'package.json');
+  if (!(await rt.exists(pkgPath))) return [];
+  let pkg: { dependencies?: Record<string, string>; devDependencies?: Record<string, string> };
+  try {
+    pkg = JSON.parse(await rt.readFile(pkgPath));
+  } catch {
+    return [];
+  }
+
+  const warnings: string[] = [];
+  const svelteRange = pkg.dependencies?.svelte ?? pkg.devDependencies?.svelte;
+  const svelteMajor = leadingMajor(svelteRange);
+  if (svelteMajor !== undefined && svelteMajor < MIN_SVELTE_MAJOR) {
+    warnings.push(
+      `this project declares svelte "${svelteRange}", but rules assume Svelte ${MIN_SVELTE_MAJOR}+ (runes) — ` +
+        `findings may miss the legacy (export let / $:) equivalent of runes-only checks.`
+    );
+  }
+  const kitRange = pkg.dependencies?.['@sveltejs/kit'] ?? pkg.devDependencies?.['@sveltejs/kit'];
+  const kitMajor = leadingMajor(kitRange);
+  if (kitMajor !== undefined && kitMajor < MIN_KIT_MAJOR) {
+    warnings.push(
+      `this project declares @sveltejs/kit "${kitRange}", but rules assume SvelteKit ${MIN_KIT_MAJOR}+ — some checks may not apply.`
+    );
+  }
+  return warnings;
+}
+
+/**
  * Verify the cwd is a SvelteKit project (design §17): either `@sveltejs/kit`
  * appears in package.json, or a svelte.config.js exists alongside src/routes/.
  * Throws ProjectError with a friendly message otherwise.

--- a/packages/cli/test/version-floor.test.ts
+++ b/packages/cli/test/version-floor.test.ts
@@ -48,6 +48,15 @@ describe('checkVersionFloor', () => {
     expect(await checkVersionFloor(rt, '')).toEqual([]);
   });
 
+  it('does not mistake a digit inside a non-semver specifier for a version (file:/git specifiers)', async () => {
+    const rt = createMemoryRuntime({
+      'package.json': JSON.stringify({
+        dependencies: { svelte: 'file:../svelte-4', '@sveltejs/kit': 'github:sveltejs/kit#v1' }
+      })
+    });
+    expect(await checkVersionFloor(rt, '')).toEqual([]);
+  });
+
   it('checks devDependencies when the package is not in dependencies', async () => {
     const rt = createMemoryRuntime({ 'package.json': JSON.stringify({ devDependencies: { svelte: '^3.0.0' } }) });
     const warnings = await checkVersionFloor(rt, '');

--- a/packages/cli/test/version-floor.test.ts
+++ b/packages/cli/test/version-floor.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { checkVersionFloor } from '../src/providers/source/project.js';
+import { createMemoryRuntime } from './helpers/memory-runtime.js';
+
+describe('checkVersionFloor', () => {
+  it('warns when svelte is below the major-version floor', async () => {
+    const rt = createMemoryRuntime({ 'package.json': JSON.stringify({ dependencies: { svelte: '^4.2.0' } }) });
+    const warnings = await checkVersionFloor(rt, '');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('svelte "^4.2.0"');
+    expect(warnings[0]).toContain('Svelte 5+');
+  });
+
+  it('warns when @sveltejs/kit is below the major-version floor', async () => {
+    const rt = createMemoryRuntime({
+      'package.json': JSON.stringify({ devDependencies: { '@sveltejs/kit': '^1.20.0' } })
+    });
+    const warnings = await checkVersionFloor(rt, '');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('@sveltejs/kit "^1.20.0"');
+    expect(warnings[0]).toContain('SvelteKit 2+');
+  });
+
+  it('warns for both when svelte and @sveltejs/kit are both below floor', async () => {
+    const rt = createMemoryRuntime({
+      'package.json': JSON.stringify({ dependencies: { svelte: '4.0.0', '@sveltejs/kit': '1.0.0' } })
+    });
+    const warnings = await checkVersionFloor(rt, '');
+    expect(warnings).toHaveLength(2);
+  });
+
+  it('does not warn when both are at or above the floor', async () => {
+    const rt = createMemoryRuntime({
+      'package.json': JSON.stringify({ dependencies: { svelte: '^5.56.6', '@sveltejs/kit': '^2.20.0' } })
+    });
+    expect(await checkVersionFloor(rt, '')).toEqual([]);
+  });
+
+  it('does not warn when svelte/@sveltejs/kit are absent from package.json', async () => {
+    const rt = createMemoryRuntime({ 'package.json': JSON.stringify({ dependencies: {} }) });
+    expect(await checkVersionFloor(rt, '')).toEqual([]);
+  });
+
+  it('does not warn (never guesses) on an unparsable range', async () => {
+    const rt = createMemoryRuntime({
+      'package.json': JSON.stringify({ dependencies: { svelte: 'workspace:*', '@sveltejs/kit': 'latest' } })
+    });
+    expect(await checkVersionFloor(rt, '')).toEqual([]);
+  });
+
+  it('checks devDependencies when the package is not in dependencies', async () => {
+    const rt = createMemoryRuntime({ 'package.json': JSON.stringify({ devDependencies: { svelte: '^3.0.0' } }) });
+    const warnings = await checkVersionFloor(rt, '');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('svelte "^3.0.0"');
+  });
+
+  it('returns no warnings when package.json is absent', async () => {
+    expect(await checkVersionFloor(createMemoryRuntime({}), '')).toEqual([]);
+  });
+
+  it('returns no warnings when package.json is malformed', async () => {
+    const rt = createMemoryRuntime({ 'package.json': '{not json' });
+    expect(await checkVersionFloor(rt, '')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

svelte-vitals's rules assume Svelte 5+ (runes) and SvelteKit 2+. Some rules — `correctness/stale-prop-derivation`, `correctness/prop-mutation` — key off `$props()`/`$state()`/`$derived()` syntax specifically and structurally cannot recognize the legacy (`export let` / `$:`) equivalent of the exact same bugs.

Until now, nothing told the user this. A project still on an older Svelte/SvelteKit gets a clean, high-scoring report — not because the code is fine, but because entire rule categories can never fire on it. That's a silent false sense of security, not a bug in any single rule.

## What changed

- New `checkVersionFloor()` in `packages/cli/src/providers/source/project.ts`: reads the analyzed project's declared `svelte`/`@sveltejs/kit` version range from `package.json` (same source `detectProject` already reads for the `@sveltejs/kit` presence check) and returns a warning string for each dependency below the floor (Svelte 5 / SvelteKit 2).
- Wired into `analyzeProject` (`packages/cli/src/index.ts`) — the warning(s) are folded into the existing `warnings` array (previously populated only from config-file warnings) and printed via the same `stderr`/`errorLog` mechanism, prefixed `svelte-vitals: `.
- **Advisory only**: never changes the exit code, never blocks analysis — the project still gets analyzed normally either way.
- Docs (`guides/cli.md`, ja included) gained a short "Supported Svelte/SvelteKit versions" section explaining this and linking the two affected rules.
- Version parsing is intentionally simple (leading integer of the semver range string, e.g. `^5.56.6` → `5`) rather than a full semver dependency — this is a soft warning, not a gate, so precision beyond "major version" isn't needed.

## Deliberately out of scope

This is the first of two planned changes. This PR only adds the warning. It does **not** change what `stale-prop-derivation`/`prop-mutation` actually detect — a Svelte-5-floor-compliant project can still have individual components on legacy (`export let`) syntax mid-migration, and those will keep being silently missed by those two rules regardless of this warning. That's tracked as a separate, deliberately-scoped follow-up (teaching `component-parse.ts`'s prop-name collection to also recognize `export let`, with mode-aware fix recommendations in each rule's message).

## Test plan
- [x] `pnpm build` / `pnpm typecheck` / `pnpm test` / `pnpm lint` / `pnpm check:publish`
- [x] `pnpm --filter docs build`
- [x] New `packages/cli/test/version-floor.test.ts` covers: below-floor svelte, below-floor kit, both below floor, both at/above floor, absent from package.json, unparsable range (never guesses), devDependencies fallback, missing/malformed package.json
- [x] Verified none of the existing `packages/cli/test/fixtures/*/package.json` fixtures are below the floor (no accidental new warnings breaking existing `warnings` assertions)
- No `packages/action/dist` change needed — release.yml now self-heals that after merge (#278)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added non-blocking warnings when analyzed projects declare Svelte versions below 5 or SvelteKit versions below 2.
  - Clarifies that analysis still runs, but rune-dependent findings may be incomplete for components using legacy syntax.
- **Documentation**
  - Added a “Supported Svelte/SvelteKit versions” section to the CLI guides, including the warning behavior and analysis limitations.
- **Tests**
  - Added automated coverage for version-floor warning logic, including edge cases for missing or malformed version ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->