### PR TITLE
fix(cli): flush stdout before exiting so a piped report is not truncated

### DIFF
--- a/.changeset/stdout-truncation-on-exit.md
+++ b/.changeset/stdout-truncation-on-exit.md
@@ -5,8 +5,9 @@
 A large report is no longer truncated when the CLI's output is piped.
 
 `svelte-vitals --reporter json` writes the report and then exits, and a write to a pipe is asynchronous — so
-anything past the first buffer, 65,536 bytes on Linux and macOS, was discarded. The exit code was unaffected,
-so a consumer saw a successful run and a payload cut mid-string. Any project whose report exceeds that size
+anything past the first buffer, 65,536 bytes on Linux and macOS, was discarded. The exit code was unaffected —
+it still reported the findings status the run warranted — so nothing distinguished a complete report from one
+cut mid-string. Any project whose report exceeds that size
 was affected, and `--reporter html` written to stdout the same way.
 
 The CLI now waits for stdout to drain before exiting. Piping to `jq`, to a file through a shell, or into

--- a/.changeset/stdout-truncation-on-exit.md
+++ b/.changeset/stdout-truncation-on-exit.md
@@ -1,0 +1,13 @@
+---
+'svelte-vitals': patch
+---
+
+A large report is no longer truncated when the CLI's output is piped.
+
+`svelte-vitals --reporter json` writes the report and then exits, and a write to a pipe is asynchronous — so
+anything past the first buffer, 65,536 bytes on Linux and macOS, was discarded. The exit code was unaffected,
+so a consumer saw a successful run and a payload cut mid-string. Any project whose report exceeds that size
+was affected, and `--reporter html` written to stdout the same way.
+
+The CLI now waits for stdout to drain before exiting. Piping to `jq`, to a file through a shell, or into
+another process delivers the whole report.

--- a/docs/superpowers/plans/2026-08-04-stdout-truncation-on-exit.md
+++ b/docs/superpowers/plans/2026-08-04-stdout-truncation-on-exit.md
@@ -123,6 +123,11 @@ cd packages/cli/test/fixtures/basic-project && node ../../../dist/bin.js --repor
 67,656 is the expected figure. A number at or below 65,536 means the fixture, not the check, needs attention —
 report it rather than adjusting the check.
 
+> **Superseded (2026-08-04):** that command cannot give the reading this step asks for. `wc -c` sits on the far
+> side of the very pipe under test, so against the unfixed CLI it reports 65,536 — the truncated length — not
+> 67,656. Redirect to a file and check its size instead. Task 2's Step 4 uses the same command correctly,
+> because there it runs after the fix.
+
 - [ ] **Step 4: Confirm nothing else regressed**
 
 ```bash

--- a/docs/superpowers/plans/2026-08-04-stdout-truncation-on-exit.md
+++ b/docs/superpowers/plans/2026-08-04-stdout-truncation-on-exit.md
@@ -244,6 +244,12 @@ Revert the `await new Promise(...)` line, rebuild, run `pnpm smoke`, and confirm
 Restore it, rebuild, confirm 8 of 8. Report both results. A fix whose removal leaves the smoke green is not
 the fix.
 
+> **Superseded (2026-08-04):** "confirm the two checks fail again" is one check too strong. The socketpair check
+> is deterministic, but the shell-pipe check is a race the writer usually — not always — wins, so an unlucky
+> revert could show only one failure and be misread as "the fix is not load-bearing". Read it the way the
+> design's Testing section reads the CI run: **any truncation confirms it, and an all-green revert is
+> inconclusive rather than exonerating.** In practice both checks failed on every revert run performed here.
+
 - [ ] **Step 6: Run the package suites and typecheck**
 
 ```bash

