### PR TITLE
fix(cli): reject flag-shaped and empty values on string flags

### DIFF
--- a/.changeset/reject-flag-shaped-values.md
+++ b/.changeset/reject-flag-shaped-values.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': patch
+---
+
+Reject flag-shaped and empty values on every CLI string flag (`--meta-components`, `--treat-dynamic-as`, `--route`, `--fail-on`, `--reporter`, `--rules`, `--ignore`, `--min-health`, `--out-file`, `--weights`, `--category`), matching the existing `--baseline` guard. Previously `--route --staged` silently consumed `--staged` as the route value (dropping it from the run), and `--min-health=` (e.g. from an unset CI environment variable) coerced to `0`, turning a health gate into one that could never fail. Both shapes now exit 2 with a clear error instead of silently proceeding. `--min-health` validation moved from `bin.ts` into `resolveArgs` alongside every other flag; `--diff` keeps its existing bare/empty-defaults-to-`HEAD` behavior.

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -118,22 +118,10 @@ async function main(): Promise<void> {
     return;
   }
 
-  const { options, warnings, errors } = resolveArgs(argv);
+  const { options, warnings, errors, minHealth } = resolveArgs(argv);
   for (const w of warnings) console.error(w);
   for (const e of errors) console.error(e);
   if (!options) process.exit(2);
