### PR TITLE
feat(core): recognize export let props in stale-prop-derivation/prop-mutation

### DIFF
--- a/.changeset/legacy-prop-detection.md
+++ b/.changeset/legacy-prop-detection.md
@@ -1,0 +1,5 @@
+---
+'@svelte-vitals/core': minor
+---
+
+`correctness/stale-prop-derivation` and `correctness/prop-mutation` now also recognize legacy-mode (`export let`) props, not just runes-mode (`$props()`) ones — the same two bugs exist under Svelte's legacy reactivity, just with a different fix (`$:` instead of `$derived`; reassign-after-mutating instead of `$bindable`), and each rule's message is tailored to whichever mode the flagged component actually uses.

--- a/docs/src/content/docs/ja/rules/correctness/prop-mutation.md
+++ b/docs/src/content/docs/ja/rules/correctness/prop-mutation.md
@@ -42,3 +42,31 @@ Svelte の公式ドキュメントは明確に「`$bindable` でない限り pro
   let { user = $bindable() } = $props();
 </script>
 ```
+
+### legacy mode（`export let`）
+
+同じ種類のバグは legacy mode のコンポーネントにも、別の理由で存在します。Svelte の legacy なリアクティビティは代入ベースなので、`bind:` で渡された prop であっても、変異メソッド呼び出しだけでは更新がトリガーされません:
+
+```svelte
+<script>
+  export let items;
+
+  // 検出対象 — 変異自体は更新をトリガーしない
+  function addItem(item) {
+    items.push(item);
+  }
+</script>
+```
+
+リアクティビティを再トリガーするには、変異後に prop を再代入してください — これは回避策ではなく、Svelte 自身が公式に示しているパターンです:
+
+```svelte
+<script>
+  export let items;
+
+  function addItem(item) {
+    items.push(item);
+    items = items; // items が変わったことをコンパイラに伝える
+  }
+</script>
+```

--- a/docs/src/content/docs/ja/rules/correctness/stale-prop-derivation.md
+++ b/docs/src/content/docs/ja/rules/correctness/stale-prop-derivation.md
@@ -38,6 +38,29 @@ Svelte のガイダンスは、props を変わるものとして扱うよう求�
 
 関数本体が必要な計算には `$derived.by(() => ...)` を使ってください。一度きりのスナップショットが本当に必要な場合（非制御コンポーネントの初期値など）は、`let value = $state(initialValue)` が公式パターンで、これは検出対象になりません。
 
+### legacy mode（`export let`）
+
+同じバグは legacy mode のコンポーネントにも存在し、修正方法だけが異なります。Svelte は 1 つのファイル内で `export let` と `$props()` を混在できないため、このルールは両方の prop 記法を認識し、メッセージを出し分けます:
+
+```svelte
+<script>
+  export let type;
+
+  // 検出対象 — 初回レンダリングの値で固定される
+  let color = type === 'danger' ? 'red' : 'green';
+</script>
+```
+
+```svelte
+<script>
+  export let type;
+
+  $: color = type === 'danger' ? 'red' : 'green';
+</script>
+```
+
+代入の前に `$:`（リアクティブ文）を付けることが、legacy mode における `$derived` の等価物です — `type` が変わるたびに再実行されるようになり、初期化時の一度きりの評価ではなくなります。
+
 ## 制限事項
 
 関数呼び出しを含む式を対象外とする制限のため、メソッドを使った派生（`type.toUpperCase()`、`items.filter(...)`）は v1 では検出されません。これは精度を優先した意図的なトレードオフで、将来のバージョンで純粋な組み込みメソッドが allow-list に加わる可能性があります。また、親がその prop を実際に変えるかどうかは静的には分かりません。ただ、変えない場合でも `$derived` のコストはゼロで、変更が起きても正しく動くコードになります。`correctness/unmutated-state` との関係にも注意してください。prop から計算され、一度も書き込まれない `$state` の正しい修正は、`const` ではなく `$derived` です。

--- a/docs/src/content/docs/rules/correctness/prop-mutation.md
+++ b/docs/src/content/docs/rules/correctness/prop-mutation.md
@@ -42,3 +42,31 @@ Static analysis catches all three at review/CI time, before the code path has to
   let { user = $bindable() } = $props();
 </script>
 ```
