### PR TITLE
docs: turn off the "Was this page helpful?" widget

### DIFF
--- a/docs/blume.config.ts
+++ b/docs/blume.config.ts
@@ -11,6 +11,10 @@ export default defineConfig({
     image: { light: '/logo-mark.svg', dark: '/logo-mark.svg', alt: 'svelte-vitals' }
   },
   github: { owner: 'oekazuma', repo: 'svelte-vitals', dir: 'docs' },
+  // Blume shows the "Was this page helpful?" widget by default, but its vote goes to
+  // whichever provider `analytics` configures — and we configure none, so a click was
+  // discarded while still thanking the reader for it.
+  feedback: false,
   i18n: {
     defaultLocale: 'en',
     locales: [


### PR DESCRIPTION
Sets `feedback: false` in `docs/blume.config.ts`, removing the per-page "Was this page helpful? Yes / No" widget.

Blume enables the widget by default. Clicking a button calls its `track()` helper, which fans the event out to whichever analytics provider `analytics` configures — Vercel Web Analytics, PostHog, GA4/GTM, or Plausible — and always dispatches a `blume:track` CustomEvent as a universal hook.

This site configures no `analytics`, and the built HTML contains none of those scripts. So every vote no-opped through all four providers and fired a CustomEvent nothing listens for. The reader saw "Thanks for your feedback!" for a vote that was discarded.

Wiring up analytics is the other way to resolve this, but there is nowhere to send the votes and no one to read them, so the honest fix is to stop asking.

## Verification

- `pnpm --filter docs check` — clean
- `pnpm --filter docs build` — zero warnings; `data-blume-page-feedback` no longer appears in any built page (checked `/`, `/rules`, `/ja/rules`, `/guides/cli`, `/ja/guides/mcp`)
- `pnpm lint`

Docs config only — no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the “Was this page helpful?” feedback widget from documentation pages.
  * Added configuration comments clarifying the feedback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->