### PR TITLE
fix(cli): point docs show at explain when given a rule id

### DIFF
--- a/.changeset/docs-show-rule-id-redirect.md
+++ b/.changeset/docs-show-rule-id-redirect.md
@@ -1,0 +1,6 @@
+---
+'svelte-vitals': patch
+'@svelte-vitals/core': patch
+---
+
+`docs show <rule-id>` now tells you the id is a rule and points at `svelte-vitals explain <rule-id>` (which already prints a rule's rationale, options, and docs URL offline) instead of only listing the workflow guide topics. The agent report's intro now mentions `explain` too, so agents can reach rule semantics without the network.

--- a/packages/cli/src/docs/cli.ts
+++ b/packages/cli/src/docs/cli.ts
@@ -1,5 +1,7 @@
+import { docsUrlFor } from '@svelte-vitals/core';
 import { parseCliArgs } from '../cli-args.js';
 import { consoleIO, type CliIO } from '../cli-io.js';
+import { knownRuleIds } from '../rules-config.js';
 import { EMBEDDED_DOCS } from './generated.js';
 
 const DOCS_HELP = `svelte-vitals docs — read the bundled guides without leaving the terminal
@@ -78,9 +80,19 @@ export function runDocsCli(args: string[], io: CliIO = consoleIO): number {
       io.errorLog(`svelte-vitals: known topics: ${knownTopicNames()}.`);
       return 2;
     }
-    const doc = EMBEDDED_DOCS.find((d) => d.name === rest[0]);
+    const name = rest[0]!; // rest.length === 1, checked above
+    const doc = EMBEDDED_DOCS.find((d) => d.name === name);
     if (!doc) {
-      io.errorLog(`svelte-vitals: unknown docs topic '${rest[0]}'.`);
+      // The agent reporter and web docs print rule ids as `<category>/<slug>` (and the web
+      // path as `rules/<category>/<slug>`); redirect those to `explain` instead of the
+      // generic "unknown topic" list, which does not include rule ids at all.
+      const ruleId = name.startsWith('rules/') ? name.slice('rules/'.length) : name;
+      if (knownRuleIds().includes(ruleId)) {
+        io.errorLog(`svelte-vitals: '${ruleId}' is a rule, not a docs topic.`);
+        io.errorLog(`svelte-vitals: rule detail: \`svelte-vitals explain ${ruleId}\`; web: ${docsUrlFor(ruleId)}`);
+        return 2;
+      }
+      io.errorLog(`svelte-vitals: unknown docs topic '${name}'.`);
       io.errorLog(`svelte-vitals: known topics: ${knownTopicNames()}.`);
       return 2;
     }

--- a/packages/cli/test/docs-cli.test.ts
+++ b/packages/cli/test/docs-cli.test.ts
@@ -66,6 +66,22 @@ describe('svelte-vitals docs show', () => {
     expect(err).toContain('one topic at a time');
   });
 
+  it('redirects a rule id to `explain` instead of the generic unknown-topic error', () => {
+    const { code, out, err } = docs(['show', 'architecture/component-size']);
+    expect(code).toBe(2);
+    expect(out).toBe('');
+    expect(err).toContain("'architecture/component-size' is a rule, not a docs topic");
+    expect(err).toContain('explain architecture/component-size');
+  });
+
+  it('redirects a rule id given with the web docs `rules/` prefix', () => {
+    const { code, out, err } = docs(['show', 'rules/architecture/component-size']);
+    expect(code).toBe(2);
+    expect(out).toBe('');
+    expect(err).toContain("'architecture/component-size' is a rule, not a docs topic");
+    expect(err).toContain('explain architecture/component-size');
+  });
+
   it('exits 2 when no topic name is given', () => {
     const { code, err } = docs(['show']);
     expect(code).toBe(2);

--- a/packages/core/src/reporter/agent.ts
+++ b/packages/core/src/reporter/agent.ts
@@ -27,7 +27,7 @@ export function formatAgentReport(results: Result[], config: Config): string {
   }
 
   lines.push(
-    `${failing.length} issue(s) to fix, ordered most-severe first. Fix critical issues first; warning and info items improve SEO but do not fail the default build. Apply each fix below, then re-run \`svelte-vitals\` (or the build) to confirm each rule passes.`,
+    `${failing.length} issue(s) to fix, ordered most-severe first. Fix critical issues first; warning and info items improve SEO but do not fail the default build. Apply each fix below, then re-run \`svelte-vitals\` (or the build) to confirm each rule passes. Run \`svelte-vitals explain <rule-id>\` for any rule's rationale and options (works offline).`,
     ''
   );
 

--- a/packages/core/test/agent-report.test.ts
+++ b/packages/core/test/agent-report.test.ts
@@ -101,6 +101,11 @@ describe('formatAgentReport', () => {
     expect(md).toContain('Fix critical issues first');
   });
 
+  it("points at `explain` for a rule's rationale and options", () => {
+    const md = formatAgentReport(results, config);
+    expect(md).toContain('svelte-vitals explain <rule-id>');
+  });
+
   it('wraps tag-like tokens in inline code so renderers do not strip them', () => {
     const withTags: Result[] = [
       {


### PR DESCRIPTION
Fixes #426.

## Problem

The agent reporter prints per-finding docs URLs like `…/rules/architecture/component-size`, and the run output points at `docs list` for the bundled guides — so the natural next step, for an agent or a human offline, is `svelte-vitals docs show architecture/component-size`. That failed with the generic "unknown docs topic" error listing five unrelated workflow topics, even though rule-level detail already ships offline in `svelte-vitals explain <rule-id>` (rationale, severity, options/thresholds, docs URL). The gap was purely discoverability.

## Fix

- `docs show <name>`: when the unknown name is a known rule id (accepted with or without the web path's `rules/` prefix), the error now says it is a rule and points at both `explain <rule-id>` and the web URL. Still exit 2 with empty stdout — the subcommand's piping contract is preserved, verified against the built `dist/bin.js`. Truly unknown names keep the generic error unchanged.
- The agent report's intro now mentions `explain <rule-id>` (works offline), so agents reach rule semantics without guessing or fetching a web page.

The skill playbook installed by `svelte-vitals install` already tells agents about `explain <rule-id>` (pinned by an existing test), so no change was needed there.

## Tests

- `docs show architecture/component-size` and `docs show rules/architecture/component-size` → exit 2, empty stdout, stderr names the rule and the `explain` command.
- Pre-existing unknown-name test pins the generic error path unchanged.
- Agent report intro pins the `explain` mention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)