### PR TITLE
feat(core): report examined counts for the three sibling directory rules

### DIFF
--- a/.changeset/examined-counts-sibling-rules.md
+++ b/.changeset/examined-counts-sibling-rules.md
@@ -1,0 +1,13 @@
+---
+'@svelte-vitals/core': minor
+---
+
+`architecture/reserved-directory-names`, `architecture/directory-naming` and `architecture/unit-entry-file`
+now report `examined` counts in the JSON report, the same mechanism `architecture/reserved-name-placement`
+already used: per declaration, how many places it judged, keyed by the same bare glob string its own
+diagnostic names. A run configuring all four rules previously got one `examined` entry and silence for the
+other three, even though all three already emit a project-scoped finding for a declaration that matched no
+directory — the count fills in the missing number for a key that governed a hundred directories versus one.
+
+No exported shape changes: `runRules`, `RuleContext.recordExamined` and `JsonReport.examined` already exist.
+This is JSON-only, matching the existing feature — no CLI or console output changes.

--- a/packages/core/src/rules/architecture/directory-naming.ts
+++ b/packages/core/src/rules/architecture/directory-naming.ts
@@ -82,6 +82,10 @@ export const architectureDirectoryNaming: Rule = {
     const globalOptions = resolveRuleOptions(ID, OPTIONS, ctx.config);
     const globalMap = mapOption(globalOptions, 'directories');
     const globalKeys = new Set(Object.keys(globalMap));
+    // The declaration identity is the bare glob key, matching the diagnostics below. Seeded so a
+    // declaration that governs no directory reports `0` rather than vanishing from the map entirely.
+    const examinedCounts: Record<string, number> = {};
+    for (const key of globalKeys) examinedCounts[key] = 0;
     const usedKeys = new Set<string>();
     // Collected only so an unmatched key can be told from a shadowed one at the end. Never
     // consulted unless some key finishes the run with no work recorded.
@@ -114,6 +118,11 @@ export const architectureDirectoryNaming: Rule = {
 
       const decoded = decodeSegment(baseName(dir));
       if (decoded === undefined) continue; // a compound route segment names no single identifier
+
+      // Judged only past the compound-segment skip above: a key that matched a directory whose name
+      // decodes to nothing was never checked against a casing, so it has not examined that directory.
+      if (globalKeys.has(m.best)) examinedCounts[m.best] = (examinedCounts[m.best] ?? 0) + 1;
+
       const allowed = casingsOf(declared[m.best] as string).known;
       if (satisfiesCasing(decoded, allowed)) continue;
 
@@ -196,6 +205,7 @@ export const architectureDirectoryNaming: Rule = {
         docsUrl
       });
     }
+    ctx.recordExamined?.(examinedCounts);
     return out;
   }
 };

--- a/packages/core/src/rules/architecture/reserved-directory-names.ts
+++ b/packages/core/src/rules/architecture/reserved-directory-names.ts
@@ -176,6 +176,14 @@ export const architectureReservedDirectoryNames: Rule = {
       const list = maps.length === 2 ? `both ${maps[0]} and ${maps[1]}` : maps.join(', ');
       return `declared in ${list}, so the scopes entry wins wherever ${losers.length > 1 ? 'they' : 'both'} apply`;
     };
+    // The declaration identity here is the bare glob key itself — the same string the two
+    // project-scoped notes below name — not a map-qualified label, because `scopes`, `unitScopes` and
+    // `anyCaseUnitScopes` can all carry the same key (the #386 partition puts one glob in both unit
+    // maps), and only one of them ever governs a given directory. Seeded from `globalKeys` so a
+    // declaration that governs nothing reports `0` rather than vanishing from the map entirely.
+    const examinedCounts: Record<string, number> = {};
+    for (const key of globalKeys) examinedCounts[key] = 0;
+
     const noteCollisions = (
       scopesMap: Record<string, string>,
       unitMap: Record<string, string>,
@@ -277,6 +285,12 @@ export const architectureReservedDirectoryNames: Rule = {
         }
       }
       if (winner === undefined) continue;
+
+      // Only the winning key is judged here: a losing candidate matched this directory but governed
+      // nothing at it, and the count answers "how many places did this declaration govern" — an
+      // `overrides`-only winner is excluded, matching the diagnostics above, which classify only
+      // globally resolved declarations.
+      if (globalKeys.has(winner.best)) examinedCounts[winner.best] = (examinedCounts[winner.best] ?? 0) + 1;
 
       const allowed = new Set(winner.names);
       for (const child of kids.get(dir) ?? []) {
@@ -391,6 +405,7 @@ export const architectureReservedDirectoryNames: Rule = {
         docsUrl
       });
     }
