### PR TITLE
fix(cli): stop treating literal spaces in route globs as wildcards

### DIFF
--- a/.changeset/route-matcher-space-glob.md
+++ b/.changeset/route-matcher-space-glob.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': patch
+---
+
+Route globs (`--route`, config `routes`) containing a literal space now match that space literally. Previously an internal placeholder collision silently turned each space into `.*`, over-matching (e.g. `blog/my post` matched `/blog/my-post`).

--- a/packages/cli/src/route-matcher.ts
+++ b/packages/cli/src/route-matcher.ts
@@ -5,13 +5,13 @@ export function routeMatcher(glob: string | undefined): (route: string) => boole
   if (!glob) return () => true;
   const body = glob
     .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-    .replace(/\*\*/g, ' ') // globstar placeholder
+    .replace(/\*\*/g, '\0') // globstar placeholder (not a literal space: a glob can contain one)
     .replace(/\*/g, '[^/]*') // single-segment wildcard (placeholder untouched)
-    .replace(/\/ $/g, '(?:/.*)?') // trailing /** -> optional subtree
-    .replace(/^ \//g, '(?:.*/)?') // leading **/ -> optional prefix
-    .replace(/ \//g, '(?:.*/)?') // internal **/ -> optional prefix
-    .replace(/\/ /g, '(?:/.*)?') // internal /** -> optional subtree
-    .replace(/ /g, '.*'); // bare ** -> .*
+    .replace(/\/\0$/g, '(?:/.*)?') // trailing /** -> optional subtree
+    .replace(/^\0\//g, '(?:.*/)?') // leading **/ -> optional prefix
+    .replace(/\0\//g, '(?:.*/)?') // internal **/ -> optional prefix
+    .replace(/\/\0/g, '(?:/.*)?') // internal /** -> optional subtree
+    .replace(/\0/g, '.*'); // bare ** -> .*
   const re = new RegExp(`^${body}$`);
   return (route) => re.test(route.replace(/^\//, ''));
 }

--- a/packages/cli/test/route-matcher.test.ts
+++ b/packages/cli/test/route-matcher.test.ts
@@ -34,4 +34,11 @@ describe('routeMatcher', () => {
     expect(m('/static')).toBe(true);
     expect(m('/static/a')).toBe(false);
   });
+
+  it('a literal space in the glob matches a literal space, not a wildcard', () => {
+    const m = routeMatcher('blog/my post');
+    expect(m('/blog/my post')).toBe(true);
+    expect(m('/blog/my-post')).toBe(false);
+    expect(m('/blog/myXpost')).toBe(false);
+  });
 });


### PR DESCRIPTION
Audit item 2608-TEST-07 (plans/README.md backlog).

`routeMatcher` used a literal space as its internal globstar placeholder, and the escape step never escaped spaces — so a real space in a `--route` / config glob was rewritten to `.*` by the final placeholder substitution, silently over-matching: `blog/my post` matched `/blog/my-post` and `/blog/myXpost`.

The placeholder is now `\0`, which cannot appear in a glob; a literal space matches a literal space. All existing globstar/single-star behaviors are pinned by the untouched test suite. Mutation-checked: the new test fails against the previous placeholder.

Changeset (`svelte-vitals` patch) declares the visible behavior change: space-containing globs now match literally instead of over-matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed route matching so literal spaces in `--route` options and route configuration match spaces exactly.
  * Prevented spaces from being incorrectly treated as wildcard patterns during glob matching.
* **Tests**
  * Added coverage for route patterns containing literal spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->