### PR TITLE
fix(cli): compute suppressions staleness project-wide, not against the scoped result set

### DIFF
--- a/.changeset/stale-suppressions-scope.md
+++ b/.changeset/stale-suppressions-scope.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': patch
+---
+
+Scoped runs (`--diff`/`--staged`/`--baseline`) no longer report `svelte-vitals-suppressions.json` entries as stale just because the scope excluded their findings — staleness is now judged against the project-wide result set, so the documented CI recipe (`--diff origin/main --baseline origin/main`) no longer prints a misleading "N stale entries — re-run --update-suppressions to prune" on every run. `--route` runs, where even the project-wide set is collected route-narrowed, omit the stale count entirely rather than report an unreliable one. `--update-suppressions` combined with `--route` now refuses (exit 2) instead of silently pruning suppression entries outside that route.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -326,6 +326,12 @@ export interface ApplyScopeOptions {
   /** Disable applying svelte-vitals-suppressions.json for this run. */
   noSuppressions?: boolean;
   errorLog?: (line: string) => void;
+  /**
+   * Also doubles as this call's route-scoping signal: `analyzeOpts.route !== undefined`
+   * tells the suppressions block that `results` (this function's first argument) was
+   * itself collected route-scoped, not just project-wide-then-narrowed — see the comment
+   * at that check.
+   */
   analyzeOpts?: AnalyzeOptions;
 }
 
