### PR TITLE
perf(cli): run independent collectors concurrently

### DIFF
--- a/.changeset/parallel-collectors.md
+++ b/.changeset/parallel-collectors.md
@@ -1,0 +1,6 @@
+---
+'svelte-vitals': patch
+'@svelte-vitals/vite': patch
+---
+
+The independent collection passes (routes, components, Kit modules, source files) now run concurrently instead of sequentially, shortening analysis wall time on larger projects. Same file reads, same results — only the awaiting overlaps.

--- a/packages/cli/src/collect-all.ts
+++ b/packages/cli/src/collect-all.ts
@@ -54,20 +54,24 @@ export async function collectAll(
   opts: CollectAllOptions = {}
 ): Promise<CollectedFacts> {
   const matches = routeMatcher(opts.route);
-  const collected = await collectRoutes(rt, cwd, config, opts.parseCache);
+  // project is resolved first: collectKitModuleFacts needs project.kitAliases, so
+  // everything else that's independent of it runs alongside it in one Promise.all.
+  const project = await collectProjectFacts(rt, cwd);
+  const [collected, components, kitModules, sourceFiles] = await Promise.all([
+    collectRoutes(rt, cwd, config, opts.parseCache),
+    // Component (Correctness) facts are file-scoped with no route attribution yet, so a
+    // route-filtered run skips them rather than reporting unrelated components (#68 review);
+    // kitModules is skipped for the same reason.
+    opts.route ? [] : collectComponentFacts(rt, cwd),
+    opts.route ? [] : collectKitModuleFacts(rt, cwd, project.kitAliases),
+    // Unlike its two neighbours above, the --route branch gets `undefined` here, not `[]`: an empty
+    // inventory would tell architecture/unit-entry-file that the declared unit directories truly do
+    // not exist, so it would report every declaration as inert, whereas `undefined` means the mode
+    // never collected the fact at all, and the rule stays silent instead of raising a false alarm.
+    opts.route ? undefined : collectSourceFiles(rt, cwd)
+  ]);
   const heads = collected.heads.filter((h) => matches(h.route));
   const images = collected.images.filter((i) => matches(i.route));
   const headings = collected.headings.filter((h) => matches(h.route));
-  const project = await collectProjectFacts(rt, cwd);
-  // Component (Correctness) facts are file-scoped with no route attribution yet, so a
-  // route-filtered run skips them rather than reporting unrelated components (#68 review);
-  // kitModules is skipped for the same reason.
-  const components = opts.route ? [] : await collectComponentFacts(rt, cwd);
-  const kitModules = opts.route ? [] : await collectKitModuleFacts(rt, cwd, project.kitAliases);
-  // Unlike its two neighbours above, the --route branch gets `undefined` here, not `[]`: an empty
-  // inventory would tell architecture/unit-entry-file that the declared unit directories truly do
-  // not exist, so it would report every declaration as inert, whereas `undefined` means the mode
-  // never collected the fact at all, and the rule stays silent instead of raising a false alarm.
-  const sourceFiles = opts.route ? undefined : await collectSourceFiles(rt, cwd);
   return { heads, images, headings, project, components, kitModules, sourceFiles };
 }

--- a/packages/vite/src/analyze.ts
+++ b/packages/vite/src/analyze.ts
@@ -87,14 +87,18 @@ export async function analyze(
 ): Promise<AnalyzeResult> {
   const { config, warnings } = resolved ?? (await resolveConfig(cwd, options));
 
-  const { heads, headings, images, htmlLang } = await collectRenderedHeads(prerenderPagesDir);
+  // collectRenderedProject needs htmlLang out of the rendered-head parse pass, so it can't
+  // join the Promise.all below; components/sourceFiles have no such dependency and do.
+  const [{ heads, headings, images, htmlLang }, components, sourceFiles] = await Promise.all([
+    collectRenderedHeads(prerenderPagesDir),
+    collectComponentFacts(cwd),
+    collectSourceFiles(cwd)
+  ]);
   const project = {
     ...(await collectRenderedProject(cwd, htmlLang)),
     ...extraProjectFacts
   };
-  const components = await collectComponentFacts(cwd);
   const kitModules = await collectKitModuleFacts(cwd, project.kitAliases);
-  const sourceFiles = await collectSourceFiles(cwd);
   const selected = selectRules(allRules, config);
   const { results: rawResults, examined } = await runRules(selected, {
     heads,


### PR DESCRIPTION
Audit item 2608-PERF-03 (plans/README.md backlog).

The collection phases awaited their collectors sequentially even though most are independent. Now:

- **cli `collect-all.ts`**: `project` resolves first (`collectKitModuleFacts` needs `project.kitAliases`), then routes, components, Kit modules, and source files run in one `Promise.all`. The `--route` short-circuits keep their exact semantics — including the deliberate `[]` vs `undefined` distinction for `sourceFiles` (empty-inventory vs not-collected, which `architecture/unit-entry-file` depends on); the explanatory comments moved with the code unchanged.
- **vite `analyze.ts`**: rendered heads, component facts, and source files overlap in one `Promise.all`; `collectRenderedProject` stays sequential because it consumes `htmlLang` from the rendered-head parse pass (a value dependency the audit note didn't list), and `kitModules` follows `project` as before.

Everything stays inside `Promise.all` (nothing floated), so an early rejection cannot strand an unhandled promise.

Verification: `io-budget.test.ts` passes **unchanged** — identical Runtime call counts, each glob still issued exactly once — which per AGENTS.md is the CI-gated signal here. `pnpm bench` on the synthetic local-disk project shows noise-level deltas (AST parsing dominates local I/O latency, as the bench's own comment notes); the win is overlap on higher-latency filesystems and larger trees. No test asserts await order; all output shapes are pinned by the existing suites (2,483 tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)