### PR TITLE
fix(core): recognize TS-cast rune declarations and collect runes-module imports

### DIFF
--- a/.changeset/see-through-ts-casts.md
+++ b/.changeset/see-through-ts-casts.md
@@ -1,0 +1,5 @@
+---
+'@svelte-vitals/core': patch
+---
+
+Recognize rune declarations behind TS casts (`as`, `satisfies`, `!`) — `let count = $state(0) as number` now feeds the same facts as the uncast form — and collect imports for `.svelte.ts`/`.svelte.js` runes modules, so import-based rules (`performance/heavy-import`, `performance/namespace-import`, `architecture/private-scope-import`, `architecture/route-component-import`) now see them. Both were silent false negatives: TypeScript-heavy components and runes modules could pass checks they should have failed. New findings may appear in TypeScript-heavy projects — they were previously missed, not newly introduced.

--- a/packages/core/src/component-parse.ts
+++ b/packages/core/src/component-parse.ts
@@ -1108,7 +1108,7 @@ function collectPropNames(program: Node, includeBindable: boolean): Set<string> 
   let seen = 0;
   let ambiguous = false;
   walkEstree(program, (n) => {
-    if (n.type !== 'VariableDeclarator' || !n.init || !isPropsCall(n.init)) return;
+    if (n.type !== 'VariableDeclarator' || !n.init || !isPropsCall(unwrapTs(n.init))) return;
     seen++;
     if (n.id?.type === 'Identifier') {
       names.add(n.id.name);
@@ -1212,7 +1212,7 @@ function countProps(program: Node): number {
   // call (a normal component has exactly one) — either way we can't trust a count.
   let uncountable = false;
   walkEstree(program, (n) => {
-    if (n.type !== 'VariableDeclarator' || !n.init || !isPropsCall(n.init)) return;
+    if (n.type !== 'VariableDeclarator' || !n.init || !isPropsCall(unwrapTs(n.init))) return;
     seen++;
     const props = n.id?.type === 'ObjectPattern' ? n.id.properties : undefined;
     if (!Array.isArray(props) || props.some((p: Node) => p?.type === 'RestElement')) {
@@ -1919,13 +1919,13 @@ function collectModuleStateDecls(program: Node, source: string): { name: string;
     const decl = unwrapExport(stmt);
     if (decl?.type === 'VariableDeclaration') {
       for (const d of decl.declarations ?? []) {
-        if (d?.id?.type === 'Identifier' && d.init && isStateDeclaration(d.init)) {
+        if (d?.id?.type === 'Identifier' && d.init && isStateDeclaration(unwrapTs(d.init))) {
           out.push({ name: d.id.name, line: lineOf(source, d.start) });
         }
       }
     } else if (decl?.type === 'ClassDeclaration' && decl.id?.type === 'Identifier') {
       const hasStateField = (decl.body?.body ?? []).some(
-        (m: Node) => m?.type === 'PropertyDefinition' && m.value && isStateDeclaration(m.value)
+        (m: Node) => m?.type === 'PropertyDefinition' && m.value && isStateDeclaration(unwrapTs(m.value))
       );
       if (hasStateField) statefulClasses.add(decl.id.name);
     }
@@ -1952,12 +1952,13 @@ function collectModuleStateDecls(program: Node, source: string): { name: string;
 }
 
 /**
- * Facts for a `.svelte.ts`/`.svelte.js` runes module (correctness/orphan-effect, correctness/orphan-lifecycle, correctness/server-browser-global). The whole file runs
- * at import time, so only `orphanEffects`, `orphanLifecycleCalls`, `browserGlobalRefs`,
- * `moduleStateDecls`, and `suppressions` are populated — component-only facts stay empty and
- * `loc` is 0 so architecture/component-size and performance/heavy-import don't fire on module files. Uses `parseModuleProgram` to get
- * the ESTree program from the wrapped source; the 1-line wrap prefix is subtracted from every
- * reported line.
+ * Facts for a `.svelte.ts`/`.svelte.js` runes module (correctness/orphan-effect, correctness/orphan-lifecycle, correctness/server-browser-global,
+ * performance/heavy-import, performance/namespace-import, architecture/private-scope-import, architecture/route-component-import).
+ * The whole file runs at import time, so only `orphanEffects`, `orphanLifecycleCalls`, `browserGlobalRefs`,
+ * `moduleStateDecls`, `imports`/`importSpans`/`namespaceImports`, and `suppressions` are populated —
+ * `loc` stays 0 so architecture/component-size skips module files (there is no component to size), and
+ * the rest of the component-only facts stay empty. Uses `parseModuleProgram` to get the ESTree program
+ * from the wrapped source; the 1-line wrap prefix is subtracted from every reported line.
  */
 function parseModuleFacts(source: string, filename: string): ParsedFacts {
   const { program, wrapped } = parseModuleProgram(source, filename);
@@ -1982,6 +1983,17 @@ function parseModuleFacts(source: string, filename: string): ParsedFacts {
     for (const l of raw) basePathLinks.push({ ...l, line: shift(l.line) });
     basePathLinks.sort((a, b) => a.line - b.line);
   }
+  const importSpans: { source: string; line: number; type?: true }[] = [];
+  const namespaceImports: { source: string; line: number }[] = [];
+  if (program) {
+    const rawImportSpans: { source: string; line: number; type?: true }[] = [];
+    collectImportSources(program, wrapped, rawImportSpans);
+    for (const s of rawImportSpans) importSpans.push({ ...s, line: shift(s.line) });
+    const rawNamespaceImports: { source: string; line: number }[] = [];
+    collectNamespaceImports(program, wrapped, rawNamespaceImports);
+    for (const n of rawNamespaceImports) namespaceImports.push({ ...n, line: shift(n.line) });
+  }
+  const imports = importSpans.map((s) => s.source);
   return {
     eachBlocks: [],
     effects: [],
@@ -1989,9 +2001,9 @@ function parseModuleFacts(source: string, filename: string): ParsedFacts {
     javascriptUrls: [],
     loc: 0,
     propCount: 0,
-    imports: [],
-    importSpans: [],
-    namespaceImports: [],
+    imports,
+    importSpans,
+    namespaceImports,
     constableStates: [],
     mutatedProps: [],
     stalePropDerivations: [],
@@ -2105,11 +2117,12 @@ export function parseComponentFacts(source: string, filename: string): ParsedFac
     const stateDecls: { name: string; line: number }[] = [];
     walkEstree(program, (n) => {
       if (n.type !== 'VariableDeclarator' || !n.init) return;
-      if (isStateDeclaration(n.init) && n.id?.type === 'Identifier') {
+      const init = unwrapTs(n.init);
+      if (isStateDeclaration(init) && n.id?.type === 'Identifier') {
         stateNames.add(n.id.name);
         stateDecls.push({ name: n.id.name, line: lineOf(source, n.start) });
       }
-      if (isStateDeclaration(n.init) || isDerivedDeclaration(n.init) || isPropsCall(n.init))
+      if (isStateDeclaration(init) || isDerivedDeclaration(init) || isPropsCall(init))
         addBoundNames(n.id, reactiveNames);
     });
     walkEstree(program, (n) => {
@@ -2136,8 +2149,10 @@ export function parseComponentFacts(source: string, filename: string): ParsedFac
     for (const stmt of program.body ?? []) {
       if (stmt?.type !== 'VariableDeclaration') continue;
       for (const d of stmt.declarations ?? []) {
-        if (d?.id?.type !== 'Identifier' || !d.init || !isPlainStateCall(d.init)) continue;
-        const arg = unwrapTs(d.init.arguments?.[0]);
+        if (d?.id?.type !== 'Identifier' || !d.init) continue;
+        const init: Node = unwrapTs(d.init);
+        if (!isPlainStateCall(init)) continue;
+        const arg = unwrapTs(init.arguments?.[0]);
         if (arg?.type === 'ObjectExpression' || arg?.type === 'ArrayExpression') {
           rawableCandidates.push({ name: d.id.name, line: lineOf(source, d.start) });
         }
@@ -2174,8 +2189,10 @@ export function parseComponentFacts(source: string, filename: string): ParsedFac
     for (const stmt of program.body ?? []) {
       if (stmt?.type !== 'VariableDeclaration') continue;
       for (const d of stmt.declarations ?? []) {
-        if (d?.id?.type !== 'Identifier' || !d.init || !isPlainStateCall(d.init)) continue;
-        const arg = unwrapTs(d.init.arguments?.[0]);
+        if (d?.id?.type !== 'Identifier' || !d.init) continue;
+        const init: Node = unwrapTs(d.init);
+        if (!isPlainStateCall(init)) continue;
+        const arg = unwrapTs(init.arguments?.[0]);
         if (
           arg?.type === 'NewExpression' &&
           arg.callee?.type === 'Identifier' &&

--- a/packages/core/test/bundle-rules.test.ts
+++ b/packages/core/test/bundle-rules.test.ts
@@ -3,6 +3,7 @@ import { performanceHeavyImport, performanceNamespaceImport } from '../src/index
 import { defineConfig, defaultProject, type Result } from '../src/types.js';
 import type { ComponentFacts, SuppressionDirective } from '../src/component.js';
 import type { RuleContext } from '../src/rule.js';
+import { parseComponentFacts } from '../src/component-parse.js';
 
 const config = defineConfig({});
 const base = { heads: [], project: defaultProject, config };
@@ -137,6 +138,12 @@ describe('performance/heavy-import heavy dependency import', () => {
       ctx([comp([{ source: 'lodash', line: 5 }], [{ line: 6, ruleIds: ['performance/heavy-import'] }])])
     );
     expect(fails(rs)).toHaveLength(1);
+  });
+  it('end-to-end: fires on a runes module importing a heavy package (was silently never checked)', async () => {
+    const facts = parseComponentFacts("import moment from 'moment';\nlet c = $state(0);", 'src/lib/state.svelte.ts');
+    const rs = await performanceHeavyImport.check(ctx([{ file: 'src/lib/state.svelte.ts', ...facts }]));
+    expect(fails(rs)).toHaveLength(1);
+    expect(fails(rs)[0]!.message).toContain('moment');
   });
 
   const cfgCtx = (components: ComponentFacts[], cfg: Parameters<typeof defineConfig>[0]): RuleContext => ({

--- a/packages/core/test/component-parse.test.ts
+++ b/packages/core/test/component-parse.test.ts
@@ -737,6 +737,32 @@ describe('parseComponentFacts — module-scope $state declarations (security/sha
   });
 });
 
+describe('parseComponentFacts — imports in runes modules (.svelte.ts/.svelte.js)', () => {
+  const facts = (src: string, file = 'src/lib/store.svelte.ts') => parseComponentFacts(src, file);
+
+  it('collects import specifiers with lines shifted back to the unwrapped source', () => {
+    const src = "import moment from 'moment';\nlet c = $state(0);";
+    const f = facts(src);
+    expect(f.importSpans).toEqual([{ source: 'moment', line: 1 }]);
+    expect(f.imports).toEqual(['moment']);
+    expect(f.loc).toBe(0);
+  });
+
+  it('collects namespace imports with shifted lines too', () => {
+    const src = "import * as _ from 'lodash';\nlet c = $state(0);";
+    expect(facts(src).namespaceImports).toEqual([{ source: 'lodash', line: 1 }]);
+  });
+
+  it('reports no imports for a module without any', () => {
+    expect(facts('let c = $state(0);').imports).toEqual([]);
+  });
+
+  it('keeps loc at 0 even for a large module file, so architecture/component-size stays quiet', () => {
+    const src = Array.from({ length: 300 }, (_, i) => `export const v${i} = ${i};`).join('\n');
+    expect(facts(src).loc).toBe(0);
+  });
+});
+
 describe('parseComponentFacts — orphan lifecycle calls (correctness/orphan-lifecycle)', () => {
   const calls = (src: string, file = 'src/lib/store.svelte.ts') => parseComponentFacts(src, file).orphanLifecycleCalls;
 
@@ -974,6 +1000,39 @@ describe('constableStates — {@const} shadowing', () => {
   it('does not attribute a reassignment of a {let} declaration tag to a same-named untouched $state', () => {
     const src = `<script>\nlet obj = $state({});\n</script>\n{#each list as g}{let obj = g.o}<button onclick={() => {\n  obj = g.p;\n}}>x</button>{/each}`;
     expect(constable(src)).toEqual([{ name: 'obj', line: 2 }]);
+  });
+});
+
+describe('parseComponentFacts — runes behind TS casts (as/satisfies/!)', () => {
+  it('recognizes $state behind an as-cast (constableStates)', () => {
+    const src = '<script lang="ts">let count = $state(0) as number;</script><p>{count}</p>';
+    expect(parseComponentFacts(src, 'C.svelte').constableStates).toEqual([{ name: 'count', line: 1 }]);
+  });
+
+  it('recognizes $derived behind a satisfies-cast as reactive (not mountOnly)', () => {
+    const src =
+      '<script lang="ts">let count = $state(0); let d = $derived(count * 2) satisfies number; $effect(() => { console.log(d); });</script>';
+    const facts = parseComponentFacts(src, 'C.svelte');
+    expect(facts.effects[0]!.mountOnly).toBe(false);
+  });
+
+  it('recognizes $props() behind an as-cast (propCount and prop names)', () => {
+    const src =
+      '<script lang="ts">let { a, b } = $props() as { a: string; b: string };</script>{a}{b}<button onclick={() => (a.x = 1)}>x</button>';
+    const facts = parseComponentFacts(src, 'C.svelte');
+    expect(facts.propCount).toBe(2);
+    expect(facts.mutatedProps.map((m) => m.name)).toEqual(['a']);
+  });
+
+  it('recognizes a plain-$state as-cast as a rawable candidate, same as the uncast form', () => {
+    const src =
+      '<script lang="ts">let big = $state({ x: 1 }) as Record<string, number>;\nfunction refresh(next: Record<string, number>) {\n  big = next;\n}</script>';
+    expect(parseComponentFacts(src, 'C.svelte').rawableStates).toEqual([{ name: 'big', line: 1 }]);
+  });
+
+  it('recognizes a non-null-asserted $state module declaration (moduleStateDecls)', () => {
+    const src = 'export const user = $state({ name: "" })!;';
+    expect(parseComponentFacts(src, 'src/lib/store.svelte.ts').moduleStateDecls).toEqual([{ name: 'user', line: 1 }]);
   });
 });
 

--- a/packages/core/test/correctness-rules.test.ts
+++ b/packages/core/test/correctness-rules.test.ts
@@ -161,6 +161,13 @@ describe('correctness/unmutated-state unmutated $state', () => {
     const rs = await correctnessUnmutatedState.check(ctx([comp({ constableStates: [] })]));
     expect(rs).toHaveLength(0);
   });
+  it('end-to-end: a $state hidden behind a TS as-cast still fires (was a silent miss)', async () => {
+    const src = '<script lang="ts">let count = $state(0) as number;</script><p>{count}</p>';
+    const facts = parseComponentFacts(src, 'src/lib/C.svelte');
+    const rs = await correctnessUnmutatedState.check(ctx([{ file: 'src/lib/C.svelte', ...facts }]));
+    expect(fails(rs)).toHaveLength(1);
+    expect(fails(rs)[0]!.message).toContain('count');
+  });
 });
 
 describe('correctness/prop-mutation mutated non-bindable prop', () => {


### PR DESCRIPTION
## Summary

Two families of silent false negatives in the component-fact parser — both made the analyzer report "checks passed" on code it never actually saw:

**A — TS casts hid runes.** `let count = $state(0) as number` produces a declarator whose `init` is a `TSAsExpression` wrapping the call; every declarator-init rune predicate read `init.callee` directly, so the cast form was invisible. The affected facts feed ~8 rules (`correctness/unmutated-state`, `correctness/effect-as-derived`/`effect-as-onmount`, `correctness/nonreactive-builtin-state`, `correctness/stale-prop-derivation`, `correctness/prop-mutation`, `performance/state-raw`, `architecture/prop-count` — a 30-prop component using `$props() as Props` counted 0 props and passed). The repo already had the right helper (`unwrapTs`) and already applied it to call **arguments** — just not to the declarator init itself.

**B — runes modules reported no imports.** `parseModuleFacts` hardcoded `imports: []` / `importSpans: []` / `namespaceImports: []`, so the four import-gated rules (`performance/heavy-import`, `performance/namespace-import`, `architecture/private-scope-import`, `architecture/route-component-import`) never saw a `.svelte.ts`/`.svelte.js` module — even though it bundles into the client exactly like a component.

## Changes

- Route all 8 declarator-init/class-field rune predicates through `unwrapTs` (`as` / `satisfies` / `!`); `.arguments` now read from the unwrapped expression. Line reporting unchanged (declarator offsets).
- `parseModuleFacts` collects `imports`/`importSpans`/`namespaceImports` via the same collectors as the component path, with the 1-line wrap shift applied. `loc` stays 0, so `architecture/component-size` still skips module files. The stale rationale comment (which credited `loc: 0` for suppressing heavy-import) is rewritten.
- 11 new tests: fact-level cast fixtures (`as`/`satisfies`/`!` across `$state`/`$derived`/`$props`), runes-module import collection with shifted lines, a `loc`-stays-0 pin, and end-to-end rule regressions (`correctness/unmutated-state` on a cast `$state`; `performance/heavy-import` on a runes module importing `moment`).

## Behavior note

New findings may appear in TypeScript-heavy projects — they were previously **missed**, not newly introduced. The changeset says so explicitly.

## Verification

`pnpm -r typecheck` / `pnpm test` (core 1303, cli 822, vite 207) / `pnpm lint` all green. A revert spot-check confirmed the new tests fail without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)