-
-  const minHealthRaw = argv['min-health'];
-  let minHealth: number | undefined;
-  if (minHealthRaw !== undefined) {
-    // A bare `--min-health` parses as `true` — NaN it so it errors instead of becoming 1.
-    const n = typeof minHealthRaw === 'string' ? Number(minHealthRaw) : NaN;
-    if (!Number.isFinite(n) || n < 0 || n > 100) {
-      console.error(`svelte-vitals: invalid --min-health '${minHealthRaw}'; expected a number 0-100.`);
-      process.exit(2);
-    }
-    minHealth = n;
-  }
 
   const code = await run({
     ...options,

--- a/packages/cli/src/resolve-args.ts
+++ b/packages/cli/src/resolve-args.ts
@@ -111,7 +111,28 @@ interface ResolvedArgs {
   warnings: string[];
   /** Fatal messages (printed to stderr; the CLI exits 2 without running). */
   errors: string[];
+  /** Parsed `--min-health` value, when present and valid. */
+  minHealth?: number;
 }
+
+// parseArgs (strict:false) lets a declared string flag consume a following
+// flag token (`--route --staged` → route '--staged') and lets `--flag=` pass
+// an empty string; either silently un-gates a CI run. Same stance as the
+// --baseline guard below, applied to every value-carrying flag. --diff is
+// exempt: bare/empty --diff deliberately defaults to HEAD (see parseRunArgs).
+const VALUE_FLAGS = [
+  'meta-components',
+  'treat-dynamic-as',
+  'route',
+  'fail-on',
+  'reporter',
+  'rules',
+  'ignore',
+  'min-health',
+  'out-file',
+  'weights',
+  'category'
+] as const;
 
 /** Parse the analysis command's argv, exactly as `main` (bin.ts) does — exported so tests share the real flag table. */
 export function parseRunArgs(args: string[]): CliArgv {
@@ -158,6 +179,27 @@ export function parseRunArgs(args: string[]): CliArgv {
 export function resolveArgs(argv: CliArgv): ResolvedArgs {
   const warnings: string[] = [];
   const errors: string[] = [];
+
+  for (const flag of VALUE_FLAGS) {
+    const v = argv[flag];
+    if (v !== undefined && (typeof v !== 'string' || v.trim() === '' || v.startsWith('-'))) {
+      errors.push(`svelte-vitals: --${flag} requires a value.`);
+    }
+  }
+
+  // --min-health lives here (not in bin.ts) so it shares the guard above. A bare/empty/
+  // flag-shaped value is already an error by this point; this only adds range/numeric
+  // validity on top, mirroring the other flags' own per-flag checks below.
+  let minHealth: number | undefined;
+  const minHealthRaw = argv['min-health'];
+  if (minHealthRaw !== undefined) {
+    const n = Number(minHealthRaw);
+    if (!Number.isFinite(n) || n < 0 || n > 100) {
+      errors.push(`svelte-vitals: invalid --min-health '${minHealthRaw}'; expected a number 0-100.`);
+    } else {
+      minHealth = n;
+    }
+  }
 
   const positional = argv._[0];
   const metaComponents = typeof argv['meta-components'] === 'string' ? toList(argv['meta-components']) : undefined;
@@ -277,6 +319,7 @@ export function resolveArgs(argv: CliArgv): ResolvedArgs {
       ...(updateSuppressions ? { updateSuppressions } : {})
     },
     warnings,
-    errors
+    errors,
+    minHealth
   };
 }

--- a/packages/cli/test/resolve-args.test.ts
+++ b/packages/cli/test/resolve-args.test.ts
@@ -264,4 +264,63 @@ describe('resolveArgs', () => {
     const { options } = resolve();
     expect(options?.noAnimation).toBeUndefined();
   });
+
+  // parseArgs (strict:false) lets a declared string flag consume a following flag token
+  // instead of erroring, so a misconfigured value silently becomes another flag's name.
+  const VALUE_FLAGS = [
+    'meta-components',
+    'treat-dynamic-as',
+    'route',
+    'fail-on',
+    'reporter',
+    'rules',
+    'ignore',
+    'min-health',
+    'out-file',
+    'weights',
+    'category'
+  ];
+
+  it.each(VALUE_FLAGS)('reports --%s followed by a flag as a fatal error instead of consuming it', (flag) => {
+    const { options, errors } = resolve(`--${flag}`, '--staged');
+    expect(options).toBeNull();
+    expect(errors.some((e) => e.includes(`--${flag} requires a value`))).toBe(true);
+  });
+
+  it.each(['min-health', 'reporter', 'meta-components'])('reports --%s= (empty value) as a fatal error', (flag) => {
+    const { options, errors } = resolve(`--${flag}=`);
+    expect(options).toBeNull();
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  describe('--min-health', () => {
+    it('reports a non-numeric value as a fatal error', () => {
+      const { options, errors } = resolve('--min-health=abc');
+      expect(options).toBeNull();
+      expect(errors.some((e) => e.includes('invalid --min-health'))).toBe(true);
+    });
+
+    it('reports an out-of-range value (150) as a fatal error', () => {
+      const { options, errors } = resolve('--min-health=150');
+      expect(options).toBeNull();
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('reports a negative value (-1) as a fatal error', () => {
+      const { options, errors } = resolve('--min-health=-1');
+      expect(options).toBeNull();
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it('accepts 0, 100, and a mid-range value', () => {
+      expect(resolve('--min-health=0').minHealth).toBe(0);
+      expect(resolve('--min-health=100').minHealth).toBe(100);
+      expect(resolve('--min-health=85').minHealth).toBe(85);
+    });
+  });
+
+  it('exempts --diff from the value guard: bare and flag-followed both default to HEAD', () => {
+    expect(resolve('--diff').options?.diffBase).toBe('HEAD');
+    expect(resolve('--diff', '--staged').options?.diffBase).toBe('HEAD');
+  });
 });


### PR DESCRIPTION
## Summary

PR #392 migrated argument parsing from `mri` to `node:util`'s `parseArgs` (`strict: false`). Under `parseArgs`, a declared string flag consumes the next token **even when that token is another flag**, and `--flag=` passes an empty string. Both silently un-gate a CI run:

- `svelte-vitals --route --staged` parsed as `{ route: "--staged" }` — the run analyzed a route literally named `--staged` (matching nothing), reported a clean result, and exited 0, with `--staged` silently dropped.
- `svelte-vitals --min-health=` parsed as `''`; `Number('') === 0` passed the range check, so the gate became "health ≥ 0" — a gate that can never fail. `--min-health="$THRESHOLD"` with an unset CI variable is the realistic way to hit this.
- `--meta-components=` yielded `[]`, discarding the config file's `metaComponents` list and producing false "missing title/description" criticals.

The repo already guarded exactly one flag against this class (`--baseline`, with a comment naming the failure mode). This PR extends that stance to every value-carrying flag.

## Changes

- `resolve-args.ts`: a shared guard over the 11 value-carrying string flags — a value that is missing, empty, or flag-shaped (leading `-`) is now a fatal error (exit 2). `--baseline` keeps its existing, more specific message; `--diff` is exempt by its documented optional-value contract (bare/empty defaults to `HEAD`).
- `--min-health` parsing moved from `bin.ts` into `resolveArgs`, where every other flag is validated (single message shape, unit-testable without process exit). `run()`'s programmatic-API range check is intentionally untouched.
- Tests: a table test over all 11 guarded flags (flag-followed-by-flag), empty-value shapes, `--min-health` numeric/range shapes incl. boundary values 0/100, and a pin for the `--diff` exemption.

## Verification

- `pnpm build` / `pnpm -r typecheck` / `pnpm test` (core 1292, cli 841, vite 207) / `pnpm lint` all green.
- Built CLI: `--route --staged` → `--route requires a value.`, exit 2; `--min-health=` → exit 2; `--diff --reporter json` unaffected (no value error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CLI string flags now reject missing, empty, or flag-shaped values with exit code 2.
  * `--min-health` now validates numeric values within the 0–100 range.
  * Invalid `--min-health` input is reported consistently during argument processing.
  * Preserved existing `--diff` behavior: bare or flag-followed usage defaults to `HEAD`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->