### PR TITLE
fix(docs): remove white gap in homepage demo terminal (light mode)

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -58,7 +58,9 @@ No build, no browser — just read the source to see your SvelteKit app's health
     color: #8b8fa3;
   }
   .demo-terminal img {
+    display: block;
     width: 100%;
+    margin: 0;
   }
   @media (max-width: 50rem) {
     .demo-terminal {

--- a/docs/src/content/docs/ja/index.mdx
+++ b/docs/src/content/docs/ja/index.mdx
@@ -58,7 +58,9 @@ description: SvelteKit 向けの静的コードヘルスチェッカー。SEO、
     color: #8b8fa3;
   }
   .demo-terminal img {
+    display: block;
     width: 100%;
+    margin: 0;
   }
   @media (max-width: 50rem) {
     .demo-terminal {


### PR DESCRIPTION
## Summary
Fixes a visual bug on the deployed homepage, reported after merging #296: in light mode, the demo terminal's dark title bar and dark GIF content had a jarring white gap between them.

**Root cause**: Blume's global stylesheet applies a default top/bottom margin to `<img>` elements. `.demo-terminal` has `overflow: hidden` and a transparent background, so that margin pushed the demo GIF down, exposing the transparent container's background (= page background) between the title bar and the image — invisible in dark mode (page background is also dark) but a visible white band in light mode.

**Fix**: reset `margin: 0` and set `display: block` explicitly on `.demo-terminal img` in both `index.mdx` and `ja/index.mdx`.

## Test plan
- [x] Reproduced on the live production site by toggling to light mode via `data-theme="light"`
- [x] Verified locally with `blume dev` that the gap is gone after the fix, in both light and dark mode
- [x] `pnpm lint` passes
- [x] Confirmed the dev-dashboard guide's `.theme-img` screenshots are unaffected (different container, no regression there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved terminal demo image rendering on the documentation homepage.
  * Removed unwanted spacing and ensured images display consistently across English and Japanese pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->