### PR TITLE
docs: document the JSON reporter's output shape

### DIFF
--- a/docs/src/content/docs/guides/(reporting)/reporters.md
+++ b/docs/src/content/docs/guides/(reporting)/reporters.md
@@ -25,6 +25,55 @@ Machine-readable JSON output. Useful for scripts, dashboards, or feeding results
 svelte-vitals --reporter json
 ```
 
+#### Shape
+
+```jsonc
+{
+  "version": "0.35.0", // the svelte-vitals version that produced this report
+  "score": 97, // combined Health score, 0-100 (floored: 100 means zero deduction)
+  "weights": { "seo": 1 }, // per-category Health weights actually applied
+  "categories": {
+    "seo": {
+      "score": 94,
+      "scoreModel": {
+        "routeAverage": 94, // mean of the per-route scores, floored
+        "sitePenalty": 0, // deducted for site-wide findings (no route)
+        "criticalCap": null // the cap value when a critical finding lowered the score, else null
+      }
+    }
+  },
+  "summary": { "critical": 0, "warning": 33, "info": 44, "passed": 610, "dynamic": 2 },
+  "routes": [
+    {
+      "route": "/about", // a route id, or a source file path for file-scoped rules
+      "score": 95,
+      "issues": [
+        {
+          "id": "seo/single-h1", // the rule id
+          "category": "seo",
+          "severity": "warning", // after any severity override you configured
+          "title": "Two <h1> elements", // the human-readable finding
+          "detection": { "presence": "none", "value": "absent" },
+          "location": "src/routes/about/+page.svelte",
+          "line": 12,
+          "recommendation": "Keep exactly one <h1> per page.",
+          "docsUrl": "https://svelte-vitals.dev/rules/seo/single-h1",
+          "fix": { "description": "…", "snippet": "…", "lang": "svelte" }
+        }
+      ]
+    }
+  ],
+  "siteIssues": [] // findings with no route (robots.txt, sitemap.xml, …), same issue shape
+}
+```
+
+Two field names are worth pointing out, because guessing them wrongly fails silently:
+
+- the rule identifier is **`id`**, not `rule`;
+- the finding text is **`title`**, not `message`.
+
+`line`, `docsUrl` and `fix` are present only when the rule supplies them, and `location` only for a finding tied to a file. `issues` lists **failing** findings only — passing checks are counted in `summary.passed` but are not listed. A route with no failures still appears in `routes`, with an empty `issues` array and its own score.
+
 ### `agent`
 
 A Markdown remediation document designed for AI coding agents. Each failing finding includes:

--- a/docs/src/content/docs/ja/guides/(reporting)/reporters.md
+++ b/docs/src/content/docs/ja/guides/(reporting)/reporters.md
@@ -25,6 +25,55 @@ svelte-vitals --reporter console
 svelte-vitals --reporter json
 ```
 
