### PR TITLE
fix(cli): analyze the baseline under the current checkout's config instead of re-loading it in the worktree

### DIFF
--- a/.changeset/baseline-config-once.md
+++ b/.changeset/baseline-config-once.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': patch
+---
+
+`--baseline` now analyzes the baseline ref under the current checkout's `svelte-vitals.config.*` instead of re-loading the config inside the temporary worktree. This fixes the gate reporting every finding as new when the config imports `svelte-vitals` (as the `install` wizard's `.ts` scaffold does) — the worktree has no `node_modules` in its ancestry, so the import used to throw and the baseline comparison silently degraded to "report everything". It also makes a config-only edit not count as an "introduced" finding, since both sides of the comparison now run under the same rules.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -37,7 +37,7 @@ import { colorEnabled, paletteFor } from './color.js';
 import { startSpinner } from './spinner.js';
 import { startMascotSpinner, mascotFitsWidth } from './mascot.js';
 import { playMascotGreeting, bubbleFitsWidth } from './speech-bubble.js';
-import { loadConfigFile } from './config-file.js';
+import { loadConfigFile, type LoadedConfigFile } from './config-file.js';
 import { playScoreAnimation, scoreAnimationEnabled } from './pulse-animation.js';
 import { resolveRuleSelection } from './rule-selection.js';
 
