### PR TITLE
fix(core): treat {@const} and {let}/{const} declaration tags as shadowing bindings

### DIFF
--- a/.changeset/const-tag-scope-shadow.md
+++ b/.changeset/const-tag-scope-shadow.md
@@ -1,0 +1,8 @@
+---
+'@svelte-vitals/core': patch
+'svelte-vitals': patch
+'@svelte-vitals/vite': patch
+'@svelte-vitals/mcp': patch
+---
+
+Scope resolution now treats `{@const ...}` declarations as shadowing bindings for their enclosing fragment, so a write to an `{@const}` alias is no longer misattributed to a same-named top-level `$state` (fewer false positives across the component-analysis rules).

--- a/.changeset/const-tag-scope-shadow.md
+++ b/.changeset/const-tag-scope-shadow.md
@@ -5,4 +5,4 @@
 '@svelte-vitals/mcp': patch
 ---
 
-Scope resolution now treats `{@const ...}` declarations as shadowing bindings for their enclosing fragment, so a write to an `{@const}` alias is no longer misattributed to a same-named top-level `$state` (fewer false positives across the component-analysis rules).
+Scope resolution now treats template declaration tags — `{@const ...}` and the newer `{let ...}` / `{const ...}` — as shadowing bindings for their enclosing fragment, so a write to such a template-local alias is no longer misattributed to a same-named top-level `$state` (fewer false positives across the component-analysis rules).

--- a/packages/core/src/component-parse.ts
+++ b/packages/core/src/component-parse.ts
@@ -308,10 +308,11 @@ export function rootObjectName(node: Node): string | undefined {
  * declaration names, a
  * `for`/`for-of`/`for-in` loop's declared variable, a Svelte `{#each ... as x, i}` block's
  * context AND index binding, a `{#snippet}` block's parameters, an `{#await}` block's
- * `then`/`catch` value/error bindings, and a fragment's own `{@const ...}` declarations
- * (attributed to the enclosing Fragment, shadowing the whole fragment like a block's
- * `let` — `{@const}` bindings are read-only, so a "write" to one was always a
- * misattribution). Used by `walkScoped` so a write/mutation detector
+ * `then`/`catch` value/error bindings, and a fragment's own `{@const ...}` /
+ * `{let ...}` / `{const ...}` declaration tags (attributed to the enclosing Fragment,
+ * shadowing the whole fragment like a block's `let` — a write to one of these
+ * template-locals, possible for `{let}`, is still not a write to the outer binding).
+ * Used by `walkScoped` so a write/mutation detector
  * doesn't misattribute a write to one of these locals as a write to an outer `$state`/prop
  * of the same name (issue #140 — originally a deliberately partial mitigation that left
  * `{#snippet}`/`{:then}`/`{:catch}` bindings untracked; now covered too. A block's own
@@ -355,7 +356,7 @@ export function scopeIntroducedNames(node: Node): Set<string> {
     if (node.error) addBoundNames(node.error, introduced);
   } else if (node.type === 'Fragment') {
     for (const child of node.nodes ?? []) {
-      if (child?.type === 'ConstTag') {
+      if (child?.type === 'ConstTag' || child?.type === 'DeclarationTag') {
         for (const d of child.declaration?.declarations ?? []) addBoundNames(d.id, introduced);
       }
     }

--- a/packages/core/src/component-parse.ts
+++ b/packages/core/src/component-parse.ts
@@ -307,8 +307,11 @@ export function rootObjectName(node: Node): string | undefined {
  * `var` invisible to sibling blocks; accepted imprecision) plus its own `function`/`class`
  * declaration names, a
  * `for`/`for-of`/`for-in` loop's declared variable, a Svelte `{#each ... as x, i}` block's
- * context AND index binding, a `{#snippet}` block's parameters, and an `{#await}` block's
- * `then`/`catch` value/error bindings. Used by `walkScoped` so a write/mutation detector
+ * context AND index binding, a `{#snippet}` block's parameters, an `{#await}` block's
+ * `then`/`catch` value/error bindings, and a fragment's own `{@const ...}` declarations
+ * (attributed to the enclosing Fragment, shadowing the whole fragment like a block's
+ * `let` — `{@const}` bindings are read-only, so a "write" to one was always a
+ * misattribution). Used by `walkScoped` so a write/mutation detector
  * doesn't misattribute a write to one of these locals as a write to an outer `$state`/prop
  * of the same name (issue #140 — originally a deliberately partial mitigation that left
  * `{#snippet}`/`{:then}`/`{:catch}` bindings untracked; now covered too. A block's own
@@ -350,6 +353,12 @@ export function scopeIntroducedNames(node: Node): Set<string> {
   } else if (node.type === 'AwaitBlock') {
     if (node.value) addBoundNames(node.value, introduced);
     if (node.error) addBoundNames(node.error, introduced);
+  } else if (node.type === 'Fragment') {
+    for (const child of node.nodes ?? []) {
+      if (child?.type === 'ConstTag') {
+        for (const d of child.declaration?.declarations ?? []) addBoundNames(d.id, introduced);
+      }
+    }
   }
   return introduced;
 }

--- a/packages/core/test/component-parse.test.ts
+++ b/packages/core/test/component-parse.test.ts
@@ -970,4 +970,9 @@ describe('constableStates — {@const} shadowing', () => {
     const src = `<script>\nlet obj = $state({});\n</script>\n{#each list as g}{@const obj = g.o}<button onclick={() => {\n  obj.x = 1;\n}}>x</button>{/each}`;
     expect(constable(src)).toEqual([{ name: 'obj', line: 2 }]);
   });
+
+  it('does not attribute a reassignment of a {let} declaration tag to a same-named untouched $state', () => {
+    const src = `<script>\nlet obj = $state({});\n</script>\n{#each list as g}{let obj = g.o}<button onclick={() => {\n  obj = g.p;\n}}>x</button>{/each}`;
+    expect(constable(src)).toEqual([{ name: 'obj', line: 2 }]);
+  });
 });

--- a/packages/core/test/component-parse.test.ts
+++ b/packages/core/test/component-parse.test.ts
@@ -962,3 +962,12 @@ describe('constableStates — directive escapes', () => {
     expect(constable(src)).toEqual([{ name: 'obj', line: 2 }]);
   });
 });
