### PR TITLE
fix(cli): exit 2 when --category excludes every rule named in --rules

### DIFF
--- a/.changeset/rules-category-empty-selection.md
+++ b/.changeset/rules-category-empty-selection.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': patch
+---
+
+Exit 2 when `--rules` and `--category` are both passed and `--category` excludes every rule named in `--rules`. Previously `analyzeProject`'s category filter ran after rule selection, so a `--rules` id whose category wasn't in `--category` was dropped silently — the run exited 0 with zero rules examined and nothing on stderr (issue #384). The check mirrors the existing unknown-rule-id error: fatal, naming the excluded rule id(s) and the `--category` list. `--ignore` is unaffected — ignoring a rule that `--category` already excludes is harmless, not a conflict.

--- a/docs/superpowers/specs/2026-08-06-rule-selection-design.md
+++ b/docs/superpowers/specs/2026-08-06-rule-selection-design.md
@@ -224,6 +224,8 @@ and `@svelte-vitals/vite` are untouched.
   same silent-selection shape as the field report that produced this design. Pre-existing and untouched here;
   recorded so it is a known gap rather than a rediscovery. The same is true of an `allowRules` id that no
   category in `--category` covers.
+  _(2026-08-08 addendum: closed by issue #384's fix — `resolveArgs` now rejects this combination fatally,
+  exit 2, instead of silently running nothing.)_
 - **Warning when a flag discards configuration.** Not needed once configuration is inherited rather than
   discarded. If a future flag has to discard, it should say so rather than exit 0 — the failure this design
   removes was silent, and that is what made it survive a release.

--- a/packages/cli/src/resolve-args.ts
+++ b/packages/cli/src/resolve-args.ts
@@ -265,6 +265,28 @@ export function resolveArgs(argv: CliArgv): ResolvedArgs {
   const weights = parseWeights(argv.weights, errors);
   const categories = parseCategories(argv.category, errors);
 
+  // A --rules id names a real, known rule but is silently dropped later if its category
+  // isn't in --category: analyzeProject's category filter (packages/cli/src/index.ts)
+  // runs after rule selection, so a force-enabled rule from an unlisted category yields
+  // no findings and no warning (issue #384). Catch it here instead, fatally, matching the
+  // unknown-rule-id shape above. Every rule id is 'category/slug', so its prefix is its
+  // category. --ignore is exempt: ignoring something --category already excludes is
+  // harmless, not a conflict. Only known ids are checked — an unknown id was already
+  // reported above and comparing its (meaningless) prefix here would just be noise.
+  // Skipped when --category resolved to no valid categories: that's already a fatal
+  // error on its own (unknown-category or empty-list, above).
+  if (categories !== undefined && categories.length > 0 && allow.length > 0) {
+    const excluded = allow
+      .filter((id) => !unknown.includes(id))
+      .filter((id) => !categories.includes(id.split('/')[0] as Category));
+    if (excluded.length > 0) {
+      errors.push(
+        `svelte-vitals: --rules id(s) excluded by --category ${categories.join(', ')}: ${excluded.join(', ')}`
+      );
+      errors.push("Add the rule's category to --category, or drop the rule from --rules.");
+    }
+  }
+
   const score = Boolean(argv.score);
   if (score && typeof argv.reporter === 'string') {
     warnings.push('svelte-vitals: --score overrides --reporter; reporter output suppressed.');

--- a/packages/cli/test/resolve-args.test.ts
+++ b/packages/cli/test/resolve-args.test.ts
@@ -45,6 +45,53 @@ describe('resolveArgs', () => {
     expect(errors.some((e) => e.includes('unknown rule id(s)'))).toBe(true);
   });
 
+  // A --rules id that names a real rule but whose category isn't in --category was
+  // silently dropped by analyzeProject's post-selection category filter (issue #384) —
+  // exit 0, zero rules ran, nothing on stderr. This must be fatal like the unknown-id case.
+  it('reports a --rules id excluded by --category as a fatal error (no options)', () => {
+    const { options, errors } = resolve('--rules', 'seo/title-presence', '--category', 'performance');
+    expect(options).toBeNull();
+    expect(errors.some((e) => e.includes('seo/title-presence') && e.includes('performance'))).toBe(true);
+  });
+
+  it('allows a --rules id whose category is included in --category', () => {
+    const { options, errors } = resolve('--rules', 'seo/title-presence', '--category', 'seo,performance');
+    expect(errors).toEqual([]);
+    expect(options?.allowRules).toEqual(['seo/title-presence']);
+    expect(options?.categories).toEqual(['seo', 'performance']);
+  });
+
+  it('does not check --rules against --category when --category is absent', () => {
+    const { options, errors } = resolve('--rules', 'seo/title-presence');
+    expect(errors).toEqual([]);
+    expect(options?.allowRules).toEqual(['seo/title-presence']);
+  });
+
+  it('does not check --category against --rules when --rules is absent', () => {
+    const { options, errors } = resolve('--category', 'performance');
+    expect(errors).toEqual([]);
+    expect(options?.categories).toEqual(['performance']);
+  });
+
+  it('does not flag a --ignore id excluded by --category (ignoring an excluded rule is harmless)', () => {
+    const { options, errors } = resolve('--ignore', 'seo/title-presence', '--category', 'performance');
+    expect(errors).toEqual([]);
+    expect(options?.ignoreRules).toEqual(['seo/title-presence']);
+    expect(options?.categories).toEqual(['performance']);
+  });
+
+  it('reports only the --rules id(s) excluded by --category, not ones whose category is included', () => {
+    const { options, errors } = resolve(
+      '--rules',
+      'seo/title-presence,performance/heavy-import',
+      '--category',
+      'performance'
+    );
+    expect(options).toBeNull();
+    expect(errors.some((e) => e.includes('seo/title-presence'))).toBe(true);
+    expect(errors.some((e) => e.includes('performance/heavy-import'))).toBe(false);
+  });
+
   it('parses --meta-components into a trimmed, non-empty list', () => {
     const { options } = resolve('--meta-components', 'MetaTags, Seo ,');
     expect(options?.metaComponents).toEqual(['MetaTags', 'Seo']);


### PR DESCRIPTION
Fixes #384.

## Summary

`svelte-vitals . --rules seo/title-presence --category performance` ran **zero rules and exited 0 silently** — `analyzeProject` applies the category filter after rule selection, so a force-enabled rule from an unlisted category was dropped without trace. A CI consumer read that as "the tree complies". The rule-selection design records this exact gap under "Deliberately not solved", and its own principle applies: a flag that discards should say so rather than exit 0.

## Changes

- `resolveArgs` now pushes a fatal error (exit 2) when `--rules` and `--category` are both present and a named rule's category prefix is absent from the category list — mirroring the existing unknown-rule-id error's aggregate two-line shape. Unknown ids are excluded from the check (already reported); an id in `--ignore` outside the categories stays harmless by design (pinned by a test).
- 6 tests beside the unknown-rule-id suite; dated addendum on the design doc's "Deliberately not solved" bullet; changeset (patch).

## Verification

- E2E (built CLI, basic-project fixture): the issue's exact reproduction now exits 2 with `--rules id(s) excluded by --category performance: seo/title-presence` on stderr, empty stdout.
- `pnpm -r typecheck` / `pnpm test` (core 1303, cli 852, vite 209) / `pnpm lint` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)