### PR TITLE
fix(cli): analyze every JSON-LD script per route instead of the last one

### DIFF
--- a/.changeset/additive-jsonld-tags.md
+++ b/.changeset/additive-jsonld-tags.md
@@ -1,0 +1,8 @@
+---
+'svelte-vitals': patch
+'@svelte-vitals/core': patch
+---
+
+The CLI's static mode now analyzes every `application/ld+json` script on a route — multiple tags in one head, tags split across the layout chain, and tags contributed by imported components — instead of silently keeping only the last one, matching what the vite plugin already does with rendered HTML. Gate movement: JSON-LD documents that were previously dropped are now checked by the whole json-ld rule family, so projects with defects in those documents will see new findings (warnings can turn a `--fail-on warning` run red, and Health can drop). Documents that were already the sole survivor are analyzed exactly as before.
+
+One movement in the head-tag presence rules: when multiple tags of the same kind match on a route — JSON-LD always can now, and rendered HTML can carry duplicate metas — the rule reports the strongest one (a satisfying tag beats an empty one, own beats inherited) instead of an arbitrary first/last survivor. A route with a valid document alongside an empty script now passes where it could (order-dependently) report 'Empty' before, so a previously-reported Empty finding can disappear; routes whose every script is empty still report Empty. Findings from layout- or component-contributed documents are attributed to the contributing file.

