### PR TITLE
fix(cli): warn on stderr when unparsable files are skipped

### DIFF
--- a/.changeset/report-skipped-unparsable-files.md
+++ b/.changeset/report-skipped-unparsable-files.md
@@ -1,0 +1,6 @@
+---
+'@svelte-vitals/core': patch
+'svelte-vitals': patch
+---
+
+Files that fail to parse are no longer silently invisible: collectors mark them (`parseFailed` on the fact) and the CLI prints a stderr warning listing the skipped files. No finding, score, or exit-code movement — stderr diagnostics only; reporter stdout (json/sarif) is unchanged and still machine-parseable.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -194,7 +194,7 @@ export interface AnalyzeResult {
   ruleIds: string[];
   /** Per-rule, per-declaration counts of places examined, unfiltered by `--diff`/`--baseline`/suppressions. */
   examined: Record<string, Record<string, number>>;
-  /** Non-fatal config-file issues (unknown top-level keys, invalid enum values). Empty when no config file or none found. */
+  /** Non-fatal issues surfaced during analysis: config-file problems (unknown top-level keys, invalid enum values), version-floor notices, `--rules`/overrides conflicts, and skipped-file notices. Empty when none apply. */
   warnings: string[];
   /**
    * This analysis's config-file load result (`undefined` when no config file exists at its
@@ -241,6 +241,24 @@ function overridesOffWarnings(allowRules: string[] | undefined, overrides: RuleO
     }
   }
   return warnings;
+}
+
+/**
+ * Warn about files a collector could not read or parse (`parseFailed`, set at the
+ * component/kit-module catch sites): the file contributes empty facts, so any findings
+ * it would have produced are simply missing rather than reported as fixed. Capped at 10
+ * inline paths so one badly-broken directory can't flood the terminal.
+ */
+function skippedFileWarnings(facts: { file: string; parseFailed?: true }[]): string[] {
+  const files = [...new Set(facts.filter((f) => f.parseFailed).map((f) => f.file))].sort();
+  if (files.length === 0) return [];
+  const shown = files.slice(0, 10);
+  const list =
+    files.length > shown.length ? `${shown.join(', ')}, … and ${files.length - shown.length} more` : shown.join(', ');
+  return [
+    `skipped ${files.length} file(s) that could not be parsed: ${list}`,
+    'findings for these files are unavailable until they parse.'
+  ];
 }
 
 /**
@@ -306,7 +324,7 @@ export async function analyzeProject(opts: AnalyzeOptions = {}): Promise<Analyze
     version: readPackageVersion(),
     ruleIds: rules.map((r) => r.id),
     examined,
-    warnings,
+    warnings: [...warnings, ...skippedFileWarnings([...components, ...kitModules])],
     loadedConfig: loaded
   };
 }

--- a/packages/cli/test/malformed-svelte.test.ts
+++ b/packages/cli/test/malformed-svelte.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { cpSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { collectComponentFacts, type Runtime } from '@svelte-vitals/core';
 import { run } from '../src/index.js';
 import { createNodeRuntime } from '../src/runtime/node.js';
@@ -57,7 +59,8 @@ describe('collectComponentFacts: malformed .svelte files (component path)', () =
       browserGlobalRefs: [],
       moduleStateDecls: [],
       suppressions: [],
-      commentLinks: []
+      commentLinks: [],
+      parseFailed: true
     });
 
     // The well-formed sibling file must still be parsed normally — one broken
@@ -125,9 +128,61 @@ describe('collectComponentFacts: malformed .svelte files (component path)', () =
       browserGlobalRefs: [],
       moduleStateDecls: [],
       suppressions: [],
-      commentLinks: []
+      commentLinks: [],
+      parseFailed: true
     });
     expect(byFile.get(goodPath)!.loc).toBeGreaterThan(0);
+  });
+});
+
+describe('run(): stderr warning for skipped (unparsable) files (issue #424)', () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    while (dirs.length > 0) {
+      const dir = dirs.pop();
+      if (dir) rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('warns on stderr and leaves stdout valid JSON', async () => {
+    const cap = capture();
+    const code = await run({
+      cwd: malformedComponentProject,
+      log: cap.log,
+      errorLog: cap.errorLog,
+      reporter: 'json',
+      env: CLEAN_ENV
+    });
+
+    const errText = cap.err.join('\n');
+    expect(errText).toContain('svelte-vitals: skipped 1 file(s) that could not be parsed: src/lib/Broken.svelte');
+    expect(errText).toContain('svelte-vitals: findings for these files are unavailable until they parse.');
+    // stdout must stay machine-parseable — the warning goes to stderr only.
+    expect(() => JSON.parse(cap.out.join('\n'))).not.toThrow();
+    expect([0, 1]).toContain(code);
+  });
+
+  it('does not change the exit code versus the same project with no broken file', async () => {
+    const brokenCap = capture();
+    const brokenCode = await run({
+      cwd: malformedComponentProject,
+      log: brokenCap.log,
+      errorLog: brokenCap.errorLog,
+      env: CLEAN_ENV
+    });
+
+    const dir = mkdtempSync(join(tmpdir(), 'svelte-vitals-424-run-'));
+    dirs.push(dir);
+    cpSync(malformedComponentProject, dir, { recursive: true });
+    // Replace the broken file with valid markup — same project, nothing left to skip.
+    writeFileSync(join(dir, 'src/lib/Broken.svelte'), '<p>fixed</p>');
+
+    const fixedCap = capture();
+    const fixedCode = await run({ cwd: dir, log: fixedCap.log, errorLog: fixedCap.errorLog, env: CLEAN_ENV });
+
+    expect(brokenCap.err.join('\n')).toContain('skipped 1 file(s)');
+    expect(fixedCap.err.join('\n')).not.toContain('skipped');
+    expect(fixedCode).toBe(brokenCode);
   });
 });
 

--- a/packages/core/src/component-collect.ts
+++ b/packages/core/src/component-collect.ts
@@ -53,7 +53,7 @@ export async function collectComponentFacts(rt: Runtime, cwd: string): Promise<C
         const source = await rt.readFile(rt.join(cwd, rel));
         return { file: rel, ...parseComponentFacts(source, rel) };
       } catch {
-        return emptyComponentFacts(rel);
+        return { ...emptyComponentFacts(rel), parseFailed: true };
       }
     })
   );

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -156,4 +156,6 @@ export interface ComponentFacts {
   suppressions?: SuppressionDirective[];
   /** Markdown links `[label](url)` appearing inside a comment (architecture/doc-link-target). */
   commentLinks: { url: string; line: number }[];
+  /** Set when the file failed to read or parse and these facts are the empty fallback — the file was NOT analyzed. */
+  parseFailed?: true;
 }

