### PR TITLE
fix(core): stop reporting a type-only import as a heavy dependency

### DIFF
--- a/.changeset/heavy-import-type-only.md
+++ b/.changeset/heavy-import-type-only.md
@@ -1,0 +1,16 @@
+---
+'@svelte-vitals/core': patch
+'svelte-vitals': patch
+'@svelte-vitals/vite': patch
+'@svelte-vitals/mcp': patch
+---
+
+`performance/heavy-import` no longer reports a type-only import. The rule's claim is bundle weight, and
+`import type { Moment } from 'moment'` — or a declaration whose every specifier is inline-typed — is
+erased at build and adds nothing, so reporting it was a false positive.
+
+Projects using type-only imports of a configured heavy package will see **fewer** findings, and a health
+score that rises accordingly. No configuration change is needed.
+
+`architecture/private-scope-import` deliberately keeps reporting type-only imports: that rule is about
+coupling between parts of a tree, which a type import creates just the same.

--- a/docs/src/content/docs/ja/rules/performance/heavy-import.md
+++ b/docs/src/content/docs/ja/rules/performance/heavy-import.md
@@ -9,6 +9,8 @@ description: サイズが大きく、ツリーシェイクも効かないパッ�
 
 重くてツリーシェイクできないことで知られるパッケージ（現状は `lodash` と `moment`）からの `import` を検出します。完全一致で判定するため、`lodash/debounce` のようなサブパス import は対象外です。`src/**/*.svelte` のスクリプトを静的（CLI）解析します。
 
+**型のみの import は報告しません。** `import type { Moment } from 'moment'` や、すべての specifier が inline type の宣言はビルド時に消えるため、バンドルには何も加わりません。なお `architecture/private-scope-import` は型のみの import も報告し続けます。こちらはツリー内の結合を見るルールで、型だけの import でも結合は同じように生まれるためです。
+
 ## なぜ重要か
 
 サイズが大きく、ツリーシェイクもできないパッケージを import すると、一部しか使っていなくてもバンドルに丸ごと取り込まれ、ページ読み込みが遅くなります。

--- a/docs/src/content/docs/rules/performance/heavy-import.md
+++ b/docs/src/content/docs/rules/performance/heavy-import.md
@@ -9,6 +9,8 @@ description: Avoid importing large, non-tree-shakeable packages.
 
 Flags an `import` from a well-known heavy / non-tree-shakeable package (currently `lodash`, `moment`). Matched by exact specifier, so a subpath import like `lodash/debounce` is **not** flagged. Static (CLI) analysis of `src/**/*.svelte` scripts.
 
+A **type-only** import is not flagged — `import type { Moment } from 'moment'`, or one whose every specifier is inline-typed — because it is erased at build and adds nothing to the bundle. Note that `architecture/private-scope-import` still reports type-only imports: that rule is about coupling between parts of your tree, which a type import creates just the same.
+
 ## Why it matters
 
 Importing a large, non-tree-shakeable package pulls its whole weight into the bundle even when you use a fraction of it, slowing page load.

