### PR TITLE
fix(cli): write the suppressions file atomically

### DIFF
--- a/.changeset/atomic-suppressions-write.md
+++ b/.changeset/atomic-suppressions-write.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': patch
+---
+
+`--update-suppressions` now writes the suppressions file atomically (temp file + rename), so an interrupted run can no longer leave a corrupt `svelte-vitals-suppressions.json` that fails every later run.

--- a/packages/cli/src/suppressions.ts
+++ b/packages/cli/src/suppressions.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { Config, Result } from '@svelte-vitals/core';
 import { isPenalized } from '@svelte-vitals/core';
@@ -111,7 +111,19 @@ export function writeSuppressions(cwd: string, results: Result[], config: Config
   entries.sort(compareEntries);
 
   const path = join(cwd, SUPPRESSIONS_FILE);
-  writeFileSync(path, JSON.stringify({ version: 1, suppressions: entries }, null, 2) + '\n');
+  // Same-directory tmp file: renameSync is only atomic within one filesystem.
+  const tmpPath = `${path}.tmp`;
+  try {
+    writeFileSync(tmpPath, JSON.stringify({ version: 1, suppressions: entries }, null, 2) + '\n');
+    renameSync(tmpPath, path);
+  } catch (err) {
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      // best-effort cleanup; original error takes precedence
+    }
+    throw err;
+  }
   return entries.length;
 }
 

--- a/packages/cli/test/suppressions.test.ts
+++ b/packages/cli/test/suppressions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { Config, Result } from '@svelte-vitals/core';
@@ -122,6 +122,36 @@ describe('writeSuppressions', () => {
     expect(count).toBe(0);
     const written = JSON.parse(readFileSync(join(dir, SUPPRESSIONS_FILE), 'utf8'));
     expect(written).toEqual({ version: 1, suppressions: [] });
+  });
+
+  it('writes byte-identical formatting: 2-space JSON plus a trailing newline', () => {
+    const dir = makeDir();
+    writeSuppressions(dir, [r({ id: 'seo/title-presence', route: '/a' })], config);
+    const raw = readFileSync(join(dir, SUPPRESSIONS_FILE), 'utf8');
+    expect(raw).toBe(
+      JSON.stringify({ version: 1, suppressions: [{ id: 'seo/title-presence', route: '/a' }] }, null, 2) + '\n'
+    );
+  });
+
+  it('leaves no .tmp file behind after a successful write', () => {
+    const dir = makeDir();
+    writeSuppressions(dir, [r({ id: 'seo/title-presence', route: '/a' })], config);
+    expect(existsSync(join(dir, `${SUPPRESSIONS_FILE}.tmp`))).toBe(false);
+  });
+
+  it('leaves the existing file untouched when the write fails', () => {
+    const dir = makeDir();
+    const path = join(dir, SUPPRESSIONS_FILE);
+    const before = JSON.stringify({ version: 1, suppressions: [{ id: 'OLD' }] }, null, 2) + '\n';
+    writeFileSync(path, before);
+    chmodSync(dir, 0o555); // read+execute only: writing the tmp file must fail with EACCES
+    try {
+      expect(() => writeSuppressions(dir, [r({ id: 'NEW', route: '/here' })], config)).toThrow();
+    } finally {
+      chmodSync(dir, 0o755);
+    }
+    expect(readFileSync(path, 'utf8')).toBe(before);
+    expect(existsSync(join(dir, `${SUPPRESSIONS_FILE}.tmp`))).toBe(false);
   });
 });
 


### PR DESCRIPTION
Audit item 2608-CLI-10 (plans/README.md backlog).

`--update-suppressions` wrote `svelte-vitals-suppressions.json` with a direct `writeFileSync`; a crash mid-write left a truncated file, and since the loader rejects malformed files, every later run failed. The write now goes to a same-directory temp file (`renameSync` is only atomic within one filesystem) and is renamed over the target; on failure the temp file is cleaned up best-effort and the original error is rethrown unmasked.

Output bytes, the returned count, and the sync API are unchanged — pinned by a byte-identical formatting test. Two more tests pin no-leftover-tmp on success and target-untouched on write failure (EACCES via directory permissions; CI runs non-root ubuntu, where this holds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)