### PR TITLE
chore(ci): disable credential persistence on checkouts that never push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Setup Node.js and dependencies
         uses: ./.github/workflows/setup-node
       - name: Run Oxlint & Oxfmt check
@@ -37,6 +39,8 @@ jobs:
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Setup Node.js and dependencies
         uses: ./.github/workflows/setup-node
       - name: Cache package builds
@@ -134,6 +138,8 @@ jobs:
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Setup Node.js and dependencies
         uses: ./.github/workflows/setup-node
       - name: Check docs

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Setup Node.js and dependencies
         uses: ./.github/workflows/setup-node
       - name: Build docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
+      # persist-credentials stays default (true) here, unlike the other workflows' checkouts:
+      # changesets/action below pushes the Version Packages release branch using these
+      # persisted git credentials.
       - name: Checkout Repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup Node.js and dependencies


### PR DESCRIPTION
From the 2026-08-08 audit (SEC-01, defense-in-depth).

## Summary

`actions/checkout` persists the workflow token into `.git/config` for the whole job unless told otherwise — readable by anything the job executes. `test` and `floor-smoke` already set `persist-credentials: false`; `lint`, `check`, `docs` (ci.yml) and the docs `build` job (deploy-docs.yml) missed the convention. None of the four pushes (verified step by step: deploy-docs deploys via `actions/deploy-pages` + OIDC from an uploaded artifact, not git credentials), so the flag is a pure hardening no-op for them.

`release.yml` deliberately keeps persisted credentials — `changesets/action` pushes the Version Packages branch through them — now documented with a comment above its checkout so the divergence reads as a decision, not an oversight.

## Verification

- All three workflow files parse as valid YAML; the diff is exactly four `persist-credentials: false` additions plus one comment.
- This PR's own CI run is the functional proof: `lint`/`check`/`docs` execute under the flag.
- No changeset (CI-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)