--- a/docs/superpowers/plans/2026-08-04-stdout-truncation-on-exit.md
+++ b/docs/superpowers/plans/2026-08-04-stdout-truncation-on-exit.md
@@ -1,0 +1,299 @@
+# A large report must survive the exit — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `svelte-vitals --reporter json` from losing everything past the first 65,536 bytes when its
+output is piped.
+
+**Architecture:** `bin.ts` writes the report and then calls `process.exit(code)`, which discards whatever has
+not drained to the pipe. One awaited empty write flushes the stream first. A new smoke check routes the report
+through a real pipe so the regression is catchable in CI, where the existing check's channel is too wide to
+catch it.
+
+**Tech Stack:** TypeScript (ESM, `.js` import specifiers), `node:assert`-based smoke script (no test runner),
+vitest for the package suites, oxlint + oxfmt.
+
+**Spec:** `docs/superpowers/specs/2026-08-04-stdout-truncation-on-exit-design.md`. Read it before Task 1. It
+was rejected three times by adversarial review — twice for a diagnosis that was backwards, once for
+prescribing a check that could not fail — so treat its stated mechanisms as measured, not as guesses.
+
+## Global Constraints
+
+- **`scripts/floor-smoke.mjs` must stay Node-builtins-only.** `AGENTS.md`: "never add a dev dependency to the
+  smoke". `sh` and `cat` are the OS, not dependencies, and are the only external programs this plan adds.
+- **The new pipe check asserts payload integrity only.** The CLI's 0/1/2 exit contract cannot survive a
+  pipeline — measured, the CLI exits 1 while `sh` reports 0 — and `/bin/sh` on `ubuntu-latest` is `dash`,
+  which has no `set -o pipefail` (added in dash 0.5.13; Ubuntu ships 0.5.12). Exit-code fidelity stays with
+  the existing `execFileSync` checks.
+- **Do not interpolate paths into a shell string.** Use `sh -c '…' sh "$@"` positional parameters, or a
+  checkout inside a directory with a space in its name breaks the check.
+- **Only the analysis path changes.** `install` (`bin.ts:103`), `ci` (`:107`) and the two argument-validation
+  exits (`:148`, `:156`) are out of scope: measured output is 1,377 bytes for `install --dry-run` and 85 for
+  `ci`, two orders of magnitude under any buffer.
+- **`docs` and `explain` are already safe** — they set `process.exitCode` and return — and are not touched.
+- **Comments and docs are for the next reader** (`AGENTS.md`): a line earns its place only when it says
+  something the code cannot. Prefer one line over three.
+- **Never name another tool, linter, plugin or product** in any comment, doc or commit message.
+- Conventional commits, scoped by package. **A changeset is required** — this is a user-visible fix, so
+  `patch`, listing `svelte-vitals` only (nothing in `core` or `vite` changes).
+
+## File Structure
+
+| File                                      | Responsibility                                                                                                       |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `scripts/floor-smoke.mjs`                 | add one check that runs the report through a real pipe and parses it. The existing checks and helpers are untouched. |
+| `packages/cli/src/bin.ts`                 | flush stdout before the analysis path's `process.exit`. One statement.                                               |
+| `.changeset/stdout-truncation-on-exit.md` | **new**                                                                                                              |
+
+Two tasks, in this order, because **the order is the experiment**: the check lands first and is pushed so CI
+runs it against the unfixed CLI. That is what turns "a Linux shell pipe truncates too" from an expectation
+into a measurement. Reversing the order destroys the evidence — a check added beside its own fix can only ever
+be seen passing.
+
+---
+
+## Task 1: A smoke check that routes the report through a real pipe
+
+**Files:**
+
+- Modify: `scripts/floor-smoke.mjs` (add a `check(...)` block after the existing
+  `the read-only subcommands deliver complete JSON through a pipe`, around line 103)
+
+**Interfaces:**
+
+- Consumes, all already in scope in that file: `execFileSync` (imported from `node:child_process`), `assert`
+  (`node:assert`, strict), `check(name, fn)`, `cliBin`, `basicProject`.
+- Produces: nothing other tasks consume.
+
+- [ ] **Step 1: Read the two checks this one sits between**
+
+Read `scripts/floor-smoke.mjs` from the top through the `a bad subcommand argument exits 2` check. Note the
+house style: `check('lowercase sentence describing the behaviour', () => { … })`, hand-rolled
+`assert` with a message naming what went wrong, and `runCli` for anything that needs the exit code.
+
+**This check does not use `runCli`** — `runCli` spawns the CLI directly, which is the socketpair channel the
+new check exists to avoid. It calls `execFileSync('sh', …)` itself.
+
+- [ ] **Step 2: Add the check**
+
+Insert after the `the read-only subcommands deliver complete JSON through a pipe` check:
+
+```js
+check('the analysis report survives a real shell pipe', () => {
+  // `runCli` and the sibling checks give the child a socketpair, whose buffer is wide enough on Linux to
+  // hide a truncation; `sh -c '… | cat'` gives it a 65,536-byte FIFO, which is what a user piping to `jq`
+  // gets. Positional parameters rather than interpolation, so a checkout path containing a space survives.
+  // Payload integrity only: a pipeline's exit status is `cat`'s, so the CLI's 0/1/2 contract is unassertable
+  // here and stays with the checks above.
+  const stdout = execFileSync(
+    'sh',
+    ['-c', '"$1" "$2" "$3" --reporter json | cat', 'sh', process.execPath, cliBin, basicProject],
+    {
+      encoding: 'utf8',
+      // stderr inherited, not ignored: a clean `--reporter json` run writes nothing there, and when the
+      // fixture is broken the CLI's own reason beats a JSON parse error as the thing the smoke prints.
+      stdio: ['ignore', 'pipe', 'inherit']
+    }
+  );
+  const report = JSON.parse(stdout);
+  assert.equal(typeof report.version, 'string');
+  assert.equal(typeof report.score, 'number');
+});
+```
+
+- [ ] **Step 3: Run the smoke and confirm the new check FAILS**
+
+```bash
+pnpm --filter svelte-vitals build   # dist must exist; the smoke never builds for you
+pnpm smoke
+```
+
+Expected on macOS: **2 of 8 checks fail** — the new one and the pre-existing
+`analysing a real project emits a well-formed JSON report` — both with
+`SyntaxError: Unterminated string in JSON at position 65488`.
+
+**If the new check passes here, stop and report it.** Either `dist` is stale, or the fixture's report has
+shrunk below 65,536 bytes and the check can no longer detect anything. Verify the size before doing anything
+else:
+
+```bash
+cd packages/cli/test/fixtures/basic-project && node ../../../dist/bin.js --reporter json | wc -c
+```
+
+67,656 is the expected figure. A number at or below 65,536 means the fixture, not the check, needs attention —
+report it rather than adjusting the check.
+
+- [ ] **Step 4: Confirm nothing else regressed**
+
+```bash
+(cd packages/cli && ../../node_modules/.bin/vitest run)
+node_modules/.bin/oxlint . && node_modules/.bin/oxfmt --check .
+```
+
+Expected: 805 tests pass, lint and format clean. The smoke is not part of the vitest suites, so its two
+failures do not appear here.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/floor-smoke.mjs
+git commit -m "test: catch a truncated report through a real shell pipe"
+```
+
+- [ ] **Step 6: Push and read CI — this is the measurement, not a formality**
+
+Push the branch and open (or update) its pull request. Wait for `test (22)`, `test (24.16.0)`, `test (26)` and
+`floor-smoke` — four runs of the smoke on `ubuntu-latest`.
+
+Record which of the two outcomes happened, with the job names and the failure text:
+
+- **Any of the four fails on the new check** — Linux truncation confirmed, the check is proven to catch it,
+  Task 2 turns it green. This is the expected outcome.
+- **All four pass** — Linux's pipe did not truncate on this run. **Do not conclude the check is useless**:
+  truncation is a race the writer usually but not always wins (12 of 12 locally, and the design's reviewer saw
+  1 run in 15 deliver the whole payload). Report all-green as an observation and continue to Task 2; the check
+  still guards the macOS path and costs nothing.
+
+Either way, **report the CI result in your task report.** It is the evidence the spec's Testing section
+mandates, and Task 2's reviewer needs it.
+
+---
+
+## Task 2: Flush stdout before the analysis path exits
+
+**Files:**
+
+- Modify: `packages/cli/src/bin.ts:166` (the `process.exit(code)` at the end of `main()`)
+- Create: `.changeset/stdout-truncation-on-exit.md`
+
+**Interfaces:**
+
+- Consumes: the smoke check added in Task 1.
+- Produces: nothing other tasks consume.
+
+- [ ] **Step 1: Confirm the check still fails before you change anything**
+
+```bash
+pnpm smoke
+```
+
+Expected: the same two failures Task 1 ended with. If the smoke is green, `dist` was rebuilt from a tree that
+already has the fix — stop and check `git log`.
+
+- [ ] **Step 2: Add the flush**
+
+In `packages/cli/src/bin.ts`, the end of `main()` currently reads:
+
+```ts
+  const code = await run({
+    ...options,
+    minHealth,
+    selectApp
+  });
+  process.exit(code);
+}
+```
+
+Change the last two lines to:
+
+```ts
+  // A write to a pipe is asynchronous, so `process.exit` can discard what has not drained — the report is
+  // the largest thing this CLI writes and the first pipe buffer is 65,536 bytes. The empty write's callback
+  // fires once the stream has flushed. `process.exit` rather than `process.exitCode` because this path can
+  // hold an interactive prompt, where returning could hang instead.
+  await new Promise((resolve) => process.stdout.write('', resolve));
+  process.exit(code);
+}
+```
+
+Do not change anything else in the file. Do not touch the `install`, `ci` or argument-validation exits.
+
+- [ ] **Step 3: Rebuild and confirm the smoke is fully green**
+
+```bash
+pnpm --filter svelte-vitals build
+pnpm smoke
+```
+
+Expected: **8 of 8 checks pass.** Both the new pipe check and the pre-existing
+`analysing a real project emits a well-formed JSON report` now pass.
+
+- [ ] **Step 4: Confirm the payload and the exit codes by hand**
+
+The smoke covers integrity; these four commands cover the exit contract, which the pipe check deliberately
+cannot assert:
+
+```bash
+BIN="$(pwd)/packages/cli/dist/bin.js"   # run this from the repo root
+(cd packages/cli/test/fixtures/basic-project && node "$BIN" --reporter json | wc -c)          # expect 67656
+(cd packages/cli/test/fixtures/basic-project && node "$BIN" --reporter json >/dev/null; echo $?)  # expect 1
+(cd "$TMPDIR" && node "$BIN" >/dev/null 2>&1; echo $?)                                        # expect 2
+```
+
+Record all three actual values in your report. A wrong exit code here is a regression the smoke would not
+catch on the piped path.
+
+- [ ] **Step 5: Prove the fix is load-bearing**
+
+Revert the `await new Promise(...)` line, rebuild, run `pnpm smoke`, and confirm the two checks fail again.
+Restore it, rebuild, confirm 8 of 8. Report both results. A fix whose removal leaves the smoke green is not
+the fix.
+
+- [ ] **Step 6: Run the package suites and typecheck**
+
+```bash
+for p in core cli vite; do (cd packages/$p && ../../node_modules/.bin/vitest run); done
+(cd packages/core && ../../node_modules/.bin/tsup)
+for p in core cli vite; do (cd packages/$p && ../../node_modules/.bin/tsc --noEmit); done
+node_modules/.bin/oxlint . && node_modules/.bin/oxfmt --check .
+```
+
+Expected: all green. (`packages/mcp` has no `tsconfig.json`; skip it.)
+
+- [ ] **Step 7: Write the changeset**
+
+Create `.changeset/stdout-truncation-on-exit.md`:
+
+```md
+---
+'svelte-vitals': patch
+---
+
+A large report is no longer truncated when the CLI's output is piped.
+
+`svelte-vitals --reporter json` writes the report and then exits, and a write to a pipe is asynchronous — so
+anything past the first buffer, 65,536 bytes on Linux and macOS, was discarded. The exit code was unaffected,
+so a consumer saw a successful run and a payload cut mid-string. Any project whose report exceeds that size
+was affected, and `--reporter html` written to stdout the same way.
+
+The CLI now waits for stdout to drain before exiting. Piping to `jq`, to a file through a shell, or into
+another process delivers the whole report.
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/cli/src/bin.ts .changeset/stdout-truncation-on-exit.md
+git commit -m "fix(cli): flush stdout before exiting so a piped report is not truncated"
+```
+
+- [ ] **Step 9: Push and confirm CI is green**
+
+Push and wait for all seven jobs. The new pipe check must pass on all four smoke runs. If it fails on Linux
+now, the flush is not sufficient there and that is a finding to report rather than to work around.
+
+---
+
+## Notes for whoever runs this
+
+- A full-workspace `pnpm` command fails in this sandbox for a known, pre-existing reason (the `docs`
+  package's dependencies). `pnpm smoke` and `pnpm --filter svelte-vitals build` both work.
+- **`pnpm smoke` does not build.** It exits 1 with a message if `packages/cli/dist/bin.js` is missing. Every
+  smoke run in this plan assumes you built first; a stale `dist` is the most likely reason a step's expected
+  result does not appear.
+- The spec records three things as deliberately out of scope, so do not implement them: `install`/`ci`, a
+  general flush helper, and the separate `--out-file -` bug (its space-separated form silently writes
+  `svelte-vitals-report.html` to the cwd because `mri` parses a lone `-` as `""`; `--out-file=-` works).
+- The design's rejected alternative was `process.exitCode = code; return;`. It measured identically. It was
+  rejected because the analysis path can hold an interactive prompt and the failure mode of being wrong is a
+  CLI that never returns. Do not "simplify" the flush into it.

--- a/docs/superpowers/specs/2026-08-04-stdout-truncation-on-exit-design.md
+++ b/docs/superpowers/specs/2026-08-04-stdout-truncation-on-exit-design.md
@@ -23,7 +23,7 @@ src/routes/+layout.svelte",
 not guaranteed to have drained when `process.exit` runs, so whatever is still buffered is discarded. This is
 silent: the exit code is still 1, so a consumer sees a successful run and a truncated payload.
 
-The file already knows. `bin.ts` line 84 onward:
+The file already knows. `bin.ts` line 85 onward:
 
 > `docs` and `explain` set `process.exitCode` and return rather than calling `process.exit`: writes to a pipe
 > are asynchronous, and exiting can discard whatever has not drained. … (`install`/`ci` and the analysis path
@@ -59,11 +59,11 @@ CI is green because its channel is wide, not because its platform is synchronous
 
 **Two consequences, both of which the first draft got wrong.**
 
-- **A Linux user piping to `jq` should be affected too.** A real shell pipe has a 65,536-byte buffer on Linux
-  and asynchronous writes, so `svelte-vitals --reporter json | jq` is expected to truncate there for the same
-  reason it does here. Stated as an expectation rather than a fact because it is exactly what the CI run
-  mandated under Testing establishes — but if it holds, this is not a macOS-only defect, and it lands on the
-  platform every CI consumer runs on.
+- **A Linux user piping to `jq` is affected too.** A real shell pipe has a 65,536-byte buffer on Linux and
+  asynchronous writes, so `svelte-vitals --reporter json | jq` truncates there for the same reason it does
+  here. Written as an expectation in the draft and **confirmed by the CI run this design mandated** — see
+  "The result" under Testing. This is not a macOS-only defect, and it lands on the platform every CI consumer
+  runs on.
 - **The regression is CI-defensible after all.** Routing the CLI through a real pipe —
   `execFileSync('sh', ['-c', '… bin.js … --reporter json | cat'])` — exercises the 65,536-byte channel on
   Linux. Measured through `sh -c … | cat` on macOS: **65,536 bytes, truncated**, against 67,656 through the
@@ -180,6 +180,20 @@ deliver the whole payload, because the reader can drain the FIFO during the writ
 The same CI run also corroborates the channel explanation directly: the socketpair check green beside the pipe
 check red, same runner, same unfixed binary, is channel-dependence demonstrated rather than inferred from a
 kernel default this design could not measure.
+
+### The result, recorded 2026-08-04
+
+**The experiment ran and Linux truncates.** PR #364 pushed the pipe check alone, against the unfixed CLI:
+`test (24.16.0)` and `floor-smoke` both failed at the smoke step on `ubuntu-latest` (the other two matrix
+entries were cancelled by fail-fast). The commit adding the fix turned all seven jobs green, including all
+four that run the smoke.
+
+So this is not a macOS-only defect: `svelte-vitals --reporter json | jq` was truncated on Linux too, and the
+check now defends the regression on the platform CI runs. Nothing about the asymmetric reading above needs to
+be exercised — one red settled it on the first push.
+
+The failing check was identified by inference rather than from the log text, which this environment cannot
+fetch: `main` had `floor-smoke` green, and the only code change on the pushed commit was the added check.
 
 **One thing to know rather than assert.** The check only means anything while the fixture's report exceeds
 65,536 bytes; it is 67,656 today, 3% above. A fixture that shrank below the buffer would make the check pass

--- a/docs/superpowers/specs/2026-08-04-stdout-truncation-on-exit-design.md
+++ b/docs/superpowers/specs/2026-08-04-stdout-truncation-on-exit-design.md
@@ -59,9 +59,11 @@ CI is green because its channel is wide, not because its platform is synchronous
 
 **Two consequences, both of which the first draft got wrong.**
 
-- **A Linux user piping to `jq` is affected.** A real shell pipe has a 65,536-byte buffer on Linux and
-  asynchronous writes, so `svelte-vitals --reporter json | jq` truncates there for the same reason it does
-  here. This is not a macOS-only defect, and it lands on the platform every CI consumer runs on.
+- **A Linux user piping to `jq` should be affected too.** A real shell pipe has a 65,536-byte buffer on Linux
+  and asynchronous writes, so `svelte-vitals --reporter json | jq` is expected to truncate there for the same
+  reason it does here. Stated as an expectation rather than a fact because it is exactly what the CI run
+  mandated under Testing establishes — but if it holds, this is not a macOS-only defect, and it lands on the
+  platform every CI consumer runs on.
 - **The regression is CI-defensible after all.** Routing the CLI through a real pipe —
   `execFileSync('sh', ['-c', '… bin.js … --reporter json | cat'])` — exercises the 65,536-byte channel on
   Linux. Measured through `sh -c … | cat` on macOS: **65,536 bytes, truncated**, against 67,656 through the
@@ -149,7 +151,10 @@ const stdout = execFileSync(
   ['-c', '"$1" "$2" "$3" --reporter json | cat', 'sh', process.execPath, cliBin, basicProject],
   {
     encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'ignore']
+    // stderr inherited, not ignored: a clean `--reporter json` run writes nothing there (the spinner and
+    // mascot are console-reporter-and-TTY gated), so passing runs stay silent — and when the fixture is
+    // broken, the CLI's own reason beats `Unexpected end of JSON input` as the thing the smoke prints.
+    stdio: ['ignore', 'pipe', 'inherit']
   }
 );
 JSON.parse(stdout);

--- a/docs/superpowers/specs/2026-08-04-stdout-truncation-on-exit-design.md
+++ b/docs/superpowers/specs/2026-08-04-stdout-truncation-on-exit-design.md
@@ -34,14 +34,33 @@ This is that separately. `--reporter json` is the largest thing the CLI writes, 
 agents use, and the release immediately before this one changed every score in it — so it is also the payload
 people are about to re-read.
 
-## Why CI never caught it
+## Why CI never caught it — and why it is not a macOS bug
 
-Node's `process.stdout` is synchronous for pipes on Linux and Windows, and **asynchronous for pipes on
-macOS**. Every CI job runs on Linux, where the write completes before `process.exit` can drop it. The bug is
-real on macOS and on any platform where the write does not complete synchronously.
+Node writes stdout asynchronously to pipes on **every** POSIX platform ("Pipes (and sockets): synchronous on
+Windows, asynchronous on POSIX"). So Linux is not exempt, and the first draft of this section — which claimed
+Linux was synchronous — had the documentation backwards.
 
-That has a consequence for this design: **the fix cannot be defended by CI.** It is stated here rather than
-papered over — see Testing.
+The difference is the **channel**, not the platform. `execFileSync`, which the smoke uses, does not give the
+child a pipe:
+
+| channel                 | child's fd 1        | buffer                |
+| ----------------------- | ------------------- | --------------------- |
+| `execFileSync(...)`     | `isSocket() → true` | AF_UNIX socketpair    |
+| `cmd \| cat` in a shell | `isFIFO() → true`   | pipe, 65,536 on Linux |
+
+Both verified by `fstatSync(1)` in a child. A socketpair's default buffer is roughly 64 KB on macOS and
+roughly 208 KB on Linux, so the 67,656-byte report fits on a Linux runner and is cut on a macOS laptop. That
+is the whole of it: CI is green because its channel is wide, not because its platform is synchronous.
+
+**Two consequences, both of which the first draft got wrong.**
+
+- **A Linux user piping to `jq` is affected.** A real shell pipe has a 65,536-byte buffer on Linux and
+  asynchronous writes, so `svelte-vitals --reporter json | jq` truncates there for the same reason it does
+  here. This is not a macOS-only defect, and it lands on the platform every CI consumer runs on.
+- **The regression is CI-defensible after all.** Routing the CLI through a real pipe —
+  `execFileSync('sh', ['-c', '… bin.js … --reporter json | cat'])` — exercises the 65,536-byte channel on
+  Linux. Measured through `sh -c … | cat` on macOS: **65,536 bytes, truncated**, against 67,656 through the
+  fix. The first draft asserted CI could not catch this and did not try.
 
 ## Design
 
@@ -73,7 +92,11 @@ replaces, and the interactive path cannot be exercised in an automated check. Th
 prompts and timers as the reason those paths exit directly; this design declines to bet against its own
 codebase's stated constraint for a uniformity gain.
 
-Flushing gets the same measured result and changes nothing about termination.
+Flushing gets the same measured result. It does change termination in one corner, which is worth stating in
+the section that rejects the alternative on termination grounds: piped to a reader that never reads
+(`| sleep 30`), the unpatched CLI exits immediately with a truncated payload while the patched one blocks
+until the reader reads or closes. That is what a well-behaved Unix writer does, and it is bounded by the
+reader's lifetime — unlike a held event loop, which is bounded by nothing.
 
 ### Scope
 
@@ -86,37 +109,56 @@ output is the same one-line change. Recorded, not done.
 
 ## Testing
 
-**The regression test already exists and already fails.** `scripts/floor-smoke.mjs` has
-`analysing a real project emits a well-formed JSON report`, which runs the built CLI through
-`execFileSync` — a pipe, not a TTY — and `JSON.parse`s the whole payload. On macOS today it fails with
-`SyntaxError: Unterminated string in JSON at position 65488`. The fix makes it pass. No new test is needed
-for the symptom, and writing one would duplicate a check whose sibling comment already names this exact
-mechanism:
+**One check exists and already fails locally; one must be added so CI can fail too.**
 
-> `execFileSync` gives the child a pipe, not a TTY — the case where `process.exit` can drop undrained writes.
-> Parsing the whole payload is what proves nothing was truncated.
+`scripts/floor-smoke.mjs` has `analysing a real project emits a well-formed JSON report`, which runs the
+built CLI through `execFileSync` and `JSON.parse`s the whole payload. On macOS today it fails with
+`SyntaxError: Unterminated string in JSON at position 65488`, and the fix makes it pass. That is a real
+regression test — but only on macOS, because its channel is a socketpair whose Linux buffer swallows the whole
+report.
 
-That sibling — `the read-only subcommands deliver complete JSON through a pipe` — covers `docs` and
-`explain`, the two paths that already return instead of exiting. The analysis path is the gap it was written
-beside.
+So **add a sibling check that routes the report through a true pipe**, alongside the existing
+`the read-only subcommands deliver complete JSON through a pipe` — whose comment already names this exact
+mechanism, and which covers only `docs` and `explain`, the two paths that already return instead of exiting:
 
-**What no test can do here.** On Linux the check passes with or without the fix, so CI cannot catch a
-regression. `pnpm smoke` on a macOS developer machine is the only gate, and `AGENTS.md` already positions the
-smoke as the thing run locally after a build. Two things follow, and both are deliberate:
+```js
+execFileSync('sh', ['-c', `${cliCmd} --reporter json | cat`]);
+```
 
-- the smoke assertion is kept as the regression test even though CI cannot fail on it, because the
-  alternative — a test that fabricates the async condition — would assert an implementation detail rather
-  than the behaviour;
-- the fixture must stay large enough to exceed a pipe buffer. It is 67,656 bytes today, 3% above 65,536.
-  A fixture that shrank below the buffer would make the check pass everywhere for the wrong reason. Worth
-  knowing, not worth pinning with an assertion on a byte count that would then need maintaining.
+`sh` is the OS shell, not a dependency, so this respects the smoke's Node-builtins-only rule; every CI job
+runs `ubuntu-latest` and every developer machine here is POSIX. Measured on macOS: 65,536 bytes and a parse
+failure without the fix, 67,656 and valid JSON with it.
+
+**The order of work matters, and the plan must follow it.** Add the pipe check _before_ the fix and push it,
+so CI runs it against the unfixed CLI. Two outcomes, both informative:
+
+- **CI fails** — the bug is confirmed on Linux, the check is proven to catch it, and the fix turns it green.
+  This is the expected outcome and the one that makes the regression permanently defensible.
+- **CI passes** — the Linux pipe does not truncate for a reason not yet identified, the check cannot defend
+  the regression there, and that measured fact gets recorded in this spec instead of the assumption it
+  replaced.
+
+Either way the claim ends up backed by a CI run rather than by reasoning, which is what the first draft of
+this section skipped.
+
+**One thing to know rather than assert.** The check only means anything while the fixture's report exceeds
+65,536 bytes; it is 67,656 today, 3% above. A fixture that shrank below the buffer would make the check pass
+everywhere for the wrong reason. Not worth pinning with a byte-count assertion that would then need
+maintaining, but worth knowing before anyone trims the fixture.
 
 ## Deliberately not solved
 
-- **`install` and `ci`.** See Scope.
-- **A general "flush before every exit" helper.** One call site does not justify an abstraction, and the
-  three other `process.exit` sites in `bin.ts` are argument-validation failures that write a single line to
-  stderr.
-- **The `pnpm smoke` / CI asymmetry.** That the smoke can fail locally and pass in CI is a property of the
-  platform difference, not of this change. Making CI run the smoke on macOS is a workflow decision with its
-  own cost, recorded here so the asymmetry is not mistaken for something this design introduced.
+- **`install` and `ci`.** See Scope. Measured output: at most 1,377 bytes for `install --dry-run` across every
+  client, 85 bytes for `ci` — two orders of magnitude under any buffer.
+- **A general "flush before every exit" helper.** One call site does not justify an abstraction. The other
+  `process.exit` sites in `bin.ts` are `install` (line 103), `ci` (107) and two argument-validation failures
+  (148, 156); the validation pair writes to stderr, and the first of them follows a loop that can emit several
+  lines — still far under a buffer, and stderr is unbuffered to a terminal anyway.
+- **`--out-file -` in its space-separated form.** Found while measuring this: `--reporter html --out-file -`
+  silently writes `svelte-vitals-report.html` into the cwd instead of stdout, because `mri` parses a lone `-`
+  as `""` and mangles the following arguments. `--out-file=-` works. Unrelated to the exit path — the flush
+  covers html-to-stdout correctly (81,333 bytes intact through a pipe) — so it needs its own issue rather
+  than a fix here.
+- **Whether the smoke should also run on macOS in CI.** If the new pipe check fails on Linux as expected, the
+  platform asymmetry stops mattering for this bug and a macOS runner buys little. Recorded so the asymmetry is
+  not mistaken for something this design introduced.

--- a/docs/superpowers/specs/2026-08-04-stdout-truncation-on-exit-design.md
+++ b/docs/superpowers/specs/2026-08-04-stdout-truncation-on-exit-design.md
@@ -48,9 +48,14 @@ child a pipe:
 | `execFileSync(...)`     | `isSocket() → true` | AF_UNIX socketpair    |
 | `cmd \| cat` in a shell | `isFIFO() → true`   | pipe, 65,536 on Linux |
 
-Both verified by `fstatSync(1)` in a child. A socketpair's default buffer is roughly 64 KB on macOS and
-roughly 208 KB on Linux, so the 67,656-byte report fits on a Linux runner and is cut on a macOS laptop. That
-is the whole of it: CI is green because its channel is wide, not because its platform is synchronous.
+Both verified by `fstatSync(1)` in a child. A socketpair's effective capacity is **exactly 65,536 bytes** on
+macOS — measured by binary search, a child writing N bytes then exiting delivers all of N below that and
+exactly 65,536 above it — against a stock Linux `wmem_default` of 212,992. So the 67,656-byte report should
+fit on a Linux runner and is cut on a macOS laptop. The Linux figure is a kernel default this design cannot
+measure from here; the CI run mandated under Testing corroborates the mechanism directly rather than resting
+on it.
+
+CI is green because its channel is wide, not because its platform is synchronous.
 
 **Two consequences, both of which the first draft got wrong.**
 
@@ -119,27 +124,57 @@ report.
 
 So **add a sibling check that routes the report through a true pipe**, alongside the existing
 `the read-only subcommands deliver complete JSON through a pipe` — whose comment already names this exact
-mechanism, and which covers only `docs` and `explain`, the two paths that already return instead of exiting:
+mechanism, and which covers only `docs` and `explain`, the two paths that already return instead of exiting.
+
+**Three details decide whether that check holds anything.** An earlier draft of this section prescribed
+`execFileSync('sh', ['-c', `${cliCmd} --reporter json | cat`])` and each of the three defeats it:
+
+- **It must capture and parse the payload.** `execFileSync` throws only on a nonzero exit, and a pipeline's
+  status is the _last_ command's — `cat`'s. Measured: `sh -c 'exit 1 | cat'` and even
+  `sh -c 'no-such-cmd | cat'` both exit 0 and do not throw. A check that only runs the pipeline passes
+  against the unfixed CLI, against a truncated payload, and against a CLI that never launched.
+- **The path must not be interpolated into the shell string**, which word-splits on a checkout containing a
+  space. Use positional parameters.
+- **It must not assert the exit code.** The CLI's 0/1/2 contract cannot survive `| cat` — measured, the CLI
+  exits 1 while `sh` reports 0. `set -o pipefail` would need bash semantics from `/bin/sh`, which is `dash` on
+  `ubuntu-latest`. So this check owns **payload integrity only**; exit-code fidelity stays with the existing
+  socketpair check, which asserts it correctly today.
+
+The form that satisfies all three, verified here — 65,536 bytes and
+`Unterminated string in JSON at position 65488` without the fix, 67,656 and valid JSON with it:
 
 ```js