+#### 構造
+
+```jsonc
+{
+  "version": "0.35.0", // このレポートを生成した svelte-vitals のバージョン
+  "score": 97, // 総合 Health スコア（0〜100、切り捨て。100 は減点ゼロを意味する）
+  "weights": { "seo": 1 }, // 実際に適用されたカテゴリ別の Health 重み
+  "categories": {
+    "seo": {
+      "score": 94,
+      "scoreModel": {
+        "routeAverage": 94, // ルートごとのスコアの平均（切り捨て）
+        "sitePenalty": 0, // サイト全体の検出（route を持たないもの）による減点
+        "criticalCap": null // critical によってスコアが抑えられた場合はその上限値、なければ null
+      }
+    }
+  },
+  "summary": { "critical": 0, "warning": 33, "info": 44, "passed": 610, "dynamic": 2 },
+  "routes": [
+    {
+      "route": "/about", // ルート ID。ファイル単位のルールではソースファイルのパス
+      "score": 95,
+      "issues": [
+        {
+          "id": "seo/single-h1", // ルール ID
+          "category": "seo",
+          "severity": "warning", // 設定した severity の上書きを反映した後の値
+          "title": "Two <h1> elements", // 人が読む検出内容
+          "detection": { "presence": "none", "value": "absent" },
+          "location": "src/routes/about/+page.svelte",
+          "line": 12,
+          "recommendation": "Keep exactly one <h1> per page.",
+          "docsUrl": "https://svelte-vitals.dev/rules/seo/single-h1",
+          "fix": { "description": "…", "snippet": "…", "lang": "svelte" }
+        }
+      ]
+    }
+  ],
+  "siteIssues": [] // route を持たない検出（robots.txt、sitemap.xml など）。issue の構造は同じ
+}
+```
+
+次の2つのフィールド名は、取り違えても**エラーにならず静かに空振りする**ため、特に注意してください。
+
+- ルールの識別子は **`id`** です（`rule` ではありません）
+- 検出内容のテキストは **`title`** です（`message` ではありません）
+
+`line`・`docsUrl`・`fix` はルールが提供した場合のみ、`location` はファイルに紐づく検出の場合のみ現れます。`issues` に並ぶのは**失敗した検出のみ**です。合格したチェックは `summary.passed` に数として計上されますが、一覧には出ません。失敗が1件も無いルートも `routes` には現れ、`issues` が空配列のまま自分のスコアを持ちます。
+
 ### `agent`
 
 AI コーディングエージェント向けに設計された Markdown 修正ドキュメントです。失敗した各検出結果には以下が含まれます：


### PR DESCRIPTION
## Why

`--reporter json` is a public integration surface, and the guide described it in one line — "Machine-readable JSON output." — with no field names. Anyone scripting against it has to reverse-engineer the schema from a sample run.

That is not hypothetical. Writing a measurement script against this reporter, I guessed `.rule` for the rule identifier and `.message` for the finding text. Both are wrong, and **both fail silently**: `jq` returns `null` rather than erroring, so the script produced `{"rule": null, "n": 77}` for every row and looked like it had simply found nothing. The real names are `id` and `title`.

## What

A `#### Shape` section under the `json` reporter in the reporters guide, English and Japanese: an annotated example covering every field, plus the parts that are easy to get wrong.

Two names are called out explicitly, because guessing them wrongly produces no error:

- the rule identifier is **`id`**, not `rule`;
- the finding text is **`title`**, not `message` — note that `Result.message` is renamed on the way into the report.

Also documented: which fields are conditional (`line`, `docsUrl` and `fix` appear only when the rule supplies them; `location` only for a finding tied to a file), and that `issues` lists **failing** findings only — passing checks are counted in `summary.passed` and never listed, while a route with no failures still appears with an empty `issues` array and its own score.

## Verification

The example was checked against real `buildJsonReport` output rather than read off the types — which caught two things a type-reading pass would have missed:

- `location` is always assigned by `issueOf`, so it appears in `Object.keys`, but `JSON.stringify` drops it when undefined. The doc describes the serialized shape, which is what a consumer sees.
- my own first draft gave the example issue `"id": "seo/single-h1"` with `"category": "architecture"`.

Re-verified against `main` at the time of this PR: the top-level keys, the nine issue fields and the five `summary` counters are unchanged, and `ScoreResult.rawScore` — added by #337 — does **not** reach the JSON, so consumers see no shape change from that PR.

`scoreModel.routeAverage` and the top-level `score` are annotated as **floored**, per #337.

No changeset: `AGENTS.md` records that doc-only changes do not need one, and this PR changes no code.

## Note

An earlier draft of this page also claimed the MCP server's `analyze` tool returned the same object. That was true when the text was written and is not now — #340 removed the MCP server in favour of the CLI and Agent Skills — so the claim is gone rather than shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed JSON reporter schema documentation in English and Japanese.
  * Documented report metadata, scores, categories, summaries, routes, issues, recommendations, fixes, and related fields.
  * Clarified optional fields, route inclusion, failed-check behavior, and the required `id` and `title` field names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->