### PR TITLE
fix(vite): fail the build on an invalid config file instead of skipping the gate

### DIFF
--- a/.changeset/fail-build-on-invalid-config.md
+++ b/.changeset/fail-build-on-invalid-config.md
@@ -1,0 +1,5 @@
+---
+'@svelte-vitals/vite': minor
+---
+
+An invalid `svelte-vitals.config.*` (unknown rule id, invalid `weights`, malformed `overrides[]`) now fails `vite build` instead of being caught and skipped with a `svelte-vitals: skipped — analysis failed` warning — matching the CLI's exit-2 stance on the same validation errors. In `vite dev`, the same invalid config no longer crashes the dev server at startup: the dashboard now warns and falls back to plugin options/defaults.

--- a/packages/vite/src/analyze.ts
+++ b/packages/vite/src/analyze.ts
@@ -37,20 +37,15 @@ export interface AnalyzeResult {
 }
 
 /**
- * Resolve the effective config the same way the CLI's `analyzeProject` does — per-field
- * precedence: an explicit `options` value wins, otherwise `svelte-vitals.config.*` in
- * `cwd`, otherwise the built-in default. Shared by build-mode `analyze()` and the dev
- * dashboard (plugin.ts). `warnings` are the config file's non-fatal issues.
+ * Merge plugin options over an optional loaded config file, per-field precedence (an
+ * explicit `options` value wins, otherwise the file, otherwise the built-in default).
+ * Extracted so the dev-server fallback (plugin.ts) can build an options-only config
+ * without re-reading the config file.
  */
