### PR TITLE
chore: auto-merge non-major Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,13 @@
     "enabled": true
   },
   "rangeStrategy": "bump",
+  "platformAutomerge": true,
   "packageRules": [
+    {
+      "description": "Auto-merge everything except major updates (those need review) — CI still has to pass first. The Renovate app is on main's ruleset bypass list specifically so these can merge without a human review.",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
     {
       "description": "Published packages' engines.node is a public compatibility floor for consumers, not a dev-toolchain pin — never auto-bump it.",
       "matchDepTypes": ["engines"],


### PR DESCRIPTION
## Summary
- Auto-merge Renovate PRs except major version bumps (those still need review).
- CI (lint, check, docs, test matrix) still gates every merge — no bypass for Renovate there.
- Companion change: switching `main`'s branch protection from classic rules to two Rulesets (one letting the Renovate app bypass the review requirement, a separate one enforcing required status checks with no bypass for Renovate) — same pattern already verified working in `svelte-vitals-action`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated merging is now enabled for minor, patch, pinned, and digest dependency updates after successful CI checks.
  * Major dependency updates continue to require manual review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->