--- a/packages/core/src/rules/architecture/private-scope-import.ts
+++ b/packages/core/src/rules/architecture/private-scope-import.ts
@@ -103,6 +103,11 @@ export const architecturePrivateScopeImport: Rule = {
       const spans = c.importSpans ?? c.imports.map((source) => ({ source, line: 0 }));
       let sawScopedImport = false;
       const violations: { line: number; message: string }[] = [];
+      // `importSpans[].type` is deliberately NOT consulted here, unlike in
+      // `performance/heavy-import` and `architecture/route-component-import`. Those two ask what
+      // the import costs at runtime, and a type-only import costs nothing. This rule asks whether
+      // one part of the tree is coupled to another's private code, and importing only a type
+      // couples them just as tightly: rename or delete the unit and the importer still breaks.
       for (const { source, line } of spans) {
         const target = resolveRepoLocalPath(source, c.file, ctx.project.kitAliases);
         if (target === undefined) continue; // bare package, unknown alias, or escapes the root

--- a/packages/core/src/rules/perf/heavy-import.ts
+++ b/packages/core/src/rules/perf/heavy-import.ts
@@ -31,8 +31,13 @@ export const performanceHeavyImport = componentRule({
     const seen = new Set<string>();
     const out: { line: number; message: string }[] = [];
     const spans = c.importSpans ?? c.imports.map((source) => ({ source, line: 0 }));
-    for (const { source: src, line } of spans) {
-      if (!Object.hasOwn(packages, src) || seen.has(src)) continue;
+    for (const { source: src, line, type } of spans) {
+      // This rule's claim is bundle weight, so an import that contributes no runtime binding
+      // costs nothing and must not be reported. Note the fallback above carries no `type`
+      // information, so a caller passing only `imports` keeps the old over-reporting — there
+      // is nothing to judge from. `architecture/private-scope-import` deliberately does NOT
+      // skip these: its claim is coupling, which a type-only import creates just the same.
+      if (type || !Object.hasOwn(packages, src) || seen.has(src)) continue;
       seen.add(src);
       out.push({ line, message: `Heavy import "${src}" — ${packages[src]}` });
     }

--- a/packages/core/test/bundle-rules.test.ts
+++ b/packages/core/test/bundle-rules.test.ts
@@ -9,7 +9,7 @@ const base = { heads: [], project: defaultProject, config };
 const fails = (rs: Result[]) => rs.filter((r) => r.detection.presence === 'none' || r.detection.value === 'absent');
 const ctx = (components: ComponentFacts[]): RuleContext => ({ components, ...base });
 const comp = (
-  importSpans: { source: string; line: number }[],
+  importSpans: ComponentFacts['importSpans'],
   suppressions: SuppressionDirective[] = []
 ): ComponentFacts => ({
   file: 'src/lib/C.svelte',
@@ -92,6 +92,31 @@ describe('performance/heavy-import heavy dependency import', () => {
   });
   it('emits nothing for a component with no imports', async () => {
     expect(await performanceHeavyImport.check(ctx([comp([])]))).toHaveLength(0);
+  });
+  // This rule's claim is bundle weight, and a type-only import contributes none: it is erased
+  // at build. Reporting it was a false positive in a default-on rule.
+  it('does not flag a type-only import of a heavy package', async () => {
+    const rs = await performanceHeavyImport.check(ctx([comp([{ source: 'moment', line: 1, type: true }])]));
+    expect(fails(rs)).toEqual([]);
+  });
+  it('still flags a value import alongside a type-only one, at its own line', async () => {
+    // Guards the obvious over-correction: skipping the type span must not skip the file.
+    const rs = await performanceHeavyImport.check(
+      ctx([
+        comp([
+          { source: 'moment', line: 1, type: true },
+          { source: 'lodash', line: 2 }
+        ])
+      ])
+    );
+    expect(fails(rs)).toHaveLength(1);
+    expect(rs[0]!.line).toBe(2);
+  });
+  it('still passes a file whose only imports are type-only, rather than falling silent', async () => {
+    // `applies` is deliberately unchanged: "we checked this file's imports and found no heavy
+    // ones" stays a true statement, and dropping the pass would move scores as a side effect.
+    const rs = await performanceHeavyImport.check(ctx([comp([{ source: 'moment', line: 1, type: true }])]));
+    expect(rs.filter((r) => r.detection.presence === 'own')).toHaveLength(1);
   });
   it('emits nothing when the component channel is unset (rendered mode)', async () => {
     expect(await performanceHeavyImport.check(base as RuleContext)).toHaveLength(0);

--- a/packages/core/test/private-scope-import.test.ts
+++ b/packages/core/test/private-scope-import.test.ts
@@ -107,6 +107,20 @@ describe('architecture/private-scope-import', () => {
     expect(rs[0]!.fix?.snippet).toBeUndefined();
   });
 
+  // Deliberately the opposite of performance/heavy-import, which skips a type-only import
+  // because its claim is bundle weight. This rule's claim is coupling, and importing only a
+  // type couples just as tightly — rename or delete the unit and the importer still breaks.
+  // Pinned so the two rules cannot be "made consistent" without this failing.
+  it('flags a type-only import of a private unit, unlike the bundle-weight rules', async () => {
+    const c = comp({
+      file: 'src/lib/Other/Other.svelte',
+      importSpans: [{ source: '../Card/parts/Badge.svelte', line: 7, type: true }]
+    });
+    const rs = await architecturePrivateScopeImport.check(scoped([c], SCOPES));
+    expect(fails(rs)).toHaveLength(1);
+    expect(rs[0]!.line).toBe(7);
+  });
+
   it('passes an import of a parts/ unit from inside the owning unit', async () => {
     const c = comp({ file: 'src/lib/Card/Card.svelte', importSpans: [{ source: './parts/Badge.svelte', line: 2 }] });
     const rs = await architecturePrivateScopeImport.check(scoped([c], SCOPES));


### PR DESCRIPTION
## Why

`performance/heavy-import` says what it is about in its own rationale: *"Importing a large, non-tree-shakeable package pulls its whole weight into the bundle even when only a fraction is used."* It then reported `import type { Moment } from 'moment'`, which is erased at build and pulls nothing. A false positive, in a rule that is on by default.

The fact needed to tell the two apart — `importSpans[].type` — landed with `architecture/route-component-import` (#335). That spec recorded the correction rather than taking it:

> the extension makes a latent correction available to `performance/heavy-import` … That is a shipped rule's behaviour and not this rule's business, so it is not taken here. **Recorded for its own decision.**

This is that decision.

## What

One condition in `bad`: a span with `type` set is skipped. `type` covers both `import type …` and a declaration whose every specifier is inline-typed; a specifier-less side-effect import is not marked, because the module really is loaded.

**`applies` is deliberately unchanged.** A file whose imports are all type-only still emits a pass — "we checked this file's imports and found no heavy ones" is a true statement, and dropping the pass would move health scores as a side effect of a behaviour fix. `computeScore` seeds every distinct route at 100 and averages, so removing passes is not a neutral act.

The `c.imports` fallback (for an external caller compiled against a version without `importSpans`) carries no type information and keeps today's behaviour. There is nothing to judge from, and the code says so.

## The rule that deliberately does the opposite

`architecture/private-scope-import` reads the same fact and **keeps** reporting type-only imports. Its claim is not weight but coupling — *"couples two parts of the tree that were meant to move independently"* — and importing only a type couples just as tightly: rename or delete the private unit and the importer still breaks.

Two rules reading one fact and reaching opposite conclusions is exactly the shape that gets "made consistent" by a later well-meaning change, so the reason is written in the code at both sites **and pinned by a test**. That test was verified load-bearing: adding the symmetrical `if (type) continue;` to `private-scope-import` makes it fail.

`performance/namespace-import` needed no change — its collector already skips declaration-level type imports, and a namespace specifier has no inline-typed form.

## User-visible effect

Findings **decrease**. A project that type-imports a configured heavy package loses those findings and its health score rises accordingly. No configuration change is needed. The rule pages say so in both languages, including the contrast with `private-scope-import` so the difference does not read as an inconsistency.

## Verification

`core` 1124, `cli` 779, `vite` 205, `mcp` 25 tests pass; typecheck clean in all four packages; lint and format clean.

Worth noting one thing the suite alone would not have caught: the test helper declared its `importSpans` parameter as a literal `{ source: string; line: number }[]` rather than referencing the fact type, so passing the new field was a type error while `vitest` stayed green — `vitest` does not typecheck. The helper now references `ComponentFacts['importSpans']`, so it follows the fact instead of restating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Heavy-import checks now ignore type-only imports that are removed during bundling.
  * Value imports continue to be reported at the correct source lines.
  * Private-scope import checks continue to flag type-only imports as dependency coupling.

* **Documentation**
  * Clarified how type-only imports are handled by both rules.

* **Tests**
  * Added coverage for type-only imports, value imports, and files containing only type-only imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->