-execFileSync('sh', ['-c', `${cliCmd} --reporter json | cat`]);
+const stdout = execFileSync(
+  'sh',
+  ['-c', '"$1" "$2" "$3" --reporter json | cat', 'sh', process.execPath, cliBin, basicProject],
+  {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore']
+  }
+);
+JSON.parse(stdout);
 ```
 
 `sh` is the OS shell, not a dependency, so this respects the smoke's Node-builtins-only rule; every CI job
-runs `ubuntu-latest` and every developer machine here is POSIX. Measured on macOS: 65,536 bytes and a parse
-failure without the fix, 67,656 and valid JSON with it.
+runs `ubuntu-latest` and every developer machine here is POSIX.
 
 **The order of work matters, and the plan must follow it.** Add the pipe check _before_ the fix and push it,
-so CI runs it against the unfixed CLI. Two outcomes, both informative:
+so CI runs it against the unfixed CLI.
 
-- **CI fails** — the bug is confirmed on Linux, the check is proven to catch it, and the fix turns it green.
-  This is the expected outcome and the one that makes the regression permanently defensible.
-- **CI passes** — the Linux pipe does not truncate for a reason not yet identified, the check cannot defend
-  the regression there, and that measured fact gets recorded in this spec instead of the assumption it
-  replaced.
+**Read the result asymmetrically, because only one direction is deterministic.** Truncation is a race the
+writer usually wins: measured 12 of 12 truncations here, but the reviewer of this design saw 1 run in 15
+deliver the whole payload, because the reader can drain the FIFO during the writer's syscall. So:
 
-Either way the claim ends up backed by a CI run rather than by reasoning, which is what the first draft of
-this section skipped.
+- **Any truncation, on any run, confirms it.** One red is proof; the check is then permanently valuable
+  because the flush makes delivery deterministic — after the fix it cannot flake red.
+- **Green does not settle anything on its own.** The `test` job runs the smoke on three matrix entries and
+  `floor-smoke` runs it again, so a single push already yields four samples; treat "cannot defend the
+  regression on Linux" as established only after repeated all-green across pushes, and record the measured
+  fact here if that happens.
+
+The same CI run also corroborates the channel explanation directly: the socketpair check green beside the pipe
+check red, same runner, same unfixed binary, is channel-dependence demonstrated rather than inferred from a
+kernel default this design could not measure.
 
 **One thing to know rather than assert.** The check only means anything while the fixture's report exceeds
 65,536 bytes; it is 67,656 today, 3% above. A fixture that shrank below the buffer would make the check pass

--- a/docs/superpowers/specs/2026-08-04-stdout-truncation-on-exit-design.md
+++ b/docs/superpowers/specs/2026-08-04-stdout-truncation-on-exit-design.md
@@ -1,0 +1,122 @@
+# A large report must survive the exit — design
+
+**Date:** 2026-08-04
+**Status:** approved
+**Origin:** found by the whole-branch review of `feat/score-proportionality` (PR #363), which hit it as a
+`pnpm smoke` failure. `packages/cli/src/bin.ts` already recorded it as a deferral.
+
+## The problem
+
+`svelte-vitals --reporter json` piped to another process emits **exactly 65,536 bytes** — one pipe buffer —
+and stops mid-string. The report is 67,656 bytes. Measured on the repo's own
+`packages/cli/test/fixtures/basic-project`:
+
+```
+$ node dist/bin.js --reporter json | wc -c
+   65536
+$ node dist/bin.js --reporter json | tail -c 40
+src/routes/+layout.svelte",
+          "r
+```
+
+`bin.ts` writes the report through `console.log` and then calls `process.exit(code)`. A write to a pipe is
+not guaranteed to have drained when `process.exit` runs, so whatever is still buffered is discarded. This is
+silent: the exit code is still 1, so a consumer sees a successful run and a truncated payload.
+
+The file already knows. `bin.ts` line 84 onward:
+
+> `docs` and `explain` set `process.exitCode` and return rather than calling `process.exit`: writes to a pipe
+> are asynchronous, and exiting can discard whatever has not drained. … (`install`/`ci` and the analysis path
+> below still exit directly — they hold prompts and timers, where returning could hang instead; **their
+> large-output paths deserve the same treatment separately.**)
+
+This is that separately. `--reporter json` is the largest thing the CLI writes, it is the channel CI and
+agents use, and the release immediately before this one changed every score in it — so it is also the payload
+people are about to re-read.
+
+## Why CI never caught it
+
+Node's `process.stdout` is synchronous for pipes on Linux and Windows, and **asynchronous for pipes on
+macOS**. Every CI job runs on Linux, where the write completes before `process.exit` can drop it. The bug is
+real on macOS and on any platform where the write does not complete synchronously.
+
+That has a consequence for this design: **the fix cannot be defended by CI.** It is stated here rather than
+papered over — see Testing.
+
+## Design
+
+Flush before exiting, in `bin.ts`'s analysis path:
+
+```ts
+await new Promise((resolve) => process.stdout.write('', resolve));
+process.exit(code);
+```
+
+The empty write's callback fires once the stream has drained to the OS, so nothing is buffered when
+`process.exit` runs. Measured with this in place: **67,656 bytes, valid JSON, exit 1** — and exit 2 still on a
+directory that is not a SvelteKit project.
+
+### Why not `process.exitCode` and return, like `docs` and `explain`
+
+That was the first candidate, and it works: measured at 67,656 bytes, valid JSON, terminating on its own with
+exit 1, and exit 2 for a non-project. It is also the more uniform answer, since it would make every path in
+`bin.ts` exit the same way.
+
+**It is rejected because it works for a reason this design cannot verify.** Returning only terminates if
+nothing is holding the event loop, and the analysis path can run the monorepo app picker — an interactive
+prompt over stdin. It happens not to matter for the reported bug: the help text promises "Analysis never
+prompts when stdout is not a TTY", so the prompt cannot be open in the piped case, and the score animation is
+likewise TTY-only. So the measurement above is sound for the case that truncates.
+
+But the failure mode of being wrong is a CLI that never returns, which is worse than the truncation it
+replaces, and the interactive path cannot be exercised in an automated check. The comment in `bin.ts` names
+prompts and timers as the reason those paths exit directly; this design declines to bet against its own
+codebase's stated constraint for a uniformity gain.
+
+Flushing gets the same measured result and changes nothing about termination.
+
+### Scope
+
+**Only the analysis path.** `install` and `ci` also call `process.exit`, and the same hazard applies to them
+in principle, but neither writes anything close to a pipe buffer — `install` prints a plan, `ci` prints a
+scaffold summary. Adding the flush there would be speculative; adding it when one of them grows a large
+output is the same one-line change. Recorded, not done.
+
+`docs` and `explain` are already safe and are not touched.
+
+## Testing
+
+**The regression test already exists and already fails.** `scripts/floor-smoke.mjs` has
+`analysing a real project emits a well-formed JSON report`, which runs the built CLI through
+`execFileSync` — a pipe, not a TTY — and `JSON.parse`s the whole payload. On macOS today it fails with
+`SyntaxError: Unterminated string in JSON at position 65488`. The fix makes it pass. No new test is needed
+for the symptom, and writing one would duplicate a check whose sibling comment already names this exact
+mechanism:
+
+> `execFileSync` gives the child a pipe, not a TTY — the case where `process.exit` can drop undrained writes.
+> Parsing the whole payload is what proves nothing was truncated.
+
+That sibling — `the read-only subcommands deliver complete JSON through a pipe` — covers `docs` and
+`explain`, the two paths that already return instead of exiting. The analysis path is the gap it was written
+beside.
+
+**What no test can do here.** On Linux the check passes with or without the fix, so CI cannot catch a
+regression. `pnpm smoke` on a macOS developer machine is the only gate, and `AGENTS.md` already positions the
+smoke as the thing run locally after a build. Two things follow, and both are deliberate:
+
+- the smoke assertion is kept as the regression test even though CI cannot fail on it, because the
+  alternative — a test that fabricates the async condition — would assert an implementation detail rather
+  than the behaviour;
+- the fixture must stay large enough to exceed a pipe buffer. It is 67,656 bytes today, 3% above 65,536.
+  A fixture that shrank below the buffer would make the check pass everywhere for the wrong reason. Worth
+  knowing, not worth pinning with an assertion on a byte count that would then need maintaining.
+
+## Deliberately not solved
+
+- **`install` and `ci`.** See Scope.
+- **A general "flush before every exit" helper.** One call site does not justify an abstraction, and the
+  three other `process.exit` sites in `bin.ts` are argument-validation failures that write a single line to
+  stderr.
+- **The `pnpm smoke` / CI asymmetry.** That the smoke can fail locally and pass in CI is a property of the
+  platform difference, not of this change. Making CI run the smoke on macOS is a workflow decision with its
+  own cost, recorded here so the asymmetry is not mistaken for something this design introduced.

--- a/docs/superpowers/specs/2026-08-04-stdout-truncation-on-exit-design.md
+++ b/docs/superpowers/specs/2026-08-04-stdout-truncation-on-exit-design.md
@@ -11,7 +11,7 @@
 and stops mid-string. The report is 67,656 bytes. Measured on the repo's own
 `packages/cli/test/fixtures/basic-project`:
 
-```
+```console
 $ node dist/bin.js --reporter json | wc -c
    65536
 $ node dist/bin.js --reporter json | tail -c 40
@@ -21,7 +21,9 @@ src/routes/+layout.svelte",
 
 `bin.ts` writes the report through `console.log` and then calls `process.exit(code)`. A write to a pipe is
 not guaranteed to have drained when `process.exit` runs, so whatever is still buffered is discarded. This is
-silent: the exit code is still 1, so a consumer sees a successful run and a truncated payload.
+silent: the exit code is whatever the findings warranted — 1 here, per the CLI's contract of 0 for no
+failing findings, 1 for a critical or a threshold, 2 for an execution error — so nothing the process signals
+distinguishes a complete report from a truncated one.
 
 The file already knows. `bin.ts` line 85 onward:
 
@@ -129,7 +131,7 @@ So **add a sibling check that routes the report through a true pipe**, alongside
 mechanism, and which covers only `docs` and `explain`, the two paths that already return instead of exiting.
 
 **Three details decide whether that check holds anything.** An earlier draft of this section prescribed
-`execFileSync('sh', ['-c', `${cliCmd} --reporter json | cat`])` and each of the three defeats it:
+``execFileSync('sh', ['-c', `${cliCmd} --reporter json | cat`])`` and each of the three defeats it:
 
 - **It must capture and parse the payload.** `execFileSync` throws only on a nonzero exit, and a pipeline's
   status is the _last_ command's — `cat`'s. Measured: `sh -c 'exit 1 | cat'` and even

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -163,6 +163,11 @@ async function main(): Promise<void> {
     minHealth,
     selectApp
   });
+  // A write to a pipe is asynchronous, so `process.exit` can discard what has not drained — the report is
+  // the largest thing this CLI writes and the first pipe buffer is 65,536 bytes. The empty write's callback
+  // fires once the stream has flushed. `process.exit` rather than `process.exitCode` because this path can
+  // hold an interactive prompt, where returning could hang instead.
+  await new Promise((resolve) => process.stdout.write('', resolve));
   process.exit(code);
 }
 

--- a/scripts/floor-smoke.mjs
+++ b/scripts/floor-smoke.mjs
@@ -102,6 +102,27 @@ check('the read-only subcommands deliver complete JSON through a pipe', () => {
   }
 });
 
+check('the analysis report survives a real shell pipe', () => {
+  // `runCli` and the sibling checks give the child a socketpair, whose buffer is wide enough on Linux to
+  // hide a truncation; `sh -c '… | cat'` gives it a 65,536-byte FIFO, which is what a user piping to `jq`
+  // gets. Positional parameters rather than interpolation, so a checkout path containing a space survives.
+  // Payload integrity only: a pipeline's exit status is `cat`'s, so the CLI's 0/1/2 contract is unassertable
+  // here and stays with the checks above.
+  const stdout = execFileSync(
+    'sh',
+    ['-c', '"$1" "$2" "$3" --reporter json | cat', 'sh', process.execPath, cliBin, basicProject],
+    {
+      encoding: 'utf8',
+      // stderr inherited, not ignored: a clean `--reporter json` run writes nothing there, and when the
+      // fixture is broken the CLI's own reason beats a JSON parse error as the thing the smoke prints.
+      stdio: ['ignore', 'pipe', 'inherit']
+    }
+  );
+  const report = JSON.parse(stdout);
+  assert.equal(typeof report.version, 'string');
+  assert.equal(typeof report.score, 'number');
+});
+
 check('a bad subcommand argument exits 2 with an empty stdout', () => {
   // The exit-2 contract the docs subcommand promises, asserted on the real process rather
   // than on the in-process handler.


### PR DESCRIPTION
## Why

`svelte-vitals --reporter json` piped to another process emits **exactly 65,536 bytes** — one pipe buffer — and stops mid-string. The report is 67,656 bytes.

`bin.ts` writes the report and then calls `process.exit(code)`. A write to a pipe is asynchronous, so whatever has not drained is discarded. The exit code is unaffected, so a consumer sees a successful run and a payload cut mid-string.

`packages/cli/src/bin.ts` already recorded this as a deferral: "`install`/`ci` and the analysis path below still exit directly … their large-output paths deserve the same treatment separately."

## Why CI never caught it

Node writes stdout asynchronously to pipes on every POSIX platform. What differs is the **channel**, not the platform:

| channel | child's fd 1 | buffer |
| --- | --- | --- |
| `execFileSync(...)` | `isSocket() → true` | AF_UNIX socketpair |
| `cmd \| cat` in a shell | `isFIFO() → true` | pipe, 65,536 on Linux |

Both verified with `fstatSync(1)` in a child. A socketpair's effective capacity is exactly 65,536 bytes on macOS — measured by binary search — against a stock Linux `wmem_default` of 212,992. So the report fits on a Linux runner and is cut on a macOS laptop. CI is green because its channel is wide, not because its platform is synchronous.

Two consequences follow, and an earlier draft of this design had both backwards: **a Linux user piping to `jq` should be affected too**, and **the regression is CI-defensible after all**.

## This pull request is deliberately incomplete

It contains **only the check**, not the fix, and it is expected to fail.

The point is to run that check against the unfixed CLI on Linux. A check added alongside its own fix can only ever be observed passing, which proves nothing — so the check lands first, CI measures it, and the fix follows in the next commit.

Read the result asymmetrically, because only one direction is deterministic:

- **Any truncation, on any run, confirms it.** One red is proof, and after the fix the check cannot flake red, because flushing makes delivery deterministic.
- **Green settles nothing on its own.** Truncation is a race the writer usually but not always wins — 12 of 12 locally, but the design's reviewer saw 1 run in 15 deliver the whole payload. The `test` matrix runs the smoke on three Node lines and `floor-smoke` runs it again, so one push yields four samples.

The same run also corroborates the channel explanation directly: the socketpair check green beside the pipe check red, same runner, same binary.

## The check

It asserts **payload integrity only**. A pipeline's exit status is `cat`'s, so the CLI's 0/1/2 contract is unassertable through it — measured, the CLI exits 1 while `sh` reports 0 — and `/bin/sh` on `ubuntu-latest` is `dash`, which has no `set -o pipefail`. Exit-code fidelity stays with the existing `execFileSync` checks. The path goes through positional parameters rather than interpolation, so a checkout inside a directory containing a space survives.

Local result on macOS: **2 of 8 checks fail** — the new one and the pre-existing `analysing a real project emits a well-formed JSON report` — both with `SyntaxError: Unterminated string in JSON at position 65488`.

Design: `docs/superpowers/specs/2026-08-04-stdout-truncation-on-exit-design.md`. Plan: `docs/superpowers/plans/2026-08-04-stdout-truncation-on-exit.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where large JSON or HTML reports could be truncated when piped from the CLI.
  * Ensured report output is fully delivered before the CLI exits.

* **Tests**
  * Added a shell-pipe smoke check that verifies complete JSON report output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->