### PR TITLE
fix(cli): warn when --rules names a rule that config.overrides scopes off

### DIFF
--- a/.changeset/warn-rules-overrides-off.md
+++ b/.changeset/warn-rules-overrides-off.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': patch
+---
+
+Naming a rule in `--rules` that a config `overrides` entry scopes `'off'` (directly by rule id, or via its category key) now prints a startup warning naming the rule and the overrides entry's `files`/`route` scope, instead of silently reporting a compliant tree. The semantics — whether `--rules` should force-enable through a scoped `'off'` — are deliberately unchanged; only the silence is fixed (#385).

--- a/docs/superpowers/specs/2026-08-06-rule-selection-design.md
+++ b/docs/superpowers/specs/2026-08-06-rule-selection-design.md
@@ -214,7 +214,8 @@ and `@svelte-vitals/vite` are untouched.
   are a separate field applied after analysis; `--rules` has never reached into them and does not start here.
   A user who scopes a rule off under `src/legacy/**` and then runs `--rules <that rule>` still gets nothing for
   those paths. Recorded rather than fixed: making a selection flag reach into path-scoped configuration is a
-  larger question than this defect.
+  larger question than this defect. **2026-08-08**: the silence (not the semantics above) is now fixed —
+  `analyzeProject` warns on stderr when a `--rules`-named rule is scoped `'off'` this way (issue #385).
 - **The two halves of the vite dev dashboard.** `plugin.ts`'s live per-route view and the dashboard's runner both
   take `options.rules` as a whole-field replacement, and neither has an allow-list, so they agree under this
   design. They disagreed only under the discarded merge. Nothing to do; recorded so the next reader does not

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,8 +17,10 @@ import {
   selectRules,
   applyRuleSeverities,
   applyOverrides,
+  settingSeverity,
   type Severity,
   type RuleSetting,
+  type RuleOverride,
   type Result,
   type Config,
   type Category
@@ -203,6 +205,44 @@ export interface AnalyzeResult {
   loadedConfig?: LoadedConfigFile;
 }
 
+function formatGlob(glob: string | string[]): string {
+  return Array.isArray(glob) ? `[${glob.map((g) => `'${g}'`).join(', ')}]` : `'${glob}'`;
+}
+
+/**
+ * `--rules` force-enables a rule through the top-level `rules` map (design
+ * 2026-08-06-rule-selection-design.md), but `overrides` is a separate field applied to results
+ * after analysis and `--rules` has never reached into it — so a rule named in `--rules` that an
+ * overrides entry scopes `'off'` for some paths still reports nothing there, silently (issue
+ * #385). This only breaks the silence with a warning per (rule, entry) pair; the run proceeds
+ * unchanged and the semantics stay exactly as recorded in that design doc's "Deliberately not
+ * solved" section.
+ */
+function overridesOffWarnings(allowRules: string[] | undefined, overrides: RuleOverride[] | undefined): string[] {
+  if (!allowRules || allowRules.length === 0 || !overrides || overrides.length === 0) return [];
+  const warnings: string[] = [];
+  for (const ruleId of allowRules) {
+    const category = ruleId.split('/')[0] ?? ruleId;
+    for (const entry of overrides) {
+      // Same precedence as `applyOverrides`: a rule-id key beats a category key, but only when
+      // it carries a severity of its own (an options-only rule-id key falls through).
+      const severity = settingSeverity(entry.rules[ruleId]) ?? settingSeverity(entry.rules[category]);
+      if (severity !== 'off') continue;
+      const scope = [
+        entry.route !== undefined ? `route: ${formatGlob(entry.route)}` : undefined,
+        entry.files !== undefined ? `files: ${formatGlob(entry.files)}` : undefined
+      ]
+        .filter((s): s is string => s !== undefined)
+        .join(', ');
+      warnings.push(
+        `--rules '${ruleId}' is scoped 'off' by overrides entry { ${scope} } — findings there will not be reported. ` +
+          `--rules overrides a global 'off' but not a scoped one.`
+      );
+    }
+  }
+  return warnings;
+}
+
 /**
  * Run static-mode analysis and return the structured findings + resolved config.
  * Throws ProjectError when `cwd` is not a SvelteKit project. Also throws when a
@@ -237,7 +277,11 @@ export async function analyzeProject(opts: AnalyzeOptions = {}): Promise<Analyze
   });
 
   await detectProject(rt, cwd); // throws ProjectError if not a SvelteKit project
-  const warnings = [...(loaded?.warnings ?? []), ...(await checkVersionFloor(rt, cwd))];
+  const warnings = [
+    ...(loaded?.warnings ?? []),
+    ...(await checkVersionFloor(rt, cwd)),
+    ...overridesOffWarnings(opts.allowRules, config.overrides)
+  ];
 
   const { heads, images, headings, project, components, kitModules, sourceFiles } = await collectAll(rt, cwd, config, {
     route: opts.route,

--- a/packages/cli/test/analyze-project.test.ts
+++ b/packages/cli/test/analyze-project.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { cpSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 
 // Mock the git layer so the --diff scope below is testable without a real repo (mirrors
 // run-diff.test.ts). Only the test in the "examined counts" describe block below touches this.
@@ -301,6 +303,79 @@ describe('allowRules keeps the named rules configured', () => {
       rules: { 'seo/title-presence': 'off' }
     });
     expect(config.rules).toEqual({ 'seo/title-presence': 'off' });
+  });
+});
+
+// A rule named in --rules that a config `overrides` entry scopes 'off' for some paths used to
+// report nothing there, silently (issue #385). Part 1 only breaks the silence with a warning —
+// the results themselves are unaffected (overrides still apply exactly as before the fix).
+describe('allowRules named a rule that overrides scopes off warns without changing results (issue #385)', () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    while (dirs.length > 0) {
+      const dir = dirs.pop();
+      if (dir) rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  /** A throwaway copy of basic-project with the given config file content written into it. */
+  function projectWithConfig(configSource: string): string {
+    const dir = mkdtempSync(join(tmpdir(), 'svelte-vitals-overrides-warning-'));
+    dirs.push(dir);
+    cpSync(fixtureDir, dir, { recursive: true });
+    writeFileSync(join(dir, 'svelte-vitals.config.mjs'), configSource);
+    return dir;
+  }
+
+  it('warns when a rule-id key scopes the --rules-named rule off, and leaves results unaffected', async () => {
+    const dir = projectWithConfig(
+      "export default { overrides: [{ files: 'src/**', rules: { 'seo/title-presence': 'off' } }] };"
+    );
+    const { results, warnings } = await analyzeProject({ cwd: dir, allowRules: ['seo/title-presence'] });
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("--rules 'seo/title-presence' is scoped 'off' by overrides entry") && w.includes("files: 'src/**'")
+      )
+    ).toBe(true);
+    // Overrides still remove every seo/title-presence result under src/** (unchanged semantics).
+    expect(results.filter((r) => r.id === 'seo/title-presence')).toEqual([]);
+  });
+
+  it('warns when a category key scopes the --rules-named rule off (rule id beats category, but category still applies when the rule id key is absent)', async () => {
+    // overrides-project's config sets the `seo` category off under src/routes/(app)/**.
+    const { warnings } = await analyzeProject({
+      cwd: join(here, 'fixtures', 'overrides-project'),
+      allowRules: ['seo/title-presence']
+    });
+    expect(
+      warnings.some(
+        (w) =>
+          w.includes("--rules 'seo/title-presence' is scoped 'off' by overrides entry") &&
+          w.includes("files: 'src/routes/(app)/**'")
+      )
+    ).toBe(true);
+  });
+
+  it('does not warn when the overrides entry scopes off a different rule', async () => {
+    const dir = projectWithConfig(
+      "export default { overrides: [{ files: 'src/**', rules: { 'seo/description-presence': 'off' } }] };"
+    );
+    const { warnings } = await analyzeProject({ cwd: dir, allowRules: ['seo/title-presence'] });
+    expect(warnings).toEqual([]);
+  });
+
+  it('does not warn when the overrides entry sets a severity (not off) for the named rule', async () => {
+    const dir = projectWithConfig(
+      "export default { overrides: [{ files: 'src/**', rules: { 'seo/title-presence': 'warning' } }] };"
+    );
+    const { warnings } = await analyzeProject({ cwd: dir, allowRules: ['seo/title-presence'] });
+    expect(warnings).toEqual([]);
+  });
+
+  it('does not warn when no --rules is given at all, even with a matching overrides entry present', async () => {
+    const { warnings } = await analyzeProject({ cwd: join(here, 'fixtures', 'overrides-project') });
+    expect(warnings).toEqual([]);
   });
 });
 