--- a/packages/cli/src/providers/source/routes.ts
+++ b/packages/cli/src/providers/source/routes.ts
@@ -137,6 +137,10 @@ async function resolveRoute(
 ): Promise<RouteFacts> {
   const files = chainFiles(pageRel, layouts);
   const composed = new Map<string, HeadTag>();
+  // JSON-LD is additive, not a singleton (issue #443): every document survives, in
+  // chain order (root layout -> ... -> page) and source order within a file, unlike
+  // composed's override-by-kind semantics for title/meta/link.
+  const jsonldTags: HeadTag[] = [];
   let broadOwn = false;
   let broadInherited = false;
   const images: ImageInfo[] = [];
@@ -155,7 +159,9 @@ async function resolveRoute(
 
     const resolved = await resolveFileTags(rt, cwd, rel, parsed, config, MAX_DEPTH, new Set([rel]), cache);
     for (const tag of resolved.tags) {
-      composed.set(tagKey(tag), { ...tag, presence: isPage ? 'own' : 'inherited', file: rel });
+      const stamped: HeadTag = { ...tag, presence: isPage ? 'own' : 'inherited', file: rel };
+      if (tag.kind === 'jsonld') jsonldTags.push(stamped);
+      else composed.set(tagKey(tag), stamped);
     }
     if (resolved.broad) {
       if (isPage) broadOwn = true;
@@ -175,7 +181,7 @@ async function resolveRoute(
 
   const route = deriveRoute(pageRel);
   return {
-    head: { route, source: 'static', tags: [...composed.values()], file: pageRel },
+    head: { route, source: 'static', tags: [...composed.values(), ...jsonldTags], file: pageRel },
     images: { route, images },
     headings: { route, headings, componentHeadings }
   };

--- a/packages/cli/test/source-provider.test.ts
+++ b/packages/cli/test/source-provider.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import {
+  seoJsonLdValidity,
   seoSingleH1,
   seoTitlePresence,
   type Config,
@@ -190,6 +191,67 @@ describe('collectRoutes componentHeadings (issue #425)', () => {
       { level: 3, line: expect.any(Number), file: 'src/routes/+page.svelte' }
     ]);
     expect(route.componentHeadings).toEqual([{ level: 1, line: expect.any(Number), file: 'src/lib/Card.svelte' }]);
+  });
+});
+
+describe('collectRoutes JSON-LD additivity (issue #443)', () => {
+  it('keeps both application/ld+json scripts in one <svelte:head>, each feeding seo/json-ld-validity separately', async () => {
+    const rt = createMemoryRuntime({
+      'src/routes/+page.svelte': `<svelte:head>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebSite","name":"Site","url":"https://example.com"}</script>
+  <script type="application/ld+json">{not valid json}</script>
+</svelte:head>`
+    });
+    const [head] = await collectHeads(rt, '');
+    expect(head!.tags.filter((t) => t.kind === 'jsonld')).toHaveLength(2);
+
+    const results = await seoJsonLdValidity.check({ heads: [head!], project: defaultProject, config: defaultConfig });
+    expect(results).toHaveLength(2);
+    expect(results.filter((r) => r.detection.presence === 'own')).toHaveLength(1); // the valid WebSite document
+    const finding = results.find((r) => r.detection.presence === 'none');
+    expect(finding?.message).toBe('JSON-LD is not valid JSON');
+  });
+
+  it('keeps a layout jsonld tag (inherited) alongside a page jsonld tag (own)', async () => {
+    const rt = createMemoryRuntime({
+      'src/routes/+layout.svelte': `<svelte:head><script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"Acme"}</script></svelte:head>`,
+      'src/routes/+page.svelte': `<svelte:head><script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Hi"}</script></svelte:head>`
+    });
+    const [head] = await collectHeads(rt, '');
+    const jsonldOnHead = head!.tags.filter((t) => t.kind === 'jsonld');
+    expect(jsonldOnHead).toHaveLength(2);
+    expect(jsonldOnHead.find((t) => t.file === 'src/routes/+layout.svelte')?.presence).toBe('inherited');
+    expect(jsonldOnHead.find((t) => t.file === 'src/routes/+page.svelte')?.presence).toBe('own');
+  });
+
+  it('keeps a $lib component jsonld tag alongside the page own jsonld tag', async () => {
+    const rt = createMemoryRuntime({
+      'src/routes/+page.svelte': `<script>import Seo from '$lib/Seo.svelte';</script><Seo /><svelte:head><script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Hi"}</script></svelte:head>`,
+      'src/lib/Seo.svelte': `<svelte:head><script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"Acme"}</script></svelte:head>`
+    });
+    const [head] = await collectHeads(rt, '');
+    expect(head!.tags.filter((t) => t.kind === 'jsonld')).toHaveLength(2);
+  });
+
+  it('still overrides the layout <title> with the page <title> (composed-path regression pin)', async () => {
+    const rt = createMemoryRuntime({
+      'src/routes/+layout.svelte': `<svelte:head><title>Layout title</title></svelte:head>`,
+      'src/routes/+page.svelte': `<svelte:head><title>Page title</title></svelte:head>`
+    });
+    const [head] = await collectHeads(rt, '');
+    expect(titleDetection(head!)).toEqual({ presence: 'own', value: 'static' });
+    expect(head!.tags.filter((t) => t.kind === 'title')).toHaveLength(1);
+  });
+
+  it('attributes a broken layout jsonld finding to the layout file, not the page', async () => {
+    const rt = createMemoryRuntime({
+      'src/routes/+layout.svelte': `<svelte:head><script type="application/ld+json">{not valid json}</script></svelte:head>`,
+      'src/routes/+page.svelte': `<svelte:head><script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","headline":"Hi"}</script></svelte:head>`
+    });
+    const [head] = await collectHeads(rt, '');
+    const results = await seoJsonLdValidity.check({ heads: [head!], project: defaultProject, config: defaultConfig });
+    const finding = results.find((r) => r.message === 'JSON-LD is not valid JSON');
+    expect(finding?.location).toBe('src/routes/+layout.svelte');
   });
 });
 

--- a/packages/core/src/rules/seo/head-tag-rule.ts
+++ b/packages/core/src/rules/seo/head-tag-rule.ts
@@ -25,7 +25,14 @@ export interface HeadTagRuleOptions {
 }
 
 function detect(head: ResolvedHead, match: (t: HeadTag) => boolean): Detection {
-  const tag = head.tags.find(match);
+  const matches = head.tags.filter(match);
+  // Additive kinds (jsonld) can match more than once. Report the strongest claim:
+  // a satisfying tag (value !== 'absent') beats an empty one, and an own tag beats
+  // an inherited one — so an empty script alongside a valid document never
+  // misreports the route, regardless of source order.
+  const rank = (t: HeadTag) => (t.value !== 'absent' ? 2 : 0) + (t.presence === 'own' ? 1 : 0);
+  let tag: HeadTag | undefined;
+  for (const m of matches) if (tag === undefined || rank(m) > rank(tag)) tag = m;
   return tag ? { presence: tag.presence, value: tag.value } : { presence: 'none', value: 'absent' };
 }
 

--- a/packages/core/src/rules/seo/json-ld-validity.ts
+++ b/packages/core/src/rules/seo/json-ld-validity.ts
@@ -85,7 +85,7 @@ export const seoJsonLdValidity: Rule = {
                 severity: 'warning',
                 detection: PENALIZED,
                 route: head.route,
-                location: head.file,
+                location: tag.file ?? head.file,
                 message: unknownTypeMessage(name),
                 recommendation: "Use the exact schema.org type name (case-sensitive), e.g. 'Article', 'Product'.",
                 docsUrl
@@ -103,7 +103,7 @@ export const seoJsonLdValidity: Rule = {
                 severity: 'warning',
                 detection: PENALIZED,
                 route: head.route,
-                location: head.file,
+                location: tag.file ?? head.file,
                 message: problem,
                 recommendation: 'Make the JSON-LD valid JSON with both @context and @type.',
                 docsUrl,
@@ -117,7 +117,7 @@ export const seoJsonLdValidity: Rule = {
                 route: head.route,
                 // Same `location` the penalized branch above uses (design
                 // 2026-08-08-pass-result-location-design.md).
-                location: head.file,
+                location: tag.file ?? head.file,
                 message: 'JSON-LD validity',
                 recommendation: 'Make the JSON-LD valid JSON with both @context and @type.',
                 docsUrl

--- a/packages/core/src/rules/seo/jsonld-engine.ts
+++ b/packages/core/src/rules/seo/jsonld-engine.ts
@@ -270,7 +270,7 @@ export function jsonldRule(opts: JsonLdRuleOptions): Rule {
                   severity: opts.severity,
                   detection: PENALIZED,
                   route: head.route,
-                  location: head.file,
+                  location: tag.file ?? head.file,
                   message: problem,
                   recommendation: opts.recommendation,
                   docsUrl,
@@ -284,7 +284,7 @@ export function jsonldRule(opts: JsonLdRuleOptions): Rule {
                   route: head.route,
                   // Same `location` the penalized branch above uses (design
                   // 2026-08-08-pass-result-location-design.md).
-                  location: head.file,
+                  location: tag.file ?? head.file,
                   message: opts.label,
                   recommendation: opts.recommendation,
                   docsUrl

--- a/packages/core/test/head-rules.test.ts
+++ b/packages/core/test/head-rules.test.ts
@@ -62,4 +62,41 @@ describe('head-tag rules', () => {
     expect(r!.severity).toBe('info');
     expect(r!.detection.presence).toBe('own');
   });
+  it('seo/json-ld reports own when an own tag matches alongside an inherited one (issue #443)', async () => {
+    const [r] = await seoJsonLd.check(
+      ctx([
+        { kind: 'jsonld', presence: 'inherited', value: 'static' },
+        { kind: 'jsonld', presence: 'own', value: 'static' }
+      ])
+    );
+    expect(r!.detection.presence).toBe('own');
+  });
+  it('seo/json-ld reports inherited when only an inherited tag matches', async () => {
+    const [r] = await seoJsonLd.check(ctx([{ kind: 'jsonld', presence: 'inherited', value: 'static' }]));
+    expect(r!.detection.presence).toBe('inherited');
+  });
+  it('seo/json-ld reports the satisfying own tag regardless of order vs. an empty own tag', async () => {
+    const [empty, valid] = [
+      { kind: 'jsonld' as const, presence: 'own' as const, value: 'absent' as const },
+      { kind: 'jsonld' as const, presence: 'own' as const, value: 'static' as const }
+    ];
+    const [before] = await seoJsonLd.check(ctx([empty, valid]));
+    expect(before!.detection).toEqual({ presence: 'own', value: 'static' });
+    const [after] = await seoJsonLd.check(ctx([valid, empty]));
+    expect(after!.detection).toEqual({ presence: 'own', value: 'static' });
+  });
+  it('seo/json-ld reports a valid inherited document over an empty own script', async () => {
+    const [r] = await seoJsonLd.check(
+      ctx([
+        { kind: 'jsonld', presence: 'inherited', value: 'static' },
+        { kind: 'jsonld', presence: 'own', value: 'absent' }
+      ])
+    );
+    expect(r!.detection).toEqual({ presence: 'inherited', value: 'static' });
+  });
+  it('seo/json-ld still reports Empty when every matching tag is empty', async () => {
+    const [r] = await seoJsonLd.check(ctx([{ kind: 'jsonld', presence: 'own', value: 'absent' }]));
+    expect(r!.detection).toEqual({ presence: 'own', value: 'absent' });
+    expect(r!.message).toBe('Empty JSON-LD (<script type="application/ld+json">)');
+  });
 });


### PR DESCRIPTION
Fixes #443.

## Problem

The source provider parses every `application/ld+json` script, but route composition folded all tags into an override `Map` where `tagKey` returns the bare constant `'jsonld'` — so the last-composed JSON-LD document won and every other one was silently dropped before any rule ran. Multi-document JSON-LD is idiomatic (Organization in the layout + Article on the page, two scripts in one head, a `$lib` SEO component contributing a document), and the vite plugin analyzes every script in rendered HTML — the providers disagreed on the same commit.

## Fix

Override semantics stay for singleton kinds (`title`, `meta`, `link`); JSON-LD is additive: `resolveRoute` accumulates jsonld tags in a separate ordered array (chain order, source order within a file, no deduplication — rendered-mode parity is the ground truth) and appends them after the composed tags. Child-component-contributed documents ride the same path.

**Presence rule (`seo/json-ld`) reports the strongest tag.** `headTagRule`'s generic `detect()` used `head.tags.find(match)` — safe before only because the map guaranteed at most one jsonld match. The executor's STOP caught the first-order problem (layout tag shadowing the page's `own`), and the independent review then measured that a first-own preference was still order-dependent when an empty `ld+json` script coexists with a valid document (valid-then-empty passed, empty-then-valid reported "Empty" on a route that HAS a valid document). `detect()` now ranks matches — a satisfying tag (`value !== 'absent'`) beats an empty one, `own` beats `inherited`, first-highest wins — making the report order-independent and truthful. Singleton kinds and rendered-mode duplicate-own sets degenerate to the previous first-match behavior.

**JSON-LD findings attribute to the contributing file.** The engine previously stamped every json-ld finding with `head.file` (the page); with layout/component documents newly analyzable, a broken layout document's finding would misattribute to the page and be invisible to `--diff` on layout-only edits (measured by the independent review). All five location sites now use `tag.file ?? head.file` — page-own documents keep identical keys, rendered mode falls back unchanged.

## Movements (declared in the changeset — `svelte-vitals` patch + `@svelte-vitals/core` patch)

1. Previously-dropped JSON-LD documents are now checked by the whole json-ld family: defects in them produce new findings (`--fail-on warning` can turn red, Health can drop). Sole-survivor documents are analyzed exactly as before; the vite plugin is untouched.
2. `seo/json-ld` reports the strongest document instead of an arbitrary composition-order survivor: a route with a valid document alongside an empty script now passes where it could (order-dependently) report "Empty" — a previously-reported Empty finding can disappear. Empty-only routes still report Empty.
3. Layout-/component-contributed findings carry the contributing file as `location` (these findings are all new — no existing keys churn).

The core patch also closes a release-ordering window the review identified: without it, the pending core minor could publish without the `detect()` change while the cli patch pins that core — shipping the inherited-shadowing regression.

## Tests

- cli: two scripts in one head both feed `seo/json-ld-validity`; layout (`inherited`) + page (`own`) both survive; `$lib` component document survives; layout-broken-doc finding located at the layout file; layout/page `<title>` override pinned unchanged.
- core: rank cells — `[empty, valid]` and `[valid, empty]` both → `{own, static}` (order independence); valid inherited beats empty own; empty-only still reports Empty; own beats inherited among satisfying tags; single inherited unchanged.

Mutation-checked (additive collection revert → 3 tests fail; `detect()` revert → rank pins fail). Coordinator re-measured the review's divergence fixtures on the final branch: valid+empty in both orders and the two-layout case all pass, empty-only exits 1. Full suite 2,527 green; io-budget unchanged.

Independent review round 1: request changes (the three findings above). All addressed; re-verification comment to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Static SEO analysis now evaluates all JSON-LD scripts across routes, layouts, and imported components.
  - JSON-LD findings identify the contributing source file when available.
  - Duplicate and inherited head tags are matched more accurately, prioritizing the most relevant valid tag.

- **Bug Fixes**
  - Improved handling of multiple JSON-LD scripts, title overrides, empty tags, and invalid inherited metadata.
  - Reduced misleading SEO findings when valid tags coexist with incomplete or invalid ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->