### PR TITLE
fix(core): parse components with argument-less $state() instead of silently skipping them

### DIFF
--- a/.changeset/state-noarg-parse-crash.md
+++ b/.changeset/state-noarg-parse-crash.md
@@ -1,0 +1,5 @@
+---
+'@svelte-vitals/core': patch
+---
+
+Fix a parse crash on argument-less `$state()` that made the whole component invisible to every rule. `let el = $state();` (the idiomatic `bind:this` declaration) threw inside fact extraction; the error was swallowed and the file silently contributed no findings at all. Such files are now analyzed normally. Note: projects using this pattern may see new findings on the next run — including critical ones (e.g. correctness/orphan-effect) in files that were previously skipped — so a previously green run can now fail the default `--fail-on critical` gate. That is the fix working, not a regression.

--- a/packages/core/src/component-parse.ts
+++ b/packages/core/src/component-parse.ts
@@ -48,9 +48,14 @@ export interface TSNonNullExpression {
 export type TsExpression = Expression | TSSatisfiesExpression | TSAsExpression | TSNonNullExpression;
 
 /** Unwrap TS wrapper expressions (`x satisfies T`, `x as T`, `x!`) to the underlying expression. Shared with the Kit-module and Vite-config parsers. */
-export function unwrapTs(expr: TsExpression): Expression {
+export function unwrapTs(expr: TsExpression): Expression;
+export function unwrapTs(expr: TsExpression | undefined): Expression | undefined;
+export function unwrapTs(expr: TsExpression | undefined): Expression | undefined {
   let cur = expr;
-  while (cur.type === 'TSSatisfiesExpression' || cur.type === 'TSAsExpression' || cur.type === 'TSNonNullExpression')
+  while (
+    cur !== undefined &&
+    (cur.type === 'TSSatisfiesExpression' || cur.type === 'TSAsExpression' || cur.type === 'TSNonNullExpression')
+  )
     cur = cur.expression;
   return cur;
 }

--- a/packages/core/test/component-collect.test.ts
+++ b/packages/core/test/component-collect.test.ts
@@ -113,4 +113,14 @@ describe('collectComponentFacts', () => {
     expect(facts).toHaveLength(1);
     expect(facts[0]!.orphanEffects).toEqual([{ line: 2, kind: 'top-level' }]);
   });
+
+  it('does not fall back to empty facts for a component with an argument-less $state() (issue #424)', async () => {
+    const rt = createMemoryRuntime({
+      'src/lib/Dialog.svelte': '<script>\n  let el = $state();\n</script>\n<dialog bind:this={el}></dialog>'
+    });
+    const facts = await collectComponentFacts(rt, '');
+    expect(facts).toHaveLength(1);
+    expect(facts[0]).not.toEqual(emptyComponentFacts('src/lib/Dialog.svelte'));
+    expect(facts[0]!.loc).toBe(4);
+  });
 });

--- a/packages/core/test/component-parse.test.ts
+++ b/packages/core/test/component-parse.test.ts
@@ -1079,6 +1079,50 @@ describe('parseComponentFacts — runes behind TS casts (as/satisfies/!)', () =>
   });
 });
 