+
+### Legacy mode (`export let`)
+
+The same class of bug exists in legacy-mode components, for a different reason — Svelte's legacy reactivity is assignment-based, so a mutating method call never triggers an update on its own, even when the prop is passed with `bind:`:
+
+```svelte
+<script>
+  export let items;
+
+  // flagged — the mutation itself doesn't trigger an update
+  function addItem(item) {
+    items.push(item);
+  }
+</script>
+```
+
+Reassign the prop after mutating it to re-trigger reactivity — this is Svelte's own documented pattern, not a workaround:
+
+```svelte
+<script>
+  export let items;
+
+  function addItem(item) {
+    items.push(item);
+    items = items; // tells the compiler `items` changed
+  }
+</script>
+```

--- a/docs/src/content/docs/rules/correctness/stale-prop-derivation.md
+++ b/docs/src/content/docs/rules/correctness/stale-prop-derivation.md
@@ -38,6 +38,29 @@ Svelte's guidance is to treat props as though they will change. The plain form e
 
 Use `$derived.by(() => ...)` when the computation needs a function body. If you genuinely want a one-time snapshot (an uncontrolled component's initial value), `let value = $state(initialValue)` is the documented pattern — and it is not flagged.
 
+### Legacy mode (`export let`)
+
+The same bug exists in legacy-mode components, with a different fix — Svelte can't mix `export let` and `$props()` in one file, so this rule recognizes both prop styles and tailors its message accordingly:
+
+```svelte
+<script>
+  export let type;
+
+  // flagged — freezes the first render's value
+  let color = type === 'danger' ? 'red' : 'green';
+</script>
+```
+
+```svelte
+<script>
+  export let type;
+
+  $: color = type === 'danger' ? 'red' : 'green';
+</script>
+```
+
+Prefixing the assignment with `$:` (a reactive statement) is the legacy-mode equivalent of `$derived` — it re-runs whenever `type` changes, instead of only once at initialization.
+
 ## Limitations
 
 The call-free restriction means method derivations (`type.toUpperCase()`, `items.filter(...)`) are not detected in v1 — a deliberate precision-first trade-off; a future version may allow-list pure built-ins. The rule cannot know whether the parent ever changes the prop; even when it doesn't, `$derived` costs nothing and keeps the code correct under change. Note the interplay with `correctness/unmutated-state`: for never-written `$state` computed from a prop, the right fix is `$derived`, not `const`.

--- a/packages/core/src/component-parse.ts
+++ b/packages/core/src/component-parse.ts
@@ -940,6 +940,25 @@ function collectPropNames(program: Node, includeBindable: boolean): Set<string> 
   return ambiguous || seen > 1 ? new Set() : names;
 }
 