--- a/packages/cli/test/run.test.ts
+++ b/packages/cli/test/run.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { cpSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { run } from '../src/index.js';
 import { GREETING_MESSAGES } from '../src/speech-bubble.js';
 
@@ -194,6 +196,49 @@ describe('run() rule selection', () => {
     expect(Object.keys(json.rules)).toEqual(['architecture/component-size']);
     // A finding at all only if the file's `max: 3` arrived — the built-in default is far higher.
     expect(json.rules['architecture/component-size'].findings).toBeGreaterThan(0);
+  });
+});
+
+// Issue #385's exact reproduction: a config `overrides` entry scopes a --rules-named rule off,
+// so pre-fix the run silently looked like a compliant tree (findings 0, score 100, exit 0,
+// nothing on stderr). Part 1 only breaks the silence with a stderr warning — the semantics
+// (whether --rules should force-enable through a scoped 'off') are deliberately unchanged here.
+describe('run() --rules named rule scoped off by overrides (issue #385)', () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    while (dirs.length > 0) {
+      const dir = dirs.pop();
+      if (dir) rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('warns on stderr but leaves today’s silent-pass behavior (exit 0, score 100) unchanged', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'svelte-vitals-issue-385-run-'));
+    dirs.push(dir);
+    cpSync(fixtureDir, dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'svelte-vitals.config.mjs'),
+      "export default { overrides: [{ files: 'src/**', rules: { 'seo/title-presence': 'off' } }] };"
+    );
+
+    const cap = capture();
+    const code = await run({
+      cwd: dir,
+      log: cap.log,
+      errorLog: cap.errorLog,
+      reporter: 'json',
+      env: CLEAN_ENV,
+      allowRules: ['seo/title-presence']
+    });
+
+    const json = JSON.parse(cap.out.join('\n'));
+    expect(json.rules['seo/title-presence']).toEqual({ findings: 0, passed: 0 });
+    expect(json.score).toBe(100);
+    expect(code).toBe(0);
+
+    const errText = cap.err.join('\n');
+    expect(errText).toContain("--rules 'seo/title-presence' is scoped 'off' by overrides entry");
+    expect(errText).toContain("files: 'src/**'");
   });
 });
 