+    ctx.recordExamined?.(examinedCounts);
     return out;
   }
 };

--- a/packages/core/src/rules/architecture/unit-entry-file.ts
+++ b/packages/core/src/rules/architecture/unit-entry-file.ts
@@ -90,6 +90,11 @@ export const architectureUnitEntryFile: Rule = {
       ...Object.keys(mapOption(globalOptions, 'pascalCaseUnits'))
     ]);
     const usedKeys = new Set<string>();
+    // Declaration identity is the bare glob key, one shared namespace across both maps (matching
+    // `globalKeys` and the inert-declaration diagnostic below). Seeded so a declaration that judges no
+    // unit reports `0` rather than vanishing from the map entirely.
+    const examinedCounts: Record<string, number> = {};
+    for (const key of globalKeys) examinedCounts[key] = 0;
     // Paths skipped as excluded, kept only so an unused key can be told apart from a shadowed one
     // at the end of the run. Never consulted unless some key ends with no work recorded.
     const excludedDirs: string[] = [];
@@ -148,6 +153,14 @@ export const architectureUnitEntryFile: Rule = {
         ext = byCasing.best === undefined ? undefined : pascalUnits[byCasing.best];
       }
       if (ext === undefined) continue;
+
+      // Whichever key actually supplied `ext` is the one that judged this directory — the other
+      // map's key, if it also matched, did not, since `units` wins outright over `pascalCaseUnits`
+      // rather than the two competing on specificity.
+      const winningKey = viaUnits ? byPath.best : byCasing.best;
+      if (winningKey !== undefined && globalKeys.has(winningKey)) {
+        examinedCounts[winningKey] = (examinedCounts[winningKey] ?? 0) + 1;
+      }
 
       const expected = `${dir}/${baseName(dir)}${ext}`;
       if (fileSet.has(expected)) {
@@ -238,6 +251,7 @@ export const architectureUnitEntryFile: Rule = {
         docsUrl
       });
     }
+    ctx.recordExamined?.(examinedCounts);
     return out;
   }
 };

--- a/packages/core/test/directory-naming.test.ts
+++ b/packages/core/test/directory-naming.test.ts
@@ -1,18 +1,30 @@
 import { describe, it, expect } from 'vitest';
 import { architectureDirectoryNaming } from '../src/index.js';
-import { defineConfig, defaultProject } from '../src/types.js';
+import { runRules } from '../src/engine.js';
+import { defineConfig, defaultProject, type Config } from '../src/types.js';
 import type { RuleContext } from '../src/rule.js';
 import type { Result } from '../src/index.js';
+
+const ID = 'architecture/directory-naming';
 
 const fails = (rs: Result[]) => rs.filter((r) => r.location !== undefined);
 const project = (rs: Result[]) => rs.filter((r) => r.route === undefined && r.location === undefined);
 