@@ -175,6 +175,13 @@ export interface AnalyzeOptions {
    * omit this; a fresh cache is created automatically.
    */
   parseCache?: ParseCache;
+  /**
+   * Result of a `loadConfigFile()` call to reuse instead of loading from `cwd`.
+   * Pass the value loaded from the real project so a secondary analysis (the
+   * `--baseline` worktree) runs under the same config file; `null` means "the
+   * project has no config file — do not look for one".
+   */
+  loadedConfig?: LoadedConfigFile | null;
 }
 
 export interface AnalyzeResult {
@@ -187,6 +194,13 @@ export interface AnalyzeResult {
   examined: Record<string, Record<string, number>>;
   /** Non-fatal config-file issues (unknown top-level keys, invalid enum values). Empty when no config file or none found. */
   warnings: string[];
+  /**
+   * This analysis's config-file load result (`undefined` when no config file exists at its
+   * `cwd`). A caller running a second `analyzeProject` against a different cwd for the same
+   * logical project (e.g. `applyScope`'s `--baseline` worktree) should pass this back in via
+   * `AnalyzeOptions.loadedConfig` (`?? null`) so both sides run under the same config.
+   */
+  loadedConfig?: LoadedConfigFile;
 }
 
 /**
@@ -204,7 +218,7 @@ export async function analyzeProject(opts: AnalyzeOptions = {}): Promise<Analyze
   const cwd = opts.cwd ?? process.cwd();
   const rt = createNodeRuntime();
 
-  const loaded = await loadConfigFile(cwd);
+  const loaded = opts.loadedConfig !== undefined ? (opts.loadedConfig ?? undefined) : await loadConfigFile(cwd);
   const file = loaded?.config;
 
   const weights = opts.weights ?? file?.weights;
@@ -242,7 +256,15 @@ export async function analyzeProject(opts: AnalyzeOptions = {}): Promise<Analyze
     sourceFiles
   });
   const results = applyOverrides(applyRuleSeverities(rawResults, config), config);
-  return { results, config, version: readPackageVersion(), ruleIds: rules.map((r) => r.id), examined, warnings };
+  return {
+    results,
+    config,
+    version: readPackageVersion(),
+    ruleIds: rules.map((r) => r.id),
+    examined,
+    warnings,
+    loadedConfig: loaded
+  };
 }
 
 export interface ApplyScopeOptions {
@@ -462,8 +484,10 @@ export async function run(opts: RunOptions = {}): Promise<number> {
       baseline: opts.baseline,
       noSuppressions: opts.noSuppressions,
       errorLog,
-      // No `cwd` — applyScope analyzes the baseline in its own checkout.
-      analyzeOpts: runAnalyzeOptions(opts)
+      // No `cwd` — applyScope analyzes the baseline in its own checkout. `loadedConfig` reuses
+      // this run's config-file load so the baseline side doesn't re-load svelte-vitals.config.*
+      // from inside the worktree, which has no node_modules in its ancestry.
+      analyzeOpts: { ...runAnalyzeOptions(opts), loadedConfig: analysis.loadedConfig ?? null }
     });
     const summary = summarize(results, config);
 

--- a/packages/cli/test/run-baseline.test.ts
+++ b/packages/cli/test/run-baseline.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
@@ -107,5 +110,146 @@ describe('run() --baseline gating', () => {
     expect(mockCheckout).toHaveBeenCalledWith(fixtureDir, 'origin/main');
     expect(cleanup).toHaveBeenCalledTimes(1);
     expect(code).toBe(0); // both filters applied -> nothing left to fail on
+  });
+});
+
+/**
+ * Plan 046 regression: `--baseline` used to let `analyzeProject` re-load
+ * `svelte-vitals.config.*` from inside the temporary worktree, which has no
+ * `node_modules` in its ancestry (git worktrees only ever contain tracked
+ * content). These tests exercise the real `checkoutBaseline` (a real git repo
+ * + a real `git worktree add`) rather than the mock above, so the worktree's
+ * missing `node_modules` is genuine, not simulated.
+ */
+describe('run() --baseline against a real git worktree (plan 046)', () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    while (dirs.length > 0) {
+      const dir = dirs.pop();
+      if (dir) rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function git(args: string[], cwd: string): string {
+    return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+  }
+
+  function makeRepo(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'svelte-vitals-baseline-config-'));
+    dirs.push(dir);
+    git(['init'], dir);
+    git(['config', 'user.email', 'test@example.com'], dir);
+    git(['config', 'user.name', 'Test'], dir);
+    return dir;
+  }
+
+  const PACKAGE_JSON = JSON.stringify({
+    name: 'fixture',
+    private: true,
+    type: 'module',
+    devDependencies: { '@sveltejs/kit': '^2.0.0', svelte: '^5.0.0' }
+  });
+  const APP_HTML =
+    '<!doctype html>\n<html lang="en">\n  <head>\n    %sveltekit.head%\n  </head>\n  <body>\n    %sveltekit.body%\n  </body>\n</html>\n';
+  const NO_TITLE_PAGE = '<h1>No title here</h1>\n';
+
+  // All issues across both `routes[].issues` and `siteIssues`, keyed by nothing in
+  // particular — callers filter by `id`/`location` themselves.
+  function allIssues(json: {
+    routes: { issues: { id: string; location?: string }[] }[];
+    siteIssues: { id: string; location?: string }[];
+  }) {
+    return [...json.routes.flatMap((r) => r.issues), ...json.siteIssues];
+  }
+
+  it('analyzes the baseline under the current checkout config instead of failing to load one inside the worktree', async () => {
+    const repo = makeRepo();
+    const actual = await vi.importActual<typeof import('../src/baseline.js')>('../src/baseline.js');
+    mockCheckout.mockImplementation(actual.checkoutBaseline);
+
+    mkdirSync(join(repo, 'src/routes'), { recursive: true });
+    writeFileSync(join(repo, '.gitignore'), 'node_modules\n');
+    writeFileSync(join(repo, 'package.json'), PACKAGE_JSON);
+    writeFileSync(join(repo, 'src/app.html'), APP_HTML);
+    writeFileSync(join(repo, 'src/routes/+page.svelte'), NO_TITLE_PAGE); // finding F, route '/'
+    // Committed config imports a runtime dependency, the way the install wizard's
+    // .ts scaffold's `import { defineConfig } from 'svelte-vitals'` does.
+    writeFileSync(join(repo, 'svelte-vitals.config.mjs'), "import 'fake-pkg';\nexport default {};\n");
+    git(['add', '.'], repo);
+    git(['commit', '-m', 'A'], repo);
+
+    // Untracked, like a real project's node_modules — present on disk for the real cwd's
+    // config load, but absent from the worktree checkoutBaseline creates (git worktrees
+    // only ever contain tracked content).
+    mkdirSync(join(repo, 'node_modules/fake-pkg'), { recursive: true });
+    writeFileSync(
+      join(repo, 'node_modules/fake-pkg/package.json'),
+      JSON.stringify({ name: 'fake-pkg', version: '1.0.0', type: 'module', main: 'index.js' })
+    );
+    writeFileSync(join(repo, 'node_modules/fake-pkg/index.js'), 'export const marker = true;\n');
+
+    // Uncommitted working-tree change: a second route with no title (finding G).
+    mkdirSync(join(repo, 'src/routes/other'), { recursive: true });
+    writeFileSync(join(repo, 'src/routes/other/+page.svelte'), NO_TITLE_PAGE);
+
+    const cap = capture();
+    const code = await run({
+      cwd: repo,
+      baseline: 'HEAD',
+      reporter: 'json',
+      log: cap.log,
+      errorLog: cap.errorLog,
+      env: CLEAN_ENV
+    });
+
+    const json = JSON.parse(cap.out.join('\n'));
+    const issues = allIssues(json);
+    expect(issues.some((i) => i.id === 'seo/title-presence' && i.location === 'src/routes/other/+page.svelte')).toBe(
+      true
+    ); // G: new, not in the baseline
+    expect(issues.some((i) => i.id === 'seo/title-presence' && i.location === 'src/routes/+page.svelte')).toBe(false); // F: present at the baseline ref too, filtered out
+    expect(cap.err.join('\n')).not.toContain('baseline analysis');
+    expect(cap.err.join('\n')).not.toContain('failed');
+    expect(code).toBe(1); // G still reported as a critical finding
+  });
+
+  it('runs the baseline under the current checkout config, not the ref config, so a config-only edit is not "introduced"', async () => {
+    const repo = makeRepo();
+    const actual = await vi.importActual<typeof import('../src/baseline.js')>('../src/baseline.js');
+    mockCheckout.mockImplementation(actual.checkoutBaseline);
+
+    mkdirSync(join(repo, 'src/routes'), { recursive: true });
+    writeFileSync(join(repo, 'package.json'), PACKAGE_JSON);
+    writeFileSync(join(repo, 'src/app.html'), APP_HTML);
+    writeFileSync(join(repo, 'src/routes/+page.svelte'), NO_TITLE_PAGE); // finding F, route '/'
+    // At the baseline ref, the rule is off — no finding, from either side, if the ref's
+    // config were consulted for its own analysis.
+    writeFileSync(
+      join(repo, 'svelte-vitals.config.mjs'),
+      "export default { rules: { 'seo/title-presence': 'off' } };\n"
+    );
+    git(['add', '.'], repo);
+    git(['commit', '-m', 'A'], repo);
+
+    // Uncommitted: the rule is re-enabled, no code change to the route itself.
+    writeFileSync(join(repo, 'svelte-vitals.config.mjs'), 'export default {};\n');
+
+    const cap = capture();
+    const code = await run({
+      cwd: repo,
+      baseline: 'HEAD',
+      reporter: 'json',
+      log: cap.log,
+      errorLog: cap.errorLog,
+      env: CLEAN_ENV
+    });
+
+    const json = JSON.parse(cap.out.join('\n'));
+    // Current-config-governs-both-sides: the rule is enabled on both sides, F exists at the
+    // baseline too (unchanged file), so it is not "new" and must not be reported.
+    expect(allIssues(json).some((i) => i.id === 'seo/title-presence')).toBe(false);
+    expect(cap.err.join('\n')).not.toContain('baseline analysis');
+    expect(code).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

`--baseline <ref>` checks out `<ref>` into a worktree under `os.tmpdir()` and runs `analyzeProject` there — which **re-loaded `svelte-vitals.config.*` from the worktree**, a directory with no `node_modules` anywhere in its ancestry (git worktrees only contain tracked content). The `install` wizard's own `.ts` scaffold emits `import { defineConfig } from 'svelte-vitals'` (a runtime bare-specifier import), so for every project that took the wizard's default, the baseline-side config load threw `ERR_MODULE_NOT_FOUND`, the catch logged one stderr line, and **all findings were reported as new** — the PR gate exited 1 on unrelated changes. The tool's own scaffolder produced the config that disabled the tool's own baseline gate.

Second, quieter wrong: even when the worktree config did load, it was the **ref's** config, so the two sides of the comparison ran under different rule sets whenever the config changed between ref and HEAD — a config-only edit produced "introduced" findings.

## Semantics

The current checkout's config now governs **both sides** of the comparison: a baseline run answers "which findings does my change introduce, under today's policy?" — policy is an input to the comparison, not part of the compared code.

## Changes

- `AnalyzeOptions.loadedConfig?: LoadedConfigFile | null` (additive, public API): reuse a prior `loadConfigFile()` result instead of loading from `cwd`; `null` means "no config file — don't look". `AnalyzeResult.loadedConfig` returns the load result so `run()` can thread it into the baseline call via `analyzeOpts`.
- 2 regression tests running the **real** `checkoutBaseline` (real git repo + real `git worktree add`, config importing an untracked `node_modules/fake-pkg`): (1) the `ERR_MODULE_NOT_FOUND` shape — new finding reported, pre-existing finding filtered, no degradation message on stderr; (2) config-governs-both-sides — a config-only rule re-enable does not report the pre-existing finding as introduced. Both were shown to fail without the fix (via `git stash` of the src change).

## Note for the action repo

`svelte-vitals-action` bundles `applyScope` directly; its baseline path keeps the old re-load-from-worktree behavior until it passes `analyzeOpts.loadedConfig` the same way `run()` now does. Small follow-up candidate there.

## Verification

`pnpm -r typecheck` / `pnpm test` (core 1292, cli 824, vite 207) / `pnpm lint` all green; `io-budget.test.ts` untouched and passing (no new collector I/O).

🤖 Generated with [Claude Code](https://claude.com/claude-code)