### PR TITLE
test(cli): guard analysis speed in CI with a deterministic I/O budget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,13 @@ install`/`ci upgrade` bundle into scaffolded workflows.
   - Other prefixes in use: `feat(vite):`, `docs:`, `chore:`.
 - **Adding a rule**: create `packages/core/src/rules/<dir>/<slug>.ts` (the Performance directory is `perf/`, not `performance/`), then register it in **four** places: `packages/core/src/rules/index.ts` (the import, the `allRules` array, and the re-export block) _and_ `packages/core/src/index.ts`'s own `export { ... } from './rules/index.js'` list, which duplicates the same names. TypeScript won't catch a missed spot in the fourth place (it's a plain re-export list), so grep for the previous rule's id after adding a new one. Add rule docs under `docs/src/content/docs/rules/<id>.md` (en) and `docs/src/content/docs/ja/rules/<id>.md` (ja) — `packages/cli/test/docs-links.test.ts` fails the build if either is missing. (`<id>` already includes the category, e.g. `docs/src/content/docs/rules/performance/heavy-import.md` — note the docs tree uses `performance/` here, not the source tree's `perf/`.) Then regenerate the index pages with `pnpm --filter svelte-vitals run gen:rules-index && pnpm format` and commit them; `packages/cli/test/rules-index.test.mjs` fails the build if they are stale. **Never hard-code rule counts or ID ranges in READMEs/guides** (e.g. "CORRECT001–009" or "the two Performance rules") — such text rots on every new rule; refer to rule _categories_ instead. Rule IDs in guides are fine only as examples or sample output.
 - **Tests**: vitest, per-package `test/` directories; fixtures live under `test/fixtures/`.
+- **I/O budget**: `packages/cli/test/io-budget.test.ts` holds the collection phase
+  (`packages/cli/src/collect-all.ts`) to a fixed number of `Runtime` calls. This is how
+  analysis speed is defended in CI — wall-clock timings are far too noisy on shared
+  runners to gate on. Adding a collector or a glob means checking that test. Lowering a
+  budget is welcome; raising one is a design decision needing a recorded reason, not a
+  number edit. The two regressions counts cannot catch — a widened analysis, and lost
+  parallelism — are measured manually with `pnpm bench` (never in CI).
 
 ## Design docs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ install`/`ci upgrade` bundle into scaffolded workflows.
   analysis speed is defended in CI — wall-clock timings are far too noisy on shared
   runners to gate on. Adding a collector or a glob means checking that test. Lowering a
   budget is welcome; raising one is a design decision needing a recorded reason, not a
-  number edit. The two regressions counts cannot catch — a widened analysis, and lost
+  number edit. The two regressions that counts cannot catch — a widened analysis, and lost
   parallelism — are measured manually with `pnpm bench` (never in CI).
 
 ## Design docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ pnpm typecheck      # tsc --noEmit
 pnpm lint           # oxlint + oxfmt --check
 pnpm format         # oxfmt --write
 pnpm check:publish  # publint + attw (--profile esm-only)
+pnpm bench          # manual timing benchmark, never run in CI
 ```
 
 ## Packages

--- a/docs/superpowers/plans/2026-07-29-io-budget-ci.md
+++ b/docs/superpowers/plans/2026-07-29-io-budget-ci.md
@@ -47,11 +47,9 @@ Expected: PASS. If it does not pass, stop — the tree is not clean.
 Create `packages/cli/src/route-matcher.ts` with the function moved verbatim from `index.ts`:
 
 ```ts
-/**
- * Match a route path against a glob (`blog/*`, `**\/admin`, `static/**`). An
- * undefined glob matches everything. Lives in its own module so `collect-all.ts`
- * can use it without importing `index.ts` (which imports `collect-all.ts`).
- */
+// Match a route path against a glob (`blog/*`, `**/admin`, `static/**`). An
+// undefined glob matches everything. Lives in its own module so `collect-all.ts`
+// can use it without importing `index.ts` (which imports `collect-all.ts`).
 export function routeMatcher(glob: string | undefined): (route: string) => boolean {
   if (!glob) return () => true;
   const body = glob
@@ -68,7 +66,7 @@ export function routeMatcher(glob: string | undefined): (route: string) => boole
 }
 ```
 
-Note: the `**\/admin` in the doc comment above is escaped only to survive this markdown code fence — write it as `**/admin` in the actual file.
+Note: the comment above uses `//` lines rather than a `/** */` block on purpose. A glob containing `**/` inside a block comment would close it early at the `*/` and break the file. The same rule applies everywhere in this plan.
 
 - [ ] **Step 3: Remove the old copy from `index.ts` and re-export**
 

--- a/docs/superpowers/plans/2026-07-29-io-budget-ci.md
+++ b/docs/superpowers/plans/2026-07-29-io-budget-ci.md
@@ -10,6 +10,13 @@
 
 **Spec:** `docs/superpowers/specs/2026-07-29-io-budget-ci-design.md`
 
+> **Executed 2026-07-29; superseded in one respect.** This file is the historical
+> plan, kept as written. While it was in review, `main` grew a fifth collector,
+> `collectSourceFiles`, so the shipped `collectAll` and the route-filtered invariant
+> cover a source-file inventory the code samples below do not mention. Read
+> `packages/cli/src/collect-all.ts` and `packages/cli/test/io-budget.test.ts` for the
+> current contract; the spec above reflects it too.
+
 ## Global Constraints
 
 - **Public API must not change.** `collect-all.ts` and `route-matcher.ts` are NOT re-exported from `packages/cli/src/index.ts` except for `routeMatcher`, which is already public and must stay exported from `index.ts`. Tests import internal modules by path, matching `packages/cli/test/parse-cache.test.ts`.