+/**
+ * Local identifier names bound to a prop via legacy `export let foo` / `export let foo = default`
+ * (correctness/stale-prop-derivation, correctness/prop-mutation: the same two bugs exist under
+ * legacy reactivity, just with a different fix). Top-level only, plain identifiers only — a
+ * component can't mix legacy `export let` props with runes-mode `$props()` in the same file
+ * (a Svelte compile error), so this and `collectPropNames`'s result are never both non-empty
+ * for the same component.
+ */
+function collectLegacyPropNames(program: Node): Set<string> {
+  const names = new Set<string>();
+  for (const stmt of program.body ?? []) {
+    if (stmt?.type !== 'ExportNamedDeclaration' || stmt.declaration?.type !== 'VariableDeclaration') continue;
+    for (const d of stmt.declaration.declarations ?? []) {
+      if (d?.id?.type === 'Identifier') names.add(d.id.name);
+    }
+  }
+  return names;
+}
+
 /** Mutating array/Set/Map methods — a call to one of these on a non-bindable prop mutates it (correctness/prop-mutation). */
 const MUTATING_METHODS = new Set([
   'push',
@@ -1719,8 +1738,8 @@ export function parseComponentFacts(source: string, filename: string): ParsedFac
 
   const effects: EffectFact[] = [];
   const constableStates: { name: string; line: number }[] = [];
-  const mutatedProps: { name: string; line: number }[] = [];
-  const stalePropDerivations: { name: string; line: number }[] = [];
+  const mutatedProps: { name: string; line: number; legacy?: boolean }[] = [];
+  const stalePropDerivations: { name: string; line: number; legacy?: boolean }[] = [];
   const rawableStates: { name: string; line: number }[] = [];
   let propCount = 0;
   const program = ast.instance?.content;
@@ -1728,10 +1747,15 @@ export function parseComponentFacts(source: string, filename: string): ParsedFac
     collectImportSources(program, source, importSpans);
     collectNamespaceImports(program, source, namespaceImports);
     propCount = countProps(program);
-    const nonBindableProps = collectPropNames(program, false);
-    collectPropMutations(program, nonBindableProps, source, mutatedProps);
-    if (ast.fragment) collectPropMutations(ast.fragment, nonBindableProps, source, mutatedProps);
-    const allPropNames = collectPropNames(program, true);
+    // A component is either runes-mode ($props()) or legacy-mode (export let), never both —
+    // Svelte rejects mixing them — so at most one of these two sets is ever non-empty.
+    const legacyPropNames = collectLegacyPropNames(program);
+    const nonBindableProps = new Set([...collectPropNames(program, false), ...legacyPropNames]);
+    const rawMutations: { name: string; line: number }[] = [];
+    collectPropMutations(program, nonBindableProps, source, rawMutations);
+    if (ast.fragment) collectPropMutations(ast.fragment, nonBindableProps, source, rawMutations);
+    for (const m of rawMutations) mutatedProps.push(legacyPropNames.has(m.name) ? { ...m, legacy: true } : m);
+    const allPropNames = new Set([...collectPropNames(program, true), ...legacyPropNames]);
     if (allPropNames.size > 0) {
       const candidates = collectStalePropCandidates(program, allPropNames, source);
       if (candidates.length > 0) {
@@ -1744,8 +1768,14 @@ export function parseComponentFacts(source: string, filename: string): ParsedFac
         }
         const referenced = new Set<string>();
         if (ast.fragment) collectFragmentRefs(ast.fragment, candidateNames, referenced);
+        // `c.name` is the derived LOCAL variable (e.g. `color`), never the prop itself (e.g.
+        // `type`) — legacy-ness is a per-component property (export let vs $props(), never
+        // mixed), not per-candidate, so every candidate here shares the same flag.
+        const isLegacy = legacyPropNames.size > 0;
         for (const c of candidates) {
-          if (!disqualified.has(c.name) && referenced.has(c.name)) stalePropDerivations.push(c);
+          if (!disqualified.has(c.name) && referenced.has(c.name)) {
+            stalePropDerivations.push(isLegacy ? { ...c, legacy: true } : c);
+          }
         }
       }
     }

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -92,12 +92,13 @@ export interface ComponentFacts {
   namespaceImports: { source: string; line: number }[];
   /** `$state` declarations never written or escaped anywhere in the component — candidates for const (correctness/unmutated-state). */
   constableStates: { name: string; line: number }[];
-  /** Mutations of a non-`$bindable` prop from `$props()` — member writes, `delete`, or a mutating method call (correctness/prop-mutation). */
-  mutatedProps: { name: string; line: number }[];
-  /** Top-level const/let bindings computed from a $props() prop without $derived, never reassigned or escaped, and referenced (eagerly) in the template — frozen at init (correctness/stale-prop-derivation). */
+  /** Mutations of a non-`$bindable` prop from `$props()`, or a legacy `export let` prop — member writes, `delete`, or a mutating method call (correctness/prop-mutation). `legacy` distinguishes which mode the prop was declared in (absent/false: `$props()`), since the fix differs — optional so existing external constructors of `ComponentFacts` are unaffected. */
+  mutatedProps: { name: string; line: number; legacy?: boolean }[];
+  /** Top-level const/let bindings computed from a $props() or legacy `export let` prop without $derived (or `$:`), never reassigned or escaped, and referenced (eagerly) in the template — frozen at init (correctness/stale-prop-derivation). `legacy` distinguishes which mode the prop was declared in, since the fix differs — optional so existing external constructors of `ComponentFacts` are unaffected. */
   stalePropDerivations: {
     name: string;
     line: number;
+    legacy?: boolean;
   }[];
   /** Object/array-literal $state bindings reassigned at least once but never mutated, escaped, aliased, or item-edited — $state.raw candidates (performance/state-raw). */
   rawableStates: {

--- a/packages/core/src/rules/correctness/prop-mutation.ts
+++ b/packages/core/src/rules/correctness/prop-mutation.ts
@@ -1,18 +1,28 @@
 import { componentRule } from '../component-rule.js';
 
+/**
+ * correctness/prop-mutation — mutating a prop directly is a silent bug in both Svelte modes,
+ * for different reasons: in runes mode, a non-$bindable prop mutation doesn't propagate to the
+ * parent; in legacy mode (export let), Svelte's reactivity is assignment-based, so a mutating
+ * method call (`.push(...)`, etc.) doesn't trigger an update at all without a following
+ * reassignment. The two modes can't be mixed in one component, so a given finding is always
+ * exactly one or the other — see `legacy` on `ComponentFacts.mutatedProps` (component-parse.ts).
+ */
 export const correctnessPropMutation = componentRule({
   id: 'correctness/prop-mutation',
   title: 'Mutated non-bindable prop',
   category: 'correctness',
   label: 'Prop mutation',
   recommendation:
-    'Clone the value before mutating it, communicate the change via a callback prop, or declare the prop $bindable if the parent and child should share it.',
+    "Runes mode: clone the value before mutating it, communicate the change via a callback prop, or declare the prop $bindable if the parent and child should share it. Legacy mode: reassign the prop after mutating it (e.g. `list = list`) so Svelte's assignment-based reactivity picks up the change.",
   rationale:
-    "Svelte's docs say plainly: don't mutate props unless they are $bindable. A plain-object prop mutation is a silent no-op (the object isn't a state proxy); a reactive-state-proxy prop mutation works but triggers the ownership_invalid_mutation dev warning only when that code path actually runs. Neither is caught by the compiler, so this rule catches both statically.",
+    "Svelte's docs say plainly: don't mutate props unless they are $bindable. A plain-object prop mutation is a silent no-op (the object isn't a state proxy); a reactive-state-proxy prop mutation works but triggers the ownership_invalid_mutation dev warning only when that code path actually runs. In legacy mode, mutating methods like .push()/.splice() never trigger an update on their own — Svelte's reactivity there is based on assignments, not mutations. Neither case is caught by the compiler, so this rule catches both statically.",
   applies: (c) => c.mutatedProps.length > 0,
   bad: (c) =>
     c.mutatedProps.map((m) => ({
       line: m.line,
-      message: `Prop "${m.name}" is mutated, but it is not declared $bindable`
+      message: m.legacy
+        ? `Prop "${m.name}" is mutated directly — Svelte's legacy-mode reactivity is assignment-based, so this alone will not update the UI. Reassign it after mutating (e.g. "${m.name} = ${m.name}").`
+        : `Prop "${m.name}" is mutated, but it is not declared $bindable`
     }))
 });

--- a/packages/core/src/rules/correctness/stale-prop-derivation.ts
+++ b/packages/core/src/rules/correctness/stale-prop-derivation.ts
@@ -1,9 +1,11 @@
 import { componentRule } from '../component-rule.js';
 
 /**
- * correctness/stale-prop-derivation — a value computed from a prop without
- * $derived is evaluated once, at init, and silently stops tracking the parent.
- * Svelte's own guidance: treat props as though they will change.
+ * correctness/stale-prop-derivation — a value computed from a prop without $derived (runes
+ * mode) or $: (legacy mode) is evaluated once, at init, and silently stops tracking the
+ * parent. Svelte's own guidance: treat props as though they will change. The two modes can't
+ * be mixed in one component, so a given finding is always exactly one or the other — see
+ * `legacy` on `ComponentFacts.stalePropDerivations` (component-parse.ts).
  */
 export const correctnessStalePropDerivation = componentRule({
   id: 'correctness/stale-prop-derivation',
@@ -11,17 +13,20 @@ export const correctnessStalePropDerivation = componentRule({
   category: 'correctness',
   severity: 'warning',
   label: 'Props derived reactively',
-  recommendation: 'Wrap the computation in $derived(...), or $derived.by(() => ...) when it needs a function body.',
+  recommendation:
+    'Wrap the computation in $derived(...) (or $derived.by(() => ...) for a function body) in runes-mode components; prefix the assignment with $: in legacy-mode components.',
   rationale:
-    "Svelte's guidance is to treat props as though they will change: a plain `let color = type === 'danger' ? 'red' : 'green'` freezes the first render's value, so the UI silently stops tracking the parent when the prop changes. $derived keeps the computation live at no cost.",
+    "Svelte's guidance is to treat props as though they will change: a plain `let color = type === 'danger' ? 'red' : 'green'` freezes the first render's value, so the UI silently stops tracking the parent when the prop changes. In runes mode, $derived keeps the computation live at no cost; in legacy mode (export let props), a $: reactive statement does the same job.",
   fix: {
     description:
-      'Wrap the prop-derived computation in $derived(...) (or $derived.by(() => ...) for a function body), keeping the same expression.'
+      'Wrap the prop-derived computation in $derived(...) (or $derived.by(() => ...) for a function body) in runes mode, or prefix the assignment with $: in legacy mode, keeping the same expression.'
   },
   applies: (c) => c.stalePropDerivations.length > 0,
   bad: (c) =>
     c.stalePropDerivations.map((s) => ({
       line: s.line,
-      message: `"${s.name}" is computed from a prop once, at initialization — it will not update when the prop changes. Wrap it in $derived.`
+      message: s.legacy
+        ? `"${s.name}" is computed from a prop once, at initialization — it will not update when the prop changes. Prefix the assignment with $: to make it a reactive statement.`
+        : `"${s.name}" is computed from a prop once, at initialization — it will not update when the prop changes. Wrap it in $derived.`
     }))
 });

--- a/packages/core/test/component-parse.test.ts
+++ b/packages/core/test/component-parse.test.ts
@@ -445,6 +445,18 @@ describe('parseComponentFacts — mutated non-bindable props (correctness/prop-m
       names('<script>let { items } = $props(); if (true) { let items = []; items.push(1); } items.sort();</script>')
     ).toEqual(['items']);
   });
+
+  it('flags a mutating method call on a legacy `export let` prop, marked legacy', () => {
+    const facts = parseComponentFacts('<script>export let items; items.push(1);</script>', 'C.svelte');
+    expect(facts.mutatedProps).toEqual([{ name: 'items', line: 1, legacy: true }]);
+  });
+  it('flags a member-expression write on a legacy `export let` prop with a default value', () => {
+    const facts = parseComponentFacts('<script>export let user = {}; user.name = "x";</script>', 'C.svelte');
+    expect(facts.mutatedProps).toEqual([{ name: 'user', line: 1, legacy: true }]);
+  });
+  it('does not flag plain reassignment of a legacy prop (the sanctioned pattern for re-triggering reactivity)', () => {
+    expect(names('<script>export let items; items = items;</script>')).toEqual([]);
+  });
 });
 
 describe('parseComponentFacts — suppression directives (issue #92)', () => {

--- a/packages/core/test/correctness-rules.test.ts
+++ b/packages/core/test/correctness-rules.test.ts
@@ -182,6 +182,15 @@ describe('correctness/prop-mutation mutated non-bindable prop', () => {
     const rs = await correctnessPropMutation.check(ctx([comp({ mutatedProps: [] })]));
     expect(rs).toHaveLength(0);
   });
+  it('recommends reassignment (not $bindable) for a legacy-mode (export let) prop', async () => {
+    const rs = await correctnessPropMutation.check(
+      ctx([comp({ mutatedProps: [{ name: 'list', line: 4, legacy: true }] })])
+    );
+    expect(fails(rs)).toHaveLength(1);
+    expect(rs[0]!.message).toBe(
+      'Prop "list" is mutated directly — Svelte\'s legacy-mode reactivity is assignment-based, so this alone will not update the UI. Reassign it after mutating (e.g. "list = list").'
+    );
+  });
 });
 
 describe('correctness/orphan-effect orphan $effect', () => {

--- a/packages/core/test/stale-prop-derivation-parse.test.ts
+++ b/packages/core/test/stale-prop-derivation-parse.test.ts
@@ -58,6 +58,28 @@ describe('stalePropDerivations — flags', () => {
   });
 });
 
+describe('stalePropDerivations — legacy mode (export let)', () => {
+  it("flags the export-let equivalent of the official don't example, marked legacy", () => {
+    const src = script(`export let type;\nlet color = type === 'danger' ? 'red' : 'green';`, '<p class={color}>x</p>');
+    expect(spd(src)).toEqual([{ name: 'color', line: 3, legacy: true }]);
+  });
+
+  it('flags a bare alias derived from an export-let prop with a default value', () => {
+    const src = script(`export let type = 'ok';\nconst color = type;`);
+    expect(spd(src)).toEqual([{ name: 'color', line: 3, legacy: true }]);
+  });
+
+  it('does not flag a correct legacy reactive statement ($: is not a VariableDeclaration)', () => {
+    const src = script(`export let type;\n$: color = type === 'danger' ? 'red' : 'green';`);
+    expect(spd(src)).toEqual([]);
+  });
+
+  it('does not flag reassigned or escaped bindings derived from an export-let prop', () => {
+    const reassigned = script(`export let type;\nlet color = type;\ncolor = 'x';`);
+    expect(spd(reassigned)).toEqual([]);
+  });
+});
+
 describe('stalePropDerivations — exclusions', () => {
   it('does not flag $derived, $state capture, calls, new, or await', () => {
     for (const init of [

--- a/packages/core/test/stale-prop-derivation-parse.test.ts
+++ b/packages/core/test/stale-prop-derivation-parse.test.ts
@@ -77,6 +77,8 @@ describe('stalePropDerivations — legacy mode (export let)', () => {
   it('does not flag reassigned or escaped bindings derived from an export-let prop', () => {
     const reassigned = script(`export let type;\nlet color = type;\ncolor = 'x';`);
     expect(spd(reassigned)).toEqual([]);
+    const escaped = script(`export let type;\nconst color = type;\nregister(color);`);
+    expect(spd(escaped)).toEqual([]);
   });
 });
 

--- a/packages/core/test/stale-prop-derivation.test.ts
+++ b/packages/core/test/stale-prop-derivation.test.ts
@@ -31,6 +31,17 @@ describe('correctness/stale-prop-derivation', () => {
     expect(penalized[0]!.fix?.description).toBeTruthy();
   });
 
+  it('recommends $: (not $derived) for a legacy-mode (export let) prop', async () => {
+    const results = await correctnessStalePropDerivation.check(
+      ctx([comp('src/lib/Badge.svelte', [{ name: 'color', line: 3, legacy: true }])])
+    );
+    const penalized = results.filter((r) => r.detection.presence === 'none');
+    expect(penalized).toHaveLength(1);
+    expect(penalized[0]!.message).toBe(
+      '"color" is computed from a prop once, at initialization — it will not update when the prop changes. Prefix the assignment with $: to make it a reactive statement.'
+    );
+  });
+
   it('emits nothing without the fact', async () => {
     expect(await correctnessStalePropDerivation.check(ctx([comp('src/lib/Ok.svelte', [])]))).toEqual([]);
   });


### PR DESCRIPTION
## Why

`correctness/stale-prop-derivation` and `correctness/prop-mutation` only ever recognized `$props()`-destructured names as props. The exact same two bugs exist under Svelte's legacy (`export let`) reactivity — verified directly against Svelte's own docs (`svelte/legacy-let`, `svelte/legacy-reactive-assignments`, `svelte/legacy-export-let`):

- A plain `let color = computeFrom(prop)` (no `$:`) evaluates once, at init, and never re-runs when the prop changes — the legacy-mode equivalent of skipping `$derived`.
- "Because Svelte's legacy mode reactivity is based on _assignments_, using array methods like `.push()` and `.splice()` won't automatically trigger updates" — mutating a prop directly is a real bug there too, just for a different reason than the runes-mode `$bindable` contract.

Until now, neither rule could see this at all — not a false-positive risk (every rune-gated fact structurally can't fire on legacy code), but a silent false-negative gap. Given how recently Svelte 5 shipped, most real SvelteKit codebases are still mid-migration with a mix of runes and legacy components, so this isn't an edge case.

## What changed

- `component-parse.ts` gains `collectLegacyPropNames()` — top-level `export let name` / `export let name = default` — merged into the same name sets `$props()`-derived names already feed into `collectPropMutations`/`collectStalePropCandidates`.
- A component can't mix `export let` and `$props()` in the same file (a Svelte compile error), so "is this component legacy-mode" is unambiguous and applies uniformly to every finding in it — threaded through as an optional `legacy?: boolean` on each `ComponentFacts.mutatedProps`/`stalePropDerivations` entry (optional so existing test-constructed `ComponentFacts` objects elsewhere are unaffected).
- Both rules use `legacy` to recommend the fix that's actually correct for the mode in use, instead of always suggesting a runes-only construct:
  - `stale-prop-derivation`: `$derived(...)` (runes) vs. prefixing with `$:` (legacy).
  - `prop-mutation`: clone/callback-prop/`$bindable` (runes) vs. reassign after mutating, e.g. `list = list` (legacy).
- Docs (both rules, en+ja) gained a "Legacy mode (`export let`)" section with a runnable before/after example.

## Second half of a two-part change

[#286](https://github.com/oekazuma/svelte-vitals/pull/286) warns when the analyzed project itself is below the Svelte 5/SvelteKit 2 floor. This PR closes the actual detection gap that warning can't cover — a project that *is* on Svelte 5 can still have individual components still on legacy syntax mid-migration, and those were (and without this PR, still would be) silently invisible to both rules regardless of the project-level version.

## Test plan
- [x] `pnpm build` / `pnpm typecheck` / `pnpm test` / `pnpm lint` / `pnpm check:publish`
- [x] `pnpm --filter docs build`
- [x] New tests: `component-parse.test.ts` (mutation fact extraction with `export let`, plain-reassignment non-flag), `stale-prop-derivation-parse.test.ts` (derivation fact extraction with `export let`, correct `$:` reactive statement NOT flagged, reassignment/escape non-flags), `stale-prop-derivation.test.ts` + `correctness-rules.test.ts` (rule-level message text for the legacy case)
- [x] Full existing suite still passes unchanged — the `legacy` field is only ever added when actually legacy, so every pre-existing `toEqual([...])` assertion (which don't mention `legacy`) stays valid
- No `packages/action/dist` change needed (#278's post-merge self-heal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added detection of prop-mutation and stale-prop-derivation issues for legacy Svelte components using `export let`.
  - Diagnostics and suggested fixes now vary by mode, with legacy findings recommending reassignment and `$:` reactive statements.

- **Documentation**
  - Updated correctness rule docs for `prop-mutation` and `stale-prop-derivation` with new “legacy mode (`export let`)” sections and examples.

- **Bug Fixes**
  - Improved rule messaging so users get the correct remediation guidance for legacy vs runes mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->