### PR TITLE
fix(docs): stop showing both demo terminal images at once

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -58,7 +58,6 @@ No build, no browser — just read the source to see your SvelteKit app's health
     color: #8b8fa3;
   }
   .demo-terminal img {
-    display: block;
     width: 100%;
     margin: 0;
   }

--- a/docs/src/content/docs/ja/index.mdx
+++ b/docs/src/content/docs/ja/index.mdx
@@ -58,7 +58,6 @@ description: SvelteKit 向けの静的コードヘルスチェッカー。SEO、
     color: #8b8fa3;
   }
   .demo-terminal img {
-    display: block;
     width: 100%;
     margin: 0;
   }


### PR DESCRIPTION
## Summary
Regression from #303 (currently live in production): the homepage demo terminal shows **both** the animated GIF and the static poster image stacked on top of each other.

**Root cause**: #303 added `display: block` to the shared `.demo-terminal img` selector to fix a white-gap bug. That selector's specificity (`.demo-terminal img` = 0-1-1) is higher than `.demo-gif-static`'s (0-1-0), so it silently overrode `display: none` on the static poster — both images render simultaneously instead of just the animated one.

**Fix**: drop `display: block` from the shared rule. `.demo-gif-animated` already sets `display: block` on its own (same specificity as `.demo-gif-static`, but they're mutually exclusive classes on different elements, so no conflict), and `.demo-gif-static`'s `display: none` is no longer overridden.

## Test plan
- [x] Verified via `blume dev` in both light and dark mode: only one image renders in each case, no white gap regression
- [x] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted demo terminal image styling on the documentation pages.
  * Removed the block display setting while preserving existing sizing and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->