### PR TITLE
fix(core): update seo/json-ld-required-props to Google's current required lists

### DIFF
--- a/.changeset/jsonld-required-props-currency.md
+++ b/.changeset/jsonld-required-props-currency.md
@@ -17,9 +17,11 @@ against developers.google.com:
   which Google does not require).
 - `VideoObject`: `description` dropped (Google: Recommended, not Required); still requires `name`,
   `thumbnailUrl`, `uploadDate`.
-- `Person`: now requires `name` **or** `alternateName` (was `name` unconditionally) — Google's
-  guidance allows `alternateName` to stand in when `name` isn't available. A `Person` node with only
-  `alternateName` no longer flags a missing `name`.
+- `Person`: row removed (was `name` required unconditionally). Google has no standalone Person rich
+  result — the only documented requirement (`name` or `alternateName`) applies to a Person filling
+  `ProfilePage.mainEntity`, a relationship this rule's per-`@type`, per-node model doesn't track, so
+  a global row overclaimed "ineligible for the rich result" for every generic Person block (e.g. an
+  Article's `author`). A generic `Person` node no longer produces a finding at all.
 - `Event`, `LocalBusiness`, `WebSite`, `BreadcrumbList` verified unchanged.
 
 No detection or message changes for any other JSON-LD rule.

--- a/.changeset/jsonld-required-props-currency.md
+++ b/.changeset/jsonld-required-props-currency.md
@@ -1,0 +1,25 @@
+---
+'@svelte-vitals/core': patch
+---
+
+`seo/json-ld-required-props`'s `REQUIRED_PROPS` table was stale against Google's current
+structured-data requirements, producing warning-level false positives on valid markup. Re-verified
+against developers.google.com:
+
+- `Article`/`BlogPosting`/`NewsArticle`: row removed. Google lists no required properties for these
+  types (`headline` is Recommended) — valid markup without a `headline` is no longer flagged.
+- `Organization`: row removed. Google lists no required properties.
+- `Product`: now `name` plus **at least one of** `review`, `aggregateRating`, or `offers` (was
+  `name` + `offers` unconditionally). A `Product` with only `aggregateRating` or only `review` no
+  longer flags a missing `offers`; a `Product` missing all three now names the group in the message
+  ("missing … one of review, aggregateRating or offers").
+- `Recipe`: now `name` + `image` only (was also requiring `recipeIngredient`/`recipeInstructions`,
+  which Google does not require).
+- `VideoObject`: `description` dropped (Google: Recommended, not Required); still requires `name`,
+  `thumbnailUrl`, `uploadDate`.
+- `Person`: now requires `name` **or** `alternateName` (was `name` unconditionally) — Google's
+  guidance allows `alternateName` to stand in when `name` isn't available. A `Person` node with only
+  `alternateName` no longer flags a missing `name`.
+- `Event`, `LocalBusiness`, `WebSite`, `BreadcrumbList` verified unchanged.
+
+No detection or message changes for any other JSON-LD rule.

--- a/docs/src/content/docs/ja/rules/seo/json-ld-required-props.md
+++ b/docs/src/content/docs/ja/rules/seo/json-ld-required-props.md
@@ -7,7 +7,7 @@ description: 認識できる @type には、リッチリザルトに必要なプ
 
 ## チェック内容
 
-既知の `@type`（Article、Product、BreadcrumbList、Organization、WebSite、Event、Recipe、Person、VideoObject、LocalBusiness）について、Google が必須とするプロパティがそろっているかを確認します。未知の型やカスタム型は検出しません。
+既知の `@type`（Product、BreadcrumbList、WebSite、Event、Recipe、Person、VideoObject、LocalBusiness）について、Google が必須とするプロパティがそろっているかを確認します。未知の型やカスタム型は検出しません。Google の構造化データドキュメントが必須プロパティを一つも挙げていない型（Article、BlogPosting、NewsArticle、Organization）も同様に検出しません。
 
 ## なぜ重要か
 
@@ -15,8 +15,13 @@ description: 認識できる @type には、リッチリザルトに必要なプ
 
 ## 修正方法
 
-不足しているプロパティを追加します。例えば `Product` には `name` と `offers` が必要です：
+不足しているプロパティを追加します。例えば `Product` には `name` に加えて、`review`・`aggregateRating`・`offers` のいずれか一つが必要です：
 
 ```json
-{ "@context": "https://schema.org", "@type": "Product", "name": "…", "offers": { "@type": "Offer", "price": "…" } }
+{
+  "@context": "https://schema.org",
+  "@type": "Product",
+  "name": "…",
+  "aggregateRating": { "@type": "AggregateRating", "ratingValue": "4.5", "reviewCount": "89" }
+}
 ```

--- a/docs/src/content/docs/ja/rules/seo/json-ld-required-props.md
+++ b/docs/src/content/docs/ja/rules/seo/json-ld-required-props.md
@@ -7,7 +7,7 @@ description: 認識できる @type には、リッチリザルトに必要なプ
 
 ## チェック内容
 
-既知の `@type`（Product、BreadcrumbList、WebSite、Event、Recipe、Person、VideoObject、LocalBusiness）について、Google が必須とするプロパティがそろっているかを確認します。未知の型やカスタム型は検出しません。Google の構造化データドキュメントが必須プロパティを一つも挙げていない型（Article、BlogPosting、NewsArticle、Organization）も同様に検出しません。
+既知の `@type`（Product、BreadcrumbList、WebSite、Event、Recipe、VideoObject、LocalBusiness）について、Google が必須とするプロパティがそろっているかを確認します。未知の型やカスタム型は検出しません。Google の構造化データドキュメントが必須プロパティを一つも挙げていない型（Article、BlogPosting、NewsArticle、Organization）も同様に検出しません。また Person も検出対象外です。Google が文書化している唯一の要件は `ProfilePage.mainEntity` に対するものであり、この関係性はノード単位のこのチェックでは追跡していません。
 
 ## なぜ重要か
 

--- a/docs/src/content/docs/rules/seo/json-ld-required-props.md
+++ b/docs/src/content/docs/rules/seo/json-ld-required-props.md
@@ -7,7 +7,7 @@ description: A recognized @type should include the properties its rich result re
 
 ## What it checks
 
-For a recognized `@type` (Product, BreadcrumbList, WebSite, Event, Recipe, Person, VideoObject, LocalBusiness), checks that Google's required properties are present. Unknown/custom types are not flagged — and so are types (Article, BlogPosting, NewsArticle, Organization) for which Google's structured-data docs list no required properties at all.
+For a recognized `@type` (Product, BreadcrumbList, WebSite, Event, Recipe, VideoObject, LocalBusiness), checks that Google's required properties are present. Unknown/custom types are not flagged — and so are types (Article, BlogPosting, NewsArticle, Organization) for which Google's structured-data docs list no required properties at all, and Person, whose only Google-documented requirement applies to `ProfilePage.mainEntity`, a relationship this per-node check doesn't track.
 
 ## Why it matters
 

--- a/docs/src/content/docs/rules/seo/json-ld-required-props.md
+++ b/docs/src/content/docs/rules/seo/json-ld-required-props.md
@@ -7,7 +7,7 @@ description: A recognized @type should include the properties its rich result re
 
 ## What it checks
 
-For a recognized `@type` (Article, Product, BreadcrumbList, Organization, WebSite, Event, Recipe, Person, VideoObject, LocalBusiness), checks that Google's required properties are present. Unknown/custom types are not flagged.
+For a recognized `@type` (Product, BreadcrumbList, WebSite, Event, Recipe, Person, VideoObject, LocalBusiness), checks that Google's required properties are present. Unknown/custom types are not flagged — and so are types (Article, BlogPosting, NewsArticle, Organization) for which Google's structured-data docs list no required properties at all.
 
 ## Why it matters
 
@@ -15,8 +15,13 @@ A recognized `@type` missing its required properties is ineligible for the corre
 
 ## How to fix
 
-Add the missing properties. For example, a `Product` needs `name` and `offers`:
+Add the missing properties. For example, a `Product` needs `name`, plus at least one of `review`, `aggregateRating`, or `offers`:
 
 ```json
-{ "@context": "https://schema.org", "@type": "Product", "name": "…", "offers": { "@type": "Offer", "price": "…" } }
+{
+  "@context": "https://schema.org",
+  "@type": "Product",
+  "name": "…",
+  "aggregateRating": { "@type": "AggregateRating", "ratingValue": "4.5", "reviewCount": "89" }
+}
 ```

--- a/packages/core/src/rules/seo/json-ld-required-props.ts
+++ b/packages/core/src/rules/seo/json-ld-required-props.ts
@@ -1,5 +1,5 @@
 import { jsonldRule } from './jsonld-engine.js';
-import { typeOf, hasNonEmpty, REQUIRED_PROPS } from './jsonld-engine.js';
+import { typeOf, missingRequiredProps, REQUIRED_PROPS } from './jsonld-engine.js';
 
 export const seoJsonLdRequiredProps = jsonldRule({
   id: 'seo/json-ld-required-props',
@@ -13,9 +13,9 @@ export const seoJsonLdRequiredProps = jsonldRule({
     for (const node of nodes) {
       for (const t of typeOf(node)) {
         const required = REQUIRED_PROPS[t];
-        if (!required) continue; // unknown/custom type → not flagged
+        if (!required) continue; // unknown/custom type, or a type Google requires nothing from → not flagged
         hasKnownType = true;
-        const missing = required.filter((p) => !hasNonEmpty(node, p));
+        const missing = missingRequiredProps(node, required);
         if (missing.length > 0) return `${t} JSON-LD is missing required ${missing.join(', ')}`;
       }
     }

--- a/packages/core/src/rules/seo/jsonld-engine.ts
+++ b/packages/core/src/rules/seo/jsonld-engine.ts
@@ -156,21 +156,43 @@ export function hasNonEmpty(node: JsonLdNode, key: string): boolean {
   return true;
 }
 
+/**
+ * A row is either a flat list of properties that must ALL be present, or an object pairing an
+ * `all` list (possibly empty) with a `oneOf` group where at least one member must be present.
+ * Article, BlogPosting, NewsArticle, and Organization have no row: Google's structured-data docs
+ * list no required properties for them, and this rule's message ("missing required X — ineligible
+ * for the rich result") only makes sense for a type that has one.
+ */
+export type RequiredPropsRow = string[] | { all: string[]; oneOf: string[] };
+
 /** Curated @type -> required properties for the rich result (Google structured-data docs). */
-export const REQUIRED_PROPS: Record<string, string[]> = {
-  Article: ['headline'],
-  BlogPosting: ['headline'],
-  NewsArticle: ['headline'],
-  Product: ['name', 'offers'],
+export const REQUIRED_PROPS: Record<string, RequiredPropsRow> = {
+  Product: { all: ['name'], oneOf: ['review', 'aggregateRating', 'offers'] },
   BreadcrumbList: ['itemListElement'],
-  Organization: ['name', 'url'],
   WebSite: ['name', 'url'],
   Event: ['name', 'startDate', 'location'],
-  Recipe: ['name', 'image', 'recipeIngredient', 'recipeInstructions'],
-  Person: ['name'],
-  VideoObject: ['name', 'description', 'thumbnailUrl', 'uploadDate'],
+  Recipe: ['name', 'image'],
+  // Google's Person guidance (profile-page doc — Person has no standalone rich-result page) allows
+  // `alternateName` to stand in when `name` isn't available, so require either.
+  Person: { all: [], oneOf: ['name', 'alternateName'] },
+  VideoObject: ['name', 'thumbnailUrl', 'uploadDate'],
   LocalBusiness: ['name', 'address']
 };
+
+/** `["a", "b", "c"]` -> `"one of a, b or c"`; a single-member group is just its own name. */
+function oneOfLabel(props: string[]): string {
+  const last = props.at(-1) ?? '';
+  return props.length <= 1 ? last : `one of ${props.slice(0, -1).join(', ')} or ${last}`;
+}
+
+/** Missing-property descriptors for a node against a `REQUIRED_PROPS` row (empty = satisfied). */
+export function missingRequiredProps(node: JsonLdNode, row: RequiredPropsRow): string[] {
+  const all = Array.isArray(row) ? row : row.all;
+  const missing = all.filter((p) => !hasNonEmpty(node, p));
+  const oneOf = Array.isArray(row) ? undefined : row.oneOf;
+  if (oneOf && !oneOf.some((p) => hasNonEmpty(node, p))) missing.push(oneOfLabel(oneOf));
+  return missing;
+}
 
 /** Static jsonld tags on a head (those with captured raw content). */
 export function jsonldTags(head: { tags: HeadTag[] }): HeadTag[] {

--- a/packages/core/src/rules/seo/jsonld-engine.ts
+++ b/packages/core/src/rules/seo/jsonld-engine.ts
@@ -161,7 +161,11 @@ export function hasNonEmpty(node: JsonLdNode, key: string): boolean {
  * `all` list (possibly empty) with a `oneOf` group where at least one member must be present.
  * Article, BlogPosting, NewsArticle, and Organization have no row: Google's structured-data docs
  * list no required properties for them, and this rule's message ("missing required X — ineligible
- * for the rich result") only makes sense for a type that has one.
+ * for the rich result") only makes sense for a type that has one. Person also has no row: Google
+ * has no standalone Person rich result — the `name`/`alternateName` requirement only applies to a
+ * Person filling `ProfilePage.mainEntity`, a relationship this per-@type, per-node engine doesn't
+ * track, so a global row would overclaim "ineligible" for every generic Person block (e.g. an
+ * Article's `author`).
  */
 export type RequiredPropsRow = string[] | { all: string[]; oneOf: string[] };
 
@@ -172,9 +176,6 @@ export const REQUIRED_PROPS: Record<string, RequiredPropsRow> = {
   WebSite: ['name', 'url'],
   Event: ['name', 'startDate', 'location'],
   Recipe: ['name', 'image'],
-  // Google's Person guidance (profile-page doc — Person has no standalone rich-result page) allows
-  // `alternateName` to stand in when `name` isn't available, so require either.
-  Person: { all: [], oneOf: ['name', 'alternateName'] },
   VideoObject: ['name', 'thumbnailUrl', 'uploadDate'],
   LocalBusiness: ['name', 'address']
 };

--- a/packages/core/test/jsonld-engine.test.ts
+++ b/packages/core/test/jsonld-engine.test.ts
@@ -100,7 +100,14 @@ describe('hasNonEmpty', () => {
 
 describe('REQUIRED_PROPS', () => {
   it('covers the common types', () => {
-    expect(REQUIRED_PROPS['Product']).toContain('name');
+    expect(REQUIRED_PROPS['Product']).toEqual({ all: ['name'], oneOf: ['review', 'aggregateRating', 'offers'] });
+    expect(REQUIRED_PROPS['Person']).toEqual({ all: [], oneOf: ['name', 'alternateName'] });
     expect(REQUIRED_PROPS['BreadcrumbList']).toContain('itemListElement');
+  });
+  it('has no row for types Google requires nothing from (a rich result cannot be "ineligible" with zero required props)', () => {
+    expect(REQUIRED_PROPS['Article']).toBeUndefined();
+    expect(REQUIRED_PROPS['BlogPosting']).toBeUndefined();
+    expect(REQUIRED_PROPS['NewsArticle']).toBeUndefined();
+    expect(REQUIRED_PROPS['Organization']).toBeUndefined();
   });
 });

--- a/packages/core/test/jsonld-engine.test.ts
+++ b/packages/core/test/jsonld-engine.test.ts
@@ -101,13 +101,13 @@ describe('hasNonEmpty', () => {
 describe('REQUIRED_PROPS', () => {
   it('covers the common types', () => {
     expect(REQUIRED_PROPS['Product']).toEqual({ all: ['name'], oneOf: ['review', 'aggregateRating', 'offers'] });
-    expect(REQUIRED_PROPS['Person']).toEqual({ all: [], oneOf: ['name', 'alternateName'] });
     expect(REQUIRED_PROPS['BreadcrumbList']).toContain('itemListElement');
   });
-  it('has no row for types Google requires nothing from (a rich result cannot be "ineligible" with zero required props)', () => {
+  it('has no row for types with no per-node-checkable requirement (zero Google-required props, or a requirement scoped to a relationship this engine does not track)', () => {
     expect(REQUIRED_PROPS['Article']).toBeUndefined();
     expect(REQUIRED_PROPS['BlogPosting']).toBeUndefined();
     expect(REQUIRED_PROPS['NewsArticle']).toBeUndefined();
     expect(REQUIRED_PROPS['Organization']).toBeUndefined();
+    expect(REQUIRED_PROPS['Person']).toBeUndefined();
   });
 });

--- a/packages/core/test/seo-jsonld-rules.test.ts
+++ b/packages/core/test/seo-jsonld-rules.test.ts
@@ -148,7 +148,7 @@ describe('seo/json-ld-deprecated-type-021', () => {
           ctx(headWithJsonLd('{"@context":"https://schema.org","@type":"Product","name":"x"}'))
         )
       )
-    ).toHaveLength(1); // missing offers
+    ).toHaveLength(1); // missing one of review/aggregateRating/offers
     expect(
       fails(
         await seoJsonLdRequiredProps.check(
@@ -166,10 +166,10 @@ describe('seo/json-ld-deprecated-type-021', () => {
     expect(
       fails(
         await seoJsonLdRequiredProps.check(
-          ctx(headWithJsonLd('{"@context":"https://schema.org","@type":"Article","headline":""}'))
+          ctx(headWithJsonLd('{"@context":"https://schema.org","@type":"Recipe","name":"x","image":""}'))
         )
       )
-    ).toHaveLength(1); // blank headline → still missing
+    ).toHaveLength(1); // blank image → still missing
     expect(
       fails(
         await seoJsonLdRequiredProps.check(
@@ -177,6 +177,91 @@ describe('seo/json-ld-deprecated-type-021', () => {
         )
       )
     ).toHaveLength(1); // empty array → still missing
+  });
+  it('seo/json-ld-required-props: Article/BlogPosting/NewsArticle/Organization have no required props (Google: none) — no finding at all, not even a pass', async () => {
+    expect(
+      await seoJsonLdRequiredProps.check(
+        ctx(headWithJsonLd('{"@context":"https://schema.org","@type":"Article","author":"x"}'))
+      )
+    ).toHaveLength(0); // no headline, and no signal either — the row was removed, not satisfied
+    expect(
+      await seoJsonLdRequiredProps.check(
+        ctx(headWithJsonLd('{"@context":"https://schema.org","@type":"Organization","logo":"https://e.com/l.png"}'))
+      )
+    ).toHaveLength(0); // no name/url, and no signal either
+  });
+  it('seo/json-ld-required-props: Product passes with name + any single one of review/aggregateRating/offers', async () => {
+    expect(
+      fails(
+        await seoJsonLdRequiredProps.check(
+          ctx(
+            headWithJsonLd(
+              '{"@context":"https://schema.org","@type":"Product","name":"x","aggregateRating":{"ratingValue":"4.5"}}'
+            )
+          )
+        )
+      )
+    ).toHaveLength(0); // aggregateRating alone satisfies the one-of group
+    expect(
+      fails(
+        await seoJsonLdRequiredProps.check(
+          ctx(
+            headWithJsonLd(
+              '{"@context":"https://schema.org","@type":"Product","name":"x","review":{"reviewBody":"great"}}'
+            )
+          )
+        )
+      )
+    ).toHaveLength(0); // review alone satisfies the one-of group
+  });
+  it('seo/json-ld-required-props: Product missing all of review/aggregateRating/offers names the group in the message', async () => {
+    const rs = fails(
+      await seoJsonLdRequiredProps.check(
+        ctx(headWithJsonLd('{"@context":"https://schema.org","@type":"Product","name":"x"}'))
+      )
+    );
+    expect(rs).toHaveLength(1);
+    expect(rs[0]?.message).toContain('one of review, aggregateRating or offers');
+  });
+  it('seo/json-ld-required-props: Recipe requires only name + image (not recipeIngredient/recipeInstructions)', async () => {
+    expect(
+      fails(
+        await seoJsonLdRequiredProps.check(
+          ctx(
+            headWithJsonLd(
+              '{"@context":"https://schema.org","@type":"Recipe","name":"x","image":"https://e.com/d.jpg"}'
+            )
+          )
+        )
+      )
+    ).toHaveLength(0);
+  });
+  it('seo/json-ld-required-props: VideoObject does not require description (Google: Recommended)', async () => {
+    expect(
+      fails(
+        await seoJsonLdRequiredProps.check(
+          ctx(
+            headWithJsonLd(
+              '{"@context":"https://schema.org","@type":"VideoObject","name":"x","thumbnailUrl":"https://e.com/t.jpg","uploadDate":"2026-01-01"}'
+            )
+          )
+        )
+      )
+    ).toHaveLength(0);
+  });
+  it('seo/json-ld-required-props: Person accepts alternateName in place of name (Google profile-page guidance)', async () => {
+    expect(
+      fails(
+        await seoJsonLdRequiredProps.check(
+          ctx(headWithJsonLd('{"@context":"https://schema.org","@type":"Person","alternateName":"x"}'))
+        )
+      )
+    ).toHaveLength(0);
+    const rs = fails(
+      await seoJsonLdRequiredProps.check(ctx(headWithJsonLd('{"@context":"https://schema.org","@type":"Person"}')))
+    );
+    expect(rs).toHaveLength(1);
+    expect(rs[0]?.message).toContain('one of name or alternateName');
   });
   it('seo/json-ld-deprecated-type-021 skip parseable JSON-LD that seo/json-ld-validity deems invalid (missing @context/@type)', async () => {
     // Relative URL present, but no @context → seo/json-ld-validity owns the finding; seo/json-ld-relative-url stays silent (no misleading pass).

--- a/packages/core/test/seo-jsonld-rules.test.ts
+++ b/packages/core/test/seo-jsonld-rules.test.ts
@@ -249,19 +249,10 @@ describe('seo/json-ld-deprecated-type-021', () => {
       )
     ).toHaveLength(0);
   });
-  it('seo/json-ld-required-props: Person accepts alternateName in place of name (Google profile-page guidance)', async () => {
+  it('seo/json-ld-required-props: a generic Person node emits no required-props finding (no standalone Person rich result; the name/alternateName requirement is scoped to ProfilePage.mainEntity, which this per-node engine does not track)', async () => {
     expect(
-      fails(
-        await seoJsonLdRequiredProps.check(
-          ctx(headWithJsonLd('{"@context":"https://schema.org","@type":"Person","alternateName":"x"}'))
-        )
-      )
-    ).toHaveLength(0);
-    const rs = fails(
       await seoJsonLdRequiredProps.check(ctx(headWithJsonLd('{"@context":"https://schema.org","@type":"Person"}')))
-    );
-    expect(rs).toHaveLength(1);
-    expect(rs[0]?.message).toContain('one of name or alternateName');
+    ).toHaveLength(0);
   });
   it('seo/json-ld-deprecated-type-021 skip parseable JSON-LD that seo/json-ld-validity deems invalid (missing @context/@type)', async () => {
     // Relative URL present, but no @context → seo/json-ld-validity owns the finding; seo/json-ld-relative-url stays silent (no misleading pass).


### PR DESCRIPTION
From the 2026-08-09 v1.0 rule-validity review (`docs/superpowers/specs/2026-08-09-v1-rule-validity-review.md`, Priority-1 row 2).

## Summary

`REQUIRED_PROPS` was curated against Google structured-data docs that have since relaxed — 5 of 12 rows produced **warning-severity false positives on valid markup**. Every row was re-fetched from developers.google.com during implementation (not trusted from the review):

| Type | Was | Now |
|---|---|---|
| Article / BlogPosting / NewsArticle | `headline` required | **Row removed** — Google lists no required properties (the rule's "ineligible for the rich result" message can't be true for a type with none; the type keeps validity/placeholder/URL coverage) |
| Organization | `name`, `url` | **Row removed** — same reason |
| Product | `name` + `offers` | `name` + **one of** `review` / `aggregateRating` / `offers` (per product-snippet; merchant-listing is a distinct, stricter rich result and deliberately not conflated) |
| Recipe | 4 props | `name`, `image` |
| VideoObject | 4 props | `name`, `thumbnailUrl`, `uploadDate` (`description` is Recommended) |
| Person | `name` | **one of** `name` / `alternateName` (Person 404s standalone; evidence from the profile-page doc, which explicitly allows the substitution — judgment call, documented in the code comment) |
| BreadcrumbList / WebSite / Event / LocalBusiness | — | Confirmed current, unchanged |

## Implementation

Minimal one-of support: `RequiredPropsRow = string[] | { all, oneOf }` + a ~20-line `missingRequiredProps()` helper reusing `hasNonEmpty`; the message names the group ("missing one of review, aggregateRating or offers"). `REQUIRED_PROPS` is not publicly re-exported — internal shape change only.

## Verification

- 7 tests written first and confirmed failing against the old table (Article/Organization false signal, Product one-of shapes, Recipe/VideoObject boundaries, message wording).
- `pnpm -r typecheck` / `pnpm test` (core 1361, cli 875, vite 213) / `pnpm lint` all green; docs updated en+ja (the stale Product example replaced); changeset enumerates every row change so users can map disappeared findings to this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated JSON-LD validation to align with current Google structured-data requirements.
  - Added support for alternative valid properties, including Product offers, reviews, or ratings and Person name or alternate name.
  - Improved handling of missing and blank required values.
  - Removed unnecessary warnings for types without Google-defined required properties.

- **Documentation**
  - Updated English and Japanese guidance and examples for Product structured data requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->