+
+describe('constableStates — {@const} shadowing', () => {
+  const constable = (src: string) => parseComponentFacts(src, 'A.svelte').constableStates;
+
+  it('does not attribute a write to an {@const} alias to a same-named untouched $state', () => {
+    const src = `<script>\nlet obj = $state({});\n</script>\n{#each list as g}{@const obj = g.o}<button onclick={() => {\n  obj.x = 1;\n}}>x</button>{/each}`;
+    expect(constable(src)).toEqual([{ name: 'obj', line: 2 }]);
+  });
+});

--- a/packages/core/test/nonreactive-builtin-state-parse.test.ts
+++ b/packages/core/test/nonreactive-builtin-state-parse.test.ts
@@ -107,6 +107,19 @@ describe('nonreactiveBuiltinStates — exclusions', () => {
     expect(nrb(src)).toEqual([]);
   });
 
+  it('does not count mutations of {let}/{const} declaration-tag aliases either', () => {
+    const letTag = script(
+      `let tags = $state(new Set());`,
+      `{#each groups as g}{let tags = g.tags}<button onclick={() => tags.add("x")}>x</button>{/each}`
+    );
+    expect(nrb(letTag)).toEqual([]);
+    const constTag = script(
+      `let tags = $state(new Set());`,
+      `{#each groups as g}{const tags = g.tags}<button onclick={() => tags.add("x")}>x</button>{/each}`
+    );
+    expect(nrb(constTag)).toEqual([]);
+  });
+
   it('resolves function-scoped var and nested declaration shadows', () => {
     const varShadow = script(`let m = $state(new Map());\nfunction f() {\n  var m = new Map();\n  m.set("k", 1);\n}`);
     expect(nrb(varShadow)).toEqual([]);

--- a/packages/core/test/nonreactive-builtin-state-parse.test.ts
+++ b/packages/core/test/nonreactive-builtin-state-parse.test.ts
@@ -99,6 +99,14 @@ describe('nonreactiveBuiltinStates — exclusions', () => {
     expect(nrb(url)).toEqual([{ name: 'u', type: 'URL', line: 2 }]);
   });
 
+  it('does not count a mutation of an {@const} alias against a same-named outer $state', () => {
+    const src = script(
+      `let tags = $state(new Set());`,
+      `{#each groups as g}{@const tags = g.tags}<button onclick={() => tags.add("x")}>x</button>{/each}`
+    );
+    expect(nrb(src)).toEqual([]);
+  });
+
   it('resolves function-scoped var and nested declaration shadows', () => {
     const varShadow = script(`let m = $state(new Map());\nfunction f() {\n  var m = new Map();\n  m.set("k", 1);\n}`);
     expect(nrb(varShadow)).toEqual([]);


### PR DESCRIPTION
## Summary

Follow-up flagged by the final review of #285: `scopeIntroducedNames` did not treat template declaration tags as scope-introducing, so a write to a template-local alias was misattributed to a same-named top-level `$state` binding. Covers **`{@const ...}`** (`ConstTag`) and the newer **`{let ...}` / `{const ...}` declaration tags** (`DeclarationTag`, svelte.dev/docs/svelte/declaration-tags — AST shape verified against svelte 5.56). Verified false positive before this fix:

```svelte
<script>
  let tags = $state(new Set());
</script>
{#each groups as g}
  {@const tags = g.tags}  <!-- same for {let tags = g.tags} / {const tags = g.tags} -->
  <button onclick={() => tags.add('x')}>x</button>
{/each}
```

`correctness/nonreactive-builtin-state` flagged the outer `tags`, and the same misattribution suppressed `correctness/unmutated-state`'s `constableStates`.

## Change

One addition to the shared `scopeIntroducedNames` helper: a `Fragment`'s own `ConstTag`/`DeclarationTag` declarations now shadow the whole fragment (same over-conservative whole-scope model as a block's `let`; both node types carry the same `declaration.declarations` shape, so one branch covers all three tags). A write to one of these template-locals — possible for `{let}` — is still not a write to the outer binding, so the fix is strictly precision-improving for every consumer of the helper (all component-analysis collectors) at once.

## Testing

- Four regression tests (nonreactive-builtin-state facts for `{@const}`/`{let}`/`{const}` + constableStates for `{@const}` mutation and `{let}` reassignment), each verified to fail without the fix and pass with it
- core 668 and cli 703 tests green; tsc, oxlint, oxfmt clean
- Changeset: patch × core / cli / vite / mcp

🤖 Generated with [Claude Code](https://claude.com/claude-code)
