### PR TITLE
fix(cli): let --out-file accept its documented '-' stdout value through the flag guard

### DIFF
--- a/.changeset/out-file-stdout-dash.md
+++ b/.changeset/out-file-stdout-dash.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': patch
+---
+
+Let `--out-file -` (space-separated) and `--out-file=-` stream to stdout again, matching the documented contract (`--help`, the reporters guide, and `svelte-vitals docs show output`). The flag-shaped/empty-value guard added in the previous release rejected the literal `-` along with every other dash-prefixed value; `-` is now the one allowed exception, exempted only for `--out-file`. Dash-shaped values for every other flag, and any other `--out-file` value, still exit 2 as before.

--- a/.changeset/out-file-stdout-dash.md
+++ b/.changeset/out-file-stdout-dash.md
@@ -2,4 +2,4 @@
 'svelte-vitals': patch
 ---
 
-Let `--out-file -` (space-separated) and `--out-file=-` stream to stdout again, matching the documented contract (`--help`, the reporters guide, and `svelte-vitals docs show output`). The flag-shaped/empty-value guard added in the previous release rejected the literal `-` along with every other dash-prefixed value; `-` is now the one allowed exception, exempted only for `--out-file`. Dash-shaped values for every other flag, and any other `--out-file` value, still exit 2 as before.
+Let `--out-file -` (space-separated) and `--out-file=-` stream to stdout again, matching the documented contract (`--help`, the reporters guide, and `svelte-vitals docs show output`). The flag-shaped/empty-value guard added in the previous release rejected the literal `-` along with every other dash-prefixed value; `-` is now the one allowed exception, exempted only for `--out-file`. Regular file paths (e.g. `--out-file report.html`) were never affected and remain valid; dash-prefixed values for every other flag — and any dash-prefixed `--out-file` value other than exactly `-` — still exit 2 as before.

--- a/packages/cli/src/resolve-args.ts
+++ b/packages/cli/src/resolve-args.ts
@@ -182,6 +182,9 @@ export function resolveArgs(argv: CliArgv): ResolvedArgs {
 
   for (const flag of VALUE_FLAGS) {
     const v = argv[flag];
+    // '-' is --out-file's documented stdout value (--help, reporters guide) — the only
+    // string flag with a legitimate dash value; anything else dash-shaped stays rejected.
+    if (flag === 'out-file' && v === '-') continue;
     if (v !== undefined && (typeof v !== 'string' || v.trim() === '' || v.startsWith('-'))) {
       errors.push(`svelte-vitals: --${flag} requires a value.`);
     }

--- a/packages/cli/test/resolve-args.test.ts
+++ b/packages/cli/test/resolve-args.test.ts
@@ -323,4 +323,36 @@ describe('resolveArgs', () => {
     expect(resolve('--diff').options?.diffBase).toBe('HEAD');
     expect(resolve('--diff', '--staged').options?.diffBase).toBe('HEAD');
   });
+
+  it('exempts --out-file "-" (space-separated) from the value guard: outFile is "-"', () => {
+    const { options, errors } = resolve('--out-file', '-');
+    expect(errors).toEqual([]);
+    expect(options?.outFile).toBe('-');
+  });
+
+  it('exempts --out-file=- from the value guard: outFile is "-"', () => {
+    const { options, errors } = resolve('--out-file=-');
+    expect(errors).toEqual([]);
+    expect(options?.outFile).toBe('-');
+  });
+
+  it('keeps a trailing positional after --out-file -', () => {
+    const { options, errors } = resolve('--out-file', '-', 'someproj');
+    expect(errors).toEqual([]);
+    expect(options?.outFile).toBe('-');
+    expect(options?.cwd).toBe('someproj');
+    expect(options?.explicitPath).toBe(true);
+  });
+
+  it('still reports --out-file followed by a flag as a fatal error (not weakened by the "-" exemption)', () => {
+    const { options, errors } = resolve('--out-file', '--staged');
+    expect(options).toBeNull();
+    expect(errors.some((e) => e.includes('--out-file requires a value'))).toBe(true);
+  });
+
+  it('still reports a dash-prefixed --out-file value other than "-" as a fatal error', () => {
+    const { options, errors } = resolve('--out-file=-x');
+    expect(options).toBeNull();
+    expect(errors.some((e) => e.includes('--out-file requires a value'))).toBe(true);
+  });
 });


### PR DESCRIPTION
Fixes #383.

## Summary

`--out-file -` is the documented way to stream the HTML report to stdout (`--help` says `'-' for stdout`; the reporters guide shows it as a copy-paste example). On current main **both** forms were broken, though differently than the issue describes:

- The issue's mechanism section (empty-string value + swallowed positional) was measured on 0.42.0's `mri` parser and is obsolete — since #392, `parseArgs` yields the literal `-` for both forms and preserves positionals (verified empirically).
- What actually rejects it today is the flag-value guard from #397, which treats any dash-prefixed value as flag-shaped — a regression that also broke the previously-working `--out-file=-` form (both exited 2).

## Changes

The guard's own design note anticipated this ("if a legitimate leading-dash value appears, allow-list that flag"): the literal `-` is now exempted, for `--out-file` only. One line plus a constraint comment. `--out-file --staged` and `--out-file=-x` still exit 2 — pinned by tests.

5 new tests (both stdout forms, positional preservation, two non-weakening pins). The issue's bin.ts pre-pass sketch is deliberately not implemented — unnecessary under `parseArgs`.

## Verification

- Manual e2e per the issue's repro: `--out-file -` and `--out-file=-` both stream 82,390 bytes of HTML to stdout, exit 1 (findings, not 2), and write no `svelte-vitals-report.html`.
- `pnpm -r typecheck` / `pnpm test` (core 1303, cli 851, vite 209) / `pnpm lint` all green.
- Confirmed `outFile` is only consumed in the html-reporter branch, so no other reporter can mis-handle `-`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored stdout streaming when using `--out-file -` or `--out-file=-`.
  - Preserved support for trailing positional paths with these options.
  - Continued rejecting invalid or other dash-prefixed output file values with an error.

- **Tests**
  - Added coverage for valid stdout output formats and invalid output file arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->