--- a/packages/core/src/kit-module-collect.ts
+++ b/packages/core/src/kit-module-collect.ts
@@ -56,7 +56,7 @@ export async function collectKitModuleFacts(
         const source = await rt.readFile(rt.join(cwd, rel));
         return { file: rel, kind, ...parseKitModuleFacts(source, rel, aliases) };
       } catch {
-        return emptyKitModuleFacts(rel, kind);
+        return { ...emptyKitModuleFacts(rel, kind), parseFailed: true };
       }
     })
   );

--- a/packages/core/src/kit-module.ts
+++ b/packages/core/src/kit-module.ts
@@ -48,4 +48,6 @@ export interface KitModuleFacts {
   loadWaterfalls?: { dependentLines: number[]; independentLines: number[] };
   /** Inline `svelte-vitals-disable-next-line` directives in this file. */
   suppressions: SuppressionDirective[];
+  /** Set when the file failed to read or parse and these facts are the empty fallback — the file was NOT analyzed. */
+  parseFailed?: true;
 }

--- a/packages/core/test/component-collect.test.ts
+++ b/packages/core/test/component-collect.test.ts
@@ -74,7 +74,21 @@ describe('collectComponentFacts', () => {
       new Set(['src/lib/Unreadable.svelte'])
     );
     const facts = await collectComponentFacts(rt, '');
-    expect(facts).toEqual([emptyComponentFacts('src/lib/Unreadable.svelte')]);
+    expect(facts).toEqual([{ ...emptyComponentFacts('src/lib/Unreadable.svelte'), parseFailed: true }]);
+  });
+
+  it('marks parseFailed on a failed file and leaves it unset on a healthy one', async () => {
+    const rt = createMemoryRuntime(
+      {
+        'src/lib/Unreadable.svelte': '<div></div>',
+        'src/routes/+page.svelte': '<p>ok</p>'
+      },
+      new Set(['src/lib/Unreadable.svelte'])
+    );
+    const facts = await collectComponentFacts(rt, '');
+    const byFile = new Map(facts.map((f) => [f.file, f]));
+    expect(byFile.get('src/lib/Unreadable.svelte')!.parseFailed).toBe(true);
+    expect(byFile.get('src/routes/+page.svelte')!.parseFailed).toBeUndefined();
   });
 
   it('sorts results by file path regardless of glob order', async () => {

--- a/packages/core/test/kit-module-collect.test.ts
+++ b/packages/core/test/kit-module-collect.test.ts
@@ -130,7 +130,23 @@ describe('collectKitModuleFacts', () => {
   });
   it('falls back to empty facts when a file fails to read', async () => {
     const rt = createMemoryRuntime({ 'src/routes/+page.server.ts': 'let x;' }, new Set(['src/routes/+page.server.ts']));
-    expect(await collectKitModuleFacts(rt, '')).toEqual([emptyKitModuleFacts('src/routes/+page.server.ts', 'server')]);
+    expect(await collectKitModuleFacts(rt, '')).toEqual([
+      { ...emptyKitModuleFacts('src/routes/+page.server.ts', 'server'), parseFailed: true }
+    ]);
+  });
+
+  it('marks parseFailed on a failed file and leaves it unset on a healthy one', async () => {
+    const rt = createMemoryRuntime(
+      {
+        'src/routes/+page.server.ts': 'let x;',
+        'src/routes/about/+page.ts': 'export const load = () => ({});'
+      },
+      new Set(['src/routes/+page.server.ts'])
+    );
+    const facts = await collectKitModuleFacts(rt, '');
+    const byFile = new Map(facts.map((f) => [f.file, f]));
+    expect(byFile.get('src/routes/+page.server.ts')!.parseFailed).toBe(true);
+    expect(byFile.get('src/routes/about/+page.ts')!.parseFailed).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Addresses the observability ask in #424 ("The silence is the worst part: nothing indicates that a file was skipped").

The never-throw collection design stays: a file that fails to read or parse still contributes empty facts instead of aborting the run. What changes is that the silence is gone:

- **core**: the component and kit-module collectors mark the fallback with `parseFailed: true` on the returned facts (set at the catch sites; the exported `empty*Facts` helpers stay semantically "empty" and untouched). The `inMemoryExportsOf` arbitration fallback is not a file-skip and is not marked.
- **cli**: `analyzeProject` feeds a deduped, sorted list of `parseFailed` files into the existing `warnings` channel, which `run()` already prints to stderr:

  ```
  svelte-vitals: skipped 1 file(s) that could not be parsed: src/lib/Broken.svelte
  svelte-vitals: findings for these files are unavailable until they parse.
  ```

  Capped at 10 inline paths (`… and N more`). Verified: `warnings` is consumed only by the stderr loop — reporter stdout (json/sarif) is untouched and still machine-parseable, and exit codes are unchanged (both pinned by tests, including an exit-code-invariance test against the same project with the broken file fixed).

- **vite**: untouched — it reuses core's collectors, so the field flows through and the dashboard simply ignores it.

Changeset declares the invariant explicitly: no finding, score, or exit-code movement — stderr diagnostics only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)