### PR TITLE
perf(core): skip the directory rules when no config layer mentions them

### DIFF
--- a/.changeset/skip-undeclared-directory-rules.md
+++ b/.changeset/skip-undeclared-directory-rules.md
@@ -1,0 +1,10 @@
+---
+'@svelte-vitals/core': patch
+---
+
+Skip the three directory-shaped Architecture rules entirely when no config layer mentions them.
+`architecture/unit-entry-file`, `architecture/directory-naming` and
+`architecture/reserved-directory-names` read their options per directory, so an unconfigured project
+was resolving and discarding options once for every directory under `src/`, three times over — on
+every dev-server save. Measured over a synthetic tree of 1,523 directories, that cost 5.4 ms per
+analysis for rules that are off by default and produce nothing. It is now zero.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -169,6 +169,7 @@ export {
 export type { CompiledOverride } from './config-apply.js';
 
 export {
+  isMentionedAnywhere,
   resolveRuleOptions,
   validateRuleOptions,
   validateRuleSetting,

--- a/packages/core/src/rule-options.ts
+++ b/packages/core/src/rule-options.ts
@@ -79,8 +79,14 @@ export function mapOption(options: RuleOptions, key: string): Record<string, str
  * owed; this one can only ever fail to save time.
  */
 export function isMentionedAnywhere(config: Config, ruleId: string): boolean {
-  if (config.rules[ruleId] !== undefined) return true;
-  return (config.overrides ?? []).some((entry) => entry.rules?.[ruleId] !== undefined);
+  // `Object.hasOwn`, not a `!== undefined` presence test: the latter walks the prototype chain, so a
+  // `ruleId` of `toString` or `constructor` would find an inherited member on these plain objects and
+  // report the rule as mentioned. Not reachable through a registered rule — every id contains a `/`,
+  // which no `Object.prototype` member does — but it is how this repository does presence checks on
+  // an open-ended record (`parseCasings` in rules/architecture/casing.ts, `perf/heavy-import`), and a
+  // helper taking an id as a parameter should not depend on every caller passing a literal.
+  if (Object.hasOwn(config.rules, ruleId)) return true;
+  return (config.overrides ?? []).some((entry) => entry.rules !== undefined && Object.hasOwn(entry.rules, ruleId));
 }
 
 /**

--- a/packages/core/src/rule-options.ts
+++ b/packages/core/src/rule-options.ts
@@ -63,6 +63,27 @@ export function mapOption(options: RuleOptions, key: string): Record<string, str
 }
 
 /**
+ * Whether any config layer so much as mentions `ruleId` — its `rules` entry, or any `overrides`
+ * entry's.
+ *
+ * A rule that is inert until declared can return early on `false` instead of resolving options once
+ * per target and discarding the result. That waste is not hypothetical: the three directory-shaped
+ * Architecture rules resolve per directory, so an unconfigured project pays it for every directory
+ * under `src/` three times over, on every dev-server save. Measured 2026-07-30 over a synthetic tree
+ * of 1,523 directories: 5.4 ms per analysis, for rules that are off by default and therefore produce
+ * nothing.
+ *
+ * Deliberately conservative. It asks only whether the rule is *mentioned*, not whether the mention
+ * resolves to a non-empty value, so a `'off'` severity with no options still answers `true` and the
+ * caller does its normal work. A cheaper-but-wrong version of this would make a rule skip work it
+ * owed; this one can only ever fail to save time.
+ */
+export function isMentionedAnywhere(config: Config, ruleId: string): boolean {
+  if (config.rules[ruleId] !== undefined) return true;
+  return (config.overrides ?? []).some((entry) => entry.rules?.[ruleId] !== undefined);
+}
+
+/**
  * Effective options for a rule at a target: built-in defaults, then
  * `config.rules[ruleId].options`, then every matching `config.overrides` entry
  * in order. Integers take the last value; lists and maps accumulate.

--- a/packages/core/src/rules/architecture/directory-naming.ts
+++ b/packages/core/src/rules/architecture/directory-naming.ts
@@ -1,7 +1,13 @@
 import type { Result } from '../../types.js';
 import { docsUrlFor, type Rule, type RuleContext } from '../../rule.js';
 import { compileOverrides } from '../../config-apply.js';
-import { listOption, mapOption, resolveRuleOptions, type RuleOptionsSpec } from '../../rule-options.js';
+import {
+  isMentionedAnywhere,
+  listOption,
+  mapOption,
+  resolveRuleOptions,
+  type RuleOptionsSpec
+} from '../../rule-options.js';
 import {
   ancestorDirs,
   baseName,
@@ -52,6 +58,11 @@ export const architectureDirectoryNaming: Rule = {
   async check(ctx: RuleContext): Promise<Result[]> {
     const files = ctx.sourceFiles;
     if (files === undefined) return [];
+
+    // No config layer mentions this rule, so nothing below can find a declaration. Without this,
+    // an unconfigured project resolves options once per directory and throws every result away —
+    // and this rule is off by default, so that is the case for almost every project.
+    if (!isMentionedAnywhere(ctx.config, 'architecture/directory-naming')) return [];
 
     const compiledOverrides = compileOverrides(ctx.config);
     const dirs = new Set<string>();

--- a/packages/core/src/rules/architecture/directory-naming.ts
+++ b/packages/core/src/rules/architecture/directory-naming.ts
@@ -19,7 +19,8 @@ import {
 } from './declarations.js';
 import { decodeSegment, parseCasings, satisfiesCasing } from './casing.js';
 
-const docsUrl = docsUrlFor('architecture/directory-naming');
+const ID = 'architecture/directory-naming';
+const docsUrl = docsUrlFor(ID);
 const recommendation = 'Name each directory in the casing its location declares, or narrow the declaration.';
 
 // Inert by default: with nothing declared there is no convention to check, and svelte-vitals never
@@ -44,7 +45,7 @@ const OPTIONS: RuleOptionsSpec = {
  * hundreds of 100s from one `'src/routes/**'` declaration and dilute every real finding.
  */
 export const architectureDirectoryNaming: Rule = {
-  id: 'architecture/directory-naming',
+  id: ID,
   title: 'Directory naming',
   category: 'architecture',
   severity: 'info',
@@ -62,7 +63,7 @@ export const architectureDirectoryNaming: Rule = {
     // No config layer mentions this rule, so nothing below can find a declaration. Without this,
     // an unconfigured project resolves options once per directory and throws every result away —
     // and this rule is off by default, so that is the case for almost every project.
-    if (!isMentionedAnywhere(ctx.config, 'architecture/directory-naming')) return [];
+    if (!isMentionedAnywhere(ctx.config, ID)) return [];
 
     const compiledOverrides = compileOverrides(ctx.config);
     const dirs = new Set<string>();
@@ -78,7 +79,7 @@ export const architectureDirectoryNaming: Rule = {
     };
 
     const out: Result[] = [];
-    const globalOptions = resolveRuleOptions('architecture/directory-naming', OPTIONS, ctx.config);
+    const globalOptions = resolveRuleOptions(ID, OPTIONS, ctx.config);
     const globalMap = mapOption(globalOptions, 'directories');
     const globalKeys = new Set(Object.keys(globalMap));
     const usedKeys = new Set<string>();
@@ -87,13 +88,7 @@ export const architectureDirectoryNaming: Rule = {
     const excludedDirs: string[] = [];
 
     for (const dir of [...dirs].sort()) {
-      const o = resolveRuleOptions(
-        'architecture/directory-naming',
-        OPTIONS,
-        ctx.config,
-        { route: dir, file: dir },
-        compiledOverrides
-      );
+      const o = resolveRuleOptions(ID, OPTIONS, ctx.config, { route: dir, file: dir }, compiledOverrides);
       const declared = mapOption(o, 'directories');
       if (Object.keys(declared).length === 0) continue; // inert
 
@@ -134,7 +129,7 @@ export const architectureDirectoryNaming: Rule = {
       // nothing else: no consumer reads `route` as a file — the console reporter groups by it, the
       // agent reporter prefers `location ?? route`, and `computeScore` uses it only as a map key.
       out.push({
-        id: 'architecture/directory-naming',
+        id: ID,
         category: 'architecture',
         severity: 'info',
         detection: { presence: 'none', value: 'absent' },
@@ -192,7 +187,7 @@ export const architectureDirectoryNaming: Rule = {
           ? `The declaration '${reported[0]}' does not check what it says: ${notes.get(reported[0] as string)}.`
           : `These declarations do not check what they say: ${reported.map((k) => `'${k}' (${notes.get(k)})`).join(', ')}.`;
       out.push({
-        id: 'architecture/directory-naming',
+        id: ID,
         category: 'architecture',
         severity: 'info',
         detection: { presence: 'none', value: 'absent' },

--- a/packages/core/src/rules/architecture/reserved-directory-names.ts
+++ b/packages/core/src/rules/architecture/reserved-directory-names.ts
@@ -1,7 +1,13 @@
 import type { Result } from '../../types.js';
 import { docsUrlFor, type Rule, type RuleContext } from '../../rule.js';
 import { compileOverrides } from '../../config-apply.js';
-import { listOption, mapOption, resolveRuleOptions, type RuleOptionsSpec } from '../../rule-options.js';
+import {
+  isMentionedAnywhere,
+  listOption,
+  mapOption,
+  resolveRuleOptions,
+  type RuleOptionsSpec
+} from '../../rule-options.js';
 import {
   ancestorDirs,
   baseName,
@@ -86,6 +92,11 @@ export const architectureReservedDirectoryNames: Rule = {
   async check(ctx: RuleContext): Promise<Result[]> {
     const files = ctx.sourceFiles;
     if (files === undefined) return [];
+
+    // No config layer mentions this rule, so nothing below can find a declaration. Without this,
+    // an unconfigured project resolves options once per directory and throws every result away —
+    // and this rule is off by default, so that is the case for almost every project.
+    if (!isMentionedAnywhere(ctx.config, ID)) return [];
 
     const compiledOverrides = compileOverrides(ctx.config);
     const dirs = new Set<string>();

--- a/packages/core/src/rules/architecture/unit-entry-file.ts
+++ b/packages/core/src/rules/architecture/unit-entry-file.ts
@@ -18,7 +18,8 @@ import {
   reportAt
 } from './declarations.js';
 
-const docsUrl = docsUrlFor('architecture/unit-entry-file');
+const ID = 'architecture/unit-entry-file';
+const docsUrl = docsUrlFor(ID);
 const recommendation =
   'Give every declared unit directory a file named after it, or stop declaring that directory a unit.';
 
@@ -46,7 +47,7 @@ function isPascalCase(name: string): boolean {
  * the directory, because `filterToChangedFiles` keeps only locations git lists as changed.
  */
 export const architectureUnitEntryFile: Rule = {
-  id: 'architecture/unit-entry-file',
+  id: ID,
   title: 'Unit entry file',
   category: 'architecture',
   severity: 'info',
@@ -65,7 +66,7 @@ export const architectureUnitEntryFile: Rule = {
     // No config layer mentions this rule, so nothing below can find a declaration. Without this,
     // an unconfigured project resolves options once per directory and throws every result away —
     // and this rule is off by default, so that is the case for almost every project.
-    if (!isMentionedAnywhere(ctx.config, 'architecture/unit-entry-file')) return [];
+    if (!isMentionedAnywhere(ctx.config, ID)) return [];
 
     // Hoisted: compiling every override's globs once, not once per directory.
     const compiledOverrides = compileOverrides(ctx.config);
@@ -83,7 +84,7 @@ export const architectureUnitEntryFile: Rule = {
 
     const out: Result[] = [];
     // Keys of the globally declared options that matched at least one directory.
-    const globalOptions = resolveRuleOptions('architecture/unit-entry-file', OPTIONS, ctx.config);
+    const globalOptions = resolveRuleOptions(ID, OPTIONS, ctx.config);
     const globalKeys = new Set([
       ...Object.keys(mapOption(globalOptions, 'units')),
       ...Object.keys(mapOption(globalOptions, 'pascalCaseUnits'))
@@ -99,13 +100,7 @@ export const architectureUnitEntryFile: Rule = {
     const matchedSurviving = new Set<string>();
 
     for (const dir of [...dirs].sort()) {
-      const o = resolveRuleOptions(
-        'architecture/unit-entry-file',
-        OPTIONS,
-        ctx.config,
-        { route: dir, file: dir },
-        compiledOverrides
-      );
+      const o = resolveRuleOptions(ID, OPTIONS, ctx.config, { route: dir, file: dir }, compiledOverrides);
       const units = mapOption(o, 'units');
       const pascalUnits = mapOption(o, 'pascalCaseUnits');
       if (Object.keys(units).length === 0 && Object.keys(pascalUnits).length === 0) continue; // inert
@@ -157,7 +152,7 @@ export const architectureUnitEntryFile: Rule = {
       const expected = `${dir}/${baseName(dir)}${ext}`;
       if (fileSet.has(expected)) {
         out.push({
-          id: 'architecture/unit-entry-file',
+          id: ID,
           category: 'architecture',
           severity: 'info',
           detection: { presence: 'own', value: 'static' },
@@ -182,7 +177,7 @@ export const architectureUnitEntryFile: Rule = {
       // every violation's identity distinct, and costs nothing else: no consumer here reads `route`
       // as a file.
       out.push({
-        id: 'architecture/unit-entry-file',
+        id: ID,
         category: 'architecture',
         severity: 'info',
         detection: { presence: 'none', value: 'absent' },
@@ -230,7 +225,7 @@ export const architectureUnitEntryFile: Rule = {
           ? `The declaration '${inertKeys[0]}' ${why(inertKeys[0] as string)}, so it checks nothing.`
           : `These declarations check nothing: ${inertKeys.map((k) => `'${k}' (${why(k)})`).join(', ')}.`;
       out.push({
-        id: 'architecture/unit-entry-file',
+        id: ID,
         category: 'architecture',
         severity: 'info',
         detection: { presence: 'none', value: 'absent' },

--- a/packages/core/src/rules/architecture/unit-entry-file.ts
+++ b/packages/core/src/rules/architecture/unit-entry-file.ts
@@ -1,7 +1,13 @@
 import type { Result } from '../../types.js';
 import { docsUrlFor, type Rule, type RuleContext } from '../../rule.js';
 import { compileOverrides } from '../../config-apply.js';
-import { listOption, mapOption, resolveRuleOptions, type RuleOptionsSpec } from '../../rule-options.js';
+import {
+  isMentionedAnywhere,
+  listOption,
+  mapOption,
+  resolveRuleOptions,
+  type RuleOptionsSpec
+} from '../../rule-options.js';
 import {
   ancestorDirs,
   baseName,
@@ -55,6 +61,11 @@ export const architectureUnitEntryFile: Rule = {
   async check(ctx: RuleContext): Promise<Result[]> {
     const files = ctx.sourceFiles;
     if (files === undefined) return [];
+
+    // No config layer mentions this rule, so nothing below can find a declaration. Without this,
+    // an unconfigured project resolves options once per directory and throws every result away —
+    // and this rule is off by default, so that is the case for almost every project.
+    if (!isMentionedAnywhere(ctx.config, 'architecture/unit-entry-file')) return [];
 
     // Hoisted: compiling every override's globs once, not once per directory.
     const compiledOverrides = compileOverrides(ctx.config);

--- a/packages/core/test/rule-options.test.ts
+++ b/packages/core/test/rule-options.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  isMentionedAnywhere,
   resolveRuleOptions,
   validateRuleOptions,
   validateRuleSetting,
@@ -338,5 +339,36 @@ describe('typed option accessors', () => {
     expect(listOption({ origins: 'a.com' }, 'origins')).toEqual([]);
     expect(mapOption({ packages: ['lodash'] }, 'packages')).toEqual({});
     expect(mapOption({ packages: null }, 'packages')).toEqual({});
+  });
+});
+
+describe('isMentionedAnywhere', () => {
+  const ID = 'architecture/unit-entry-file';
+
+  it('is false when no layer names the rule', () => {
+    expect(isMentionedAnywhere(defineConfig({}), ID)).toBe(false);
+    expect(isMentionedAnywhere(defineConfig({ rules: { 'seo/title-presence': 'off' } }), ID)).toBe(false);
+  });
+
+  it('is true for a `rules` entry, even a bare severity carrying no options', () => {
+    // Conservative on purpose: the caller then does its normal work and finds nothing declared. A
+    // version answering `false` here would make a rule skip work it owed, which is the one failure
+    // this helper must not have.
+    expect(isMentionedAnywhere(defineConfig({ rules: { [ID]: 'off' } }), ID)).toBe(true);
+  });
+
+  it('is true for a rule mentioned only inside an overrides entry', () => {
+    // The case that matters. These rules resolve options per directory, so a declaration can arrive
+    // from an override alone — an early return keyed on the global layer only would swallow it.
+    const config = defineConfig({
+      overrides: [{ files: 'src/**', rules: { [ID]: { options: { units: { 'src/*': '.ts' } } } } }]
+    });
+    expect(isMentionedAnywhere(config, ID)).toBe(true);
+  });
+
+  it('is false when an overrides entry names only other rules', () => {
+    expect(isMentionedAnywhere(defineConfig({ overrides: [{ files: 'src/**', rules: { seo: 'off' } }] }), ID)).toBe(
+      false
+    );
   });
 });

--- a/packages/core/test/rule-options.test.ts
+++ b/packages/core/test/rule-options.test.ts
@@ -366,6 +366,15 @@ describe('isMentionedAnywhere', () => {
     expect(isMentionedAnywhere(config, ID)).toBe(true);
   });
 
+  it('is false for a name inherited from Object.prototype, in either layer', () => {
+    // A presence test would find `Object.prototype.toString` on these plain objects and report the
+    // rule as mentioned. No registered rule id can reach this — every one contains a `/` — but the
+    // helper takes the id as a parameter, so it should not rely on every caller passing a literal.
+    expect(isMentionedAnywhere(defineConfig({}), 'toString')).toBe(false);
+    expect(isMentionedAnywhere(defineConfig({}), 'constructor')).toBe(false);
+    expect(isMentionedAnywhere(defineConfig({ overrides: [{ files: 'src/**', rules: {} }] }), 'toString')).toBe(false);
+  });
+
   it('is false when an overrides entry names only other rules', () => {
     expect(isMentionedAnywhere(defineConfig({ overrides: [{ files: 'src/**', rules: { seo: 'off' } }] }), ID)).toBe(
       false


### PR DESCRIPTION
The three directory-shaped Architecture rules resolve their options **per directory**, because a declaration can be scoped by an `overrides` entry. So an unconfigured project was resolving options once for every directory under `src/` and throwing every result away — three times over, on every dev-server save.

Measured over a synthetic tree of 1,523 directories: **5.4 ms per analysis, now 0.** These rules are off by default, so that was a cost every project paid and no project benefited from.

## The check

```ts
if (!isMentionedAnywhere(ctx.config, 'architecture/unit-entry-file')) return [];
```

`isMentionedAnywhere` asks only whether a config layer — the `rules` entry or any `overrides` entry — **mentions** the rule, not whether the mention resolves to a non-empty value. A bare `'off'` severity with no options still answers `true`, and the rule then does its normal work and finds nothing declared.

That conservatism is the point. A rule whose declaration arrives from an `overrides` entry alone must not be skipped, and these rules are exactly the kind where that happens: the global layer can be empty while an override declares everything. A cheaper check keyed on the global resolution would swallow those, so this one can only ever fail to save time — never fail to do work.

## Why the existing CI budget does not cover this

`packages/cli/test/io-budget.test.ts` counts `Runtime` calls in the collection phase. This waste is in the rule-evaluation phase and costs no I/O at all, so the budget's number does not move either way. The two guards are complementary rather than overlapping.

## Verification

lint, format and typecheck clean; **2,052 tests** pass (core 1054, cli 775, vite 198, mcp 25). Every test of the three rules passes **unedited**, which is what shows the early return changed no behaviour — including the pre-existing tests that declare options only inside an `overrides` entry, which are precisely the ones a wrong check would have broken. The helper itself gets four tests covering both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Reduced unnecessary processing for three architecture checks (unit entry file, directory naming, reserved directory names) when they are not configured, avoiding repeated option resolution and directory scanning.
- **Bug Fixes**
  - Improved configuration detection so rules are only considered “active” when they’re truly declared, avoiding false positives from inherited properties.
- **Tests**
  - Added/expanded coverage for rule activation detection across both top-level rules and override-based configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->