### PR DESCRIPTION
Fixes #385.

## Summary

`--rules X` force-enables through a global `rules: { X: 'off' }`, but `overrides` entries are applied to results after analysis and no flag reaches into them — so a rule named in `--rules` that an overrides entry scopes `'off'` reported **nothing, silently**: findings 0, passed 0, score 100, exit 0, byte-for-byte the shape of a compliant tree.

Per the issue's own scoping, this implements **part 1 only** (break the silence). Whether `--rules` should force-enable through a scoped `'off'` — part 2 — is deliberately unchanged and stays recorded in the rule-selection design.

## Changes

- `analyzeProject` now emits a startup warning per (rule, entry) pair when a `--rules`-named rule is set `'off'` by an overrides entry — directly by rule id or via its category key. Off-detection reuses core's `settingSeverity` with the same precedence as `applyOverrides` (a rule-id key beats the category key only when it carries its own severity; options-only keys fall through), so the warning can't disagree with the actual override semantics.
- Warning names the rule and the entry's `route:`/`files:` scope; printed once even under `--baseline` (the second analysis's warnings are discarded by design).
- 5 unit tests + the issue's exact reproduction end-to-end (warning on stderr, exit 0/score 100 pinned as deliberately unchanged); dated addendum on the design doc's "Deliberately not solved" bullet; changeset (patch).

## Verification

`pnpm -r typecheck` / `pnpm test` (core 1303, cli 852, vite 209) / `pnpm lint` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)