-export async function resolveConfig(
-  cwd: string,
-  options: SvelteVitalsOptions
-): Promise<{ config: Config; warnings: string[] }> {
-  const loaded = await loadConfigFile(cwd);
-  const fileConfig = loaded?.config;
+export function mergeConfig(options: SvelteVitalsOptions, fileConfig: Partial<Config> | undefined): Config {
   const weights = options.weights ?? fileConfig?.weights;
   const overrides = options.overrides ?? fileConfig?.overrides;
-  const config = defineConfig({
+  return defineConfig({
     treatDynamicAs: options.treatDynamicAs ?? fileConfig?.treatDynamicAs ?? 'pass',
     metaComponents: options.metaComponents ?? fileConfig?.metaComponents ?? [],
     rules: options.rules ?? fileConfig?.rules ?? {},
@@ -58,20 +53,39 @@ export async function resolveConfig(
     ...(weights !== undefined ? { weights } : {}),
     ...(overrides !== undefined ? { overrides } : {})
   });
+}
+
+/**
+ * Resolve the effective config the same way the CLI's `analyzeProject` does — per-field
+ * precedence: an explicit `options` value wins, otherwise `svelte-vitals.config.*` in
+ * `cwd`, otherwise the built-in default. Shared by build-mode `analyze()` and the dev
+ * dashboard (plugin.ts). `warnings` are the config file's non-fatal issues. Throws if
+ * the config file itself is invalid (unknown rule id, malformed `overrides`, …) —
+ * callers decide whether that's fatal (build) or a fall-back-to-defaults warning (dev).
+ */
+export async function resolveConfig(
+  cwd: string,
+  options: SvelteVitalsOptions
+): Promise<{ config: Config; warnings: string[] }> {
+  const loaded = await loadConfigFile(cwd);
+  const config = mergeConfig(options, loaded?.config);
   return { config, warnings: loaded?.warnings ?? [] };
 }
 
 /**
  * Collect prerendered heads + project facts + component facts, run the core pipeline, and
- * format reports. Config precedence: see `resolveConfig`.
+ * format reports. Config precedence: see `resolveConfig`. Pass `resolved` when the caller
+ * already resolved config itself (build mode resolves it outside `analyze`'s try/catch so a
+ * config-file validation error fails the build instead of being caught as an analysis error).
  */
 export async function analyze(
   prerenderPagesDir: string,
   cwd: string,
   options: SvelteVitalsOptions,
-  extraProjectFacts?: Partial<Project>
+  extraProjectFacts?: Partial<Project>,
+  resolved?: { config: Config; warnings: string[] }
 ): Promise<AnalyzeResult> {
-  const { config, warnings } = await resolveConfig(cwd, options);
+  const { config, warnings } = resolved ?? (await resolveConfig(cwd, options));
 
   const { heads, headings, images, htmlLang } = await collectRenderedHeads(prerenderPagesDir);
   const project = {

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -2,7 +2,15 @@ import { existsSync } from 'node:fs';
 import { writeFile, mkdir } from 'node:fs/promises';
 import { join, isAbsolute, dirname, relative, basename, sep } from 'node:path';
 import type { Plugin, ViteDevServer } from 'vite';
-import type { Category, RuleOptions, RuleOverride, RuleSetting, Severity, TreatDynamicAs } from '@svelte-vitals/core';
+import type {
+  Category,
+  Config,
+  RuleOptions,
+  RuleOverride,
+  RuleSetting,
+  Severity,
+  TreatDynamicAs
+} from '@svelte-vitals/core';
 import {
   CATEGORIES,
   defaultConfig,
@@ -11,7 +19,7 @@ import {
   validateRuleSetting
 } from '@svelte-vitals/core';
 import { findUnknownRuleIds, knownRuleIds, ruleOptionsSpec } from 'svelte-vitals';
-import { analyze, resolveConfig } from './analyze.js';
+import { analyze, mergeConfig, resolveConfig } from './analyze.js';
 import { resolveMinifyDisabled } from './minify-flag.js';
 import { installUiMiddleware } from './ui/middleware.js';
 import { createStore } from './ui/store.js';
@@ -195,16 +203,29 @@ export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin | Plugin
       // don't emit a spurious "0 routes" report or gate on nothing.
       if (!existsSync(resolved)) return;
 
+      // Resolved OUTSIDE the try: a config-file validation error must fail the
+      // build (same stance as the CLI's exit 2) — the catch below is only for
+      // the analysis itself (unreadable output, glob errors), not for config errors.
+      const resolvedConfig = await resolveConfig(root, options);
+
       let result;
       try {
         const viteMinifyDisabled = minifyFlag
           ? await resolveMinifyDisabled(minifyFlag.minify, minifyFlag.configFile, root)
           : undefined;
-        result = await analyze(resolved, root, options, viteMinifyDisabled ? { viteMinifyDisabled } : undefined);
+        result = await analyze(
+          resolved,
+          root,
+          options,
+          viteMinifyDisabled ? { viteMinifyDisabled } : undefined,
+          resolvedConfig
+        );
       } catch (err) {
         // The analysis itself failed (unreadable/malformed output, glob error,
         // …). That's our problem, not a real SEO finding, so warn and skip the
         // gate instead of failing the whole build — distinct from `result.failed`.
+        // Config-file validation errors never reach here: resolved above, before
+        // the try, they propagate and fail the build instead.
         console.warn(`svelte-vitals: skipped — analysis failed: ${err instanceof Error ? err.message : String(err)}`);
         return;
       }
@@ -242,7 +263,20 @@ export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin | Plugin
       // buildSnapshot → buildJsonReport) — the whole-project `runner` below gets its
       // config-file values independently, since it calls analyzeProject (which loads
       // the config file itself).
-      const { config, warnings } = await resolveConfig(uiRoot, options);
+      let config: Config;
+      let warnings: string[];
+      try {
+        ({ config, warnings } = await resolveConfig(uiRoot, options));
+      } catch (err) {
+        // Dev must not crash on a config typo; the dashboard runs on plugin
+        // options/defaults and says so. The build path (closeBundle) intentionally
+        // DOES fail — see the comment there.
+        console.warn(
+          `svelte-vitals: config file invalid — dashboard using plugin options/defaults: ${err instanceof Error ? err.message : String(err)}`
+        );
+        config = mergeConfig(options, undefined);
+        warnings = [];
+      }
       for (const w of warnings) console.warn(`svelte-vitals: ${w}`);
       const store = createStore();
 

--- a/packages/vite/test/plugin-config-error.test.ts
+++ b/packages/vite/test/plugin-config-error.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { EventEmitter } from 'node:events';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { Plugin, ViteDevServer } from 'vite';
+import { svelteVitals } from '../src/index.js';
+
+// Plan 047: an invalid svelte-vitals.config.* (e.g. an unknown rule id) must fail
+// `vite build` — the same stance as the CLI's exit 2 — but must NOT crash `vite dev`;
+// the dashboard warns and falls back to plugin options/defaults instead.
+
+async function makeInvalidConfigProject() {
+  const cwd = await mkdtemp(join(tmpdir(), 'sv-cfg-err-'));
+  const pages = join(cwd, '.svelte-kit/output/prerendered/pages');
+  await mkdir(pages, { recursive: true });
+  await writeFile(join(pages, 'index.html'), `<html lang="en"><head><title>Home</title></head><body></body></html>`);
+  await writeFile(join(cwd, 'svelte-vitals.config.mjs'), `export default { rules: { 'nope/nope': 'off' } };\n`);
+  return cwd;
+}
+
+describe('svelteVitals build — invalid config file', () => {
+  function closeBundleOf(p: Plugin): () => Promise<void> {
+    const hook = typeof p.closeBundle === 'function' ? p.closeBundle : p.closeBundle?.handler;
+    return (hook as () => Promise<void>).bind({});
+  }
+
+  let cwd: string;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(async () => {
+    cwd = await makeInvalidConfigProject();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(async () => {
+    warnSpy.mockRestore();
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('rejects closeBundle instead of skipping the gate with a warning', async () => {
+    const p = svelteVitals({ cwd, ui: false }) as Plugin;
+    await expect(closeBundleOf(p)()).rejects.toThrow(/svelte-vitals\.config\.mjs.*unknown rule id/);
+    // Distinct from the "analysis failed" warn-and-skip path (plugin-error.test.ts) —
+    // a config error must propagate, not be swallowed as a tool-side analysis failure.
+    expect(warnSpy.mock.calls.some((args: unknown[]) => String(args[0]).includes('skipped — analysis failed'))).toBe(
+      false
+    );
+  });
+});
+
+describe('svelteVitals dev — invalid config file', () => {
+  type MiddlewareHandler = (req: IncomingMessage, res: ServerResponse, next: () => void) => void;
+
+  function fakeRes() {
+    const chunks: string[] = [];
+    const r = {
+      statusCode: 200,
+      setHeader: () => {},
+      writeHead: (c: number) => {
+        r.statusCode = c;
+      },
+      write: (c: string) => chunks.push(c),
+      end: (c?: string) => {
+        if (c) chunks.push(c);
+      }
+    };
+    return { res: r as unknown as ServerResponse, body: () => chunks.join('') };
+  }
+
+  function req(method: string, url: string): IncomingMessage {
+    return Object.assign(new EventEmitter(), {
+      method,
+      url,
+      headers: { host: 'localhost:5173' },
+      resume: () => {}
+    }) as unknown as IncomingMessage;
+  }
+
+  let cwd: string;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  afterEach(async () => {
+    delete process.env.SVELTE_VITALS_UI;
+    warnSpy.mockRestore();
+    await rm(cwd, { recursive: true, force: true });
+  });
+
+  it('completes server setup, warns, and serves a config built from plugin options alone', async () => {
+    cwd = await makeInvalidConfigProject();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // An explicit plugin option — proves the dev fallback is mergeConfig(options, undefined)
+    // (plugin options honored), not a bare built-in default (which would leave weights.seo unset).
+    const plugins = svelteVitals({ ui: true, cwd, weights: { seo: 7 } }) as Plugin[];
+    const ui = plugins.find((p) => p.name === 'svelte-vitals:ui')!;
+    let handler: MiddlewareHandler = () => {};
+    const server = {
+      config: { root: cwd },
+      watcher: { on: () => {} },
+      middlewares: { use: (_path: string, fn: MiddlewareHandler) => (handler = fn) }
+    } as unknown as ViteDevServer;
+    const hook = typeof ui.configureServer === 'function' ? ui.configureServer : ui.configureServer!.handler;
+
+    // Server setup must complete (not reject / crash) despite the invalid config file.
+    await expect((hook as (s: ViteDevServer) => void | Promise<void>).call({}, server)).resolves.toBeUndefined();
+
+    expect(warnSpy.mock.calls.some((args: unknown[]) => String(args[0]).includes('config file invalid'))).toBe(true);
+
+    // Seed a real 'seo' finding via /ingest so computeHealth's `weights` map (which only
+    // contains categories present in the results) includes 'seo' (same technique as
+    // ui-plugin-config-file.test.ts).
+    const call = (r: IncomingMessage, res: ServerResponse) => handler(r, res, () => {});
+    const ingestReq = req('POST', '/ingest');
+    call(ingestReq, fakeRes().res);
+    ingestReq.emit(
+      'data',
+      Buffer.from(
+        JSON.stringify({
+          route: '/a',
+          results: [
+            {
+              id: 'seo/title-presence',
+              message: 'Missing <title>',
+              category: 'seo',
+              detection: { presence: 'none', value: 'absent' },
+              route: '/a',
+              severity: 'critical'
+            }
+          ]
+        })
+      )
+    );
+    ingestReq.emit('end');
+    await new Promise((r) => setTimeout(r, 0));
+
+    const { res, body } = fakeRes();
+    call(req('GET', '/data.json'), res);
+    const data = JSON.parse(body());
+    expect(data.report.weights.seo).toBe(7);
+  });
+});

--- a/packages/vite/test/plugin-error.test.ts
+++ b/packages/vite/test/plugin-error.test.ts
@@ -5,11 +5,18 @@ import { join } from 'node:path';
 import type { Plugin } from 'vite';
 
 // Force the analysis itself to fail; the plugin must NOT fail the build for it.
-vi.mock('../src/analyze.js', () => ({
-  analyze: vi.fn(async () => {
-    throw new Error('boom: unreadable output');
-  })
-}));
+// resolveConfig is kept real (via importOriginal) since closeBundle now calls it
+// outside this mocked analyze() — the temp dir here has no config file, so it
+// resolves cleanly and the failure under test stays isolated to analyze().
+vi.mock('../src/analyze.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/analyze.js')>();
+  return {
+    ...actual,
+    analyze: vi.fn(async () => {
+      throw new Error('boom: unreadable output');
+    })
+  };
+});
 
 import { svelteVitals } from '../src/index.js';
 


### PR DESCRIPTION
## Summary

`svelte-vitals.config.*` validation errors throw (unknown rule id, invalid `weights`, malformed `overrides[]`), and the CLI exits 2 on them — a silently-inert config is exactly the failure the strictness exists to prevent. The vite plugin defeated this in both modes:

- **Build**: `closeBundle` wrapped the whole analysis — including config resolution — in a catch that warned and returned. One typo in the config file turned `vite build` from "gates on findings" into "prints a warning and ships", exit 0.
- **Dev**: `configureServer` awaited `resolveConfig` with no guard, so the same typo crashed the dev server at startup with an unhandled rejection.

Same input, three behaviors: plugin-**option** errors fatal at construction, config-**file** errors silently swallowed in build and fatal-by-crash in dev.

## Changes

- **Build fails loudly**: `closeBundle` resolves the config *before* the `try` and passes it into `analyze()` (new optional `resolved` parameter), so a config-file validation error propagates and fails the build — same stance as the CLI. The catch keeps its warn-and-skip role for genuine analysis failures only; both comments name the boundary.
- **Dev warns and survives**: `configureServer` wraps the resolve; on failure it warns (`config file invalid — dashboard using plugin options/defaults`) and builds the config from plugin options alone via the newly extracted `mergeConfig(options, fileConfig?)` (not re-exported from the package entry — the public type surface is unchanged).
- Tests: build path rejects with the config path + unknown-rule message AND does not fire the `skipped — analysis failed` warn; dev path completes setup, warns, and `/data.json` proves the fallback honors explicit plugin options (`weights.seo` set via option survives). The existing `plugin-error.test.ts` mock now keeps `resolveConfig` real via `importOriginal` since `closeBundle` calls it outside the mocked `analyze`.

## Behavior change

An invalid config file now fails `vite build` (previously: warning + exit 0) and no longer crashes `vite dev` (previously: unhandled rejection). Changeset is a **minor** for `@svelte-vitals/vite` and names both.

## Verification

`pnpm -r typecheck` / `pnpm test` (core 1292, cli 822, vite 209) / `pnpm lint` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)