-const ctx = (sourceFiles: string[], options?: Record<string, unknown>): RuleContext => ({
+const ctx = (sourceFiles: string[], options?: Record<string, unknown>, extra: Partial<Config> = {}): RuleContext => ({
   sourceFiles,
   heads: [],
   project: defaultProject,
-  config: defineConfig(options ? { rules: { 'architecture/directory-naming': { options } } } : {})
+  config: defineConfig({
+    ...(options ? { rules: { [ID]: { options } } } : {}),
+    ...extra
+  })
 });
+
+/** Runs through the engine so `recordExamined` is wired up, returning the counts alongside the results. */
+async function runWithCounts(sourceFiles: string[], options?: Record<string, unknown>, extra: Partial<Config> = {}) {
+  const { results, examined } = await runRules([architectureDirectoryNaming], ctx(sourceFiles, options, extra));
+  return { results, examined: examined[ID] ?? {} };
+}
 
 describe('architecture/directory-naming — inertness', () => {
   it('emits nothing when no declaration is given', async () => {
@@ -242,5 +254,107 @@ describe('architecture/directory-naming — the casing vocabulary', () => {
     expect(project(rs)[0]!.message).toContain('checks nothing');
     // Nothing is checked, so nothing is reported about a directory either.
     expect(fails(rs)).toEqual([]);
+  });
+});
+
+// Issue #387: the count answers "how many directories did this declaration judge", keyed on the same
+// bare glob the project-scoped notes above already name.
+describe('architecture/directory-naming — examined counts', () => {
+  it('counts every directory a declaration judged, conforming or not', async () => {
+    const { examined } = await runWithCounts(['src/lib/dialog/a.ts', 'src/lib/Bad_Name/b.ts'], {
+      directories: { 'src/lib/*': 'camelCase' }
+    });
+    // 'dialog' conforms, 'Bad_Name' is reported — both were judged.
+    expect(examined['src/lib/*']).toBe(2);
+  });
+
+  it('reports a count even when every judged directory conforms, with no finding', async () => {
+    const { examined, results } = await runWithCounts(['src/lib/dialog/a.ts'], {
+      directories: { 'src/lib/*': 'camelCase' }
+    });
+    expect(examined['src/lib/*']).toBe(1);
+    expect(results).toEqual([]);
+  });
+
+  it('reports zero for a declaration that matches no directory, alongside its existing diagnostic', async () => {
+    const { examined, results } = await runWithCounts(['src/lib/dialog/a.ts'], {
+      directories: { 'src/lib/*': 'camelCase', 'src/nowhere/*': 'camelCase' }
+    });
+    expect(examined['src/nowhere/*']).toBe(0);
+    expect(project(results)).toHaveLength(1);
+    expect(project(results)[0]!.message).toContain("'src/nowhere/*'");
+    expect(project(results)[0]!.message).toContain('matched no directory');
+  });
+
+  it('does not count a key that matched but lost the tie-break', async () => {
+    const { examined } = await runWithCounts(['src/lib/dialog/a.ts'], {
+      directories: { 'src/lib/**': 'camelCase', 'src/lib/*': 'camelCase' }
+    });
+    // 'src/lib/**' never wins here (bare-prefix guard, then loses on ** count) but it matched.
+    expect(examined['src/lib/*']).toBe(1);
+    expect(examined['src/lib/**']).toBe(0);
+  });
+
+  // The rule's own decision, distinct from the tie-break above: a compound segment was matched and
+  // won the tie-break, but `decodeSegment` finds no single identifier in it, so no casing check ever
+  // ran there. "Matched but not judged" reads 0, the same as "never matched" — the design's vocabulary
+  // for "examined" is places judged, not places identified.
+  it('does not count a directory skipped for being a compound route segment', async () => {
+    const { examined, results } = await runWithCounts(['src/routes/[a]-[b]/+page.svelte'], {
+      directories: { 'src/routes/*': 'camelCase' }
+    });
+    expect(examined['src/routes/*']).toBe(0);
+    expect(project(results)).toEqual([]);
+  });
+
+  it('does not count an excluded directory', async () => {
+    const { examined, results } = await runWithCounts(['src/lib/tests/Bad_Name/a.ts'], {
+      directories: { 'src/lib/**': 'camelCase' },
+      exclude: ['**/tests']
+    });
+    expect(examined['src/lib/**']).toBe(0);
+    expect(fails(results)).toEqual([]);
+  });
+
+  it('does not count a declaration that exists only in an overrides layer', async () => {
+    // The entry must be EMPTY, not absent — the rule still runs and counts, it just has nothing
+    // globally resolved. `runWithCounts`'s `?? {}` fallback can't distinguish the two, so this
+    // asserts against the raw `examined` map instead.
+    const { examined } = await runRules(
+      [architectureDirectoryNaming],
+      ctx(['src/lib/dialog/a.ts'], undefined, {
+        overrides: [
+          { files: 'src/**', rules: { [ID]: { options: { directories: { 'src/nowhere/*': 'camelCase' } } } } }
+        ]
+      } as never)
+    );
+    expect(Object.hasOwn(examined, ID)).toBe(true);
+    expect(examined[ID]).toEqual({});
+  });
+
+  it('reports no counts at all on a run with no file inventory', async () => {
+    const config = defineConfig({ rules: { [ID]: { options: { directories: { 'src/lib/*': 'camelCase' } } } } });
+    const seen: Record<string, number>[] = [];
+    await architectureDirectoryNaming.check({
+      sourceFiles: undefined,
+      heads: [],
+      project: defaultProject,
+      config,
+      recordExamined: (c: Record<string, number>) => void seen.push(c)
+    } as unknown as RuleContext);
+    expect(seen).toEqual([]);
+  });
+
+  it('reports no counts at all when no config layer mentions the rule', async () => {
+    const config = defineConfig({});
+    const seen: Record<string, number>[] = [];
+    await architectureDirectoryNaming.check({
+      sourceFiles: ['src/lib/dialog/a.ts'],
+      heads: [],
+      project: defaultProject,
+      config,
+      recordExamined: (c: Record<string, number>) => void seen.push(c)
+    } as unknown as RuleContext);
+    expect(seen).toEqual([]);
   });
 });

--- a/packages/core/test/engine.test.ts
+++ b/packages/core/test/engine.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { runRules } from '../src/engine.js';
+import {
+  architectureDirectoryNaming,
+  architectureReservedDirectoryNames,
+  architectureReservedNamePlacement,
+  architectureUnitEntryFile,
+  defaultProject,
+  defineConfig
+} from '../src/index.js';
 import type { Rule, RuleContext } from '../src/rule.js';
 
 const ctx = { heads: [], project: {}, config: { rules: {} } } as unknown as RuleContext;
@@ -52,5 +60,50 @@ describe('runRules examined counts', () => {
   it('still returns the results', async () => {
     const { results } = await runRules([ruleThatDoesNot('a/two')], ctx);
     expect(results).toEqual([]);
+  });
+});
+
+// Issue #387: reserved-name-placement already reported examined counts; the three glob-configured
+// siblings did not, so a run configuring all four produced one entry and silence for the rest. This
+// runs the four real rules together and pins that every one of them now reports.
+describe('runRules examined counts — the four architecture directory rules together', () => {
+  it('gives every configured sibling its own entry, keyed on its own declaration identity', async () => {
+    const realCtx: RuleContext = {
+      sourceFiles: [
+        'src/lib/Card/Card.svelte',
+        'src/lib/Card/parts/Badge.svelte',
+        'src/routes/blog/+page.svelte',
+        'src/lib/svc/api/api.ts'
+      ],
+      heads: [],
+      project: defaultProject,
+      config: defineConfig({
+        rules: {
+          'architecture/reserved-name-placement': { options: { capitalisedUnitPlacements: { parts: 'src/**' } } },
+          'architecture/reserved-directory-names': { options: { unitScopes: { 'src/**': 'parts' } } },
+          'architecture/directory-naming': { options: { directories: { 'src/routes/*': 'camelCase' } } },
+          'architecture/unit-entry-file': { options: { units: { 'src/lib/svc/*': '.ts' } } }
+        }
+      })
+    };
+    const { examined } = await runRules(
+      [
+        architectureReservedNamePlacement,
+        architectureReservedDirectoryNames,
+        architectureDirectoryNaming,
+        architectureUnitEntryFile
+      ],
+      realCtx
+    );
+    expect(Object.keys(examined).sort()).toEqual([
+      'architecture/directory-naming',
+      'architecture/reserved-directory-names',
+      'architecture/reserved-name-placement',
+      'architecture/unit-entry-file'
+    ]);
+    expect(examined['architecture/reserved-name-placement']?.['capitalisedUnitPlacements.parts → src/**']).toBe(1);
+    expect(examined['architecture/reserved-directory-names']?.['src/**']).toBe(1);
+    expect(examined['architecture/directory-naming']?.['src/routes/*']).toBe(1);
+    expect(examined['architecture/unit-entry-file']?.['src/lib/svc/*']).toBe(1);
   });
 });

--- a/packages/core/test/reserved-directory-names.test.ts
+++ b/packages/core/test/reserved-directory-names.test.ts
@@ -2,18 +2,31 @@ import { describe, it, expect } from 'vitest';
 import { architectureReservedDirectoryNames } from '../src/index.js';
 import { isUnitDir, isAnyCaseUnitDir } from '../src/rules/architecture/reserved-directory-names.js';
 import { childFiles } from '../src/rules/architecture/declarations.js';
-import { defineConfig, defaultProject } from '../src/types.js';
+import { runRules } from '../src/engine.js';
+import { defineConfig, defaultProject, type Config } from '../src/types.js';
 import type { RuleContext } from '../src/rule.js';
 import type { Result } from '../src/index.js';
 
-const fails = (rs: Result[]) => rs.filter((r) => r.location !== undefined);
+const ID = 'architecture/reserved-directory-names';
 
-const ctx = (sourceFiles: string[], options?: Record<string, unknown>): RuleContext => ({
+const fails = (rs: Result[]) => rs.filter((r) => r.location !== undefined);
+const project = (rs: Result[]) => rs.filter((r) => r.route === undefined && r.location === undefined);
+
+const ctx = (sourceFiles: string[], options?: Record<string, unknown>, extra: Partial<Config> = {}): RuleContext => ({
   sourceFiles,
   heads: [],
   project: defaultProject,
-  config: defineConfig(options ? { rules: { 'architecture/reserved-directory-names': { options } } } : {})
+  config: defineConfig({
+    ...(options ? { rules: { [ID]: { options } } } : {}),
+    ...extra
+  })
 });
+
+/** Runs through the engine so `recordExamined` is wired up, returning the counts alongside the results. */
+async function runWithCounts(sourceFiles: string[], options?: Record<string, unknown>, extra: Partial<Config> = {}) {
+  const { results, examined } = await runRules([architectureReservedDirectoryNames], ctx(sourceFiles, options, extra));
+  return { results, examined: examined[ID] ?? {} };
+}
 
 describe('isUnitDir', () => {
   const filesIn = (files: string[]) => childFiles(files);
@@ -294,8 +307,6 @@ describe('architecture/reserved-directory-names — exclude', () => {
     expect(fails(rs)).toEqual([]);
   });
 });
-
-const project = (rs: Result[]) => rs.filter((r) => r.route === undefined && r.location === undefined);
 
 describe('architecture/reserved-directory-names — declarations that check nothing', () => {
   it('reports a glob that matched no directory', async () => {
@@ -646,5 +657,124 @@ describe('architecture/reserved-directory-names — anyCaseUnitScopes declaratio
     );
     expect(project(rs)).toHaveLength(1);
     expect(project(rs)[0]!.message).toContain('declared in both scopes and anyCaseUnitScopes');
+  });
+});
+
+// Issue #387: the count answers "how many positions did this declaration govern", keyed on the same
+// bare glob the project-scoped notes above already name — not a map-qualified label, since `scopes`,
+// `unitScopes` and `anyCaseUnitScopes` can all carry the same key.
+describe('architecture/reserved-directory-names — examined counts', () => {
+  it('counts every position a declaration governed, whether its children conformed or not', async () => {
+    const { examined } = await runWithCounts(
+      ['src/lib/Card/Card.svelte', 'src/lib/Card/parts/a.ts', 'src/lib/Panel/Panel.svelte', 'src/lib/Panel/other/b.ts'],
+      { unitScopes: { 'src/**': 'parts' } }
+    );
+    // Two units governed by 'src/**': Card (its 'parts' child is declared) and Panel (its 'other'
+    // child is not, and is reported) — the count is places governed, not places clean.
+    expect(examined['src/**']).toBe(2);
+  });
+
+  it('reports a count even when every governed child conforms, with no finding at all', async () => {
+    const { examined, results } = await runWithCounts(['src/lib/Card/Card.svelte', 'src/lib/Card/parts/a.ts'], {
+      unitScopes: { 'src/**': 'parts' }
+    });
+    expect(examined['src/**']).toBe(1);
+    expect(results).toEqual([]);
+  });
+
+  // Unlike the fourth rule, "checked nothing" is not silent for this one: the same run already
+  // carries the 'matched no directory' project-scoped note. The count adds the missing number
+  // alongside it rather than replacing it.
+  it('reports zero for a declaration that matches no directory, alongside its existing diagnostic', async () => {
+    const { examined, results } = await runWithCounts(['src/lib/Card/Card.svelte'], {
+      unitScopes: { 'src/nowhere/**': 'parts' }
+    });
+    expect(examined['src/nowhere/**']).toBe(0);
+    expect(project(results)).toHaveLength(1);
+    expect(project(results)[0]!.message).toContain("'src/nowhere/**'");
+    expect(project(results)[0]!.message).toContain('matched no directory');
+  });
+
+  it('does not count a key that matched but lost the specificity tie-break', async () => {
+    const { examined } = await runWithCounts(['src/lib/Card/Card.svelte', 'src/lib/Card/tests/a.ts'], {
+      scopes: { 'src/lib/*': 'parts' },
+      unitScopes: { 'src/**': 'parts|tests' }
+    });
+    // 'src/lib/*' governs src/lib/Card (more segments), so 'src/**' matched there and lost. It
+    // governed nothing, so it must read 0 — a loser is not a place examined for this declaration.
+    expect(examined['src/lib/*']).toBe(1);
+    expect(examined['src/**']).toBe(0);
+  });
+
+  // The #386 partition: the same glob key sits in both unit maps, governing a capitalised unit
+  // through unitScopes and a lowercase unit through anyCaseUnitScopes. Bare-glob identity means both
+  // maps' work lands under the one label — summing here is coherent with the diagnostics above, which
+  // already report a collision or an unused key by that same bare string regardless of which map it
+  // came from.
+  it("sums both unit maps' work under one bare-glob label", async () => {
+    const { examined } = await runWithCounts(
+      [
+        'src/lib/Card/Card.svelte',
+        'src/lib/Card/tests/a.ts',
+        'src/lib/formatDate/formatDate.ts',
+        'src/lib/formatDate/parts/a.ts'
+      ],
+      { unitScopes: { 'src/**': 'parts|tests' }, anyCaseUnitScopes: { 'src/**': 'tests' } }
+    );
+    // Card wins through unitScopes (capitalised unit), formatDate through anyCaseUnitScopes
+    // (lowercase unit, ineligible for unitScopes) — one label, two governed positions.
+    expect(examined['src/**']).toBe(2);
+  });
+
+  it('does not count an excluded position', async () => {
+    // Mirrors the exclude fixture above ('prunes an excluded parent'): with Card excluded, 'src/**'
+    // matches only non-unit directories, so it also earns the pre-existing 'never a unit' note —
+    // that diagnostic is not this test's concern, only that the excluded position is not counted.
+    const { examined, results } = await runWithCounts(['src/lib/Card/Card.svelte'], {
+      unitScopes: { 'src/**': 'parts' },
+      exclude: ['src/lib/Card']
+    });
+    expect(examined['src/**']).toBe(0);
+    expect(fails(results)).toEqual([]);
+  });
+
+  it('does not count a declaration that exists only in an overrides layer', async () => {
+    // isMentionedAnywhere sees the rule through the overrides entry, so it runs and counts — but the
+    // global resolution declares nothing, so the entry must be EMPTY, not absent. `runWithCounts`'s
+    // `?? {}` fallback can't tell those apart, so this asserts against the raw `examined` map.
+    const { examined } = await runRules(
+      [architectureReservedDirectoryNames],
+      ctx(['src/lib/Card/Card.svelte'], undefined, {
+        overrides: [{ files: 'src/**', rules: { [ID]: { options: { unitScopes: { 'src/nowhere/*': 'parts' } } } } }]
+      } as never)
+    );
+    expect(Object.hasOwn(examined, ID)).toBe(true);
+    expect(examined[ID]).toEqual({});
+  });
+
+  it('reports no counts at all on a run with no file inventory', async () => {
+    const config = defineConfig({ rules: { [ID]: { options: { unitScopes: { 'src/**': 'parts' } } } } });
+    const seen: Record<string, number>[] = [];
+    await architectureReservedDirectoryNames.check({
+      sourceFiles: undefined,
+      heads: [],
+      project: defaultProject,
+      config,
+      recordExamined: (c: Record<string, number>) => void seen.push(c)
+    } as unknown as RuleContext);
+    expect(seen).toEqual([]);
+  });
+
+  it('reports no counts at all when no config layer mentions the rule', async () => {
+    const config = defineConfig({});
+    const seen: Record<string, number>[] = [];
+    await architectureReservedDirectoryNames.check({
+      sourceFiles: ['src/lib/Card/Card.svelte'],
+      heads: [],
+      project: defaultProject,
+      config,
+      recordExamined: (c: Record<string, number>) => void seen.push(c)
+    } as unknown as RuleContext);
+    expect(seen).toEqual([]);
   });
 });

--- a/packages/core/test/unit-entry-file.test.ts
+++ b/packages/core/test/unit-entry-file.test.ts
@@ -1,19 +1,31 @@
 import { describe, it, expect } from 'vitest';
 import { architectureUnitEntryFile, applyOverrides, computeScore, summarize } from '../src/index.js';
-import { defineConfig, defaultProject } from '../src/types.js';
+import { runRules } from '../src/engine.js';
+import { defineConfig, defaultProject, type Config } from '../src/types.js';
 import type { RuleContext } from '../src/rule.js';
 import type { Result } from '../src/index.js';
+
+const ID = 'architecture/unit-entry-file';
 
 const fails = (rs: Result[]) => rs.filter((r) => r.detection.presence === 'none' || r.detection.value === 'absent');
 const passes = (rs: Result[]) => rs.filter((r) => r.detection.presence === 'own' && r.detection.value === 'static');
 
 /** A RuleContext carrying a source-file inventory and the rule's options. */
-const ctx = (sourceFiles: string[], options?: Record<string, unknown>): RuleContext => ({
+const ctx = (sourceFiles: string[], options?: Record<string, unknown>, extra: Partial<Config> = {}): RuleContext => ({
   sourceFiles,
   heads: [],
   project: defaultProject,
-  config: defineConfig(options ? { rules: { 'architecture/unit-entry-file': { options } } } : {})
+  config: defineConfig({
+    ...(options ? { rules: { [ID]: { options } } } : {}),
+    ...extra
+  })
 });
+
+/** Runs through the engine so `recordExamined` is wired up, returning the counts alongside the results. */
+async function runWithCounts(sourceFiles: string[], options?: Record<string, unknown>, extra: Partial<Config> = {}) {
+  const { results, examined } = await runRules([architectureUnitEntryFile], ctx(sourceFiles, options, extra));
+  return { results, examined: examined[ID] ?? {} };
+}
 
 const PASCAL = { pascalCaseUnits: { 'src/**': '.svelte' } };
 
@@ -534,5 +546,113 @@ describe('architecture/unit-entry-file — a pass is evidence, not a score key',
       }
     ];
     expect(computeScore([...other, ...passes], CONFIG).score).toBe(computeScore(other, CONFIG).score);
+  });
+});
+
+// Issue #387: the count answers "how many units did this declaration judge", keyed on the same bare
+// glob the inert-declaration note above already names — one namespace shared by both maps, since a
+// directory a `units` key wins is a directory `pascalCaseUnits` never judged, even if its own key
+// also matched there.
+describe('architecture/unit-entry-file — examined counts', () => {
+  it('counts every unit a declaration judged, conforming or not', async () => {
+    const { examined } = await runWithCounts(['src/lib/api/api.ts', 'src/lib/db/x.ts'], {
+      units: { 'src/lib/*': '.ts' }
+    });
+    // api/ has its entry file (pass), db/ does not (violation) — both were judged.
+    expect(examined['src/lib/*']).toBe(2);
+  });
+
+  it('reports a count even when every judged unit conforms, with only passes', async () => {
+    const { examined, results } = await runWithCounts(['src/lib/api/api.ts'], { units: { 'src/lib/*': '.ts' } });
+    expect(examined['src/lib/*']).toBe(1);
+    expect(fails(results)).toEqual([]);
+  });
+
+  it('reports zero for a declaration that matches no directory, alongside its existing diagnostic', async () => {
+    const { examined, results } = await runWithCounts(['src/lib/Card/Card.svelte'], {
+      ...PASCAL,
+      units: { 'src/nowhere/*': '.ts' }
+    });
+    expect(examined['src/nowhere/*']).toBe(0);
+    const inert = results.filter((r) => r.route === undefined && r.location === undefined);
+    expect(inert).toHaveLength(1);
+    expect(inert[0]!.message).toContain('src/nowhere/*');
+  });
+
+  it('does not count a key that matched but lost the tie-break', async () => {
+    const { examined } = await runWithCounts(['src/lib/x/stores/s/s.ts'], {
+      units: { 'src/**/stores/*': '.svelte.ts', 'src/lib/x/stores/*': '.ts' }
+    });
+    expect(examined['src/lib/x/stores/*']).toBe(1);
+    expect(examined['src/**/stores/*']).toBe(0);
+  });
+
+  // The rule's own precedence, not a specificity tie-break: `units` wins outright over
+  // `pascalCaseUnits` for any directory both match, so the casing key did not judge it — even though
+  // it matched (and would count as "used" for the inert-declaration note above).
+  it('does not count the pascalCaseUnits key at a directory units already won', async () => {
+    const { examined } = await runWithCounts(['src/lib/Thing/Thing.ts'], {
+      units: { 'src/lib/*': '.ts' },
+      ...PASCAL
+    });
+    expect(examined['src/lib/*']).toBe(1);
+    expect(examined['src/**']).toBe(0);
+  });
+
+  it('counts a pascalCaseUnits key when it alone governs', async () => {
+    const { examined } = await runWithCounts(['src/lib/Card/Badge.svelte'], PASCAL);
+    expect(examined['src/**']).toBe(1);
+  });
+
+  it('does not count an excluded unit', async () => {
+    // A second, non-excluded unit on the same declaration keeps the key from also going globally
+    // unused (which would add an unrelated 'matched no directory' note to the count under test).
+    const { examined, results } = await runWithCounts(['src/lib/Card/Badge.svelte', 'src/lib/Other/Other.svelte'], {
+      ...PASCAL,
+      exclude: ['src/lib/Card']
+    });
+    // Only Other/ is judged: Card/ is excluded before the check ever runs.
+    expect(examined['src/**']).toBe(1);
+    expect(fails(results)).toEqual([]);
+  });
+
+  it('does not count a declaration that exists only in an overrides layer', async () => {
+    // The entry must be EMPTY, not absent — the rule still runs and counts, it just has nothing
+    // globally resolved. `runWithCounts`'s `?? {}` fallback can't distinguish the two, so this
+    // asserts against the raw `examined` map instead.
+    const { examined } = await runRules(
+      [architectureUnitEntryFile],
+      ctx(['src/lib/Card/Card.svelte'], undefined, {
+        overrides: [{ files: 'src/lib/**', rules: { [ID]: { options: { units: { 'src/nowhere/*': '.ts' } } } } }]
+      } as never)
+    );
+    expect(Object.hasOwn(examined, ID)).toBe(true);
+    expect(examined[ID]).toEqual({});
+  });
+
+  it('reports no counts at all on a run with no file inventory', async () => {
+    const config = defineConfig({ rules: { [ID]: { options: PASCAL } } });
+    const seen: Record<string, number>[] = [];
+    await architectureUnitEntryFile.check({
+      sourceFiles: undefined,
+      heads: [],
+      project: defaultProject,
+      config,
+      recordExamined: (c: Record<string, number>) => void seen.push(c)
+    } as unknown as RuleContext);
+    expect(seen).toEqual([]);
+  });
+
+  it('reports no counts at all when no config layer mentions the rule', async () => {
+    const config = defineConfig({});
+    const seen: Record<string, number>[] = [];
+    await architectureUnitEntryFile.check({
+      sourceFiles: ['src/lib/Card/Card.svelte'],
+      heads: [],
+      project: defaultProject,
+      config,
+      recordExamined: (c: Record<string, number>) => void seen.push(c)
+    } as unknown as RuleContext);
+    expect(seen).toEqual([]);
   });
 });


### PR DESCRIPTION
Fixes #387. **Stacked on #409** (base: `fix/386-any-case-unit-scopes`) — the counts must handle the third option map #409 adds; GitHub will retarget this PR to `main` when #409 merges.

## Summary

`architecture/reserved-name-placement` reports per-declaration examined counts; its three glob-configured siblings (`reserved-directory-names`, `directory-naming`, `unit-entry-file`) never called `recordExamined`, so a run configuring all four yielded counts for one rule and silence for three. Per the issue, each rule needed its own small spec of what one "examined" unit is — shipped as three definitions grounded in each rule's own diagnostics:

- **reserved-directory-names**: identity = bare glob key (the diagnostics' naming, shared across all three maps). Counts one directory per **winning** key — a key that matched but lost the tie-break governed nothing there and stays 0 (pinned). Under #409's partition (one glob in `unitScopes` + `anyCaseUnitScopes`), both maps' work sums under the shared bare-glob label, consistent with how the diagnostics already name that string regardless of source map (pinned: shared label reads 2 across one capitalised + one lowercase unit).
- **directory-naming**: a compound route segment (`decodeSegment` → undefined) was matched but never judged against a casing — not counted. A letterless name (`2024`) vacuously passes casing and **is** counted; only the decode-failure path is excluded (pinned).
- **unit-entry-file**: one namespace over both maps' keys (matching the existing merged inert-key diagnostic); the count goes to whichever key actually supplied the expected extension (`units` beats `pascalCaseUnits` where both match — pinned).

Cross-cutting, per the examined-counts design: `--route` runs (no `sourceFiles` inventory) produce **no entry** (the rules' existing early return sits above the counting); counts are unfiltered by `--diff`/baseline by construction (recorded inside `check()`); empty-value keys are seeded at 0 (identity is the map key, which the diagnostics also name); override-only keys stay invisible, matching each rule's existing diagnostics scope. The empty-entry vs no-entry distinction is asserted with `Object.hasOwn` + `toEqual({})`, not a filtered subset.

## Verification

- Every new counting site was mutation-checked (increment disabled → named tests fail → restored, diffed clean): 5/4/7 tests catch the three sites respectively, plus a combined four-rule pin in `engine.test.ts`.
- `pnpm -r typecheck` / `pnpm test` (core 1346, cli 846, vite 209) / `pnpm lint` all green.
- Changeset: `@svelte-vitals/core` minor (JSON-only surface). No engine/`rule.ts` changes needed. Per-rule doc-page mentions of the counts can follow if wanted — the `examined` map is documented generically today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)