@@ -375,12 +381,24 @@ export async function applyScope(results: Result[], opts: ApplyScopeOptions): Pr
   if (!opts.noSuppressions && opts.config) {
     const entries = loadSuppressions(opts.cwd);
     if (entries !== undefined) {
-      const { results: afterSuppressions, suppressed, stale } = applySuppressions(scoped, entries, opts.config);
+      // `results` (this function's own pre-narrow argument, before the --diff/--staged/--baseline
+      // filtering above) is project-wide and is what staleness should be judged against — otherwise
+      // a scoped run would call every entry outside its scope "stale" and steer --update-suppressions
+      // toward pruning entries that are still needed project-wide. `--route`, however, narrows at
+      // collection time (collectAll), before `results` ever reaches this function, so `results` is
+      // itself only route-scoped; in that case staleness is unknowable and the clause is omitted
+      // below rather than reporting a misleading count.
+      const {
+        results: afterSuppressions,
+        suppressed,
+        stale
+      } = applySuppressions(scoped, entries, opts.config, results);
       scoped = afterSuppressions;
-      if (suppressed > 0 || stale > 0) {
+      const routeScoped = opts.analyzeOpts?.route !== undefined;
+      if (suppressed > 0 || (stale > 0 && !routeScoped)) {
         errorLog(
           `svelte-vitals: ${suppressed} finding(s) suppressed by ${SUPPRESSIONS_FILE}` +
-            (stale > 0
+            (stale > 0 && !routeScoped
               ? ` (${stale} stale entr${stale === 1 ? 'y' : 'ies'} — re-run --update-suppressions to prune)`
               : '') +
             '.'
@@ -512,6 +530,18 @@ export async function run(opts: RunOptions = {}): Promise<number> {
     const { config, version } = analysis;
 
     if (opts.updateSuppressions) {
+      // Unlike --diff/--staged/--baseline (applied only inside applyScope, never touching
+      // analysis.results — deliberately ignored here, design doc
+      // 2026-07-13-suppressions-file-design.md decision 2), --route narrows analysis.results
+      // itself at collection time (collectAll). Writing from a route-narrowed result set would
+      // silently prune every suppression entry outside that route as if fixed — refuse loudly
+      // instead, matching this file's "a silently-ignored typo would un-gate CI" philosophy.
+      if (opts.route !== undefined) {
+        errorLog(
+          `svelte-vitals: --update-suppressions cannot be combined with --route ('${opts.route}') — it would prune every suppression entry outside that route from ${SUPPRESSIONS_FILE}. Re-run --update-suppressions without --route.`
+        );
+        return 2;
+      }
       // Scoping flags (--diff/--staged/--baseline) are deliberately ignored here —
       // the suppressions file is meant to record the whole project's current state,
       // not a diff (design doc 2026-07-13-suppressions-file-design.md, decision 2).

--- a/packages/cli/src/suppressions.ts
+++ b/packages/cli/src/suppressions.ts
@@ -120,14 +120,20 @@ export function writeSuppressions(cwd: string, results: Result[], config: Config
  * seeds are never removed even if their key happens to match. Reports how many
  * findings were suppressed and how many entries in `entries` matched nothing
  * (stale — most likely fixed since the file was last written).
+ *
+ * `allResults` (defaults to `results`) is used only for the staleness tally, not
+ * for filtering: a caller that narrows `results` to a subset of files/findings
+ * (`--diff`/`--staged`/`--baseline`) can still pass the pre-scope, project-wide
+ * result set here so an entry whose finding survives elsewhere in the project
+ * isn't misreported as stale just because this run's scope excluded it.
  */
 export function applySuppressions(
   results: Result[],
   entries: SuppressionEntry[],
-  config: Config
+  config: Config,
+  allResults?: Result[]
 ): { results: Result[]; suppressed: number; stale: number } {
   const keys = new Set(entries.map((e) => findingKey(e)));
-  const usedKeys = new Set<string>();
   const kept: Result[] = [];
   let suppressed = 0;
 
@@ -135,12 +141,17 @@ export function applySuppressions(
     const key = findingKey(r);
     if (keys.has(key) && isPenalized(r.detection, config.treatDynamicAs)) {
       suppressed++;
-      usedKeys.add(key);
       continue;
     }
     kept.push(r);
   }
 
+  const usedKeys = new Set<string>();
+  for (const r of allResults ?? results) {
+    const key = findingKey(r);
+    if (keys.has(key) && isPenalized(r.detection, config.treatDynamicAs)) usedKeys.add(key);
+  }
   const stale = [...keys].filter((k) => !usedKeys.has(k)).length;
+
   return { results: kept, suppressed, stale };
 }

--- a/packages/cli/test/run-suppressions.test.ts
+++ b/packages/cli/test/run-suppressions.test.ts
@@ -222,5 +222,88 @@ describe('run() svelte-vitals-suppressions.json', () => {
     expect(cap.out.join('\n')).not.toContain('seo/title-presence');
     expect(cap.out.join('\n')).toContain('seo/canonical-url'); // same diff-narrowed file, not suppressed -> still fails the gate
     expect(code).toBe(1);
+    // The one entry that did match is used, so it isn't stale either.
+    expect(cap.err.join('\n')).not.toContain('stale');
+  });
+
+  it('the CI recipe (--diff against a base branch): entries outside the diff scope are not stale when their findings still exist project-wide', async () => {
+    const dir = makeProjectCopy();
+    // Both entries' findings are real and still present on /none and /widget — the diff below
+    // just doesn't touch those files.
+    writeFileSync(
+      join(dir, SUPPRESSIONS_FILE),
+      JSON.stringify({
+        version: 1,
+        suppressions: [
+          { id: 'seo/title-presence', route: '/none', location: 'src/routes/none/+page.svelte' },
+          { id: 'seo/title-presence', route: '/widget', location: 'src/routes/widget/+page.svelte' }
+        ]
+      })
+    );
+    mockGet.mockReturnValue(new Set(['src/routes/img/+page.svelte']));
+    const cap = capture();
+    await run({ cwd: dir, diffBase: 'main', log: cap.log, errorLog: cap.errorLog, env: CLEAN_ENV });
+    // Neither entry's file is in the diff scope, so nothing is suppressed in-scope — but under
+    // the old bug, both entries would have been counted stale (0 suppressed, "2 stale entries")
+    // even though their findings are still there, just outside this diff.
+    expect(cap.err.join('\n')).not.toContain('suppressed by');
+    expect(cap.err.join('\n')).not.toContain('stale');
+    // /img's own real, unsuppressed finding still surfaces — the diff scope itself is unaffected.
+    expect(cap.out.join('\n')).toContain('performance/image-dimensions');
+  });
+
+  it('a genuinely stale entry (matches nothing project-wide) is still reported stale under --diff scoping', async () => {
+    const dir = makeProjectCopy();
+    writeFileSync(
+      join(dir, SUPPRESSIONS_FILE),
+      JSON.stringify({
+        version: 1,
+        suppressions: [
+          { id: 'seo/title-presence', route: '/none', location: 'src/routes/none/+page.svelte' },
+          { id: 'SEO999', route: '/does-not-exist' } // never matches anywhere -> genuinely stale
+        ]
+      })
+    );
+    mockGet.mockReturnValue(new Set(['src/routes/none/+page.svelte']));
+    const cap = capture();
+    await run({ cwd: dir, diffBase: 'main', log: cap.log, errorLog: cap.errorLog, env: CLEAN_ENV });
+    expect(cap.err.join('\n')).toContain(`1 finding(s) suppressed by ${SUPPRESSIONS_FILE}`);
+    expect(cap.err.join('\n')).toContain('1 stale entry');
+  });
+
+  it('--route run: the stale clause is omitted (staleness against a route-narrowed set is unknowable)', async () => {
+    const dir = makeProjectCopy();
+    // /widget's entry has a real, still-current finding — just not inside the --route scope
+    // below, where it can't be told apart from a genuinely fixed one.
+    writeFileSync(
+      join(dir, SUPPRESSIONS_FILE),
+      JSON.stringify({
+        version: 1,
+        suppressions: [
+          { id: 'seo/title-presence', route: '/none', location: 'src/routes/none/+page.svelte' },
+          { id: 'seo/title-presence', route: '/widget', location: 'src/routes/widget/+page.svelte' }
+        ]
+      })
+    );
+    const cap = capture();
+    await run({ cwd: dir, route: 'none', log: cap.log, errorLog: cap.errorLog, env: CLEAN_ENV });
+    expect(cap.err.join('\n')).toContain(`1 finding(s) suppressed by ${SUPPRESSIONS_FILE}`);
+    expect(cap.err.join('\n')).not.toContain('stale');
+  });
+
+  it('--update-suppressions refuses to run combined with --route (it would prune entries outside that route)', async () => {
+    const dir = makeProjectCopy();
+    const cap = capture();
+    const code = await run({
+      cwd: dir,
+      updateSuppressions: true,
+      route: 'none',
+      log: cap.log,
+      errorLog: cap.errorLog,
+      env: CLEAN_ENV
+    });
+    expect(code).toBe(2);
+    expect(cap.err.join('\n')).toContain('--update-suppressions cannot be combined with --route');
+    expect(cap.out).toEqual([]);
   });
 });


### PR DESCRIPTION
From the 2026-08-08 audit (finding 2608-CLI-07).

## The bug

`applyScope` narrows results (`--diff`/`--staged`/`--baseline`) first and then hands the narrowed set to `applySuppressions`, whose `stale` counter flags every suppressions-file entry that matched nothing **in that narrowed set**. On the documented CI recipe (`--diff origin/main --baseline origin/main`), essentially the whole file read as stale — every run printed `N stale entries — re-run --update-suppressions to prune`, burying genuine staleness in noise.

One audit claim corrected during implementation: following that advice was **not** destructive for `--diff`/`--staged`/`--baseline` — `--update-suppressions` deliberately ignores those flags and writes from the unfiltered result set (design doc 2026-07-13, decision 2). The genuinely destructive combination was `--update-suppressions --route`, where results are route-narrowed at collection time: it would silently prune every entry outside that route.

## Changes

1. `applySuppressions` gains an optional `allResults` parameter used **only** for the staleness tally (filtering unchanged); `applyScope` passes its pre-narrow, project-wide result set. Unscoped runs are byte-identical (the parameter defaults to `results`).
2. `--route` runs omit the stale clause entirely — with route-narrowed collection, even the "full" set is partial, and an unreliable number is worse than none.
3. New guard: `--update-suppressions --route` refuses with exit 2 and a diagnostic naming what it would have pruned, matching the file's "refuse loudly rather than silently mis-prune" philosophy.
4. 5 new tests: the CI-recipe shape now reports 0 stale (was: all entries), a genuinely stale entry stays stale under `--diff`, `--route` omits the clause, and the new guard refuses.

## Verification

`pnpm -r typecheck` / `pnpm test` (2430 tests across core/cli/vite) / `pnpm lint` / `pnpm -r build` all green. Hunks are disjoint from #414's baseline-block changes in the same file — either merge order is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)