### PR TITLE
fix(cli): read changed-file paths NUL-separated so non-ASCII paths survive --diff/--staged

### DIFF
--- a/.changeset/fix-changed-files-non-ascii.md
+++ b/.changeset/fix-changed-files-non-ascii.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': patch
+---
+
+Fix `--diff`/`--staged` silently dropping findings in files whose paths contain non-ASCII characters (e.g. Japanese route directories). Git's default `core.quotePath=true` octal-escapes such paths in `--name-only` output, which never matched the raw UTF-8 `Result.location`; changed-file detection now reads NUL-separated (`-z`) output instead.

--- a/packages/cli/src/changed-files.ts
+++ b/packages/cli/src/changed-files.ts
@@ -8,8 +8,9 @@ interface ChangedFilesOptions {
   base?: string;
 }
 
+/** `-z` is required: default `core.quotePath` octal-escapes non-ASCII paths, which would never match `Result.location`. */
 function git(args: string[], cwd: string): string[] {
-  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).split('\n');
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).split('\0');
 }
 
 /**
@@ -31,12 +32,15 @@ function git(args: string[], cwd: string): string[] {
 export function getChangedFiles(cwd: string, opts: ChangedFilesOptions): Set<string> | undefined {
   try {
     const files = opts.staged
-      ? git(['diff', '--name-only', '--relative', '--cached', '--diff-filter=d'], cwd)
+      ? git(['diff', '--name-only', '--relative', '--cached', '--diff-filter=d', '-z'], cwd)
       : [
-          ...git(['diff', '--name-only', '--relative', '--diff-filter=d', '--merge-base', opts.base ?? 'HEAD'], cwd),
-          ...git(['ls-files', '--others', '--exclude-standard'], cwd) // untracked / new files
+          ...git(
+            ['diff', '--name-only', '--relative', '--diff-filter=d', '--merge-base', opts.base ?? 'HEAD', '-z'],
+            cwd
+          ),
+          ...git(['ls-files', '--others', '--exclude-standard', '-z'], cwd) // untracked / new files
         ];
-    return new Set(files.map((s) => s.trim()).filter(Boolean));
+    return new Set(files.filter(Boolean));
   } catch {
     return undefined;
   }

--- a/packages/cli/test/changed-files.test.ts
+++ b/packages/cli/test/changed-files.test.ts
@@ -147,4 +147,52 @@ describe('getChangedFiles', () => {
     const changed = getChangedFiles(repo, { base: 'HEAD' });
     expect(changed).toEqual(new Set(['src/routes/+page.svelte']));
   });
+
+  // Regression: default core.quotePath octal-escapes non-ASCII paths in git output
+  // (e.g. `"src/routes/\343\203\226..."`), which never matches raw-UTF-8 Result.location.
+  // `-z` returns raw NUL-separated paths, sidestepping the quoting entirely.
+
+  it('reports the raw path for a non-ASCII tracked change', () => {
+    const repo = makeRepo();
+    mkdirSync(join(repo, 'src/routes/ブログ'), { recursive: true });
+    const pagePath = join(repo, 'src/routes/ブログ/+page.svelte');
+    writeFileSync(pagePath, '<h1>hello</h1>\n');
+    git(['add', '.'], repo);
+    git(['commit', '-m', 'init'], repo);
+
+    writeFileSync(pagePath, '<h1>changed</h1>\n');
+
+    const changed = getChangedFiles(repo, { base: 'HEAD' });
+    expect(changed).toEqual(new Set(['src/routes/ブログ/+page.svelte']));
+  });
+
+  it('reports the raw path for a non-ASCII staged change', () => {
+    const repo = makeRepo();
+    mkdirSync(join(repo, 'src/routes/ブログ'), { recursive: true });
+    const pagePath = join(repo, 'src/routes/ブログ/+page.svelte');
+    writeFileSync(pagePath, '<h1>hello</h1>\n');
+    git(['add', '.'], repo);
+    git(['commit', '-m', 'init'], repo);
+
+    writeFileSync(pagePath, '<h1>changed</h1>\n');
+    git(['add', '.'], repo);
+
+    const changed = getChangedFiles(repo, { staged: true });
+    expect(changed).toEqual(new Set(['src/routes/ブログ/+page.svelte']));
+  });
+
+  it('reports the raw path for a non-ASCII untracked file via the ls-files path', () => {
+    const repo = makeRepo();
+    mkdirSync(join(repo, 'src/routes'), { recursive: true });
+    // A committed file so HEAD exists for the merge-base diff.
+    writeFileSync(join(repo, 'src/routes/+layout.svelte'), '<slot />\n');
+    git(['add', '.'], repo);
+    git(['commit', '-m', 'init'], repo);
+
+    mkdirSync(join(repo, 'src/routes/café'), { recursive: true });
+    writeFileSync(join(repo, 'src/routes/café/+page.svelte'), '<h1>new</h1>\n');
+
+    const changed = getChangedFiles(repo, { base: 'HEAD' });
+    expect(changed).toEqual(new Set(['src/routes/café/+page.svelte']));
+  });
 });


### PR DESCRIPTION
## Summary

With git's default `core.quotePath=true`, `git diff --name-only` returns any path containing non-ASCII bytes octal-escaped and wrapped in double quotes — a change under `src/routes/ブログ/` comes back as `"src/routes/\343\203\226\343\203\255\343\202\260/+page.svelte"`, while `Result.location` holds the raw UTF-8 path. `filterToChangedFiles` compares the two with `Set.has`, so **every finding in such a file was silently dropped from `--diff` and `--staged` runs** — the gate failed open on exactly the files that changed, with no diagnostic. Japanese or accented route directories are ordinary in SvelteKit projects, since route directories map to URL segments.

## Changes

- `changed-files.ts`: all three git invocations (`diff --cached`, `diff --merge-base`, `ls-files --others`) now pass `-z`, and the module-local `git()` helper splits on NUL instead of newline. Per-entry `trim()` is dropped (a path may legitimately start or end with a space; with `-z` entries are exact).
- 3 regression tests against a real temp git repo: non-ASCII tracked change, non-ASCII staged change, and a non-ASCII untracked file through the `ls-files` path — each asserting exact `Set` equality with the raw UTF-8 path.

## Verification

- `pnpm -r typecheck` / `pnpm test` (core 1292, cli 825, vite 207) / `pnpm lint` all green.
- The old-pattern grep was cross-checked against pre-fix `HEAD` to confirm it discriminates (the literal `split('\n')` exists there, absent after the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)