### PR TITLE
fix(core): report a hand-rolled in-memory store under $lib/server

### DIFF
--- a/.changeset/server-store-arbitration.md
+++ b/.changeset/server-store-arbitration.md
@@ -23,8 +23,8 @@ export async function load({ locals }) {
 svelte-vitals now reads the target module and keeps the call exempt only when the export is not an
 in-memory container. An export initialized to `new Map`/`Set`/`WeakMap`/`WeakSet`, or to an object
 or array literal, is reported; anything else — a client constructed from a package, a re-export, an
-unreadable module — stays exempt, so a wrapper this cannot see is silence rather than a false
-positive. Only the modules a handler actually writes to are read, so a project whose handlers never
+unreadable module — stays exempt. A wrapper the read cannot inspect therefore stays silent rather
+than becoming a false positive. Only the modules a handler actually writes to are read, so a project whose handlers never
 touch `$lib/server` does no extra I/O.
 
 Property writes (`store.user = …`) were already reported wherever they appear and are unchanged.

--- a/.changeset/server-store-arbitration.md
+++ b/.changeset/server-store-arbitration.md
@@ -1,0 +1,30 @@
+---
+'@svelte-vitals/core': minor
+---
+
+`security/handler-state-write` now reports a hand-rolled in-memory store under `$lib/server`.
+
+The rule exempts `.set()`/`.update()` on imports resolving under the `$lib` server root, because
+that is where database and KV clients live and `db.set(…)` there is persistence, not shared state.
+The check was purely path-based, so a plain `new Map()` in the same directory — one shared
+instance, overwritten by every request — was exempt too:
+
+```ts
+// src/lib/server/store.ts
+export const db = new Map();
+
+// src/routes/+page.server.ts
+import { db } from '$lib/server/store';
+export async function load({ locals }) {
+  db.set('user', locals.user); // previously not reported
+}
+```
+
+svelte-vitals now reads the target module and keeps the call exempt only when the export is not an
+in-memory container. An export initialized to `new Map`/`Set`/`WeakMap`/`WeakSet`, or to an object
+or array literal, is reported; anything else — a client constructed from a package, a re-export, an
+unreadable module — stays exempt, so a wrapper this cannot see is silence rather than a false
+positive. Only the modules a handler actually writes to are read, so a project whose handlers never
+touch `$lib/server` does no extra I/O.
+
+Property writes (`store.user = …`) were already reported wherever they appear and are unchanged.

--- a/docs/src/content/docs/ja/rules/security/handler-state-write.md
+++ b/docs/src/content/docs/ja/rules/security/handler-state-write.md
@@ -15,9 +15,19 @@ universal な `+page.ts`/`+layout.ts` の load も対象です。SSR 時はサ�
 
 - 読み取り、その他のメソッド呼び出し（`logger.info(…)`）、ローカル変数への書き込み。
 - インストール済みパッケージからの import への `.set()`/`.update()`。
-- 解決先が `src/lib/server` になる import への `.set()`/`.update()`。ディレクトリエントリポイント（`import { db } from '$lib/server'`）と `src/lib/server/**` 配下のモジュールが該当します。Drizzle の `db.update(...).set(...)` のような DB/KV クライアント呼び出しは永続化であり、共有状態への書き込みではないためです。
+- 解決先が `src/lib/server` になる **永続化クライアント**への `.set()`/`.update()`。ディレクトリエントリポイント（`import { db } from '$lib/server'`）と `src/lib/server/**` 配下が該当します。Drizzle の `db.update(...).set(...)` のような呼び出しは永続化であり、共有状態への書き込みではないためです。
 
 `src/lib/server` の除外は解決後のパスに対して働くので、`$lib/server/` alias 経由でも相対パス（`../../lib/server/db`）経由でも同じように適用されます。`..` でプロジェクトルートの外へ抜ける specifier は、保守的にリポジトリ内の共有状態としては扱いません。
+
+ただし除外の条件はディレクトリだけではありません。svelte-vitals は対象モジュールを読み、export がインメモリコンテナで**ない**場合にのみ除外します。`new Map`/`Set`/`WeakMap`/`WeakSet`、あるいはオブジェクト・配列リテラルで初期化された export は自作ストア（リクエストごとに上書きされる単一の共有インスタンス）なので、`src/lib/server` 配下でも検出します。
+
+```ts
+// src/lib/server/store.ts
+export const db = new Map(); // handler から db.set(...) すると検出
+export const client = drizzle(url); // コンテナリテラルではないので除外
+```
+
+コンテナだと断定できないものはすべて除外のままなので、実クライアントのラッパーや re-export、読めないモジュールが誤検知になることはありません。読み込むのは handler が実際に書き込んでいるモジュールだけです。
 
 ## なぜ重要か
 

--- a/docs/src/content/docs/rules/security/handler-state-write.md
+++ b/docs/src/content/docs/rules/security/handler-state-write.md
@@ -13,9 +13,19 @@ Not flagged:
 
 - Reads, other method calls (`logger.info(…)`), and writes to local variables.
 - `.set()`/`.update()` on imports from installed packages.
-- `.set()`/`.update()` on anything resolving to `src/lib/server` — the directory entrypoint (`import { db } from '$lib/server'`) and anything under `src/lib/server/**`, such as a database or KV client (Drizzle's `db.update(...).set(...)`). Those are persistence, not shared module state.
+- `.set()`/`.update()` on a **persistence client** resolving to `src/lib/server` — the directory entrypoint (`import { db } from '$lib/server'`) or anything under `src/lib/server/**`, such as Drizzle's `db.update(...).set(...)`. Those calls are persistence, not shared module state.
 
 The `src/lib/server` exemption applies to the **resolved** path, so it holds however the module is imported — via the `$lib/server/` alias or a relative path (`../../lib/server/db`). A specifier whose `..` segments escape the project root is conservatively never treated as repo-local state.
+
+The exemption is not the directory alone. svelte-vitals reads the target module and keeps the call exempt only when the export is _not_ an in-memory container. An export initialized to `new Map`/`Set`/`WeakMap`/`WeakSet`, or to an object or array literal, is a hand-rolled store — one shared instance overwritten per request — and is reported even under `src/lib/server`:
+
+```ts
+// src/lib/server/store.ts
+export const db = new Map(); // reported when a handler calls db.set(...)
+export const client = drizzle(url); // exempt — not a container literal
+```
+
+Anything the read cannot positively identify as a container stays exempt, so a wrapper around a real client, a re-export, or an unreadable module is never a false positive. Only the modules a handler actually writes to are read.
 
 ## Why it matters
 

--- a/packages/core/src/kit-module-collect.ts
+++ b/packages/core/src/kit-module-collect.ts
@@ -63,8 +63,17 @@ export async function collectKitModuleFacts(
   return arbitrateServerStoreWrites(rt, cwd, facts);
 }
 
-/** Extensions and index forms a bare repo path may name, in resolution order. */
-const MODULE_CANDIDATES = ['.ts', '.js', '/index.ts', '/index.js'];
+/**
+ * The files a resolved specifier may name, in resolution order. An extensionless path takes an
+ * extension or an index file; a path that already ends in `.js` is checked as written and then
+ * remapped to `.ts`, which is how a NodeNext/ESM TypeScript project spells an import of its own
+ * `.ts` source (`from '$lib/server/store.js'` -> `src/lib/server/store.ts`).
+ */
+function moduleCandidates(repoPath: string): string[] {
+  if (repoPath.endsWith('.js')) return [repoPath, `${repoPath.slice(0, -3)}.ts`];
+  if (repoPath.endsWith('.ts')) return [repoPath];
+  return [`${repoPath}.ts`, `${repoPath}.js`, `${repoPath}/index.ts`, `${repoPath}/index.js`];
+}
 
 /**
  * Read the module a pending write targets and return the names it exports as an in-memory
@@ -72,8 +81,7 @@ const MODULE_CANDIDATES = ['.ts', '.js', '/index.ts', '/index.js'];
  * unarbitrated, which leaves the write exempt.
  */
 async function inMemoryExportsOf(rt: Runtime, cwd: string, repoPath: string): Promise<ReadonlySet<string>> {
-  for (const suffix of MODULE_CANDIDATES) {
-    const rel = `${repoPath}${suffix}`;
+  for (const rel of moduleCandidates(repoPath)) {
     try {
       if (!(await rt.exists(rt.join(cwd, rel)))) continue;
       return parseInMemoryExports(await rt.readFile(rt.join(cwd, rel)), rel);

--- a/packages/core/src/kit-module-collect.ts
+++ b/packages/core/src/kit-module-collect.ts
@@ -1,4 +1,4 @@
-import { parseKitModuleFacts } from './kit-module-parse.js';
+import { parseInMemoryExports, parseKitModuleFacts } from './kit-module-parse.js';
 import type { KitModuleFacts } from './kit-module.js';
 import type { Runtime } from './runtime.js';
 import type { KitAlias } from './types.js';
@@ -11,6 +11,7 @@ export function emptyKitModuleFacts(file: string, kind: KitModuleFacts['kind']):
     moduleStateReassignments: [],
     importedStateWrites: [],
     importedStateWritesOutsideHandlers: [],
+    pendingServerStoreWrites: [],
     runesModuleImports: [],
     lifecycleCalls: [],
     browserGlobalRefs: [],
@@ -48,7 +49,7 @@ export async function collectKitModuleFacts(
   ];
   const lists = await Promise.all(patterns.map((p) => rt.glob(p, cwd)));
   const files = [...new Set(lists.flat())];
-  return Promise.all(
+  const facts = await Promise.all(
     files.sort().map(async (rel): Promise<KitModuleFacts> => {
       const kind = kindOf(rel);
       try {
@@ -59,4 +60,54 @@ export async function collectKitModuleFacts(
       }
     })
   );
+  return arbitrateServerStoreWrites(rt, cwd, facts);
+}
+
+/** Extensions and index forms a bare repo path may name, in resolution order. */
+const MODULE_CANDIDATES = ['.ts', '.js', '/index.ts', '/index.js'];
+
+/**
+ * Read the module a pending write targets and return the names it exports as an in-memory
+ * container. Returns an empty set when the file cannot be found or read: unresolvable means
+ * unarbitrated, which leaves the write exempt.
+ */
+async function inMemoryExportsOf(rt: Runtime, cwd: string, repoPath: string): Promise<ReadonlySet<string>> {
+  for (const suffix of MODULE_CANDIDATES) {
+    const rel = `${repoPath}${suffix}`;
+    try {
+      if (!(await rt.exists(rt.join(cwd, rel)))) continue;
+      return parseInMemoryExports(await rt.readFile(rt.join(cwd, rel)), rel);
+    } catch {
+      return new Set();
+    }
+  }
+  return new Set();
+}
+
+/**
+ * Decide the `.set()`/`.update()` calls the parse could not: a call on a binding exported from
+ * under the `$lib` server root is shared module state when that binding is an in-memory
+ * container, and persistence when it is anything else. Only the modules actually targeted are
+ * read, so a project whose handlers never write to `$lib/server` pays nothing.
+ */
+async function arbitrateServerStoreWrites(
+  rt: Runtime,
+  cwd: string,
+  facts: KitModuleFacts[]
+): Promise<KitModuleFacts[]> {
+  const targets = [...new Set(facts.flatMap((f) => f.pendingServerStoreWrites.map((w) => w.resolved)))];
+  if (targets.length === 0) return facts;
+  const byPath = new Map(
+    await Promise.all(targets.map(async (t) => [t, await inMemoryExportsOf(rt, cwd, t)] as const))
+  );
+  return facts.map((f) => {
+    const promoted = f.pendingServerStoreWrites
+      .filter((w) => byPath.get(w.resolved)?.has(w.imported))
+      .map((w) => ({ name: w.name, line: w.line, via: 'set-call' as const }));
+    if (promoted.length === 0) return f;
+    return {
+      ...f,
+      importedStateWrites: [...f.importedStateWrites, ...promoted].sort((a, b) => a.line - b.line)
+    };
+  });
 }

--- a/packages/core/src/kit-module-parse.ts
+++ b/packages/core/src/kit-module-parse.ts
@@ -596,12 +596,56 @@ function libServerRoot(aliases?: readonly KitAlias[]): string | undefined {
  * risks a false positive in this default-on security rule, and staying silent only costs a
  * missed finding.
  */
+/** The resolved repo path when `spec` lands on, or under, the `$lib` server root; else undefined. */
+function serverRootRelativePath(spec: string, importerFile: string, aliases?: readonly KitAlias[]): string | undefined {
+  const serverRoot = libServerRoot(aliases);
+  if (serverRoot === undefined) return undefined;
+  const path = resolveRepoLocalPath(spec, importerFile, aliases);
+  if (path === undefined) return undefined;
+  return path === serverRoot || path.startsWith(`${serverRoot}/`) ? path : undefined;
+}
+
 function isLocalStateSpecifier(spec: string, importerFile: string, aliases?: readonly KitAlias[]): boolean {
   const serverRoot = libServerRoot(aliases);
   if (serverRoot === undefined) return false;
   const path = resolveRepoLocalPath(spec, importerFile, aliases);
   if (path === undefined) return false;
   return path !== serverRoot && !path.startsWith(`${serverRoot}/`);
+}
+
+/** Container constructors whose instances hold data in process memory. */
+const IN_MEMORY_CTORS = new Set(['Map', 'Set', 'WeakMap', 'WeakSet']);
+
+/** Whether an initializer positively identifies an in-memory container. */
+function isInMemoryInit(init: Node | undefined): boolean {
+  if (!init) return false;
+  if (init.type === 'ObjectExpression' || init.type === 'ArrayExpression') return true;
+  return init.type === 'NewExpression' && init.callee?.type === 'Identifier' && IN_MEMORY_CTORS.has(init.callee.name);
+}
+
+/**
+ * The exported bindings of a module that are initialized to an in-memory container — an object
+ * or array literal, or `new Map`/`Set`/`WeakMap`/`WeakSet`. Used to arbitrate a `.set()` call on
+ * an import from under the `$lib` server root, where the call shape alone cannot separate a
+ * hand-rolled store from a database client.
+ *
+ * Precision-first, matching the rest of this default-on security rule: only an initializer that
+ * positively names a container counts. Anything else — a call into an imported package, a
+ * re-export, an unreadable file — is left alone, so a wrapper this cannot see stays exempt
+ * rather than becoming a false positive.
+ */
+export function parseInMemoryExports(source: string, filename: string): ReadonlySet<string> {
+  const names = new Set<string>();
+  const { program } = parseModuleProgram(source, filename);
+  for (const stmt of program?.body ?? []) {
+    if (stmt?.type !== 'ExportNamedDeclaration' || !stmt.declaration) continue;
+    const decl = stmt.declaration;
+    if (decl.type !== 'VariableDeclaration') continue;
+    for (const d of decl.declarations ?? []) {
+      if (d?.id?.type === 'Identifier' && isInMemoryInit(d.init)) names.add(d.id.name);
+    }
+  }
+  return names;
 }
 
 /**
@@ -619,6 +663,7 @@ export function parseKitModuleFacts(
   const moduleStateReassignments: KitModuleFacts['moduleStateReassignments'] = [];
   const importedStateWrites: KitModuleFacts['importedStateWrites'] = [];
   const importedStateWritesOutsideHandlers: KitModuleFacts['importedStateWritesOutsideHandlers'] = [];
+  const pendingServerStoreWrites: KitModuleFacts['pendingServerStoreWrites'] = [];
   const runesModuleImports: KitModuleFacts['runesModuleImports'] = [];
   const lifecycleCalls: KitModuleFacts['lifecycleCalls'] = [];
   const browserGlobalRefs: KitModuleFacts['browserGlobalRefs'] = [];
@@ -627,6 +672,7 @@ export function parseKitModuleFacts(
       moduleStateReassignments,
       importedStateWrites,
       importedStateWritesOutsideHandlers,
+      pendingServerStoreWrites,
       runesModuleImports,
       lifecycleCalls,
       browserGlobalRefs,
@@ -639,6 +685,9 @@ export function parseKitModuleFacts(
   // Imported value bindings (type-only skipped): local name → raw specifier, plus
   // the subset whose specifier resolves to a repo-local runes module (security/shared-state-import).
   const importedSpecifiers = new Map<string, string>();
+  // local name -> exported name, so arbitration can look up the right export of the target
+  // module when the import is aliased (`import { db as store }`).
+  const importedNames = new Map<string, string>();
   for (const stmt of program.body ?? []) {
     if (stmt?.type !== 'ImportDeclaration' || stmt.importKind === 'type') continue;
     const spec = typeof stmt.source?.value === 'string' ? stmt.source.value : '';
@@ -647,6 +696,10 @@ export function parseKitModuleFacts(
       if (s?.importKind === 'type' || s?.local?.type !== 'Identifier') continue;
       names.push(s.local.name);
       importedSpecifiers.set(s.local.name, spec);
+      importedNames.set(
+        s.local.name,
+        s.type === 'ImportSpecifier' && s.imported?.type === 'Identifier' ? s.imported.name : s.local.name
+      );
     }
     if (names.length === 0) continue;
     const resolved = resolveRunesModuleSpecifier(spec, filename, aliases);
@@ -747,8 +800,23 @@ export function parseKitModuleFacts(
       const method = n.callee.property?.type === 'Identifier' ? n.callee.property.name : undefined;
       if (method === 'set' || method === 'update') {
         const r = importedRoot(n.callee.object);
-        if (r && isLocalStateSpecifier(importedSpecifiers.get(r)!, filename, aliases))
-          write = { name: r, via: 'set-call' };
+        const spec = r ? importedSpecifiers.get(r)! : undefined;
+        if (r && spec !== undefined) {
+          if (isLocalStateSpecifier(spec, filename, aliases)) write = { name: r, via: 'set-call' };
+          else {
+            // Under the `$lib` server root: the call shape cannot tell a persistence client from
+            // a hand-rolled store, so defer to the collector, which can read the target module.
+            const resolved = serverRootRelativePath(spec, filename, aliases);
+            if (resolved !== undefined && inHandler) {
+              pendingServerStoreWrites.push({
+                name: r,
+                imported: importedNames.get(r) ?? r,
+                resolved,
+                line: line(n.start)
+              });
+            }
+          }
+        }
       }
     } else if (
       n.type === 'AssignmentExpression' &&
@@ -810,6 +878,7 @@ export function parseKitModuleFacts(
     moduleStateReassignments: byLine(moduleStateReassignments),
     importedStateWrites: byLine(importedStateWrites),
     importedStateWritesOutsideHandlers: byLine(importedStateWritesOutsideHandlers),
+    pendingServerStoreWrites: byLine(pendingServerStoreWrites),
     runesModuleImports: byLine(runesModuleImports),
     lifecycleCalls: byLine(lifecycleCalls),
     browserGlobalRefs: byLine(browserGlobalRefs),

--- a/packages/core/src/kit-module.ts
+++ b/packages/core/src/kit-module.ts
@@ -15,6 +15,15 @@ export interface KitModuleFacts {
   importedStateWrites: { name: string; line: number; via: 'assignment' | 'set-call' }[];
   /** Writes to an imported binding outside handlers — top level or helper functions (security/shared-state-import's write flavour). */
   importedStateWritesOutsideHandlers: { name: string; line: number }[];
+  /**
+   * `.set()`/`.update()` in a handler on an import resolving under the `$lib` server root.
+   * The call shape alone cannot tell a persistence client (`db.set(…)`) from a hand-rolled
+   * in-memory store, so the decision needs the target module — which this pure parse cannot
+   * read. `collectKitModuleFacts` resolves each one and promotes the in-memory ones into
+   * `importedStateWrites`; a consumer that ignores this field sees the pre-arbitration
+   * behaviour, i.e. every one of these exempt.
+   */
+  pendingServerStoreWrites: { name: string; imported: string; resolved: string; line: number }[];
   /** Value imports whose specifier resolves to a repo-local `.svelte.ts`/`.svelte.js` runes module (security/shared-state-import). */
   runesModuleImports: { source: string; resolved: string; names: string[]; line: number }[];
   /** Svelte lifecycle/context calls that run outside component initialisation — top level, handler bodies, or the `init` hook (correctness/orphan-lifecycle). */

--- a/packages/core/test/correctness-rules.test.ts
+++ b/packages/core/test/correctness-rules.test.ts
@@ -52,6 +52,7 @@ const kitFacts = (over: Partial<KitModuleFacts>): KitModuleFacts => ({
   moduleStateReassignments: [],
   importedStateWrites: [],
   importedStateWritesOutsideHandlers: [],
+  pendingServerStoreWrites: [],
   runesModuleImports: [],
   lifecycleCalls: [],
   browserGlobalRefs: [],

--- a/packages/core/test/kit-module-collect.test.ts
+++ b/packages/core/test/kit-module-collect.test.ts
@@ -32,6 +32,74 @@ function createMemoryRuntime(files: Record<string, string>, unreadable: Set<stri
   };
 }
 
+describe('collectKitModuleFacts — $lib/server store arbitration', () => {
+  const handler = (spec: string, expr: string) =>
+    `import { ${expr.split('.')[0]} } from '${spec}';\nexport function load({ locals }) {\n  ${expr};\n}`;
+  const writes = async (files: Record<string, string>) => {
+    const facts = await collectKitModuleFacts(createMemoryRuntime(files), '');
+    return facts.flatMap((f) => f.importedStateWrites);
+  };
+
+  it('flags a .set() on a hand-rolled Map exported from $lib/server', async () => {
+    // The gap this arbitration exists to close: one shared Map, overwritten per request.
+    expect(
+      await writes({
+        'src/lib/server/store.ts': 'export const db = new Map();',
+        'src/routes/+page.server.ts': handler('$lib/server/store', "db.set('user', locals.user)")
+      })
+    ).toEqual([{ name: 'db', line: 3, via: 'set-call' }]);
+  });
+
+  it('leaves a persistence client exempt — the reason the exemption exists', async () => {
+    expect(
+      await writes({
+        'src/lib/server/store.ts': "import { drizzle } from 'drizzle-orm';\nexport const db = drizzle(url);",
+        'src/routes/+page.server.ts': handler('$lib/server/store', "db.set('user', locals.user)")
+      })
+    ).toEqual([]);
+  });
+
+  it('resolves the exported name through an aliased import', async () => {
+    const facts = await collectKitModuleFacts(
+      createMemoryRuntime({
+        'src/lib/server/store.ts': 'export const cache = new Map();',
+        'src/routes/+page.server.ts':
+          "import { cache as c } from '$lib/server/store';\nexport function load({ locals }) {\n  c.set('u', locals.user);\n}"
+      }),
+      ''
+    );
+    expect(facts.flatMap((f) => f.importedStateWrites)).toEqual([{ name: 'c', line: 3, via: 'set-call' }]);
+  });
+
+  it('accepts object and array literals, and the index form of the module path', async () => {
+    expect(
+      await writes({
+        'src/lib/server/store/index.ts': 'export const bag = {};',
+        'src/routes/+page.server.ts': handler('$lib/server/store', "bag.set('u', 1)")
+      })
+    ).toHaveLength(1);
+  });
+
+  it('stays exempt when the target module cannot be found or read', async () => {
+    // Unresolvable means unarbitrated: silence beats a false positive in a default-on rule.
+    expect(await writes({ 'src/routes/+page.server.ts': handler('$lib/server/missing', "db.set('u', 1)") })).toEqual(
+      []
+    );
+  });
+
+  it('reads only the modules a handler actually writes to', async () => {
+    const reads: string[] = [];
+    const base = createMemoryRuntime({
+      'src/lib/server/used.ts': 'export const db = new Map();',
+      'src/lib/server/unused.ts': 'export const other = new Map();',
+      'src/routes/+page.server.ts': handler('$lib/server/used', "db.set('u', 1)")
+    });
+    const rt: Runtime = { ...base, readFile: (p) => (reads.push(p), base.readFile(p)) };
+    await collectKitModuleFacts(rt, '');
+    expect(reads).not.toContain('src/lib/server/unused.ts');
+  });
+});
+
 describe('collectKitModuleFacts', () => {
   it('collects route server/universal files, +server endpoints, and hooks with kinds', async () => {
     const rt = createMemoryRuntime({

--- a/packages/core/test/kit-module-collect.test.ts
+++ b/packages/core/test/kit-module-collect.test.ts
@@ -50,7 +50,7 @@ describe('collectKitModuleFacts — $lib/server store arbitration', () => {
     ).toEqual([{ name: 'db', line: 3, via: 'set-call' }]);
   });
 
-  it('leaves a persistence client exempt — the reason the exemption exists', async () => {
+  it('leaves an export that is not an in-memory container exempt', async () => {
     expect(
       await writes({
         'src/lib/server/store.ts': "import { drizzle } from 'drizzle-orm';\nexport const db = drizzle(url);",
@@ -76,6 +76,15 @@ describe('collectKitModuleFacts — $lib/server store arbitration', () => {
       await writes({
         'src/lib/server/store/index.ts': 'export const bag = {};',
         'src/routes/+page.server.ts': handler('$lib/server/store', "bag.set('u', 1)")
+      })
+    ).toHaveLength(1);
+  });
+
+  it('follows a NodeNext `.js` specifier to the `.ts` source', async () => {
+    expect(
+      await writes({
+        'src/lib/server/store.ts': 'export const db = new Map();',
+        'src/routes/+page.server.ts': handler('$lib/server/store.js', "db.set('u', 1)")
       })
     ).toHaveLength(1);
   });

--- a/packages/core/test/security-kit-rules.test.ts
+++ b/packages/core/test/security-kit-rules.test.ts
@@ -25,6 +25,7 @@ const kit = (over: Partial<KitModuleFacts>): KitModuleFacts => ({
   moduleStateReassignments: [],
   importedStateWrites: [],
   importedStateWritesOutsideHandlers: [],
+  pendingServerStoreWrites: [],
   runesModuleImports: [],
   lifecycleCalls: [],
   browserGlobalRefs: [],


### PR DESCRIPTION
Closes #354.

## The gap

`security/handler-state-write` exempts `.set()`/`.update()` on imports resolving under the `$lib` server root. That exemption earns its keep — it is where database and KV clients live, and `db.set(…)` on one is persistence, not shared state. But the check was purely path-based, so this was exempt too:

```ts
// src/lib/server/store.ts
export const db = new Map();

// src/routes/+page.server.ts
import { db } from '$lib/server/store';
export async function load({ locals }) {
  db.set('user', locals.user); // previously not reported
}
```

One shared instance, overwritten by every request, readable by every other — the exact failure the rule exists to catch, hidden by the directory it sits in. The sibling rule cannot cover it either: `collectKitModuleFacts` deliberately does not scan `src/lib/server/**`, so `security/server-module-state` never sees the declaration.

## Approach

The call shape cannot separate a hand-rolled store from a client, and `parseKitModuleFacts` is pure — it cannot read another file. So arbitration moves one level out, to the collector that already holds the `Runtime`:

1. `parseKitModuleFacts` stops silently dropping the call. It records a `pendingServerStoreWrites` entry carrying the resolved path and the **exported** name (so an aliased `import { db as store }` still resolves).
2. `collectKitModuleFacts` reads each targeted module once and promotes into `importedStateWrites` only the writes whose export is an in-memory container.

A consumer that ignores the new field sees exactly the old behaviour, so nothing changes for anything downstream that has not opted in.

## Precision-first, like the rest of the rule

Reported: an export initialized to `new Map`/`Set`/`WeakMap`/`WeakSet`, or to an object or array literal.

Exempt: everything else — a client constructed from a package import, a re-export, a module that cannot be found or read. What the read cannot **positively** identify as a container stays silent. In a default-on security rule a missed finding is the cheaper failure than noise on every project using Drizzle.

## Verified

Three cases, run against the built CLI on a real fixture:

| | Before | After |
| --- | --- | --- |
| `new Map()` under `$lib/server`, `.set()` from a handler | not reported | **reported** |
| `drizzle(url)` under `$lib/server`, `.set()` from a handler | not reported | not reported |
| aliased import of the hand-rolled store | not reported | **reported** |

Plus six collector tests covering the index-form module path, the unreadable/missing target, and — asserted explicitly — that **only the modules a handler actually writes to are read**, so a project whose handlers never touch `$lib/server` does no extra I/O.

Property writes (`store.user = …`) were already reported wherever they appear and are untouched. Both the CLI and the Vite plugin go through this collector, so both surfaces gain it.

## Docs

The exemption paragraph on the rule page now states the real condition and shows the two-line contrast, en and ja together. Changeset is a `@svelte-vitals/core` minor.

`build`, `typecheck`, `test` (1149 in core), `lint`, `check:publish`, `smoke`, `blume check` and the docs build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of shared in-memory state accessed through server modules.
  * Reports writes to exported `Map`, `Set`, weak collections, objects, and arrays.
  * Continues to exclude recognized database and KV persistence clients.
  * Supports aliased and relative imports while avoiding uncertain, wrapped, re-exported, or unreadable modules.
  * Limits module inspection to server modules actually written to by handlers.

* **Documentation**
  * Clarified server-module state detection, persistence-client exemptions, and supported import patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->