+describe('parseComponentFacts — argument-less $state() (issue #424)', () => {
+  it('parses a component with a bind:this-only $state() alongside other state, yielding normal facts', () => {
+    const src = [
+      '<script>',
+      '  let el = $state();',
+      '  let count = $state(0);',
+      '  let doubled = $state(0);',
+      '  $effect(() => {',
+      '    doubled = count * 2;',
+      '  });',
+      '</script>',
+      '',
+      '<div bind:this={el}>{doubled}</div>'
+    ].join('\n');
+    const facts = parseComponentFacts(src, 'C.svelte');
+    expect(facts.loc).toBe(10);
+    expect(facts.effects).toEqual([{ line: 5, assignsOnlyState: true, mountOnly: false }]);
+    // `count` is read-only (correctness/unmutated-state); `el`/`doubled` are excluded
+    // (bound via bind:this, written in the effect). rawableStates/nonreactiveBuiltinStates
+    // pin the two scans that read a $state() call's argument.
+    expect(facts.constableStates).toEqual([{ name: 'count', line: 3 }]);
+    expect(facts.rawableStates).toEqual([]);
+    expect(facts.nonreactiveBuiltinStates).toEqual([]);
+  });
+
+  it('parses a typed argument-less $state<T>() declaration, yielding normal facts', () => {
+    const src = [
+      '<script lang="ts">',
+      '  let el: HTMLDialogElement | undefined = $state<HTMLDialogElement>();',
+      '  let count = $state(0);',
+      '</script>',
+      '<dialog bind:this={el}>{count}</dialog>'
+    ].join('\n');
+    const facts = parseComponentFacts(src, 'C.svelte');
+    expect(facts.loc).toBe(5);
+    expect(facts.constableStates).toEqual([{ name: 'count', line: 3 }]);
+  });
+
+  it('parses a .svelte.ts runes module with an argument-less $state() (already worked before the fix)', () => {
+    const src = 'export const el = $state();';
+    expect(parseComponentFacts(src, 'src/lib/store.svelte.ts').moduleStateDecls).toEqual([{ name: 'el', line: 1 }]);
+  });
+});
+
 describe('parseComponentFacts — type-only imports in importSpans', () => {
   const spans = (src: string) => parseComponentFacts(src, 'src/routes/a/+page.svelte').importSpans;
 


### PR DESCRIPTION
Fixes #424.

## Problem

`let el = $state();` — the idiomatic `bind:this` declaration — crashed fact extraction: two scans in `component-parse.ts` (the `$state.raw` candidates scan and the builtin-state candidates scan) call `unwrapTs(init.arguments?.[0])`, and `unwrapTs` dereferenced `.type` on the `undefined` argument. The resulting `TypeError` was swallowed by `collectComponentFacts`'s deliberate never-throw fallback, so the whole file silently contributed `emptyComponentFacts` — invisible to every rule, with a clean Health 100/100 to show for it.

Verified blast radius: only bare `$state()` in `.svelte` components. `$state.raw()` / `$state.frozen()` with no argument and argument-less `$state()` in `.svelte.ts` runes modules never reached the crashing scans (pinned by a regression test so that stays true).

## Fix

`unwrapTs` now tolerates `undefined` via an overload pair — one guard in the shared helper covers both current call sites and any future caller, while keeping the non-undefined callers' return type narrow. No call sites changed; the never-throw fallback in `component-collect.ts` is untouched (it remains the safety net for genuinely malformed files).

## Tests

- The issue's exact repro (`$state()` alongside `count`/`doubled`/`$effect`) yields normal facts — `loc`, `effects`, `constableStates`, plus `rawableStates`/`nonreactiveBuiltinStates` to exercise both formerly-crashing scans.
- The typed `$state<HTMLDialogElement>()` variant from the issue's trigger table.
- `.svelte.ts` runes module with argument-less `$state()` (already worked; pinned against regression).
- `collectComponentFacts` no longer falls back to empty facts for such a file (the user-visible symptom).

Mutation-checked: with the `unwrapTs` guard reverted, the three `.svelte` tests fail with the original `TypeError`; the `.svelte.ts` pin passes, as expected.

## Release note

Changeset (`@svelte-vitals/core` patch) states the gate movement explicitly: files previously skipped by this crash are now analyzed, so projects using this pattern may see new findings — including critical ones — and a previously green run can fail the default `--fail-on critical` gate. That is the fix working.

## Follow-up (out of scope)

The issue's secondary point — nothing surfaces when a file is skipped by the never-throw fallback — is a real observability gap but a separate design decision (skipped-file counter / stderr note). Filing it separately keeps this a pure crash fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed analysis for argument-less `$state()` declarations so affected components are processed normally instead of being skipped.
  * Restored detection of findings that were previously hidden when these declarations caused parsing errors.
  * Added support for typed argument-less `$state<T>()` declarations.

* **Tests**
  * Added regression coverage for component and module-state analysis, including locations, effects, and state findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->