--- a/docs/superpowers/plans/2026-07-29-io-budget-ci.md
+++ b/docs/superpowers/plans/2026-07-29-io-budget-ci.md
@@ -1,0 +1,756 @@
+# I/O Budget CI Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Defend svelte-vitals' analysis speed with a CI gate that counts `Runtime` calls instead of wall-clock time, so it can never be flaky.
+
+**Architecture:** Extract the analysis I/O phase into `packages/cli/src/collect-all.ts`, then hold that real function to a fixed I/O budget from `packages/cli/test/io-budget.test.ts` using a counting `Runtime` wrapper over the existing in-memory `Runtime`. No new CI job — the test rides the existing `test` job. The existing timing benchmark is promoted from throwaway script to documented manual tool.
+
+**Tech Stack:** TypeScript, vitest, pnpm workspaces, oxlint/oxfmt.
+
+**Spec:** `docs/superpowers/specs/2026-07-29-io-budget-ci-design.md`
+
+## Global Constraints
+
+- **Public API must not change.** `collect-all.ts` and `route-matcher.ts` are NOT re-exported from `packages/cli/src/index.ts` except for `routeMatcher`, which is already public and must stay exported from `index.ts`. Tests import internal modules by path, matching `packages/cli/test/parse-cache.test.ts`.
+- **No `@svelte-vitals/core` source changes.** Core purity rule (no `node:` imports, no I/O) is untouched because we do not modify `packages/core/src` at all.
+- **No changeset.** This is an internal-only change; `AGENTS.md` requires changesets only for user-facing changes.
+- **Budget constant is `MAX_READS_PER_FILE = 2`** — the measured status quo, not an ideal. Lowering it is welcome; raising it needs a recorded reason.
+- **Conventional commits, scoped by package**: `refactor(cli):`, `test(cli):`, `chore(vite):`, `docs:`.
+- **Verify before claiming done**: `pnpm lint`, `pnpm typecheck`, `pnpm test` must all pass. Run `pnpm format` before committing (oxfmt).
+- `tsconfig.base.json` sets `strict: true` but NOT `exactOptionalPropertyTypes`, so passing a possibly-`undefined` value to an optional property is allowed.
+
+---
+
+### Task 1: Move `routeMatcher` into its own module
+
+`collectAll` needs `routeMatcher`, but `routeMatcher` currently lives in `index.ts`, which will import `collect-all.ts`. Moving it first avoids a circular import. This is a pure move: no behaviour changes.
+
+**Files:**
+
+- Create: `packages/cli/src/route-matcher.ts`
+- Modify: `packages/cli/src/index.ts:127-140` (remove the function), and add a re-export
+- Test: `packages/cli/test/route-matcher.test.ts` (exists already; imports from `../src/index.js` and must keep passing unchanged)
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks.
+- Produces: `routeMatcher(glob: string | undefined): (route: string) => boolean`, importable from `./route-matcher.js`. Task 2 imports it.
+
+- [ ] **Step 1: Confirm the existing test passes before touching anything**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/route-matcher.test.ts`
+Expected: PASS. If it does not pass, stop — the tree is not clean.
+
+- [ ] **Step 2: Create the new module**
+
+Create `packages/cli/src/route-matcher.ts` with the function moved verbatim from `index.ts`:
+
+```ts
+/**
+ * Match a route path against a glob (`blog/*`, `**\/admin`, `static/**`). An
+ * undefined glob matches everything. Lives in its own module so `collect-all.ts`
+ * can use it without importing `index.ts` (which imports `collect-all.ts`).
+ */
+export function routeMatcher(glob: string | undefined): (route: string) => boolean {
+  if (!glob) return () => true;
+  const body = glob
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*\*/g, ' ') // globstar placeholder
+    .replace(/\*/g, '[^/]*') // single-segment wildcard (placeholder untouched)
+    .replace(/\/ $/g, '(?:/.*)?') // trailing /** -> optional subtree
+    .replace(/^ \//g, '(?:.*/)?') // leading **/ -> optional prefix
+    .replace(/ \//g, '(?:.*/)?') // internal **/ -> optional prefix
+    .replace(/\/ /g, '(?:/.*)?') // internal /** -> optional subtree
+    .replace(/ /g, '.*'); // bare ** -> .*
+  const re = new RegExp(`^${body}$`);
+  return (route) => re.test(route.replace(/^\//, ''));
+}
+```
+
+Note: the `**\/admin` in the doc comment above is escaped only to survive this markdown code fence — write it as `**/admin` in the actual file.
+
+- [ ] **Step 3: Remove the old copy from `index.ts` and re-export**
+
+Delete lines 127-140 of `packages/cli/src/index.ts` (the whole `export function routeMatcher` block). Add this to the re-export block near the bottom of the file, next to the existing `export { ProjectError } from './providers/source/project.js';` (line 544):
+
+```ts
+export { routeMatcher } from './route-matcher.js';
+```
+
+The public API is unchanged: `routeMatcher` is still exported from `index.ts`.
+
+- [ ] **Step 4: Run the test suite**
+
+Run: `pnpm --filter svelte-vitals exec vitest run`
+Expected: PASS, same test count as before the move.
+
+- [ ] **Step 5: Typecheck and lint**
+
+Run: `pnpm typecheck && pnpm lint`
+Expected: both pass. If lint reports formatting, run `pnpm format` and re-run.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/cli/src/route-matcher.ts packages/cli/src/index.ts
+git commit -m "refactor(cli): move routeMatcher into its own module"
+```
+
+---
+
+### Task 2: Extract the collection phase into `collectAll`
+
+**Files:**
+
+- Create: `packages/cli/src/collect-all.ts`
+- Modify: `packages/cli/src/index.ts` (imports at lines 20/28/30/31, and `analyzeProject` body at lines 206-217)
+- Test: `packages/cli/test/collect-all.test.ts` (new)
+
+**Interfaces:**
+
+- Consumes: `routeMatcher` from `./route-matcher.js` (Task 1).
+- Produces:
+  - `interface CollectedFacts { heads: ResolvedHead[]; images: ResolvedImages[]; headings: ResolvedHeadings[]; project: Project; components: ComponentFacts[]; kitModules: KitModuleFacts[] }`
+  - `interface CollectAllOptions { route?: string; parseCache?: ParseCache }`
+  - `collectAll(rt: Runtime, cwd: string, config: Config, opts?: CollectAllOptions): Promise<CollectedFacts>`
+
+  Tasks 4 and 5 call `collectAll` and rely on these exact names.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/cli/test/collect-all.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { defaultConfig } from '@svelte-vitals/core';
+import { collectAll } from '../src/collect-all.js';
+import { createMemoryRuntime } from './helpers/memory-runtime.js';
+
+const PROJECT = {
+  'src/app.html': `<!doctype html><html lang="en"><body></body></html>`,
+  'src/routes/+layout.svelte': `<script>let { children } = $props();</script>{@render children()}`,
+  'src/routes/a/+page.svelte': `<svelte:head><title>A</title></svelte:head><h1>A</h1>`,
+  'src/routes/b/+page.svelte': `<svelte:head><title>B</title></svelte:head><h1>B</h1>`,
+  'src/lib/Card.svelte': `<script>let { title = '' } = $props();</script><h3>{title}</h3>`
+};
+
+describe('collectAll', () => {
+  it('returns facts for every route plus project-wide and component facts', async () => {
+    const rt = createMemoryRuntime(PROJECT);
+
+    const facts = await collectAll(rt, '', defaultConfig);
+
+    expect(facts.heads.map((h) => h.route).sort()).toEqual(['/a', '/b']);
+    expect(facts.images.map((i) => i.route).sort()).toEqual(['/a', '/b']);
+    expect(facts.headings.map((h) => h.route).sort()).toEqual(['/a', '/b']);
+    expect(facts.project.htmlLang).toEqual({ presence: 'own', value: 'static' });
+    // Every .svelte under src/ is scanned, routes and $lib alike.
+    expect(facts.components.map((c) => c.file).sort()).toEqual([
+      'src/lib/Card.svelte',
+      'src/routes/+layout.svelte',
+      'src/routes/a/+page.svelte',
+      'src/routes/b/+page.svelte'
+    ]);
+    expect(facts.kitModules).toEqual([]);
+  });
+
+  it('filters route-scoped facts and skips component/kit-module scanning when route is set', async () => {
+    const rt = createMemoryRuntime(PROJECT);
+
+    const facts = await collectAll(rt, '', defaultConfig, { route: 'a' });
+
+    expect(facts.heads.map((h) => h.route)).toEqual(['/a']);
+    expect(facts.images.map((i) => i.route)).toEqual(['/a']);
+    expect(facts.headings.map((h) => h.route)).toEqual(['/a']);
+    // File-scoped facts have no route attribution, so a route-filtered run skips them.
+    expect(facts.components).toEqual([]);
+    expect(facts.kitModules).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/collect-all.test.ts`
+Expected: FAIL — `Failed to resolve import "../src/collect-all.js"`.
+
+- [ ] **Step 3: Create `collect-all.ts`**
+
+Create `packages/cli/src/collect-all.ts`. The body is moved verbatim from `analyzeProject` (`index.ts:206-217`), preserving statement order exactly so this stays a pure move:
+
+```ts
+import {
+  collectKitModuleFacts,
+  type ComponentFacts,
+  type Config,
+  type KitModuleFacts,
+  type Project,
+  type ResolvedHead,
+  type ResolvedHeadings,
+  type ResolvedImages,
+  type Runtime
+} from '@svelte-vitals/core';
+import { collectComponentFacts } from './providers/source/components.js';
+import { collectProjectFacts } from './providers/source/project.js';
+import type { ParseCache } from './providers/source/resolve.js';
+import { collectRoutes } from './providers/source/routes.js';
+import { routeMatcher } from './route-matcher.js';
+
+/** Everything the rule engine needs about a project, gathered through the Runtime. */
+export interface CollectedFacts {
+  heads: ResolvedHead[];
+  images: ResolvedImages[];
+  headings: ResolvedHeadings[];
+  project: Project;
+  components: ComponentFacts[];
+  kitModules: KitModuleFacts[];
+}
+
+export interface CollectAllOptions {
+  /** Restrict route-scoped facts to routes matching this glob. */
+  route?: string;
+  /** Reuse a parse cache across calls (the vite dev dashboard passes a long-lived one). */
+  parseCache?: ParseCache;
+}
+
+/**
+ * The whole I/O phase of an analysis: every Runtime call made to gather rule input
+ * goes through here. Validation (`detectProject`, `checkVersionFloor`) deliberately
+ * stays in `analyzeProject` — it has its own error semantics (ProjectError → exit 2)
+ * and is per-run, not per-file.
+ *
+ * Kept as one function so `test/io-budget.test.ts` can hold the REAL pipeline to a
+ * fixed I/O budget: a collector added here falls under that budget automatically,
+ * with no test change. See docs/superpowers/specs/2026-07-29-io-budget-ci-design.md.
+ */
+export async function collectAll(
+  rt: Runtime,
+  cwd: string,
+  config: Config,
+  opts: CollectAllOptions = {}
+): Promise<CollectedFacts> {
+  const matches = routeMatcher(opts.route);
+  const collected = await collectRoutes(rt, cwd, config, opts.parseCache);
+  const heads = collected.heads.filter((h) => matches(h.route));
+  const images = collected.images.filter((i) => matches(i.route));
+  const headings = collected.headings.filter((h) => matches(h.route));
+  const project = await collectProjectFacts(rt, cwd);
+  // Component (Correctness) facts are file-scoped with no route attribution yet, so a
+  // route-filtered run skips them rather than reporting unrelated components (#68 review);
+  // kitModules is skipped for the same reason.
+  const components = opts.route ? [] : await collectComponentFacts(rt, cwd);
+  const kitModules = opts.route ? [] : await collectKitModuleFacts(rt, cwd);
+  return { heads, images, headings, project, components, kitModules };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/collect-all.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Rewire `analyzeProject` to use it**
+
+In `packages/cli/src/index.ts`, replace lines 206-217 (from `const matches = routeMatcher(opts.route);` through the `kitModules` line) with:
+
+```ts
+const { heads, images, headings, project, components, kitModules } = await collectAll(rt, cwd, config, {
+  route: opts.route,
+  parseCache: opts.parseCache
+});
+```
+
+Then fix the imports:
+
+- Remove `collectKitModuleFacts,` from the `@svelte-vitals/core` import block (line 20).
+- Remove `import { collectRoutes } from './providers/source/routes.js';` (line 28).
+- Remove `import { collectComponentFacts } from './providers/source/components.js';` (line 30).
+- On line 31, drop `collectProjectFacts` but keep the rest: `import { detectProject, ProjectError, checkVersionFloor } from './providers/source/project.js';`
+- Add: `import { collectAll } from './collect-all.js';`
+- Keep `import type { ParseCache } from './providers/source/resolve.js';` — it is still used by `AnalyzeOptions.parseCache` (line 165) and the re-export on line 545.
+
+Do NOT add `collect-all.js` to the re-export block; it stays internal.
+
+- [ ] **Step 6: Run the whole suite to prove the move changed no behaviour**
+
+Run: `pnpm --filter svelte-vitals exec vitest run`
+Expected: PASS. `analyze-project.test.ts`, `run.test.ts`, `run-diff.test.ts` and the rest must be green — this was a pure move, so any failure is a bug in the extraction, not a test to update.
+
+- [ ] **Step 7: Typecheck, lint, format**
+
+Run: `pnpm typecheck && pnpm format && pnpm lint`
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/cli/src/collect-all.ts packages/cli/src/index.ts packages/cli/test/collect-all.test.ts
+git commit -m "refactor(cli): extract the analysis collection phase into collectAll"
+```
+
+---
+
+### Task 3: Add the counting Runtime helper
+
+**Files:**
+
+- Create: `packages/cli/test/helpers/counting-runtime.ts`
+- Modify: `packages/cli/test/parse-cache.test.ts` (replace its local `withReadSpy`)
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks.
+- Produces: `createCountingRuntime(base: Runtime): { rt: Runtime; counts: RuntimeCounts }` where `RuntimeCounts` is `{ readFile: Map<string, number>; exists: Map<string, number>; glob: Map<string, number> }`. Tasks 4 and 5 use both names.
+
+The helper's correctness is proven by `parse-cache.test.ts`, which asserts exact read counts — if the wrapper miscounts, those assertions fail. No separate self-test is needed.
+
+- [ ] **Step 1: Create the helper**
+
+Create `packages/cli/test/helpers/counting-runtime.ts`:
+
+```ts
+import type { Runtime } from '@svelte-vitals/core';
+
+/** Call counts keyed by path (readFile/exists) or by pattern (glob). */
+export interface RuntimeCounts {
+  readFile: Map<string, number>;
+  exists: Map<string, number>;
+  glob: Map<string, number>;
+}
+
+/**
+ * Wrap a Runtime so every call through it is counted. These counts are what
+ * `test/io-budget.test.ts` holds the analysis pipeline to: unlike wall-clock
+ * timings they are identical on every machine, so the gate cannot be flaky.
+ * See docs/superpowers/specs/2026-07-29-io-budget-ci-design.md.
+ */
+export function createCountingRuntime(base: Runtime): { rt: Runtime; counts: RuntimeCounts } {
+  const counts: RuntimeCounts = { readFile: new Map(), exists: new Map(), glob: new Map() };
+  const bump = (m: Map<string, number>, key: string) => m.set(key, (m.get(key) ?? 0) + 1);
+  return {
+    counts,
+    rt: {
+      ...base,
+      readFile(path) {
+        bump(counts.readFile, path);
+        return base.readFile(path);
+      },
+      exists(path) {
+        bump(counts.exists, path);
+        return base.exists(path);
+      },
+      glob(pattern, cwd) {
+        bump(counts.glob, pattern);
+        return base.glob(pattern, cwd);
+      }
+    }
+  };
+}
+```
+
+- [ ] **Step 2: Switch `parse-cache.test.ts` to the shared helper**
+
+In `packages/cli/test/parse-cache.test.ts`:
+
+Delete the local `withReadSpy` function (lines 6-20, the block starting `/** Wraps a Runtime's readFile to count calls per path...`) and the now-unused `import type { Runtime } from '@svelte-vitals/core';` on line 2.
+
+Add the import next to the existing `createMemoryRuntime` import:
+
+```ts
+import { createCountingRuntime } from './helpers/counting-runtime.js';
+```
+
+Change the call site from:
+
+```ts
+const { rt, counts } = withReadSpy(base);
+```
+
+to:
+
+```ts
+const { rt, counts } = createCountingRuntime(base);
+```
+
+Then update the four assertions to read from the `readFile` map:
+
+```ts
+expect(counts.readFile.get('src/routes/+layout.svelte')).toBe(1);
+expect(counts.readFile.get('src/lib/Seo.svelte')).toBe(1);
+expect(counts.readFile.get('src/routes/a/+page.svelte')).toBe(1);
+expect(counts.readFile.get('src/routes/b/+page.svelte')).toBe(1);
+```
+
+- [ ] **Step 3: Run the test to verify the helper counts correctly**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/parse-cache.test.ts`
+Expected: PASS. The exact-count assertions are the helper's proof.
+
+- [ ] **Step 4: Typecheck, lint, format**
+
+Run: `pnpm typecheck && pnpm format && pnpm lint`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/test/helpers/counting-runtime.ts packages/cli/test/parse-cache.test.ts
+git commit -m "test(cli): add a shared counting Runtime helper"
+```
+
+---
+
+### Task 4: Budget invariants 1 and 2 (per-file reads, per-pattern globs)
+
+**Files:**
+
+- Create: `packages/cli/test/io-budget.test.ts`
+
+**Interfaces:**
+
+- Consumes: `collectAll` / `CollectAllOptions` from `../src/collect-all.js` (Task 2), `createCountingRuntime` from `./helpers/counting-runtime.js` (Task 3), `createMemoryRuntime` from `./helpers/memory-runtime.js` (existing).
+- Produces: the `project(routeCount)` fixture builder, used again in Task 5 from the same file.
+
+A guard test starts green, so the TDD cycle here is inverted: write it, watch it pass, then deliberately break the behaviour it guards and confirm it goes red with a useful message. A guard that has never been seen failing is not a guard.
+
+- [ ] **Step 1: Write the budget test**
+
+Create `packages/cli/test/io-budget.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { defaultConfig } from '@svelte-vitals/core';
+import { collectAll } from '../src/collect-all.js';
+import { createMemoryRuntime } from './helpers/memory-runtime.js';
+import { createCountingRuntime } from './helpers/counting-runtime.js';
+
+/**
+ * Reads per file allowed across one full collection phase. TWO is the measured
+ * status quo, not an ideal. Two independent paths sit at exactly this cap:
+ *
+ *   - every `.svelte` file: `collectRoutes` reads it for head resolution
+ *     (parseFile) and `collectComponentFacts` reads it again for component facts
+ *     (parseComponentFacts) — different parsers, separate caches, and the
+ *     component glob also matches route files.
+ *   - the Vite config: `collectProjectFacts` reads it once via
+ *     `detectViteMinifyDisabled` and once via `detectKitPathsBase`.
+ *
+ * Lowering this number is welcome and should accompany any unification of those
+ * read paths. RAISING it is a design decision that needs a recorded reason — not a
+ * number edit. See docs/superpowers/specs/2026-07-29-io-budget-ci-design.md.
+ */
+const MAX_READS_PER_FILE = 2;
+
+/**
+ * A SvelteKit-shaped project as a path→source map: `routeCount` pages that all
+ * inherit one root layout, which itself pulls in one shared $lib component. The
+ * sharing is the point — it is what a broken parse cache would read repeatedly.
+ */
+function project(routeCount: number): Record<string, string> {
+  const files: Record<string, string> = {
+    'svelte.config.js': `export default { kit: {} };\n`,
+    'vite.config.ts': `export default { plugins: [] };\n`,
+    'src/app.html': `<!doctype html><html lang="en"><body></body></html>\n`,
+    'src/routes/+layout.svelte': `<script>\n  import Card from '$lib/Card.svelte';\n  let { children } = $props();\n</script>\n\n<Card title="shared" />\n{@render children()}\n`,
+    'src/lib/Card.svelte': `<script>\n  let { title = '' } = $props();\n</script>\n\n<svelte:head><meta name="description" content="shared" /></svelte:head>\n<h3>{title}</h3>\n`
+  };
+  for (let i = 0; i < routeCount; i++) {
+    files[`src/routes/p${i}/+page.svelte`] =
+      `<svelte:head><title>Page ${i}</title></svelte:head>\n<h1>Page ${i}</h1>\n`;
+  }
+  return files;
+}
+
+describe('I/O budget for the collection phase', () => {
+  it(`reads no file more than ${MAX_READS_PER_FILE} times`, async () => {
+    const { rt, counts } = createCountingRuntime(createMemoryRuntime(project(6)));
+
+    await collectAll(rt, '', defaultConfig);
+
+    // Collect the offenders rather than asserting per entry, so a failure names
+    // every file that blew the budget and by how much.
+    const over = [...counts.readFile].filter(([, n]) => n > MAX_READS_PER_FILE);
+    expect(over).toEqual([]);
+  });
+
+  it('issues each glob pattern exactly once', async () => {
+    const { rt, counts } = createCountingRuntime(createMemoryRuntime(project(6)));
+
+    await collectAll(rt, '', defaultConfig);
+
+    // A second call for the same pattern is a second full directory traversal.
+    const repeated = [...counts.glob].filter(([, n]) => n !== 1);
+    expect(repeated).toEqual([]);
+    // Sanity: the run really did glob (an empty map would pass the check above).
+    expect(counts.glob.size).toBeGreaterThan(0);
+  });
+});
+```
+
+Note on comments: never write a glob containing `**/` inside a `/** */` block comment — the `*/` terminates the comment. The `MAX_READS_PER_FILE` doc block above is worded to avoid this; keep it that way. Inside `//` line comments and string literals the glob is fine as-is.
+
+- [ ] **Step 2: Run it and confirm it passes on current code**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/io-budget.test.ts`
+Expected: PASS (2 tests).
+
+Two files are expected to sit exactly at the cap of 2 (`.svelte` files, and `vite.config.ts` — see the `MAX_READS_PER_FILE` comment), so the test is green but with no headroom. If it instead FAILS, some file is read three or more times: record which file and why in the test comment, and treat it as a finding to report rather than a reason to raise the constant.
+
+- [ ] **Step 3: Break the parse cache and confirm invariant 1 catches it**
+
+In `packages/cli/src/providers/source/resolve.ts`, temporarily change the first line of `readAndParse`'s body from:
+
+```ts
+let hit = cache.get(rel);
+```
+
+to:
+
+```ts
+let hit = undefined; // TEMPORARY: cache bypass, to prove the budget test bites
+```
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/io-budget.test.ts`
+Expected: FAIL on the first test, with the shared files listed — `src/routes/+layout.svelte` and `src/lib/Card.svelte` read once per route instead of once. Confirm the failure output actually names them; that readability is the point of the `over` array.
+
+- [ ] **Step 4: Revert the break**
+
+Restore the line to `let hit = cache.get(rel);`.
+
+Run: `git diff packages/cli/src/providers/source/resolve.ts`
+Expected: empty output — the file is back to its committed state.
+
+- [ ] **Step 5: Break the glob count and confirm invariant 2 catches it**
+
+In `packages/cli/src/collect-all.ts`, temporarily add a duplicate call right after the `kitModules` line:
+
+```ts
+await collectComponentFacts(rt, cwd); // TEMPORARY: prove the glob budget bites
+```
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/io-budget.test.ts`
+Expected: FAIL on both tests — `src/**/*.svelte{,.ts,.js}` globbed twice, and every `.svelte` read three times.
+
+- [ ] **Step 6: Revert the break and confirm green**
+
+Remove the temporary line.
+
+Run: `git diff packages/cli/src/collect-all.ts && pnpm --filter svelte-vitals exec vitest run test/io-budget.test.ts`
+Expected: empty diff, then PASS (2 tests).
+
+- [ ] **Step 7: Typecheck, lint, format**
+
+Run: `pnpm typecheck && pnpm format && pnpm lint`
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/cli/test/io-budget.test.ts
+git commit -m "test(cli): guard per-file read and per-pattern glob budgets"
+```
+
+---
+
+### Task 5: Budget invariants 3 and 4 (cache scaling, route fast path)
+
+**Files:**
+
+- Modify: `packages/cli/test/io-budget.test.ts` (add two tests to the existing `describe`)
+
+**Interfaces:**
+
+- Consumes: `project(routeCount)`, `MAX_READS_PER_FILE`, `collectAll`, `createCountingRuntime`, `createMemoryRuntime` — all already in the file from Task 4.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Add the two tests**
+
+Append inside the existing `describe('I/O budget for the collection phase', ...)` block in `packages/cli/test/io-budget.test.ts`:
+
+```ts
+it('does not read shared files more often as route count grows', async () => {
+  const small = createCountingRuntime(createMemoryRuntime(project(2)));
+  const large = createCountingRuntime(createMemoryRuntime(project(12)));
+
+  await collectAll(small.rt, '', defaultConfig);
+  await collectAll(large.rt, '', defaultConfig);
+
+  // 6x the routes must not mean more reads of the files they share. This is the
+  // primary parse-cache-breakage detector: per-file budgets alone stay green if
+  // the cache dies but every file happens to stay under the cap.
+  for (const shared of ['src/routes/+layout.svelte', 'src/lib/Card.svelte']) {
+    expect([shared, large.counts.readFile.get(shared)]).toEqual([shared, small.counts.readFile.get(shared)]);
+  }
+});
+
+it('scans no components or kit modules for a route-filtered run', async () => {
+  const { rt, counts } = createCountingRuntime(createMemoryRuntime(project(6)));
+
+  await collectAll(rt, '', defaultConfig, { route: 'p0' });
+
+  // File-scoped facts are skipped when a single route was asked for; issuing
+  // their globs anyway would pay for a whole-project scan nobody reads.
+  const patterns = [...counts.glob.keys()];
+  expect(patterns).not.toContain('src/**/*.svelte{,.ts,.js}');
+  expect(patterns.filter((p) => p.includes('+{page,layout}') || p.includes('hooks.server'))).toEqual([]);
+});
+```
+
+The `[shared, count]` tuple form is deliberate: a bare count comparison fails with `expected 6 to be 1`, which does not say _which_ file regressed.
+
+- [ ] **Step 2: Run and confirm both pass**
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/io-budget.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 3: Break the cache and confirm invariant 3 catches it**
+
+Apply the same temporary edit as Task 4 Step 3 — in `packages/cli/src/providers/source/resolve.ts`, change `let hit = cache.get(rel);` to `let hit = undefined;`.
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/io-budget.test.ts`
+Expected: FAIL on the scaling test, showing `['src/routes/+layout.svelte', 12]` against `['src/routes/+layout.svelte', 2]`.
+
+- [ ] **Step 4: Revert and break the fast path instead**
+
+Restore `let hit = cache.get(rel);` in `resolve.ts`. Then in `packages/cli/src/collect-all.ts`, temporarily change:
+
+```ts
+const components = opts.route ? [] : await collectComponentFacts(rt, cwd);
+```
+
+to:
+
+```ts
+const components = await collectComponentFacts(rt, cwd); // TEMPORARY
+```
+
+Run: `pnpm --filter svelte-vitals exec vitest run test/io-budget.test.ts`
+Expected: FAIL on the route-filtered test — `src/**/*.svelte{,.ts,.js}` is now in the pattern list.
+
+- [ ] **Step 5: Revert both breaks and confirm green**
+
+Restore the `opts.route ? [] :` guard.
+
+Run: `git diff packages/cli/src && pnpm --filter svelte-vitals exec vitest run`
+Expected: empty diff, then the full CLI suite passes.
+
+- [ ] **Step 6: Typecheck, lint, format**
+
+Run: `pnpm typecheck && pnpm format && pnpm lint`
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/cli/test/io-budget.test.ts
+git commit -m "test(cli): guard parse-cache scaling and the route-filtered fast path"
+```
+
+---
+
+### Task 6: Promote the timing benchmark and document the budget
+
+The benchmark answers what counts cannot: a widened analysis (more AST walking for the same I/O) and lost parallelism. It stays out of CI because shared-runner noise makes its numbers uncomparable, but it must stop describing itself as disposable.
+
+**Files:**
+
+- Modify: `packages/vite/package.json` (scripts)
+- Modify: `package.json` (root scripts)
+- Modify: `packages/vite/scripts/bench/bench.mjs:1-5` (header)
+- Modify: `packages/vite/scripts/bench/gen-project.mjs:1-5` (header)
+- Modify: `AGENTS.md` (Conventions section)
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: `pnpm bench`.
+
+- [ ] **Step 1: Register the script in the vite package**
+
+In `packages/vite/package.json`, add to `scripts` (after `"build"`):
+
+```json
+    "bench": "node scripts/bench/bench.mjs",
+```
+
+- [ ] **Step 2: Register the root passthrough**
+
+In the root `package.json`, add to `scripts` after `"test"`:
+
+```json
+    "bench": "pnpm --filter @svelte-vitals/vite run bench",
+```
+
+- [ ] **Step 3: Rewrite the `bench.mjs` header**
+
+Replace lines 1-5 of `packages/vite/scripts/bench/bench.mjs` (everything from `// Throwaway benchmark for Plan 037` down to and including the line ending `dev-server-analysis-isolation-design.md.`) with:
+
+```js
+// Manual timing benchmark for the whole-project analysis path — the same
+// `analyzeProject()` call packages/vite/src/ui/analysis.ts's `runOnce` makes on
+// every dev-server save. Run it with `pnpm bench`.
+//
+// CI deliberately does NOT run this. Shared GitHub runners vary by 1.5-2x under
+// neighbour load, so absolute timings are not comparable across runs; the speed
+// regression gate CI *does* run is the deterministic I/O budget in
+// packages/cli/test/io-budget.test.ts. Reach for this benchmark for the two things
+// call counts cannot catch: a widened analysis (more AST walking for the same I/O)
+// and lost parallelism. See
+// docs/superpowers/specs/2026-07-29-io-budget-ci-design.md.
+//
+// Not part of the shipped package — do not import from packages/vite/src.
+```
+
+Leave the `// Measures, for synthetic SvelteKit-like projects...` paragraph and everything below it untouched.
+
+- [ ] **Step 4: Rewrite the `gen-project.mjs` header**
+
+Replace lines 1-5 of `packages/vite/scripts/bench/gen-project.mjs` (from `// Throwaway benchmark fixture generator` through the line ending `dev-server-analysis-isolation-design.md).`) with:
+
+```js
+// Fixture generator for the manual timing benchmark (`pnpm bench`, bench.mjs).
+// Not part of the shipped package — never imported from packages/vite/src.
+```
+
+Leave the `// Generates a synthetic SvelteKit-like project with N pages...` paragraph and everything below it untouched.
+
+- [ ] **Step 5: Verify `pnpm bench` runs**
+
+Run: `pnpm build && pnpm bench --sizes=50 --runs=1`
+Expected: a line like `routes=50 run=1/1 total=<n>ms ... results=1465`, then a `--- JSON ---` block. The `results=1465` figure should match; a different finding count means rules changed since the spec was written, which is fine — the timing is what matters here.
+
+- [ ] **Step 6: Document the budget in `AGENTS.md`**
+
+In `AGENTS.md`, in the `## Conventions` section, add this bullet immediately after the existing `- **Tests**: vitest, per-package \`test/\` directories; fixtures live under \`test/fixtures/\`.` bullet:
+
+```markdown
+- **I/O budget**: `packages/cli/test/io-budget.test.ts` holds the collection phase
+  (`packages/cli/src/collect-all.ts`) to a fixed number of `Runtime` calls. This is how
+  analysis speed is defended in CI — wall-clock timings are far too noisy on shared
+  runners to gate on. Adding a collector or a glob means checking that test. Lowering a
+  budget is welcome; raising one is a design decision needing a recorded reason, not a
+  number edit. The two regressions counts cannot catch — a widened analysis, and lost
+  parallelism — are measured manually with `pnpm bench` (never in CI).
+```
+
+- [ ] **Step 7: Full verification**
+
+Run: `pnpm format && pnpm lint && pnpm typecheck && pnpm test`
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/vite/package.json package.json packages/vite/scripts/bench/bench.mjs packages/vite/scripts/bench/gen-project.mjs AGENTS.md
+git commit -m "chore(vite): promote the timing benchmark to a documented manual tool"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the full verify set from a clean tree: `pnpm format && pnpm lint && pnpm typecheck && pnpm build && pnpm test`
+- [ ] Confirm `git diff main --stat` shows only: 3 new source/test helper files, 1 new test file, and edits to `index.ts`, `parse-cache.test.ts`, both `package.json`s, both bench scripts, and `AGENTS.md`.
+- [ ] Confirm `packages/cli/src/index.ts` does NOT re-export `collect-all.js` (public API unchanged), while `routeMatcher` IS still exported from it.
+- [ ] No changeset file was added.

--- a/docs/superpowers/specs/2026-07-29-io-budget-ci-design.md
+++ b/docs/superpowers/specs/2026-07-29-io-budget-ci-design.md
@@ -139,12 +139,12 @@ test behaviour for no benefit to this goal.
 New file `packages/cli/test/io-budget.test.ts`, run by the existing `test` CI
 job. It uses the in-memory Runtime, so its contribution to CI time is negligible.
 
-| #   | Invariant                                                                                                        | Regression it catches                                                            |
-| --- | ---------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| 1   | Each file is read at most **twice**                                                                              | Parse-cache breakage, duplicate reads, a new rule or collector doing its own I/O |
-| 2   | Each glob pattern is issued **exactly once**                                                                     | Repeated directory traversal                                                     |
-| 3   | Reads of a shared layout / shared `$lib` component **do not vary with route count** (2-route vs 6-route fixture) | Parse-cache breakage — the primary case                                          |
-| 4   | With `route` set, component/kit-module globs are **not issued**                                                  | Loss of the single-route fast path                                               |
+| #   | Invariant                                                                                                         | Regression it catches                                                            |
+| --- | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| 1   | Each file is read at most **twice**                                                                               | Parse-cache breakage, duplicate reads, a new rule or collector doing its own I/O |
+| 2   | Each glob pattern is issued **exactly once**                                                                      | Repeated directory traversal                                                     |
+| 3   | Reads of a shared layout / shared `$lib` component **do not vary with route count** (2-route vs 12-route fixture) | Parse-cache breakage — the primary case                                          |
+| 4   | With `route` set, component/kit-module globs are **not issued**                                                   | Loss of the single-route fast path                                               |
 
 The budget covers **`collectAll` only**. Validation reads in `analyzeProject`
 (`detectProject` and `checkVersionFloor` both read `package.json`) sit outside it

--- a/docs/superpowers/specs/2026-07-29-io-budget-ci-design.md
+++ b/docs/superpowers/specs/2026-07-29-io-budget-ci-design.md
@@ -1,0 +1,203 @@
+# Design: guarding analysis speed in CI with a deterministic I/O budget
+
+**Date:** 2026-07-29
+**Status:** Approved for implementation.
+**Packages:** `svelte-vitals` (CLI) only. No `@svelte-vitals/core` source changes.
+No public API changes, so no changeset.
+
+## Goal
+
+svelte-vitals is fast because of deliberate design choices, not incidental luck.
+Nothing currently defends those choices: a PR can break the parse cache, add a
+second directory traversal, or give a new rule its own file reads, and CI stays
+green. This design adds a **regression gate that cannot be flaky**, plus a
+manual tool for the (real, but noisier) questions the gate cannot answer.
+
+## Why not a timing benchmark in CI
+
+`packages/vite/scripts/bench/bench.mjs` already exists and still works — a run on
+2026-07-29 reproduced the numbers in
+`2026-07-13-dev-server-analysis-isolation-design.md` exactly (50 routes → 1465
+findings, ~25ms). But it is unfit as a CI gate:
+
+- GitHub's shared `ubuntu-latest` runners vary by 1.5–2× under neighbour load.
+  Absolute thresholds on 25ms/215ms figures would fail spuriously until everyone
+  learns to ignore the red — the standard way perf CI dies.
+- The benchmark's headline metrics (event-loop delay, tick drift) exist to answer
+  "does this block the dev server", not "is this slower than last week". They do
+  not survive cross-machine comparison.
+
+So the gate measures **counts**, not time. Counts come from the `Runtime`
+interface, are identical on every machine, and cannot be flaky.
+
+## What counts can and cannot catch
+
+Deciding this explicitly matters, because the gate must not be mistaken for
+complete coverage.
+
+**Caught:** parse-cache breakage, duplicate reads, repeated directory
+traversals, a new rule or collector doing its own I/O, loss of the
+single-glob-per-pattern property.
+
+**Not caught, by construction:**
+
+- **Widening the analysis** — e.g. abandoning the "we do NOT follow the
+  expression" boundary in `packages/core/src/svelte-ast.ts`. I/O counts stay
+  identical while AST walk volume grows.
+- **Losing parallelism** — replacing a `Promise.all` with sequential `await`
+  leaves every call count unchanged.
+
+Both are visible only in wall-clock time. They are the reason the timing
+benchmark is kept and promoted to a documented manual tool rather than deleted.
+
+## Measured starting point
+
+A counting `Runtime` was injected into `collectRoutes`, `collectComponentFacts`
+and `collectKitModuleFacts` on a 4-file fixture (2 routes, a shared root layout,
+a shared `$lib` component). `collectProjectFacts` was not part of this probe, so
+its config-file reads are not reflected below:
+
+```
+after collectRoutes:  every .svelte = 1 read
+after all collectors: every .svelte = 2 reads
+globs:                9 patterns, each called exactly once
+```
+
+**Every `.svelte` file is read and parsed twice per run.** `collectRoutes`
+(head resolution, `parseFile`) and `collectComponentFacts` (component facts,
+`parseComponentFacts`) use different parsers and separate caches, and
+`collectComponentFacts`'s `src/**/*.svelte{,.ts,.js}` glob also matches route
+files. This is not a bug — the two parsers extract different facts — but it is
+the largest single I/O redundancy in the pipeline, and the budget makes any
+future unification measurable.
+
+## Design
+
+### 1. Extract the collection step
+
+New file `packages/cli/src/collect-all.ts`, holding what is today inline in
+`analyzeProject` (`packages/cli/src/index.ts:208-217`):
+
+```ts
+export interface CollectedFacts {
+  heads: ResolvedHead[];
+  images: ResolvedImages[];
+  headings: ResolvedHeadings[];
+  project: Project;
+  components: ComponentFacts[];
+  kitModules: KitModuleFacts[];
+}
+
+export async function collectAll(
+  rt: Runtime,
+  cwd: string,
+  config: Config,
+  opts?: { route?: string; parseCache?: ParseCache }
+): Promise<CollectedFacts>;
+```
+
+This moves the four collector calls and the route filtering. `detectProject` and
+`checkVersionFloor` stay in `analyzeProject`: they are validation with their own
+error semantics (`ProjectError` → exit 2), not collection.
+
+`collect-all.ts` is **not** re-exported from `index.ts`. Tests import
+`../src/collect-all.js` directly, matching how `parse-cache.test.ts` already
+imports `../src/providers/source/routes.js`. The public API is unchanged and
+`check:publish` is unaffected.
+
+The extraction is what lets the budget test call the **real** pipeline. A fifth
+collector added later falls under the budget automatically, with no test change.
+
+### 2. Counting Runtime helper
+
+New file `packages/cli/test/helpers/counting-runtime.ts`:
+
+```ts
+export interface RuntimeCounts {
+  readFile: Map<string, number>;
+  exists: Map<string, number>;
+  glob: Map<string, number>;
+}
+
+export function createCountingRuntime(base: Runtime): { rt: Runtime; counts: RuntimeCounts };
+```
+
+The local `withReadSpy` in `packages/cli/test/parse-cache.test.ts` is replaced by
+this helper, removing the duplication.
+
+All budget tests live in `packages/cli/test/`. `collectComponentFacts` and
+`collectKitModuleFacts` are core functions but are importable from the CLI
+package, and `collectAll` calls all four collectors, so one location covers
+everything. Core's own test helpers are left alone: `createMemoryRuntime` is
+duplicated across `packages/core/test/component-collect.test.ts` and
+`kit-module-collect.test.ts` with a different (pattern-hardcoded) glob
+implementation from the CLI's, and unifying them would risk changing existing
+test behaviour for no benefit to this goal.
+
+### 3. The invariants
+
+New file `packages/cli/test/io-budget.test.ts`, run by the existing `test` CI
+job. It uses the in-memory Runtime, so its contribution to CI time is negligible.
+
+| #   | Invariant                                                                                                        | Regression it catches                                                            |
+| --- | ---------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| 1   | Each file is read at most **twice**                                                                              | Parse-cache breakage, duplicate reads, a new rule or collector doing its own I/O |
+| 2   | Each glob pattern is issued **exactly once**                                                                     | Repeated directory traversal                                                     |
+| 3   | Reads of a shared layout / shared `$lib` component **do not vary with route count** (2-route vs 6-route fixture) | Parse-cache breakage — the primary case                                          |
+| 4   | With `route` set, component/kit-module globs are **not issued**                                                  | Loss of the single-route fast path                                               |
+
+The budget covers **`collectAll` only**. Validation reads in `analyzeProject`
+(`detectProject` and `checkVersionFloor` both read `package.json`) sit outside it
+by design — they are per-run constants, not per-file work that scales.
+
+Invariant 1's limit of 2 is the **measured status quo for `.svelte` files, not an
+ideal**. The test comments record why (separate parsers, separate caches) and the
+rule for changing it: lowering the budget is welcome and should accompany any
+unification of the two read paths; raising it is a design decision that needs
+justification, not a number edit. `collectProjectFacts`'s config-file reads
+(`svelte.config.*`, `vite.config.*`) were not part of the probe above; if
+implementation finds one legitimately exceeds 2, it is recorded as a named
+exception with its reason rather than by raising the global limit.
+
+Assertions collect the offenders rather than asserting per entry, so a failure
+names the culprits directly:
+
+```ts
+const over = [...counts.readFile].filter(([, n]) => n > MAX_READS_PER_FILE);
+expect(over).toEqual([]);
+```
+
+### 4. Promote the timing benchmark to a manual tool
+
+- Register `bench` in `packages/vite/package.json` (`node scripts/bench/bench.mjs`)
+  and at the root, so `pnpm bench` works.
+- Rewrite the headers of `bench.mjs` and `gen-project.mjs`: drop `Throwaway` and
+  `disposable once the design doc is written`; state that it is a manual
+  measurement tool, that CI deliberately does not run it (shared-runner noise
+  makes cross-run comparison meaningless), and that it is the tool to reach for
+  when a change is suspected of widening analysis or losing parallelism.
+- Measurement logic and JSON output are unchanged.
+
+### 5. Documentation
+
+Add an "I/O budget" note to `AGENTS.md`: adding a collector or a glob means
+checking `io-budget.test.ts`, and raising a budget is a design decision.
+
+## Testing
+
+The budget tests _are_ the deliverable, so the verification that matters is that
+they fail when they should. Before landing, each invariant is confirmed to catch
+its target by temporarily breaking the corresponding behaviour (bypassing the
+`ParseCache`, issuing a glob twice) and observing a red test with a useful
+message. `pnpm lint`, `pnpm typecheck`, and `pnpm test` must all pass, and the
+`collect-all.ts` extraction must leave the existing CLI test suite green —
+it is a pure move, so any behavioural diff is a bug in the extraction.
+
+## Out of scope
+
+- Any timing assertion in CI.
+- Counting AST walk volume (would require instrumenting core, which the
+  `Runtime` seam does not cover).
+- Unifying the two `.svelte` read paths to lower the budget from 2 to 1. The
+  budget makes that work measurable; doing it is separate.
+- Consolidating core's duplicated `createMemoryRuntime` helpers.

--- a/docs/superpowers/specs/2026-07-29-io-budget-ci-design.md
+++ b/docs/superpowers/specs/2026-07-29-io-budget-ci-design.md
@@ -86,6 +86,8 @@ export interface CollectedFacts {
   project: Project;
   components: ComponentFacts[];
   kitModules: KitModuleFacts[];
+  /** `undefined` (not `[]`) for a route-filtered run. */
+  sourceFiles: string[] | undefined;
 }
 
 export async function collectAll(
@@ -96,7 +98,7 @@ export async function collectAll(
 ): Promise<CollectedFacts>;
 ```
 
-This moves the four collector calls and the route filtering. `detectProject` and
+This moves every collector call and the route filtering. `detectProject` and
 `checkVersionFloor` stay in `analyzeProject`: they are validation with their own
 error semantics (`ProjectError` → exit 2), not collection.
 
@@ -105,8 +107,12 @@ error semantics (`ProjectError` → exit 2), not collection.
 imports `../src/providers/source/routes.js`. The public API is unchanged and
 `check:publish` is unaffected.
 
-The extraction is what lets the budget test call the **real** pipeline. A fifth
-collector added later falls under the budget automatically, with no test change.
+The extraction is what lets the budget test call the **real** pipeline: a collector
+added later falls under the read and glob budgets automatically. One exception —
+a collector that is skipped when `route` is set must also be added to invariant 4's
+expected list. That happened for real during this work: `main` gained
+`collectSourceFiles` while the branch was in review, and invariant 4 went red until
+its glob was admitted.
 
 ### 2. Counting Runtime helper
 
@@ -127,7 +133,7 @@ this helper, removing the duplication.
 
 All budget tests live in `packages/cli/test/`. `collectComponentFacts` and
 `collectKitModuleFacts` are core functions but are importable from the CLI
-package, and `collectAll` calls all four collectors, so one location covers
+package, and `collectAll` calls every collector, so one location covers
 everything. Core's own test helpers are left alone: `createMemoryRuntime` is
 duplicated across `packages/core/test/component-collect.test.ts` and
 `kit-module-collect.test.ts` with a different (pattern-hardcoded) glob
@@ -144,7 +150,7 @@ job. It uses the in-memory Runtime, so its contribution to CI time is negligible
 | 1   | Each file is read at most **twice**                                                                               | Parse-cache breakage, duplicate reads, a new rule or collector doing its own I/O |
 | 2   | Each glob pattern is issued **exactly once**                                                                      | Repeated directory traversal                                                     |
 | 3   | Reads of a shared layout / shared `$lib` component **do not vary with route count** (2-route vs 12-route fixture) | Parse-cache breakage — the primary case                                          |
-| 4   | With `route` set, component/kit-module globs are **not issued**                                                   | Loss of the single-route fast path                                               |
+| 4   | With `route` set, the file-scoped globs (component, kit-module, source-file inventory) are **not issued**         | Loss of the single-route fast path                                               |
 
 The budget covers **`collectAll` only**. Validation reads in `analyzeProject`
 (`detectProject` and `checkVersionFloor` both read `package.json`) sit outside it

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "pnpm -r build",
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm -r test",
+    "bench": "pnpm --filter @svelte-vitals/vite run bench",
     "lint": "oxlint . && oxfmt --check .",
     "format": "oxfmt --write .",
     "check:publish": "pnpm run check:publint && pnpm run check:types",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "pnpm -r build",
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm -r test",
-    "bench": "pnpm build && pnpm --filter @svelte-vitals/vite run bench",
+    "bench": "pnpm --filter svelte-vitals... build && pnpm --filter @svelte-vitals/vite run bench",
     "lint": "oxlint . && oxfmt --check .",
     "format": "oxfmt --write .",
     "check:publish": "pnpm run check:publint && pnpm run check:types",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "pnpm -r build",
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm -r test",
-    "bench": "pnpm --filter @svelte-vitals/vite run bench",
+    "bench": "pnpm build && pnpm --filter @svelte-vitals/vite run bench",
     "lint": "oxlint . && oxfmt --check .",
     "format": "oxfmt --write .",
     "check:publish": "pnpm run check:publint && pnpm run check:types",

--- a/packages/cli/src/collect-all.ts
+++ b/packages/cli/src/collect-all.ts
@@ -42,8 +42,10 @@ export interface CollectAllOptions {
  * and is per-run, not per-file.
  *
  * Kept as one function so `test/io-budget.test.ts` can hold the REAL pipeline to a
- * fixed I/O budget: a collector added here falls under that budget automatically,
- * with no test change. See docs/superpowers/specs/2026-07-29-io-budget-ci-design.md.
+ * fixed I/O budget: a collector added here falls under the read and glob budgets
+ * automatically. One exception — a collector skipped when `route` is set must also
+ * be added to the route-filtered test's expected list, which is why that test pins
+ * the skipped patterns. See docs/superpowers/specs/2026-07-29-io-budget-ci-design.md.
  */
 export async function collectAll(
   rt: Runtime,

--- a/packages/cli/src/collect-all.ts
+++ b/packages/cli/src/collect-all.ts
@@ -1,0 +1,71 @@
+import {
+  collectKitModuleFacts,
+  collectSourceFiles,
+  type ComponentFacts,
+  type Config,
+  type KitModuleFacts,
+  type Project,
+  type ResolvedHead,
+  type ResolvedHeadings,
+  type ResolvedImages,
+  type Runtime
+} from '@svelte-vitals/core';
+import { collectComponentFacts } from './providers/source/components.js';
+import { collectProjectFacts } from './providers/source/project.js';
+import type { ParseCache } from './providers/source/resolve.js';
+import { collectRoutes } from './providers/source/routes.js';
+import { routeMatcher } from './route-matcher.js';
+
+/** Everything the rule engine needs about a project, gathered through the Runtime. */
+export interface CollectedFacts {
+  heads: ResolvedHead[];
+  images: ResolvedImages[];
+  headings: ResolvedHeadings[];
+  project: Project;
+  components: ComponentFacts[];
+  kitModules: KitModuleFacts[];
+  /** `undefined` (not `[]`) for a route-filtered run — see the comment at the call site. */
+  sourceFiles: string[] | undefined;
+}
+
+export interface CollectAllOptions {
+  /** Restrict route-scoped facts to routes matching this glob. */
+  route?: string;
+  /** Reuse a parse cache across calls (the vite dev dashboard passes a long-lived one). */
+  parseCache?: ParseCache;
+}
+
+/**
+ * The whole I/O phase of an analysis: every Runtime call made to gather rule input
+ * goes through here. Validation (`detectProject`, `checkVersionFloor`) deliberately
+ * stays in `analyzeProject` — it has its own error semantics (ProjectError → exit 2)
+ * and is per-run, not per-file.
+ *
+ * Kept as one function so `test/io-budget.test.ts` can hold the REAL pipeline to a
+ * fixed I/O budget: a collector added here falls under that budget automatically,
+ * with no test change. See docs/superpowers/specs/2026-07-29-io-budget-ci-design.md.
+ */
+export async function collectAll(
+  rt: Runtime,
+  cwd: string,
+  config: Config,
+  opts: CollectAllOptions = {}
+): Promise<CollectedFacts> {
+  const matches = routeMatcher(opts.route);
+  const collected = await collectRoutes(rt, cwd, config, opts.parseCache);
+  const heads = collected.heads.filter((h) => matches(h.route));
+  const images = collected.images.filter((i) => matches(i.route));
+  const headings = collected.headings.filter((h) => matches(h.route));
+  const project = await collectProjectFacts(rt, cwd);
+  // Component (Correctness) facts are file-scoped with no route attribution yet, so a
+  // route-filtered run skips them rather than reporting unrelated components (#68 review);
+  // kitModules is skipped for the same reason.
+  const components = opts.route ? [] : await collectComponentFacts(rt, cwd);
+  const kitModules = opts.route ? [] : await collectKitModuleFacts(rt, cwd);
+  // Unlike its two neighbours above, the --route branch gets `undefined` here, not `[]`: an empty
+  // inventory would tell architecture/unit-entry-file that the declared unit directories truly do
+  // not exist, so it would report every declaration as inert, whereas `undefined` means the mode
+  // never collected the fact at all, and the rule stays silent instead of raising a false alarm.
+  const sourceFiles = opts.route ? undefined : await collectSourceFiles(rt, cwd);
+  return { heads, images, headings, project, components, kitModules, sourceFiles };
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -38,6 +38,7 @@ import { checkoutBaseline, filterToNewFindings } from './baseline.js';
 import { loadSuppressions, writeSuppressions, applySuppressions, SUPPRESSIONS_FILE } from './suppressions.js';
 import { colorEnabled, paletteFor } from './color.js';
 import { startSpinner } from './spinner.js';
+import { routeMatcher } from './route-matcher.js';
 import { startMascotSpinner, mascotFitsWidth } from './mascot.js';
 import { playMascotGreeting, bubbleFitsWidth } from './speech-bubble.js';
 import { loadConfigFile } from './config-file.js';
@@ -123,21 +124,6 @@ export function spinnerEnabled(opts: {
     !isAutoDetectedAgent(opts.rawReporter, opts.env) &&
     colorEnabled({ reporter: opts.reporter, isTTY: opts.stderrIsTTY, env: opts.env, noColorFlag: opts.noColorFlag })
   );
-}
-
-export function routeMatcher(glob: string | undefined): (route: string) => boolean {
-  if (!glob) return () => true;
-  const body = glob
-    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-    .replace(/\*\*/g, ' ') // globstar placeholder
-    .replace(/\*/g, '[^/]*') // single-segment wildcard (placeholder untouched)
-    .replace(/\/ $/g, '(?:/.*)?') // trailing /** -> optional subtree
-    .replace(/^ \//g, '(?:.*/)?') // leading **/ -> optional prefix
-    .replace(/ \//g, '(?:.*/)?') // internal **/ -> optional prefix
-    .replace(/\/ /g, '(?:/.*)?') // internal /** -> optional subtree
-    .replace(/ /g, '.*'); // bare ** -> .*
-  const re = new RegExp(`^${body}$`);
-  return (route) => re.test(route.replace(/^\//, ''));
 }
 
 export interface AnalyzeOptions {
@@ -548,6 +534,7 @@ export async function run(opts: RunOptions = {}): Promise<number> {
 }
 
 export { ProjectError } from './providers/source/project.js';
+export { routeMatcher } from './route-matcher.js';
 export type { ParseCache } from './providers/source/resolve.js';
 export { buildRulesConfig, findUnknownRuleIds, knownRuleIds, ruleOptionsSpec } from './rules-config.js';
 export { loadConfigFile } from './config-file.js';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,8 +17,6 @@ import {
   selectRules,
   applyRuleSeverities,
   applyOverrides,
-  collectKitModuleFacts,
-  collectSourceFiles,
   type Severity,
   type RuleSetting,
   type Result,
@@ -26,10 +24,9 @@ import {
   type Category
 } from '@svelte-vitals/core';
 import { createNodeRuntime } from './runtime/node.js';
-import { collectRoutes } from './providers/source/routes.js';
 import type { ParseCache } from './providers/source/resolve.js';
-import { collectComponentFacts } from './providers/source/components.js';
-import { detectProject, ProjectError, collectProjectFacts, checkVersionFloor } from './providers/source/project.js';
+import { detectProject, ProjectError, checkVersionFloor } from './providers/source/project.js';
+import { collectAll } from './collect-all.js';
 import { discoverApps } from './discover-apps.js';
 import { readPackageVersion, readCoreVersion } from './version.js';
 import { resolveReporter, isAutoDetectedAgent, isAutoDetectedGithub, type ReporterName } from './reporter-resolve.js';
@@ -38,7 +35,6 @@ import { checkoutBaseline, filterToNewFindings } from './baseline.js';
 import { loadSuppressions, writeSuppressions, applySuppressions, SUPPRESSIONS_FILE } from './suppressions.js';
 import { colorEnabled, paletteFor } from './color.js';
 import { startSpinner } from './spinner.js';
-import { routeMatcher } from './route-matcher.js';
 import { startMascotSpinner, mascotFitsWidth } from './mascot.js';
 import { playMascotGreeting, bubbleFitsWidth } from './speech-bubble.js';
 import { loadConfigFile } from './config-file.js';
@@ -191,22 +187,10 @@ export async function analyzeProject(opts: AnalyzeOptions = {}): Promise<Analyze
   await detectProject(rt, cwd); // throws ProjectError if not a SvelteKit project
   const warnings = [...(loaded?.warnings ?? []), ...(await checkVersionFloor(rt, cwd))];
 
-  const matches = routeMatcher(opts.route);
-  const collected = await collectRoutes(rt, cwd, config, opts.parseCache);
-  const heads = collected.heads.filter((h) => matches(h.route));
-  const images = collected.images.filter((i) => matches(i.route));
-  const headings = collected.headings.filter((h) => matches(h.route));
-  const project = await collectProjectFacts(rt, cwd);
-  // Component (Correctness) facts are file-scoped with no route attribution yet, so a
-  // route-filtered run skips them rather than reporting unrelated components (#68 review);
-  // kitModules is skipped for the same reason.
-  const components = opts.route ? [] : await collectComponentFacts(rt, cwd);
-  const kitModules = opts.route ? [] : await collectKitModuleFacts(rt, cwd);
-  // Unlike its two neighbours above, the --route branch gets `undefined` here, not `[]`: an empty
-  // inventory would tell architecture/unit-entry-file that the declared unit directories truly do
-  // not exist, so it would report every declaration as inert, whereas `undefined` means the mode
-  // never collected the fact at all, and the rule stays silent instead of raising a false alarm.
-  const sourceFiles = opts.route ? undefined : await collectSourceFiles(rt, cwd);
+  const { heads, images, headings, project, components, kitModules, sourceFiles } = await collectAll(rt, cwd, config, {
+    route: opts.route,
+    parseCache: opts.parseCache
+  });
   const selected = selectRules(allRules, config);
   const rules = opts.categories ? selected.filter((r) => opts.categories!.includes(r.category)) : selected;
   const results = applyOverrides(

--- a/packages/cli/src/route-matcher.ts
+++ b/packages/cli/src/route-matcher.ts
@@ -1,0 +1,17 @@
+// Match a route path against a glob (`blog/*`, `**/admin`, `static/**`). An
+// undefined glob matches everything. Lives in its own module so `collect-all.ts`
+// can use it without importing `index.ts` (which imports `collect-all.ts`).
+export function routeMatcher(glob: string | undefined): (route: string) => boolean {
+  if (!glob) return () => true;
+  const body = glob
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*\*/g, ' ') // globstar placeholder
+    .replace(/\*/g, '[^/]*') // single-segment wildcard (placeholder untouched)
+    .replace(/\/ $/g, '(?:/.*)?') // trailing /** -> optional subtree
+    .replace(/^ \//g, '(?:.*/)?') // leading **/ -> optional prefix
+    .replace(/ \//g, '(?:.*/)?') // internal **/ -> optional prefix
+    .replace(/\/ /g, '(?:/.*)?') // internal /** -> optional subtree
+    .replace(/ /g, '.*'); // bare ** -> .*
+  const re = new RegExp(`^${body}$`);
+  return (route) => re.test(route.replace(/^\//, ''));
+}

--- a/packages/cli/test/collect-all.test.ts
+++ b/packages/cli/test/collect-all.test.ts
@@ -33,6 +33,15 @@ describe('collectAll', () => {
     // Non-empty on purpose: an empty-fixture assertion here would pass identically
     // if the collectKitModuleFacts call were deleted from collectAll outright.
     expect(facts.kitModules.map((m) => m.file).sort()).toEqual(['src/hooks.server.ts', 'src/routes/a/+page.server.ts']);
+    expect(facts.sourceFiles).toEqual([
+      'src/app.html',
+      'src/hooks.server.ts',
+      'src/lib/Card.svelte',
+      'src/routes/+layout.svelte',
+      'src/routes/a/+page.server.ts',
+      'src/routes/a/+page.svelte',
+      'src/routes/b/+page.svelte'
+    ]);
   });
 
   it('filters route-scoped facts and skips component/kit-module scanning when route is set', async () => {
@@ -46,5 +55,11 @@ describe('collectAll', () => {
     // File-scoped facts have no route attribution, so a route-filtered run skips them.
     expect(facts.components).toEqual([]);
     expect(facts.kitModules).toEqual([]);
+    // `undefined`, NOT `[]` — the distinction is load-bearing. An empty inventory tells
+    // architecture/unit-entry-file that the declared unit directories really are absent,
+    // so it reports every declaration as inert; `undefined` means the fact was never
+    // collected and the rule stays silent. Pinned here as well as in
+    // analyze-project.test.ts so a break points at collectAll rather than at the CLI.
+    expect(facts.sourceFiles).toBeUndefined();
   });
 });

--- a/packages/cli/test/collect-all.test.ts
+++ b/packages/cli/test/collect-all.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { defaultConfig } from '@svelte-vitals/core';
+import { collectAll } from '../src/collect-all.js';
+import { createMemoryRuntime } from './helpers/memory-runtime.js';
+
+const PROJECT = {
+  'src/app.html': `<!doctype html><html lang="en"><body></body></html>`,
+  'src/routes/+layout.svelte': `<script>let { children } = $props();</script>{@render children()}`,
+  'src/routes/a/+page.svelte': `<svelte:head><title>A</title></svelte:head><h1>A</h1>`,
+  'src/routes/b/+page.svelte': `<svelte:head><title>B</title></svelte:head><h1>B</h1>`,
+  'src/lib/Card.svelte': `<script>let { title = '' } = $props();</script><h3>{title}</h3>`
+};
+
+describe('collectAll', () => {
+  it('returns facts for every route plus project-wide and component facts', async () => {
+    const rt = createMemoryRuntime(PROJECT);
+
+    const facts = await collectAll(rt, '', defaultConfig);
+
+    expect(facts.heads.map((h) => h.route).sort()).toEqual(['/a', '/b']);
+    expect(facts.images.map((i) => i.route).sort()).toEqual(['/a', '/b']);
+    expect(facts.headings.map((h) => h.route).sort()).toEqual(['/a', '/b']);
+    expect(facts.project.htmlLang).toEqual({ presence: 'own', value: 'static' });
+    // Every .svelte under src/ is scanned, routes and $lib alike.
+    expect(facts.components.map((c) => c.file).sort()).toEqual([
+      'src/lib/Card.svelte',
+      'src/routes/+layout.svelte',
+      'src/routes/a/+page.svelte',
+      'src/routes/b/+page.svelte'
+    ]);
+    expect(facts.kitModules).toEqual([]);
+  });
+
+  it('filters route-scoped facts and skips component/kit-module scanning when route is set', async () => {
+    const rt = createMemoryRuntime(PROJECT);
+
+    const facts = await collectAll(rt, '', defaultConfig, { route: 'a' });
+
+    expect(facts.heads.map((h) => h.route)).toEqual(['/a']);
+    expect(facts.images.map((i) => i.route)).toEqual(['/a']);
+    expect(facts.headings.map((h) => h.route)).toEqual(['/a']);
+    // File-scoped facts have no route attribution, so a route-filtered run skips them.
+    expect(facts.components).toEqual([]);
+    expect(facts.kitModules).toEqual([]);
+  });
+});

--- a/packages/cli/test/collect-all.test.ts
+++ b/packages/cli/test/collect-all.test.ts
@@ -8,7 +8,9 @@ const PROJECT = {
   'src/routes/+layout.svelte': `<script>let { children } = $props();</script>{@render children()}`,
   'src/routes/a/+page.svelte': `<svelte:head><title>A</title></svelte:head><h1>A</h1>`,
   'src/routes/b/+page.svelte': `<svelte:head><title>B</title></svelte:head><h1>B</h1>`,
-  'src/lib/Card.svelte': `<script>let { title = '' } = $props();</script><h3>{title}</h3>`
+  'src/lib/Card.svelte': `<script>let { title = '' } = $props();</script><h3>{title}</h3>`,
+  'src/hooks.server.ts': `export async function handle({ event, resolve }) {\n  return resolve(event);\n}\n`,
+  'src/routes/a/+page.server.ts': `export async function load() {\n  return {};\n}\n`
 };
 
 describe('collectAll', () => {
@@ -28,7 +30,9 @@ describe('collectAll', () => {
       'src/routes/a/+page.svelte',
       'src/routes/b/+page.svelte'
     ]);
-    expect(facts.kitModules).toEqual([]);
+    // Non-empty on purpose: an empty-fixture assertion here would pass identically
+    // if the collectKitModuleFacts call were deleted from collectAll outright.
+    expect(facts.kitModules.map((m) => m.file).sort()).toEqual(['src/hooks.server.ts', 'src/routes/a/+page.server.ts']);
   });
 
   it('filters route-scoped facts and skips component/kit-module scanning when route is set', async () => {

--- a/packages/cli/test/helpers/counting-runtime.ts
+++ b/packages/cli/test/helpers/counting-runtime.ts
@@ -1,6 +1,13 @@
 import type { Runtime } from '@svelte-vitals/core';
 
-/** Call counts keyed by path (readFile/exists) or by pattern (glob). */
+/**
+ * Call counts keyed by path (readFile/exists) or by pattern (glob).
+ *
+ * `exists` is captured for completeness but no io-budget invariant currently
+ * asserts on it — the design doc doesn't budget it either. That's a deliberate
+ * gap, not an oversight; add an invariant deliberately if that changes rather
+ * than assuming the omission was accidental.
+ */
 export interface RuntimeCounts {
   readFile: Map<string, number>;
   exists: Map<string, number>;

--- a/packages/cli/test/helpers/counting-runtime.ts
+++ b/packages/cli/test/helpers/counting-runtime.ts
@@ -1,0 +1,37 @@
+import type { Runtime } from '@svelte-vitals/core';
+
+/** Call counts keyed by path (readFile/exists) or by pattern (glob). */
+export interface RuntimeCounts {
+  readFile: Map<string, number>;
+  exists: Map<string, number>;
+  glob: Map<string, number>;
+}
+
+/**
+ * Wrap a Runtime so every call through it is counted. These counts are what
+ * `test/io-budget.test.ts` holds the analysis pipeline to: unlike wall-clock
+ * timings they are identical on every machine, so the gate cannot be flaky.
+ * See docs/superpowers/specs/2026-07-29-io-budget-ci-design.md.
+ */
+export function createCountingRuntime(base: Runtime): { rt: Runtime; counts: RuntimeCounts } {
+  const counts: RuntimeCounts = { readFile: new Map(), exists: new Map(), glob: new Map() };
+  const bump = (m: Map<string, number>, key: string) => m.set(key, (m.get(key) ?? 0) + 1);
+  return {
+    counts,
+    rt: {
+      ...base,
+      readFile(path) {
+        bump(counts.readFile, path);
+        return base.readFile(path);
+      },
+      exists(path) {
+        bump(counts.exists, path);
+        return base.exists(path);
+      },
+      glob(pattern, cwd) {
+        bump(counts.glob, pattern);
+        return base.glob(pattern, cwd);
+      }
+    }
+  };
+}

--- a/packages/cli/test/io-budget.test.ts
+++ b/packages/cli/test/io-budget.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { defaultConfig } from '@svelte-vitals/core';
 import { collectAll } from '../src/collect-all.js';
 import { createMemoryRuntime } from './helpers/memory-runtime.js';
-import { createCountingRuntime } from './helpers/counting-runtime.js';
+import { createCountingRuntime, type RuntimeCounts } from './helpers/counting-runtime.js';
 
 /**
  * Reads per file allowed across one full collection phase. TWO is the measured
@@ -48,16 +48,26 @@ function project(routeCount: number): Record<string, string> {
   return files;
 }
 
+/**
+ * Files read more than the budget allows. Returned as `[path, count]` pairs rather
+ * than asserted per entry so a failure names every offender and by how much.
+ */
+function overReadBudget(counts: RuntimeCounts): [string, number][] {
+  return [...counts.readFile].filter(([, n]) => n > MAX_READS_PER_FILE);
+}
+
+/** Glob patterns issued more than once — each repeat is another full directory traversal. */
+function repeatedGlobs(counts: RuntimeCounts): [string, number][] {
+  return [...counts.glob].filter(([, n]) => n !== 1);
+}
+
 describe('I/O budget for the collection phase', () => {
   it(`reads no file more than ${MAX_READS_PER_FILE} times`, async () => {
     const { rt, counts } = createCountingRuntime(createMemoryRuntime(project(6)));
 
     await collectAll(rt, '', defaultConfig);
 
-    // Collect the offenders rather than asserting per entry, so a failure names
-    // every file that blew the budget and by how much.
-    const over = [...counts.readFile].filter(([, n]) => n > MAX_READS_PER_FILE);
-    expect(over).toEqual([]);
+    expect(overReadBudget(counts)).toEqual([]);
   });
 
   it('issues each glob pattern exactly once', async () => {
@@ -65,9 +75,7 @@ describe('I/O budget for the collection phase', () => {
 
     await collectAll(rt, '', defaultConfig);
 
-    // A second call for the same pattern is a second full directory traversal.
-    const repeated = [...counts.glob].filter(([, n]) => n !== 1);
-    expect(repeated).toEqual([]);
+    expect(repeatedGlobs(counts)).toEqual([]);
     // Sanity: the run really did glob (an empty map would pass the check above).
     expect(counts.glob.size).toBeGreaterThan(0);
   });
@@ -115,5 +123,13 @@ describe('I/O budget for the collection phase', () => {
       'src/routes/**/+{page,layout}.server.{ts,js}',
       'src/routes/**/+{page,layout}.{ts,js}'
     ]);
+
+    // The filtered run is held to the same count budgets as the unfiltered one. The
+    // set comparison above proves only WHICH patterns were issued, never how many
+    // times, and the two invariants that do count never exercise this path — so
+    // without these two lines a regression confined to the `--route` path (say a
+    // glob moved inside a per-route loop) would stay green in every check here.
+    expect(overReadBudget(filtered.counts)).toEqual([]);
+    expect(repeatedGlobs(filtered.counts)).toEqual([]);
   });
 });

--- a/packages/cli/test/io-budget.test.ts
+++ b/packages/cli/test/io-budget.test.ts
@@ -64,4 +64,31 @@ describe('I/O budget for the collection phase', () => {
     // Sanity: the run really did glob (an empty map would pass the check above).
     expect(counts.glob.size).toBeGreaterThan(0);
   });
+
+  it('does not read shared files more often as route count grows', async () => {
+    const small = createCountingRuntime(createMemoryRuntime(project(2)));
+    const large = createCountingRuntime(createMemoryRuntime(project(12)));
+
+    await collectAll(small.rt, '', defaultConfig);
+    await collectAll(large.rt, '', defaultConfig);
+
+    // 6x the routes must not mean more reads of the files they share. This is the
+    // primary parse-cache-breakage detector: per-file budgets alone stay green if
+    // the cache dies but every file happens to stay under the cap.
+    for (const shared of ['src/routes/+layout.svelte', 'src/lib/Card.svelte']) {
+      expect([shared, large.counts.readFile.get(shared)]).toEqual([shared, small.counts.readFile.get(shared)]);
+    }
+  });
+
+  it('scans no components or kit modules for a route-filtered run', async () => {
+    const { rt, counts } = createCountingRuntime(createMemoryRuntime(project(6)));
+
+    await collectAll(rt, '', defaultConfig, { route: 'p0' });
+
+    // File-scoped facts are skipped when a single route was asked for; issuing
+    // their globs anyway would pay for a whole-project scan nobody reads.
+    const patterns = [...counts.glob.keys()];
+    expect(patterns).not.toContain('src/**/*.svelte{,.ts,.js}');
+    expect(patterns.filter((p) => p.includes('+{page,layout}') || p.includes('hooks.server'))).toEqual([]);
+  });
 });

--- a/packages/cli/test/io-budget.test.ts
+++ b/packages/cli/test/io-budget.test.ts
@@ -25,6 +25,11 @@ const MAX_READS_PER_FILE = 2;
  * A SvelteKit-shaped project as a path→source map: `routeCount` pages that all
  * inherit one root layout, which itself pulls in one shared $lib component. The
  * sharing is the point — it is what a broken parse cache would read repeatedly.
+ *
+ * Also includes one kit-module file of each shape `collectKitModuleFacts` looks
+ * for (a hooks file and a route `+page.server.ts`) so that collector's globs and
+ * reads fall under the budget too, instead of running unbudgeted against a
+ * fixture with nothing for it to find.
  */
 function project(routeCount: number): Record<string, string> {
   const files: Record<string, string> = {
@@ -32,7 +37,9 @@ function project(routeCount: number): Record<string, string> {
     'vite.config.ts': `export default { plugins: [] };\n`,
     'src/app.html': `<!doctype html><html lang="en"><body></body></html>\n`,
     'src/routes/+layout.svelte': `<script>\n  import Card from '$lib/Card.svelte';\n  let { children } = $props();\n</script>\n\n<Card title="shared" />\n{@render children()}\n`,
-    'src/lib/Card.svelte': `<script>\n  let { title = '' } = $props();\n</script>\n\n<svelte:head><meta name="description" content="shared" /></svelte:head>\n<h3>{title}</h3>\n`
+    'src/lib/Card.svelte': `<script>\n  let { title = '' } = $props();\n</script>\n\n<svelte:head><meta name="description" content="shared" /></svelte:head>\n<h3>{title}</h3>\n`,
+    'src/hooks.server.ts': `export async function handle({ event, resolve }) {\n  return resolve(event);\n}\n`,
+    'src/routes/p0/+page.server.ts': `export async function load() {\n  return {};\n}\n`
   };
   for (let i = 0; i < routeCount; i++) {
     files[`src/routes/p${i}/+page.svelte`] =
@@ -76,19 +83,36 @@ describe('I/O budget for the collection phase', () => {
     // primary parse-cache-breakage detector: per-file budgets alone stay green if
     // the cache dies but every file happens to stay under the cap.
     for (const shared of ['src/routes/+layout.svelte', 'src/lib/Card.svelte']) {
+      // Guard against a vacuous pass: Map#get returns undefined for a file that was
+      // never read at all, and undefined === undefined would satisfy the equality
+      // below just as well as a real match would.
+      expect(small.counts.readFile.get(shared)).toBeGreaterThan(0);
       expect([shared, large.counts.readFile.get(shared)]).toEqual([shared, small.counts.readFile.get(shared)]);
     }
   });
 
   it('scans no components or kit modules for a route-filtered run', async () => {
-    const { rt, counts } = createCountingRuntime(createMemoryRuntime(project(6)));
+    const full = createCountingRuntime(createMemoryRuntime(project(6)));
+    const filtered = createCountingRuntime(createMemoryRuntime(project(6)));
 
-    await collectAll(rt, '', defaultConfig, { route: 'p0' });
+    await collectAll(full.rt, '', defaultConfig);
+    await collectAll(filtered.rt, '', defaultConfig, { route: 'p0' });
 
-    // File-scoped facts are skipped when a single route was asked for; issuing
-    // their globs anyway would pay for a whole-project scan nobody reads.
-    const patterns = [...counts.glob.keys()];
-    expect(patterns).not.toContain('src/**/*.svelte{,.ts,.js}');
-    expect(patterns.filter((p) => p.includes('+{page,layout}') || p.includes('hooks.server'))).toEqual([]);
+    // Derived-set comparison rather than pinned string literals: this fails both if
+    // a pattern that should be skipped starts being issued anyway, and if a pattern
+    // gets reworded (the string literals below would then no longer match anything
+    // in `full`, so the two runs would look identical and this would go red rather
+    // than passing vacuously).
+    const skipped = [...full.counts.glob.keys()].filter((p) => !filtered.counts.glob.has(p));
+    // Component scanning plus every kit-module glob (page/layout, their .server
+    // variants, +server endpoints, and hooks.server) — the whole file-scoped-facts
+    // surface that a route-filtered run has no use for.
+    expect(skipped.sort()).toEqual([
+      'src/**/*.svelte{,.ts,.js}',
+      'src/hooks.server.{ts,js}',
+      'src/routes/**/+server.{ts,js}',
+      'src/routes/**/+{page,layout}.server.{ts,js}',
+      'src/routes/**/+{page,layout}.{ts,js}'
+    ]);
   });
 });

--- a/packages/cli/test/io-budget.test.ts
+++ b/packages/cli/test/io-budget.test.ts
@@ -104,10 +104,11 @@ describe('I/O budget for the collection phase', () => {
     // in `full`, so the two runs would look identical and this would go red rather
     // than passing vacuously).
     const skipped = [...full.counts.glob.keys()].filter((p) => !filtered.counts.glob.has(p));
-    // Component scanning plus every kit-module glob (page/layout, their .server
-    // variants, +server endpoints, and hooks.server) — the whole file-scoped-facts
-    // surface that a route-filtered run has no use for.
+    // The source-file inventory, component scanning, and every kit-module glob
+    // (page/layout, their .server variants, +server endpoints, and hooks.server) —
+    // the whole file-scoped-facts surface that a route-filtered run has no use for.
     expect(skipped.sort()).toEqual([
+      'src/**/*',
       'src/**/*.svelte{,.ts,.js}',
       'src/hooks.server.{ts,js}',
       'src/routes/**/+server.{ts,js}',

--- a/packages/cli/test/io-budget.test.ts
+++ b/packages/cli/test/io-budget.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { defaultConfig } from '@svelte-vitals/core';
+import { collectAll } from '../src/collect-all.js';
+import { createMemoryRuntime } from './helpers/memory-runtime.js';
+import { createCountingRuntime } from './helpers/counting-runtime.js';
+
+/**
+ * Reads per file allowed across one full collection phase. TWO is the measured
+ * status quo, not an ideal. Two independent paths sit at exactly this cap:
+ *
+ *   - every `.svelte` file: `collectRoutes` reads it for head resolution
+ *     (parseFile) and `collectComponentFacts` reads it again for component facts
+ *     (parseComponentFacts) — different parsers, separate caches, and the
+ *     component glob also matches route files.
+ *   - the Vite config: `collectProjectFacts` reads it once via
+ *     `detectViteMinifyDisabled` and once via `detectKitPathsBase`.
+ *
+ * Lowering this number is welcome and should accompany any unification of those
+ * read paths. RAISING it is a design decision that needs a recorded reason — not a
+ * number edit. See docs/superpowers/specs/2026-07-29-io-budget-ci-design.md.
+ */
+const MAX_READS_PER_FILE = 2;
+
+/**
+ * A SvelteKit-shaped project as a path→source map: `routeCount` pages that all
+ * inherit one root layout, which itself pulls in one shared $lib component. The
+ * sharing is the point — it is what a broken parse cache would read repeatedly.
+ */
+function project(routeCount: number): Record<string, string> {
+  const files: Record<string, string> = {
+    'svelte.config.js': `export default { kit: {} };\n`,
+    'vite.config.ts': `export default { plugins: [] };\n`,
+    'src/app.html': `<!doctype html><html lang="en"><body></body></html>\n`,
+    'src/routes/+layout.svelte': `<script>\n  import Card from '$lib/Card.svelte';\n  let { children } = $props();\n</script>\n\n<Card title="shared" />\n{@render children()}\n`,
+    'src/lib/Card.svelte': `<script>\n  let { title = '' } = $props();\n</script>\n\n<svelte:head><meta name="description" content="shared" /></svelte:head>\n<h3>{title}</h3>\n`
+  };
+  for (let i = 0; i < routeCount; i++) {
+    files[`src/routes/p${i}/+page.svelte`] =
+      `<svelte:head><title>Page ${i}</title></svelte:head>\n<h1>Page ${i}</h1>\n`;
+  }
+  return files;
+}
+
+describe('I/O budget for the collection phase', () => {
+  it(`reads no file more than ${MAX_READS_PER_FILE} times`, async () => {
+    const { rt, counts } = createCountingRuntime(createMemoryRuntime(project(6)));
+
+    await collectAll(rt, '', defaultConfig);
+
+    // Collect the offenders rather than asserting per entry, so a failure names
+    // every file that blew the budget and by how much.
+    const over = [...counts.readFile].filter(([, n]) => n > MAX_READS_PER_FILE);
+    expect(over).toEqual([]);
+  });
+
+  it('issues each glob pattern exactly once', async () => {
+    const { rt, counts } = createCountingRuntime(createMemoryRuntime(project(6)));
+
+    await collectAll(rt, '', defaultConfig);
+
+    // A second call for the same pattern is a second full directory traversal.
+    const repeated = [...counts.glob].filter(([, n]) => n !== 1);
+    expect(repeated).toEqual([]);
+    // Sanity: the run really did glob (an empty map would pass the check above).
+    expect(counts.glob.size).toBeGreaterThan(0);
+  });
+});

--- a/packages/cli/test/parse-cache.test.ts
+++ b/packages/cli/test/parse-cache.test.ts
@@ -1,22 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import type { Runtime } from '@svelte-vitals/core';
 import { collectRoutes } from '../src/providers/source/routes.js';
 import { createMemoryRuntime } from './helpers/memory-runtime.js';
-
-/** Wraps a Runtime's readFile to count calls per path, proving the parse cache dedupes reads. */
-function withReadSpy(rt: Runtime): { rt: Runtime; counts: Map<string, number> } {
-  const counts = new Map<string, number>();
-  return {
-    rt: {
-      ...rt,
-      async readFile(path: string) {
-        counts.set(path, (counts.get(path) ?? 0) + 1);
-        return rt.readFile(path);
-      }
-    },
-    counts
-  };
-}
+import { createCountingRuntime } from './helpers/counting-runtime.js';
 
 describe('parse cache (per-run readFile dedup)', () => {
   it('reads a shared root layout and a shared $lib component exactly once across routes', async () => {
@@ -26,17 +11,17 @@ describe('parse cache (per-run readFile dedup)', () => {
       'src/routes/b/+page.svelte': `<h1>B</h1>`,
       'src/lib/Seo.svelte': `<svelte:head><title>{data.title}</title><meta name="description" content={data.desc} /></svelte:head>`
     });
-    const { rt, counts } = withReadSpy(base);
+    const { rt, counts } = createCountingRuntime(base);
 
     const { heads, images, headings } = await collectRoutes(rt, '');
 
     // Root layout and the shared component are each on both routes' chains, but
     // must be read+parsed exactly once for the whole run.
-    expect(counts.get('src/routes/+layout.svelte')).toBe(1);
-    expect(counts.get('src/lib/Seo.svelte')).toBe(1);
+    expect(counts.readFile.get('src/routes/+layout.svelte')).toBe(1);
+    expect(counts.readFile.get('src/lib/Seo.svelte')).toBe(1);
     // Each page is still read once (never merged across distinct route files).
-    expect(counts.get('src/routes/a/+page.svelte')).toBe(1);
-    expect(counts.get('src/routes/b/+page.svelte')).toBe(1);
+    expect(counts.readFile.get('src/routes/a/+page.svelte')).toBe(1);
+    expect(counts.readFile.get('src/routes/b/+page.svelte')).toBe(1);
 
     // Output is unaffected by caching: both routes see the composed title/description
     // (inherited from the layout's Seo usage) and the layout's <img>/page's <h1>.

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -40,6 +40,7 @@
   ],
   "scripts": {
     "build": "tsup",
+    "bench": "node scripts/bench/bench.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/packages/vite/scripts/bench/bench.mjs
+++ b/packages/vite/scripts/bench/bench.mjs
@@ -1,8 +1,16 @@
-// Throwaway benchmark for Plan 037 (dev-server analysis isolation spike,
-// plans/037-design-spike-dev-server-analysis-isolation.md).
-// Not part of the shipped package — do not import from packages/vite/src. No tests:
-// this is a one-off measurement tool whose results are transcribed into
-// docs/superpowers/specs/2026-07-13-dev-server-analysis-isolation-design.md.
+// Manual timing benchmark for the whole-project analysis path — the same
+// `analyzeProject()` call packages/vite/src/ui/analysis.ts's `runOnce` makes on
+// every dev-server save. Run it with `pnpm bench`.
+//
+// CI deliberately does NOT run this. Shared GitHub runners vary by 1.5-2x under
+// neighbour load, so absolute timings are not comparable across runs; the speed
+// regression gate CI *does* run is the deterministic I/O budget in
+// packages/cli/test/io-budget.test.ts. Reach for this benchmark for the two things
+// call counts cannot catch: a widened analysis (more AST walking for the same I/O)
+// and lost parallelism. See
+// docs/superpowers/specs/2026-07-29-io-budget-ci-design.md.
+//
+// Not part of the shipped package — do not import from packages/vite/src.
 //
 // Measures, for synthetic SvelteKit-like projects of increasing route count, how long
 // a single whole-project `analyzeProject()` call takes (the same call

--- a/packages/vite/scripts/bench/gen-project.mjs
+++ b/packages/vite/scripts/bench/gen-project.mjs
@@ -1,8 +1,5 @@
-// Throwaway benchmark fixture generator for Plan 037 (dev-server analysis isolation
-// spike, plans/037-design-spike-dev-server-analysis-isolation.md).
-// Not part of the shipped package — never imported from packages/vite/src. No tests:
-// this is a one-off measurement tool, disposable once the design doc is written
-// (see docs/superpowers/specs/2026-07-13-dev-server-analysis-isolation-design.md).
+// Fixture generator for the manual timing benchmark (`pnpm bench`, bench.mjs).
+// Not part of the shipped package — never imported from packages/vite/src.
 //
 // Generates a synthetic SvelteKit-like project with N pages grouped into sections of
 // GROUP_SIZE, each section with its own +layout.svelte, so the layout-chain walk


### PR DESCRIPTION
## Why

svelte-vitals is fast because of deliberate design choices — a parse cache that reads each file once per path, one directory traversal per glob pattern, rules that consume precomputed facts instead of doing their own I/O. Nothing defended those choices: a PR could break the parse cache, add a second traversal, or give a new rule its own file reads, and CI would stay green.

Wall-clock timing is unusable as a CI gate. Shared `ubuntu-latest` runners vary by 1.5–2x under neighbour load, so a threshold on the ~25ms/~215ms figures this project actually produces would fail spuriously until everyone learned to ignore the red. So this gate counts `Runtime` calls instead. Counts come from the injected `Runtime` interface, are identical on every machine, and cannot be flaky.

Design: `docs/superpowers/specs/2026-07-29-io-budget-ci-design.md`

## What

`packages/cli/src/collect-all.ts` (new) holds the analysis I/O phase — the four (now five) collectors plus route filtering — that was previously inline in `analyzeProject`. It is a pure move; the existing suite is the proof. It is deliberately **not** re-exported from `index.ts`, so the public API is unchanged and no changeset is needed.

`packages/cli/test/io-budget.test.ts` (new) then holds that real function to four invariants, running on the existing `test` job with negligible added time (it uses the in-memory `Runtime`):

| Invariant | Regression it catches |
| --- | --- |
| Each file read at most **twice** | Parse-cache breakage, duplicate reads, a new collector doing its own I/O |
| Each glob pattern issued **exactly once** | Repeated directory traversal |
| Reads of a shared layout / `$lib` component **do not vary with route count** (2 vs 12 routes) | Parse-cache breakage — the primary case |
| A route-filtered run **skips exactly** the file-scoped globs | Loss of the single-route fast path |

`MAX_READS_PER_FILE = 2` is the **measured status quo, not an ideal**. Two paths sit exactly at the cap: every `.svelte` file is read once by `collectRoutes` (head resolution, `parseFile`) and again by `collectComponentFacts` (component facts, `parseComponentFacts`) — different parsers, separate caches — and the Vite config is read once each by `detectViteMinifyDisabled` and `detectKitPathsBase`. The test comment records both, plus the rule for changing the number: lowering it is welcome and should accompany any unification of those read paths; raising it needs a recorded reason, not a number edit.

## What this gate deliberately does not catch

Stating this explicitly, because a gate mistaken for complete coverage is worse than none:

- **A widened analysis** — e.g. abandoning the "we do NOT follow the expression" boundary in `packages/core/src/svelte-ast.ts`. I/O counts stay identical while AST walk volume grows.
- **Lost parallelism** — replacing a `Promise.all` with sequential `await` leaves every call count unchanged.

Both are visible only in wall-clock time, which is why `packages/vite/scripts/bench/bench.mjs` is kept rather than deleted. It stops describing itself as a `Throwaway` one-off and becomes `pnpm bench`: a documented manual tool, scoped to build only `svelte-vitals` and its dependencies, never run in CI.

## Verification

Every invariant was confirmed to actually fail when the behaviour it guards breaks — a guard never seen failing is not a guard. Bypassing the `ParseCache` made the shared layout and `$lib` component show 7 reads each, named in the output. Removing each route fast-path guard, and deleting the `collectKitModuleFacts` call outright, each turned the expected test red. All breaks were reverted and the tree re-verified.

The rebase onto `main` produced a live demonstration: `main` grew a fifth collector (`collectSourceFiles`) while this branch was in review, and the route-filtered invariant went red until its glob was admitted to the expected set — exactly the behaviour `collectAll`'s docstring describes.

`pnpm lint`, `pnpm typecheck`, `pnpm test` all pass (1,987 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added route-scoped collection to skip unnecessary scanning and return route-relevant results.
  * Introduced a manual `pnpm bench` workflow for whole-project timing.
* **Bug Fixes**
  * Improved route-filtered reporting by suppressing misleading `sourceFiles` output.
  * Reduced redundant I/O during multi-route analyses via improved collection/reuse.
* **Documentation**
  * Documented the deterministic I/O budget CI gate and clarified benchmark/bench usage.
* **Tests**
  * Added deterministic `collectAll` and I/O budget CI tests; updated cache-read counting assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->