### PR TITLE
fix(cli): require stdin TTY for install's interactive prompts

### DIFF
--- a/.changeset/install-stdin-tty-gate.md
+++ b/.changeset/install-stdin-tty-gate.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': patch
+---
+
+`install` no longer hangs waiting for input when stdin is piped while stdout is a terminal — interactive prompts now require both stdin and stdout to be TTYs, matching the analyzer's existing gate.

--- a/packages/cli/src/install/cli.ts
+++ b/packages/cli/src/install/cli.ts
@@ -68,7 +68,9 @@ export function realIO(): InstallIO {
       writeFileSync(path, content);
     },
     cwd: process.cwd(),
-    isTTY: Boolean(process.stdout.isTTY),
+    // clack reads from stdin and renders to stdout, so both must be interactive —
+    // a piped/redirected stdin would leave the prompt hanging for input that never comes.
+    isTTY: Boolean(process.stdin.isTTY) && Boolean(process.stdout.isTTY),
     nodeVersion: process.version,
     log: (line) => console.log(line),
     errorLog: (line) => console.error(line),

--- a/packages/cli/test/install/cli.test.ts
+++ b/packages/cli/test/install/cli.test.ts
@@ -14,6 +14,23 @@ describe('realIO().readFile', () => {
   });
 });
 
+describe('realIO().isTTY', () => {
+  it('is false when stdin is not a TTY even if stdout is (piped stdin would hang a prompt)', () => {
+    const stdin = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
+    const stdout = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    try {
+      expect(realIO().isTTY).toBe(false);
+    } finally {
+      if (stdin) Object.defineProperty(process.stdin, 'isTTY', stdin);
+      else delete (process.stdin as { isTTY?: boolean }).isTTY;
+      if (stdout) Object.defineProperty(process.stdout, 'isTTY', stdout);
+      else delete (process.stdout as { isTTY?: boolean }).isTTY;
+    }
+  });
+});
+
 describe('runInstallCli --help', () => {
   afterEach(() => {
     vi.restoreAllMocks();


### PR DESCRIPTION
Audit item 2608-CLI-08 (plans/README.md backlog).

`install` gated its interactive prompts on `process.stdout.isTTY` alone, so a piped stdin with a terminal stdout (`echo | svelte-vitals install`, wrappers feeding stdin) took the prompt path and hung waiting for input that never comes. The gate now requires both streams, mirroring the analyzer's existing two-stream check in `index.ts` (same reason, same comment — clack reads stdin and renders to stdout). The analyzer side had this exact bug once before (Plan 019); this closes the remaining call site.

With stdin piped, `install` now takes the same non-interactive path it already takes for non-TTY stdout. Test pins the gate at the `realIO()` seam (stdin non-TTY + stdout TTY → non-interactive), with process descriptors restored afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)