### PR TITLE
feat(core): show category reach beside scores in the HTML report and dashboard

### DIFF
--- a/.changeset/render-category-reach.md
+++ b/.changeset/render-category-reach.md
@@ -1,0 +1,5 @@
+---
+'@svelte-vitals/core': minor
+---
+
+The HTML report and the dev dashboard now show each category's reach ("N of M keys affected") beside its score. The score floor design (2026-08-05) moved magnitude out of the score and into `categories[cat].affectedKeys`/`keys`, so a reader could no longer tell one affected file from forty-one — both surfaces received the fields and rendered nothing. Per-route category rendering (`routes[].categories`) remains a deferred, separate question.

--- a/packages/core/src/reporter/app-shell.ts
+++ b/packages/core/src/reporter/app-shell.ts
@@ -114,6 +114,7 @@ body{background:var(--ground);color:var(--ink);font-family:var(--sans);line-heig
 .dv-cat-top{display:flex;justify-content:space-between;font-size:13px;margin-bottom:6px}
 .dv-bar{height:7px;border-radius:999px;background:var(--line);overflow:hidden}
 .dv-bar>i{display:block;height:100%;border-radius:999px}
+.dv-cat-reach{font-size:11.5px;color:var(--muted);margin-top:5px}
 .dv-filters{display:flex;gap:8px;flex-wrap:wrap;margin:16px 0}
 .dv-chip{font:inherit;font-size:12.5px;font-weight:600;cursor:pointer;background:var(--panel);border:1px solid var(--line-strong);color:var(--muted);padding:5px 12px;border-radius:999px}
 .dv-chip[aria-pressed="true"]{background:var(--active-bg);border-color:var(--active-bg);color:var(--active-ink)}
@@ -596,12 +597,21 @@ export const APP_SCRIPT: string = `
       var band = scoreBand(c.score);
       var weight = s.report.weights[cat];
       var name = cat === 'seo' ? 'SEO' : cat.charAt(0).toUpperCase() + cat.slice(1);
+      // keys/affectedKeys are absent on hand-built snapshots (older fixtures, tests) —
+      // render nothing rather than "undefined of undefined". 0 affected of N keys is still
+      // rendered: on a real project that's the signal a thin score can't give, that the
+      // category is clean project-wide and not just on the one key it happened to look at
+      // (design: 2026-08-05-score-floor-and-reach-design.md).
+      var reach = typeof c.keys === 'number' && c.keys > 0
+        ? h('div', { class: 'dv-cat-reach', text: c.affectedKeys + ' of ' + c.keys + ' keys affected' }, [])
+        : null;
       return h('div', { class: 'dv-cat' }, [
         h('div', { class: 'dv-cat-top' }, [
           h('span', { text: name + (weight !== undefined ? ' (weight ' + weight + ')' : '') }, []),
           h('span', { style: 'color:' + BAND_COLOR[band], text: String(c.score) }, [])
         ]),
-        h('div', { class: 'dv-bar' }, [h('i', { style: 'width:' + c.score + '%;background:' + BAND_COLOR[band] }, [])])
+        h('div', { class: 'dv-bar' }, [h('i', { style: 'width:' + c.score + '%;background:' + BAND_COLOR[band] }, [])]),
+        reach
       ]);
     });
     var chips = renderFilterChips(s.report.categories);

--- a/packages/core/test/html-report.test.ts
+++ b/packages/core/test/html-report.test.ts
@@ -176,6 +176,33 @@ describe('formatHtmlReport', () => {
     const html = formatHtmlReport(results, defineConfig({}), { version: '0.0.0' });
     expect(html).toContain('"categories":{"seo":95}');
   });
+
+  it('carries category reach (keys/affectedKeys) into the embedded snapshot (issue #388)', () => {
+    // core has no jsdom dependency, so unlike packages/vite/test/dashboard-script-overview-reach.test.ts
+    // this only pins the data reaching the client, not the client's rendering of it.
+    const results: Result[] = [
+      {
+        id: 'seo/canonical-url',
+        category: 'seo',
+        severity: 'warning',
+        detection: { presence: 'none', value: 'absent' },
+        route: '/a',
+        message: 'x'
+      },
+      {
+        id: 'seo/canonical-url',
+        category: 'seo',
+        severity: 'warning',
+        detection: { presence: 'own', value: 'static' },
+        route: '/b',
+        message: 'x'
+      }
+    ];
+    const html = formatHtmlReport(results, defineConfig({}), { version: '0.0.0' });
+    const snapshot = extractEmbeddedSnapshot(html);
+    expect(snapshot.report.categories.seo).toMatchObject({ keys: 2, affectedKeys: 1 });
+    expect(html).toContain('"keys":2,"affectedKeys":1');
+  });
 });
 
 describe('parity with the live dashboard shell', () => {

--- a/packages/vite/test/dashboard-script-overview-reach.test.ts
+++ b/packages/vite/test/dashboard-script-overview-reach.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { buildHtmlDocument, type JsonReport } from '@svelte-vitals/core';
+
+/**
+ * Boots the shared app shell (see app-shell-static.test.ts for why this lives in
+ * packages/vite: core has no jsdom dependency) and pins the category-overview reach
+ * line added for issue #388 — "N of M keys affected" beside each category's score,
+ * the affectedKeys/keys fields the score floor design moved magnitude into
+ * (docs/superpowers/specs/2026-08-05-score-floor-and-reach-design.md).
+ */
+
+const model = { routeAverage: 0, sitePenalty: 0, criticalCap: null };
+
+function baseReport(categories: JsonReport['categories']): JsonReport {
+  return {
+    version: '1',
+    score: 90,
+    weights: { architecture: 1 },
+    categories,
+    summary: { critical: 0, warning: 0, info: 0, passed: 0, dynamic: 0 } as never,
+    rules: {},
+    inventories: {},
+    routes: [],
+    siteIssues: []
+  };
+}
+
+function bootStatic(report: JsonReport): void {
+  const html = buildHtmlDocument(report, { version: '9.9.9' });
+  document.documentElement.innerHTML = html.replace(/^<!doctype html><html[^>]*>/, '').replace('</html>', '');
+  const start = html.lastIndexOf('<script>') + '<script>'.length;
+  const end = html.lastIndexOf('</script>');
+  // Parse+run of our own generated shell against this test's own fixture — not
+  // execution of untrusted input.
+  new Function(html.slice(start, end))();
+}
+
+describe('dashboard overview — category reach line', () => {
+  it('renders "N of M keys affected" beside a category with affectedKeys/keys present', () => {
+    bootStatic(baseReport({ architecture: { score: 99, scoreModel: model, keys: 334, affectedKeys: 41 } }));
+    const reach = document.querySelector('.dv-cat-reach');
+    expect(reach).not.toBeNull();
+    expect(reach!.textContent).toBe('41 of 334 keys affected');
+  });
+
+  it('renders the zero-affected state ("0 of N") rather than hiding it', () => {
+    bootStatic(baseReport({ architecture: { score: 100, scoreModel: model, keys: 334, affectedKeys: 0 } }));
+    const reach = document.querySelector('.dv-cat-reach');
+    expect(reach).not.toBeNull();
+    expect(reach!.textContent).toBe('0 of 334 keys affected');
+  });
+
+  it('renders no reach line, and no "undefined", when keys is 0', () => {
+    bootStatic(baseReport({ architecture: { score: 100, scoreModel: model, keys: 0, affectedKeys: 0 } }));
+    const cats = document.querySelector('.dv-cats')!;
+    expect(cats.querySelector('.dv-cat-reach')).toBeNull();
+    expect(cats.textContent).not.toContain('undefined');
+  });
+
+  it('renders no reach line, and no "undefined", when the fields are absent entirely', () => {
+    // A hand-built snapshot older than the score-floor design (or a test fixture) — the
+    // category object carries only score/scoreModel, same shape dashboard-script-ai-prompt
+    // and dashboard-script-staleness use.
+    const report = baseReport({ architecture: { score: 100 } as never });
+    bootStatic(report);
+    const cats = document.querySelector('.dv-cats')!;
+    expect(cats.querySelector('.dv-cat-reach')).toBeNull();
+    expect(cats.textContent).not.toContain('undefined');
+  });
+});


### PR DESCRIPTION
Fixes #388.

## Summary

The score-floor design deliberately moved magnitude out of the category score and into `categories[cat].affectedKeys`/`keys` — but both visual surfaces received the fields and rendered nothing, so `architecture 99` looked identical whether 1 file or 41 were affected. The fix is one change in the one renderer behind both surfaces (`app-shell.ts` serves `--reporter html` and the dev dashboard).

## Changes

- `renderOverview` now renders `N of M keys affected` as muted secondary text under each category row, via the shell's existing `h()`/`textContent` helper (XSS convention unchanged) and a minimal `.dv-cat-reach` rule reusing the muted style.
- **Zero state is rendered** (`0 of 334 keys affected`): per the design doc, a project-wide-clean reach is exactly the signal a bare score can't give. The line is skipped only when the fields are absent (hand-built/older snapshots) or `keys` is 0 — no `undefined of undefined`.
- Tests boot the real generated shell (jsdom + the established `bootStatic` technique): present fields, zero-affected, `keys: 0`, and absent fields; plus a `formatHtmlReport` pass-through pin on the embedded snapshot.
- Per-route `routes[].categories` rendering is **explicitly deferred** — the route-category-scores design records it as an open UI question.
- Changeset: `@svelte-vitals/core` minor.

## Verification

`pnpm -r typecheck` / `pnpm test` (core 1304, cli 846, vite 213) / `pnpm lint` / `pnpm -r build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)