### PR TITLE
test(cli): pin help, error, and exit-code contracts ahead of the gunshi migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,10 @@ jobs:
       # correct here — actions/setup-node puts the matrix version on PATH.
       - name: Run the floor smoke on the matrix Node
         run: node scripts/floor-smoke.mjs
+      # dist is already built by this point (restored from cache or built above) — the
+      # gate-flag E2E (Phase 0 of the gunshi migration) runs the same built bin.js.
+      - name: Run the CLI gate-flag E2E
+        run: pnpm e2e
 
   floor-smoke:
     needs: check

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "typecheck": "pnpm -r typecheck",
     "test": "pnpm -r test",
     "smoke": "node scripts/floor-smoke.mjs",
+    "e2e": "node scripts/cli-e2e.mjs",
     "bench": "pnpm --filter svelte-vitals... build && pnpm --filter @svelte-vitals/vite run bench",
     "lint": "oxlint . && oxfmt --check .",
     "format": "oxfmt --write .",

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1,139 +1,14 @@
 #!/usr/bin/env node
-import { run } from './index.js';
-import { readPackageVersion, readCoreVersion } from './version.js';
-import { parseRunArgs, resolveArgs } from './resolve-args.js';
-import { runInstallCli, selectAppPrompt } from './install/cli.js';
-import { runCiCli } from './ci/cli.js';
-import { runExplainCli } from './explain.js';
+import { runCli } from './cli.js';
 
-const HELP = `svelte-vitals — a deterministic SvelteKit code-health scanner (SEO · performance · correctness · security · architecture)
-
-Usage:
-  svelte-vitals [path] [options]
-  svelte-vitals docs list        List the bundled guides (docs show <name> prints one)
-  svelte-vitals explain --list   List every rule (explain <rule-id> explains one)
-  svelte-vitals install          Set up the Vite integration, agent skills/rules, config file, or CI
-  svelte-vitals ci install       Add a GitHub Actions PR gate (annotations + summary comment)
-  svelte-vitals ci upgrade       Refresh the pinned @svelte-vitals/action in an existing workflow
-
-Options:
-  --meta-components <names>   Comma-separated component names that emit head metadata
-  --treat-dynamic-as <mode>   pass | warn | fail (default: pass)
-  --route <glob>              Only analyze routes matching this glob
-  --diff [ref]                Report only findings in files changed vs ref (default HEAD; e.g. --diff main)
-  --staged                    Report only findings in files staged for commit (pre-commit gate)
-  --baseline <ref>            Report only findings not present at ref (compare against e.g. origin/main)
-  --update-suppressions       Write svelte-vitals-suppressions.json accepting all current findings (introduce gates on legacy projects)
-  --no-suppressions           Ignore svelte-vitals-suppressions.json for this run
-  --by-route                  Show per-route score breakdown in console output
-  --reporter <fmt>            console | json | agent | sarif | github | html | md (auto: agent under AI-agent envs, github under GitHub Actions)
-  --out-file <path>           Output path for --reporter html (default: svelte-vitals-report.html; '-' for stdout)
-  --fail-on <severity>        Fail (exit 1) when any finding reaches this severity: critical | warning | info
-  --min-health <0-100>        Fail (exit 1) when the combined Health score is below this value
-  --rules <ids>               Comma-separated rule ids to enable (all others disabled)
-  --ignore <ids>              Comma-separated rule ids to disable
-  --category <cats>           Comma-separated categories to analyze: seo | performance | correctness | security | architecture
-  --weights <pairs>           Per-category Health weight overrides, e.g. seo=2,performance=1 (unlisted categories default to 1)
-  --score                     Print only the combined Health score (works with --min-health for gating)
-  --no-color                  Disable ANSI color in console output
-  --no-animation               Disable the Health-score reveal animation and mascot on an interactive terminal
-  --verbose                    Show every finding uncapped and ungrouped (default: capped, grouped by rule)
-  -h, --help                  Show this help
-  -v, --version               Show version
-
-Config file:
-  svelte-vitals.config.{mjs,js,ts} in the analyzed directory; flags override it.
-
-Exit codes:
-  0  no failing findings
-  1  critical finding present (or --fail-on threshold reached)
-  2  execution error (not a SvelteKit project / internal error)
-
-If you are an AI agent:
-  - \`svelte-vitals docs list\` then \`docs show <name>\` — the guides ship inside this CLI, so
-    they match this exact version and need no network. Read those before searching the web.
-  - \`--reporter agent\` gives every failing finding a location, a concrete fix and an acceptance
-    check; it is auto-selected when an agent environment is detected. \`--reporter json\` is the
-    structured form.
-  - \`--diff\` scopes the report to what you just changed; \`--staged\` is the pre-commit gate.
-  - \`svelte-vitals explain <rule-id>\` says why a rule exists and which options it takes, before
-    you decide to turn it off.
-  - Do NOT reach for \`--update-suppressions\` to make a run pass: it accepts every current
-    finding into a committed file and un-gates CI for all of them. Fix the findings, or scope
-    the run with \`--diff\`. Only a human should decide to accept a backlog.
-  - Exit 2 is never a pass — it means the analysis did not run. Read stderr.
-  - Analysis never prompts when stdout is not a TTY: where it would have asked, it exits 2
-    naming the flag to pass. \`install\` is the exception — non-interactively it skips its
-    confirmation and writes, so pass \`--dry-run\` first if you need to see the plan.`;
-
-const VERSION = readPackageVersion();
-
-/** Monorepo app picker (design doc 2026-07-08-monorepo-app-picker-design.md): single-select via @clack/prompts, same style as the `install` wizard. */
-function selectApp(apps: string[]): Promise<string | null> {
-  return selectAppPrompt(apps, 'Multiple SvelteKit apps found — which one should svelte-vitals analyze?');
-}
-
-/** CLI entrypoint: dispatches `docs`/`explain`/`install`/`ci` subcommands, otherwise parses argv, resolves it into `run()` options, executes the analysis, and exits with the resulting code. */
+/** Thin entry point: `runCli` does the full dispatch and never exits the process itself — see `CliResult.exit` for why the two mechanics below still have to differ per path. */
 async function main(): Promise<void> {
-  const rawArgs = process.argv.slice(2);
-  // `docs` and `explain` set `process.exitCode` and return rather than calling `process.exit`:
-  // writes to a pipe are asynchronous, and exiting can discard whatever has not drained. Both
-  // are pure-sync and hold no handles, so returning always terminates. (`install`/`ci` and the
-  // analysis path below still exit directly — they hold prompts and timers, where returning
-  // could hang instead; their large-output paths deserve the same treatment separately.)
-  if (rawArgs[0] === 'docs') {
-    // Loaded on demand: the bundled topics are ~20KB of string literals that the analysis path
-    // — the one the I/O budget test and `pnpm bench` defend — would otherwise parse every run.
-    const { runDocsCli } = await import('./docs/cli.js');
-    process.exitCode = runDocsCli(rawArgs.slice(1));
-    return;
-  }
-  if (rawArgs[0] === 'explain') {
-    process.exitCode = runExplainCli(rawArgs.slice(1));
-    return;
-  }
-  if (rawArgs[0] === 'install') {
-    const code = await runInstallCli(rawArgs.slice(1));
+  const { code, exit } = await runCli(process.argv.slice(2));
+  if (exit === 'immediate') {
     process.exit(code);
+  } else {
+    process.exitCode = code;
   }
-  if (rawArgs[0] === 'ci') {
-    const code = await runCiCli(rawArgs.slice(1));
-    process.exit(code);
-  }
-
-  const argv = parseRunArgs(rawArgs);
-
-  if (argv.help) {
-    console.log(HELP);
-    return;
-  }
-  if (argv.version) {
-    // Printing the resolved core version alongside the CLI's own lets users compare
-    // it directly against the `@svelte-vitals/vite` live dashboard's "core vX.Y.Z" line —
-    // the two packages are versioned independently and can drift (see docs).
-    console.log(`${VERSION} (core ${readCoreVersion()})`);
-    // stdout stays exactly the version string so it can be parsed; the pointer goes to stderr.
-    // An agent that runs only `--version` and never `--help` still learns the guides exist.
-    console.error('svelte-vitals: run `svelte-vitals docs list` for the bundled guides.');
-    return;
-  }
-
-  const { options, warnings, errors, minHealth } = resolveArgs(argv);
-  for (const w of warnings) console.error(w);
-  for (const e of errors) console.error(e);
-  if (!options) process.exit(2);
-
-  const code = await run({
-    ...options,
-    minHealth,
-    selectApp
-  });
-  // A write to a pipe is asynchronous, so `process.exit` can discard what has not drained — the report is
-  // the largest thing this CLI writes and the first pipe buffer is 65,536 bytes. The empty write's callback
-  // fires once the stream has flushed. `process.exit` rather than `process.exitCode` because this path can
-  // hold an interactive prompt, where returning could hang instead.
-  await new Promise((resolve) => process.stdout.write('', resolve));
-  process.exit(code);
 }
 
 void main();

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,0 +1,154 @@
+import { run } from './index.js';
+import { readPackageVersion, readCoreVersion } from './version.js';
+import { parseRunArgs, resolveArgs } from './resolve-args.js';
+import { runInstallCli, selectAppPrompt, realIO } from './install/cli.js';
+import { runCiCli } from './ci/cli.js';
+import { runExplainCli } from './explain.js';
+import { consoleIO, type CliIO } from './cli-io.js';
+
+const HELP = `svelte-vitals — a deterministic SvelteKit code-health scanner (SEO · performance · correctness · security · architecture)
+
+Usage:
+  svelte-vitals [path] [options]
+  svelte-vitals docs list        List the bundled guides (docs show <name> prints one)
+  svelte-vitals explain --list   List every rule (explain <rule-id> explains one)
+  svelte-vitals install          Set up the Vite integration, agent skills/rules, config file, or CI
+  svelte-vitals ci install       Add a GitHub Actions PR gate (annotations + summary comment)
+  svelte-vitals ci upgrade       Refresh the pinned @svelte-vitals/action in an existing workflow
+
+Options:
+  --meta-components <names>   Comma-separated component names that emit head metadata
+  --treat-dynamic-as <mode>   pass | warn | fail (default: pass)
+  --route <glob>              Only analyze routes matching this glob
+  --diff [ref]                Report only findings in files changed vs ref (default HEAD; e.g. --diff main)
+  --staged                    Report only findings in files staged for commit (pre-commit gate)
+  --baseline <ref>            Report only findings not present at ref (compare against e.g. origin/main)
+  --update-suppressions       Write svelte-vitals-suppressions.json accepting all current findings (introduce gates on legacy projects)
+  --no-suppressions           Ignore svelte-vitals-suppressions.json for this run
+  --by-route                  Show per-route score breakdown in console output
+  --reporter <fmt>            console | json | agent | sarif | github | html | md (auto: agent under AI-agent envs, github under GitHub Actions)
+  --out-file <path>           Output path for --reporter html (default: svelte-vitals-report.html; '-' for stdout)
+  --fail-on <severity>        Fail (exit 1) when any finding reaches this severity: critical | warning | info
+  --min-health <0-100>        Fail (exit 1) when the combined Health score is below this value
+  --rules <ids>               Comma-separated rule ids to enable (all others disabled)
+  --ignore <ids>              Comma-separated rule ids to disable
+  --category <cats>           Comma-separated categories to analyze: seo | performance | correctness | security | architecture
+  --weights <pairs>           Per-category Health weight overrides, e.g. seo=2,performance=1 (unlisted categories default to 1)
+  --score                     Print only the combined Health score (works with --min-health for gating)
+  --no-color                  Disable ANSI color in console output
+  --no-animation               Disable the Health-score reveal animation and mascot on an interactive terminal
+  --verbose                    Show every finding uncapped and ungrouped (default: capped, grouped by rule)
+  -h, --help                  Show this help
+  -v, --version               Show version
+
+Config file:
+  svelte-vitals.config.{mjs,js,ts} in the analyzed directory; flags override it.
+
+Exit codes:
+  0  no failing findings
+  1  critical finding present (or --fail-on threshold reached)
+  2  execution error (not a SvelteKit project / internal error)
+
+If you are an AI agent:
+  - \`svelte-vitals docs list\` then \`docs show <name>\` — the guides ship inside this CLI, so
+    they match this exact version and need no network. Read those before searching the web.
+  - \`--reporter agent\` gives every failing finding a location, a concrete fix and an acceptance
+    check; it is auto-selected when an agent environment is detected. \`--reporter json\` is the
+    structured form.
+  - \`--diff\` scopes the report to what you just changed; \`--staged\` is the pre-commit gate.
+  - \`svelte-vitals explain <rule-id>\` says why a rule exists and which options it takes, before
+    you decide to turn it off.
+  - Do NOT reach for \`--update-suppressions\` to make a run pass: it accepts every current
+    finding into a committed file and un-gates CI for all of them. Fix the findings, or scope
+    the run with \`--diff\`. Only a human should decide to accept a backlog.
+  - Exit 2 is never a pass — it means the analysis did not run. Read stderr.
+  - Analysis never prompts when stdout is not a TTY: where it would have asked, it exits 2
+    naming the flag to pass. \`install\` is the exception — non-interactively it skips its
+    confirmation and writes, so pass \`--dry-run\` first if you need to see the plan.`;
+
+const VERSION = readPackageVersion();
+
+/** Monorepo app picker (design doc 2026-07-08-monorepo-app-picker-design.md): single-select via @clack/prompts, same style as the `install` wizard. */
+function selectApp(apps: string[]): Promise<string | null> {
+  return selectAppPrompt(apps, 'Multiple SvelteKit apps found — which one should svelte-vitals analyze?');
+}
+
+export interface CliResult {
+  code: number;
+  /**
+   * How `bin.ts`'s thin entry should terminate the process:
+   * - `'natural'` — set `process.exitCode` and return; the path is pure-sync and holds no
+   *   handles (`docs`/`explain`/`--help`/`--version`), so an explicit `process.exit` would
+   *   only risk truncating an unflushed pipe write for no benefit.
+   * - `'immediate'` — call `process.exit(code)` right away. `install`/`ci` hold prompts/timers
+   *   that could hang a natural exit; an argv-resolution error exits before any output large
+   *   enough to need a flush; the analyzer path below has already awaited its own stdout flush
+   *   by the time it returns this, so `process.exit` here is safe.
+   */
+  exit: 'natural' | 'immediate';
+}
+
+/**
+ * CLI dispatch: routes `docs`/`explain`/`install`/`ci` subcommands, otherwise parses argv,
+ * resolves it into `run()` options, executes the analysis, and computes the exit code. Never
+ * calls `process.exit` itself — see `CliResult.exit` for why the caller still needs to pick
+ * between `process.exit` and `process.exitCode` per path.
+ */
+export async function runCli(argv: string[], io: CliIO = consoleIO): Promise<CliResult> {
+  if (argv[0] === 'docs') {
+    // Loaded on demand: the bundled topics are ~20KB of string literals that the analysis path
+    // — the one the I/O budget test and `pnpm bench` defend — would otherwise parse every run.
+    const { runDocsCli } = await import('./docs/cli.js');
+    return { code: runDocsCli(argv.slice(1), io), exit: 'natural' };
+  }
+  if (argv[0] === 'explain') {
+    return { code: runExplainCli(argv.slice(1), io), exit: 'natural' };
+  }
+  if (argv[0] === 'install') {
+    return { code: await runInstallCli(argv.slice(1), io), exit: 'immediate' };
+  }
+  if (argv[0] === 'ci') {
+    // ci's own IO is disk-backed (realIO()) for reading/writing the workflow file; only the
+    // log/errorLog sinks are swapped for the caller's, so a test-injected `io` still observes
+    // everything ci prints without having to fake the filesystem for paths that never touch it
+    // (--help, the error surfaces below).
+    const code = await runCiCli(argv.slice(1), { ...realIO(), log: io.log, errorLog: io.errorLog });
+    return { code, exit: 'immediate' };
+  }
+
+  const parsed = parseRunArgs(argv);
+
+  if (parsed.help) {
+    io.log(HELP);
+    return { code: 0, exit: 'natural' };
+  }
+  if (parsed.version) {
+    // Printing the resolved core version alongside the CLI's own lets users compare
+    // it directly against the `@svelte-vitals/vite` live dashboard's "core vX.Y.Z" line —
+    // the two packages are versioned independently and can drift (see docs).
+    io.log(`${VERSION} (core ${readCoreVersion()})`);
+    // stdout stays exactly the version string so it can be parsed; the pointer goes to stderr.
+    // An agent that runs only `--version` and never `--help` still learns the guides exist.
+    io.errorLog('svelte-vitals: run `svelte-vitals docs list` for the bundled guides.');
+    return { code: 0, exit: 'natural' };
+  }
+
+  const { options, warnings, errors, minHealth } = resolveArgs(parsed);
+  for (const w of warnings) io.errorLog(w);
+  for (const e of errors) io.errorLog(e);
+  if (!options) return { code: 2, exit: 'immediate' };
+
+  const code = await run({
+    ...options,
+    minHealth,
+    selectApp,
+    log: io.log,
+    errorLog: io.errorLog
+  });
+  // A write to a pipe is asynchronous, so `process.exit` can discard what has not drained — the report is
+  // the largest thing this CLI writes and the first pipe buffer is 65,536 bytes. The empty write's callback
+  // fires once the stream has flushed, so it's safe for the thin entry to call `process.exit` as soon as
+  // this resolves.
+  await new Promise((resolve) => process.stdout.write('', resolve));
+  return { code, exit: 'immediate' };
+}

--- a/packages/cli/src/install/cli.ts
+++ b/packages/cli/src/install/cli.ts
@@ -5,6 +5,7 @@ import * as p from '@clack/prompts';
 import { runInstall, type InstallIO, type InstallPrompts } from './index.js';
 import { parseInstallArgs, resolveInstallArgs } from './args.js';
 import { readPackageVersion } from '../version.js';
+import { consoleIO, type CliIO } from '../cli-io.js';
 import type { SelectableOption, TargetId } from './index.js';
 
 const INSTALL_HELP = `svelte-vitals install — set up the svelte-vitals Vite integration, agent skills/rules, config file, and CI
@@ -130,15 +131,15 @@ function clackPrompts(): InstallPrompts {
 }
 
 /** Parse install args, print diagnostics, and run the wizard. Returns the exit code. */
-export async function runInstallCli(args: string[]): Promise<number> {
+export async function runInstallCli(args: string[], io: CliIO = consoleIO): Promise<number> {
   const argv = parseInstallArgs(args);
   if (argv.help) {
-    console.log(INSTALL_HELP);
+    io.log(INSTALL_HELP);
     return 0;
   }
   const { flags, warnings, errors } = resolveInstallArgs(argv);
-  for (const w of warnings) console.error(w);
-  for (const e of errors) console.error(e);
+  for (const w of warnings) io.errorLog(w);
+  for (const e of errors) io.errorLog(e);
   if (!flags) return 2;
   return runInstall(flags, realIO(), clackPrompts(), readPackageVersion());
 }

--- a/packages/cli/test/__snapshots__/help-golden.test.ts.snap
+++ b/packages/cli/test/__snapshots__/help-golden.test.ts.snap
@@ -1,0 +1,188 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`help goldens > --version 1`] = `
+{
+  "err": "svelte-vitals: run \`svelte-vitals docs list\` for the bundled guides.",
+  "out": "X.Y.Z (core X.Y.Z)",
+}
+`;
+
+exports[`help goldens > ci --help 1`] = `
+{
+  "err": "",
+  "out": "svelte-vitals ci — scaffold CI integration
+
+Usage:
+  svelte-vitals ci install [options]
+  svelte-vitals ci upgrade [--dry-run]
+
+Adds a GitHub Actions workflow (.github/workflows/svelte-vitals.yml) that calls the \`@svelte-vitals/action\`
+GitHub Action on pull requests: inline annotations, a job summary, and a sticky PR
+comment with the findings.
+
+\`ci upgrade\` rewrites only the pinned \`@svelte-vitals/action\` reference in an existing
+workflow to the pin bundled with this CLI, leaving the rest of the file (and any other
+pins, like actions/checkout) untouched. To pick up the latest pin, run
+\`npx svelte-vitals@latest ci upgrade\`.
+
+Options:
+  --force       Overwrite an existing workflow file (install only)
+  --dry-run     Print the plan and exit without writing
+  -h, --help    Show this help",
+}
+`;
+
+exports[`help goldens > docs --help 1`] = `
+{
+  "err": "",
+  "out": "svelte-vitals docs — read the bundled guides without leaving the terminal
+
+Usage:
+  svelte-vitals docs list [--json]     List every topic with a one-line description
+  svelte-vitals docs show <name>       Print a topic
+
+Options:
+  --json        Machine-readable output (list only)
+  -h, --help    Show this help
+
+The topics ship inside the CLI, so they always match the version you are running and need no
+network. The full docs site is at https://oekazuma.github.io/svelte-vitals.
+
+\`docs\` is a subcommand, so it wins over a directory of the same name: to analyze a directory
+called \`docs\`, write \`svelte-vitals ./docs\`.",
+}
+`;
+
+exports[`help goldens > explain --help 1`] = `
+{
+  "err": "",
+  "out": "svelte-vitals explain — print a rule's rationale, fix, and configurable options
+
+Usage:
+  svelte-vitals explain --list          List every rule id, grouped by category
+  svelte-vitals explain <rule-id>       Explain one rule
+
+Options:
+  --list        List every rule instead of explaining one
+  --json        Machine-readable output (works with --list and with a rule id)
+  -h, --help    Show this help
+
+Rule ids are category/kebab-case and matched exactly, e.g. \`svelte-vitals explain seo/ssr-disabled\`.",
+}
+`;
+
+exports[`help goldens > install --help 1`] = `
+{
+  "err": "",
+  "out": "svelte-vitals install — set up the svelte-vitals Vite integration, agent skills/rules, config file, and CI
+
+Usage:
+  svelte-vitals install [options]
+
+Options:
+  --client <ids>    Comma-separated: vite-plugin,vite-hooks,claude-skill,cursor-rules,claude-skill-improve,config-file,ci-workflow
+                    (skips the interactive picker; the picker groups these by category —
+                    Vite integration, Agent Skills & rules, CI, Config file)
+                    vite-plugin registers the build-mode plugin in vite.config.{ts,js,mjs}; vite-hooks
+                    wires up the svelteVitalsHandle hook in src/hooks.server.{ts,js}, which improves the
+                    live dashboard's per-route accuracy as you browse. --force does not apply
+                    to either of these two — an existing registration is always left as-is.
+                    claude-skill writes an agent skill (Claude Code, Codex, and Cursor —
+                    .claude/skills/, .agents/skills/, and .cursor/skills/ under svelte-vitals/);
+                    cursor-rules writes a Cursor rules file (.cursor/rules/svelte-vitals.mdc).
+                    Both are generated from the current rule set and support --force to regenerate.
+                    claude-skill-improve writes a second, read-only agent skill (same three
+                    locations, under improve-svelte/) that audits the whole project and writes
+                    implementation plans instead of a run-after-every-edit playbook; also
+                    supports --force.
+                    config-file scaffolds svelte-vitals.config.{mjs,ts} with every option commented
+                    out, auto-picking .ts (with defineConfig) when the current Node supports it, the
+                    project looks TypeScript-oriented (tsconfig.json or vite.config.ts present), and
+                    svelte-vitals is a declared dependency (defineConfig's import resolves at load
+                    time); else the safe .mjs default. Supports --force to regenerate the file
+                    that's already there (its extension never changes on --force).
+                    ci-workflow scaffolds .github/workflows/svelte-vitals.yml, the same file
+                    \`svelte-vitals ci install\` writes standalone — pick it here to set it up in
+                    the same pass as everything else; supports --force to regenerate. \`svelte-vitals
+                    ci upgrade\` remains the way to bump an existing workflow's pinned action version.
+  --app <dir>       Monorepo: the SvelteKit app directory the vite-plugin/vite-hooks/config-file
+                    targets write into (e.g. --app apps/web). Without it, when the current
+                    directory isn't itself a SvelteKit app, one detected app is used
+                    automatically (with a notice), several prompt a picker on a TTY, and
+                    non-interactive runs exit 2 asking for --app. All other targets
+                    (skills, ci-workflow) always write at the current directory —
+                    the repo root is their correct home.
+  --yes, -y         Skip the confirmation prompt
+  --dry-run         Print the planned changes and exit without writing
+  --force           Overwrite an existing svelte-vitals entry
+  --refresh         Regenerate existing agent skill/rules files with the current rule set
+                    (claude-skill / cursor-rules / claude-skill-improve). Only regenerates files already
+                    present on disk — it never creates one. Cannot be combined with --client.
+  -h, --help        Show this help",
+}
+`;
+
+exports[`help goldens > root --help 1`] = `
+{
+  "err": "",
+  "out": "svelte-vitals — a deterministic SvelteKit code-health scanner (SEO · performance · correctness · security · architecture)
+
+Usage:
+  svelte-vitals [path] [options]
+  svelte-vitals docs list        List the bundled guides (docs show <name> prints one)
+  svelte-vitals explain --list   List every rule (explain <rule-id> explains one)
+  svelte-vitals install          Set up the Vite integration, agent skills/rules, config file, or CI
+  svelte-vitals ci install       Add a GitHub Actions PR gate (annotations + summary comment)
+  svelte-vitals ci upgrade       Refresh the pinned @svelte-vitals/action in an existing workflow
+
+Options:
+  --meta-components <names>   Comma-separated component names that emit head metadata
+  --treat-dynamic-as <mode>   pass | warn | fail (default: pass)
+  --route <glob>              Only analyze routes matching this glob
+  --diff [ref]                Report only findings in files changed vs ref (default HEAD; e.g. --diff main)
+  --staged                    Report only findings in files staged for commit (pre-commit gate)
+  --baseline <ref>            Report only findings not present at ref (compare against e.g. origin/main)
+  --update-suppressions       Write svelte-vitals-suppressions.json accepting all current findings (introduce gates on legacy projects)
+  --no-suppressions           Ignore svelte-vitals-suppressions.json for this run
+  --by-route                  Show per-route score breakdown in console output
+  --reporter <fmt>            console | json | agent | sarif | github | html | md (auto: agent under AI-agent envs, github under GitHub Actions)
+  --out-file <path>           Output path for --reporter html (default: svelte-vitals-report.html; '-' for stdout)
+  --fail-on <severity>        Fail (exit 1) when any finding reaches this severity: critical | warning | info
+  --min-health <0-100>        Fail (exit 1) when the combined Health score is below this value
+  --rules <ids>               Comma-separated rule ids to enable (all others disabled)
+  --ignore <ids>              Comma-separated rule ids to disable
+  --category <cats>           Comma-separated categories to analyze: seo | performance | correctness | security | architecture
+  --weights <pairs>           Per-category Health weight overrides, e.g. seo=2,performance=1 (unlisted categories default to 1)
+  --score                     Print only the combined Health score (works with --min-health for gating)
+  --no-color                  Disable ANSI color in console output
+  --no-animation               Disable the Health-score reveal animation and mascot on an interactive terminal
+  --verbose                    Show every finding uncapped and ungrouped (default: capped, grouped by rule)
+  -h, --help                  Show this help
+  -v, --version               Show version
+
+Config file:
+  svelte-vitals.config.{mjs,js,ts} in the analyzed directory; flags override it.
+
+Exit codes:
+  0  no failing findings
+  1  critical finding present (or --fail-on threshold reached)
+  2  execution error (not a SvelteKit project / internal error)
+
+If you are an AI agent:
+  - \`svelte-vitals docs list\` then \`docs show <name>\` — the guides ship inside this CLI, so
+    they match this exact version and need no network. Read those before searching the web.
+  - \`--reporter agent\` gives every failing finding a location, a concrete fix and an acceptance
+    check; it is auto-selected when an agent environment is detected. \`--reporter json\` is the
+    structured form.
+  - \`--diff\` scopes the report to what you just changed; \`--staged\` is the pre-commit gate.
+  - \`svelte-vitals explain <rule-id>\` says why a rule exists and which options it takes, before
+    you decide to turn it off.
+  - Do NOT reach for \`--update-suppressions\` to make a run pass: it accepts every current
+    finding into a committed file and un-gates CI for all of them. Fix the findings, or scope
+    the run with \`--diff\`. Only a human should decide to accept a backlog.
+  - Exit 2 is never a pass — it means the analysis did not run. Read stderr.
+  - Analysis never prompts when stdout is not a TTY: where it would have asked, it exits 2
+    naming the flag to pass. \`install\` is the exception — non-interactively it skips its
+    confirmation and writes, so pass \`--dry-run\` first if you need to see the plan.",
+}
+`;

--- a/packages/cli/test/cli-contract.test.ts
+++ b/packages/cli/test/cli-contract.test.ts
@@ -1,0 +1,179 @@
+// Phase 0 of the gunshi migration (docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md):
+// pins the bin-level guard class and dispatch quirks through the real `runCli` seam, one
+// representative per class. `resolve-args.test.ts` (59 cases) already owns the exhaustive
+// per-flag matrix at the `resolveArgs` layer — this file does not duplicate it; it only proves
+// the same guard reaches an end user through the full dispatch, with the right exit code and
+// stdout/stderr shape.
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runCli, type CliResult } from '../src/cli.js';
+import { captureIO } from './helpers/capture-io.js';
+
+async function cli(args: string[]): Promise<CliResult & { out: string; err: string }> {
+  const io = captureIO();
+  const result = await runCli(args, io);
+  return { ...result, out: io.out, err: io.err };
+}
+
+const dirs: string[] = [];
+function tmpProjectDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'svelte-vitals-cli-contract-'));
+  dirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  while (dirs.length > 0) {
+    const dir = dirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('unknown/malformed flags', () => {
+  it('an unknown flag is silently ignored, not rejected — parseArgs(strict:false) passthrough', async () => {
+    // A non-project dir gives a deterministic, unrelated exit-2 reason; the assertion is that
+    // NOTHING about '--nonsense-flag' appears in stderr, proving it was never even inspected.
+    const dir = tmpProjectDir();
+    const { code, err, exit } = await cli(['--nonsense-flag', dir]);
+    expect(code).toBe(2);
+    expect(exit).toBe('immediate');
+    expect(err).not.toContain('nonsense-flag');
+    expect(err).toContain('No SvelteKit project found');
+  });
+
+  it('an unknown value for an enum flag (--reporter) is a fatal argv error', async () => {
+    const { code, out, err, exit } = await cli(['--reporter', 'nope']);
+    expect(code).toBe(2);
+    expect(exit).toBe('immediate');
+    expect(out).toBe('');
+    expect(err).toContain("unknown reporter 'nope'");
+  });
+
+  it('--reporter= (empty value) is rejected by both the value guard and the enum check', async () => {
+    const { code, out, err } = await cli(['--reporter=']);
+    expect(code).toBe(2);
+    expect(out).toBe('');
+    expect(err).toContain('svelte-vitals: --reporter requires a value.');
+    expect(err).toContain("unknown reporter ''");
+  });
+
+  it('--reporter followed by another flag consumes it as the value, then rejects it', async () => {
+    const { code, out, err } = await cli(['--reporter', '--json']);
+    expect(code).toBe(2);
+    expect(out).toBe('');
+    expect(err).toContain('svelte-vitals: --reporter requires a value.');
+    expect(err).toContain("unknown reporter '--json'");
+  });
+});
+
+describe('--out-file accepts the literal stdout marker', () => {
+  it('--out-file - is accepted (fails later, for an unrelated project-detection reason)', async () => {
+    const dir = tmpProjectDir();
+    const { code, err } = await cli(['--out-file', '-', dir]);
+    expect(code).toBe(2);
+    expect(err).not.toContain('--out-file requires a value');
+    expect(err).toContain('No SvelteKit project found');
+  });
+
+  it('--out-file=- is accepted the same way', async () => {
+    const dir = tmpProjectDir();
+    const { code, err } = await cli([`--out-file=-`, dir]);
+    expect(code).toBe(2);
+    expect(err).not.toContain('--out-file requires a value');
+    expect(err).toContain('No SvelteKit project found');
+  });
+});
+
+describe('--min-health', () => {
+  it('rejects a non-numeric value', async () => {
+    const { code, out, err } = await cli(['--min-health', 'abc']);
+    expect(code).toBe(2);
+    expect(out).toBe('');
+    expect(err).toContain("invalid --min-health 'abc'; expected a number 0-100.");
+  });
+
+  it('rejects an out-of-range value', async () => {
+    const { code, out, err } = await cli(['--min-health', '150']);
+    expect(code).toBe(2);
+    expect(out).toBe('');
+    expect(err).toContain("invalid --min-health '150'; expected a number 0-100.");
+  });
+});
+
+describe('--rules x --category conflict', () => {
+  it('a --rules id excluded by --category is a fatal error', async () => {
+    const { code, out, err } = await cli(['--rules', 'seo/title-presence', '--category', 'performance']);
+    expect(code).toBe(2);
+    expect(out).toBe('');
+    expect(err).toContain('--rules id(s) excluded by --category performance: seo/title-presence');
+  });
+});
+
+describe('docs show', () => {
+  it('an unknown topic prints the generic error, stdout empty', async () => {
+    const { code, out, err } = await cli(['docs', 'show', 'no-such-topic']);
+    expect(code).toBe(2);
+    expect(out).toBe('');
+    expect(err).toContain("unknown docs topic 'no-such-topic'");
+  });
+
+  it('a rule id redirects to `explain` instead of the generic error, stdout empty', async () => {
+    const { code, out, err } = await cli(['docs', 'show', 'seo/title-presence']);
+    expect(code).toBe(2);
+    expect(out).toBe('');
+    expect(err).toContain("'seo/title-presence' is a rule, not a docs topic");
+    expect(err).toContain('svelte-vitals explain seo/title-presence');
+  });
+});
+
+describe('explain', () => {
+  it('an unknown rule id errors, stdout empty', async () => {
+    const { code, out, err } = await cli(['explain', 'not/a-rule']);
+    expect(code).toBe(2);
+    expect(out).toBe('');
+    expect(err).toContain("unknown rule id 'not/a-rule'");
+  });
+});
+
+describe('subcommand-vs-path dispatch', () => {
+  it('the literal `docs` positional routes to the subcommand', async () => {
+    const { code, out } = await cli(['docs', 'list']);
+    expect(code).toBe(0);
+    expect(out).toContain('Topics');
+  });
+
+  it('a `./docs`-style path is not the subcommand — it falls through to the analyzer', async () => {
+    const dir = tmpProjectDir();
+    const prevCwd = process.cwd();
+    process.chdir(dir);
+    try {
+      const { code, out, err, exit } = await cli(['./docs']);
+      expect(code).toBe(2);
+      expect(exit).toBe('immediate');
+      expect(out).toBe('');
+      expect(err).toContain('No SvelteKit project found');
+    } finally {
+      process.chdir(prevCwd);
+    }
+  });
+});
+
+describe('ci/install exit-2 surfaces', () => {
+  it('ci with an unknown sub-subcommand prints CI_HELP to stdout and exits 2 (not the docs/explain empty-stdout contract)', async () => {
+    const { code, out, err } = await cli(['ci', 'bogus']);
+    expect(code).toBe(2);
+    // Unlike docs/explain, ci's non-help error path writes its help text via `io.log` (stdout),
+    // not `io.errorLog` — a real quirk this suite pins as-is rather than smoothing over.
+    expect(out).toContain('svelte-vitals ci — scaffold CI integration');
+    expect(err).toBe('');
+  });
+
+  it('install with an unknown --client value warns per-value then fails fatally, exit 2', async () => {
+    const { code, out, err } = await cli(['install', '--client', 'bogus']);
+    expect(code).toBe(2);
+    expect(out).toBe('');
+    expect(err).toContain("unknown --client 'bogus'");
+    expect(err).toContain('no valid --client values');
+  });
+});

--- a/packages/cli/test/help-golden.test.ts
+++ b/packages/cli/test/help-golden.test.ts
@@ -1,0 +1,65 @@
+// Phase 0 of the gunshi migration (docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md):
+// pins every command surface's help/version output before any gunshi code exists, so a Phase 2
+// diff review is a snapshot diff against this file. Update these snapshots only for a deliberate,
+// declared help-format change — never to make a CI failure go away.
+import { describe, it, expect } from 'vitest';
+import { runCli } from '../src/cli.js';
+import { captureIO } from './helpers/capture-io.js';
+
+async function cli(args: string[]): Promise<{ code: number; out: string; err: string }> {
+  const io = captureIO();
+  const { code } = await runCli(args, io);
+  return { code, out: io.out, err: io.err };
+}
+
+describe('help goldens', () => {
+  it('root --help', async () => {
+    const { code, out, err } = await cli(['--help']);
+    expect(code).toBe(0);
+    expect({ out, err }).toMatchSnapshot();
+  });
+
+  it('docs --help', async () => {
+    const { code, out, err } = await cli(['docs', '--help']);
+    expect(code).toBe(0);
+    expect({ out, err }).toMatchSnapshot();
+  });
+
+  it('explain --help', async () => {
+    const { code, out, err } = await cli(['explain', '--help']);
+    expect(code).toBe(0);
+    expect({ out, err }).toMatchSnapshot();
+  });
+
+  it('install --help', async () => {
+    const { code, out, err } = await cli(['install', '--help']);
+    expect(code).toBe(0);
+    expect({ out, err }).toMatchSnapshot();
+  });
+
+  it('ci --help', async () => {
+    const { code, out, err } = await cli(['ci', '--help']);
+    expect(code).toBe(0);
+    expect({ out, err }).toMatchSnapshot();
+  });
+
+  it('--version', async () => {
+    const { code, out, err } = await cli(['--version']);
+    expect(code).toBe(0);
+    // Normalized: the CLI/core version numbers bump on every release (Changesets), and a raw
+    // snapshot would fail every Version Packages PR with no drift in the format to review.
+    expect({
+      out: out.replace(/\d+\.\d+\.\d+(?:-[\w.]+)?/g, 'X.Y.Z'),
+      err
+    }).toMatchSnapshot();
+  });
+});
+
+// Deliberately not pinned here: the no-args-in-a-non-project error surface. Under vitest, argv-less
+// dispatch falls back to `process.cwd()` (packages/cli), which isn't a SvelteKit project itself but
+// whose subtree holds dozens of fixture kit apps — `run()`'s monorepo auto-discovery finds several
+// and its behavior forks on `process.stdin/stdout.isTTY`, neither of which this seam lets a caller
+// override. That branch is TTY-dependent, not CLI-dependent, so it isn't a fair characterization
+// target. The same "not a SvelteKit project" surface is pinned deterministically by
+// cli-contract.test.ts's `./docs`-style-path and by scripts/cli-e2e.mjs's non-project-dir check,
+// both of which control cwd explicitly instead of relying on discovery.

--- a/scripts/cli-e2e.mjs
+++ b/scripts/cli-e2e.mjs
@@ -1,0 +1,188 @@
+// Built-dist gate-flag E2E (Phase 0 of the gunshi migration:
+// docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md). Pins the exit codes the
+// --fail-on/--min-health gates promise, against tiny fixture projects this script generates
+// itself — never the shared packages/cli/test/fixtures, whose findings can drift as rules
+// change. Follows scripts/floor-smoke.mjs's conventions (same runner, same hand-rolled
+// node:assert style) but is wired into the `test` job (pnpm e2e, after floor-smoke), not
+// `floor-smoke` — see AGENTS.md's floor-smoke section for why that job stays untouched.
+//
+//   node scripts/cli-e2e.mjs   (needs `pnpm build` first)
+
+import { strict as assert } from 'node:assert';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const root = join(import.meta.dirname, '..');
+const cliBin = join(root, 'packages/cli/dist/bin.js');
+
+if (!existsSync(cliBin)) {
+  console.error('cli-e2e: packages/cli/dist/bin.js is missing — run `pnpm build` first.');
+  process.exit(1);
+}
+
+/** Run the built CLI. Never throws: returns the exit code alongside the captured streams. */
+function runCli(args, opts = {}) {
+  try {
+    const stdout = execFileSync(process.execPath, [cliBin, ...args], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf8',
+      ...opts
+    });
+    return { code: 0, signal: null, stdout, stderr: '' };
+  } catch (err) {
+    return {
+      code: err.status,
+      signal: err.signal ?? null,
+      stdout: String(err.stdout ?? ''),
+      stderr: String(err.stderr ?? '')
+    };
+  }
+}
+
+const PACKAGE_JSON = JSON.stringify({
+  name: 'cli-e2e-fixture',
+  private: true,
+  type: 'module',
+  devDependencies: { '@sveltejs/kit': '^2.0.0', svelte: '^5.0.0' }
+});
+
+/**
+ * `@sveltejs/kit` in package.json is enough for detectProject — an empty (or absent)
+ * src/routes is not an error, and zero routes means zero results, which computeHealth
+ * treats as a perfect 100 (see packages/core/src/scoring/score.ts). The most future-proof
+ * "clean" fixture: no rule can ever find anything to flag in a project with no files.
+ */
+function makeCleanProject() {
+  const dir = mkdtempSync(join(tmpdir(), 'cli-e2e-clean-'));
+  writeFileSync(join(dir, 'package.json'), PACKAGE_JSON);
+  return dir;
+}
+
+/**
+ * A title-only page. `seo/title-presence` is the only 'critical' SEO rule (verified against
+ * packages/core/src/rules/**\/*.ts: the only other critical rules are correctness/security
+ * checks for `$effect`/lifecycle/`window`/`document` misuse and event-handler state writes,
+ * none of which this markup can trigger), so this satisfies it and nothing else — every other
+ * SEO presence rule (description, canonical, og:*, ...) is 'warning', so at least one warning
+ * finding is guaranteed. Imperfect by construction: health is under 100, and there is no
+ * critical finding, so the default gate (--fail-on critical) passes while --fail-on warning
+ * and --min-health 100 both fail.
+ */
+function makeWarningOnlyProject() {
+  const dir = mkdtempSync(join(tmpdir(), 'cli-e2e-warning-'));
+  writeFileSync(join(dir, 'package.json'), PACKAGE_JSON);
+  mkdirSync(join(dir, 'src/routes'), { recursive: true });
+  writeFileSync(
+    join(dir, 'src/routes/+page.svelte'),
+    '<svelte:head>\n  <title>Home</title>\n</svelte:head>\n\n<h1>Home</h1>\n'
+  );
+  return dir;
+}
+
+const checks = [];
+function check(name, fn) {
+  checks.push([name, fn]);
+}
+
+check('a clean project (no routes) exits 0 under the default gate', () => {
+  const dir = makeCleanProject();
+  try {
+    const args = [dir];
+    const { code, signal, stderr } = runCli(args);
+    assert.equal(signal, null, `killed by signal ${signal} (stderr: ${stderr})`);
+    assert.equal(code, 0, `\`svelte-vitals ${args.join(' ')}\` expected exit 0, got ${code}: ${stderr}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+check('a warning-only project exits 0 under the default gate (fail-on critical)', () => {
+  const dir = makeWarningOnlyProject();
+  try {
+    const args = [dir];
+    const { code, signal, stderr } = runCli(args);
+    assert.equal(signal, null, `killed by signal ${signal} (stderr: ${stderr})`);
+    assert.equal(code, 0, `\`svelte-vitals ${args.join(' ')}\` expected exit 0, got ${code}: ${stderr}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+check('the same project exits 1 under --fail-on warning', () => {
+  const dir = makeWarningOnlyProject();
+  try {
+    const args = [dir, '--fail-on', 'warning'];
+    const { code, signal, stderr } = runCli(args);
+    assert.equal(signal, null, `killed by signal ${signal} (stderr: ${stderr})`);
+    assert.equal(code, 1, `\`svelte-vitals ${args.join(' ')}\` expected exit 1, got ${code}: ${stderr}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+check('--min-health 100 fails on an imperfect project', () => {
+  const dir = makeWarningOnlyProject();
+  try {
+    const args = [dir, '--min-health', '100'];
+    const { code, signal, stderr } = runCli(args);
+    assert.equal(signal, null, `killed by signal ${signal} (stderr: ${stderr})`);
+    assert.equal(code, 1, `\`svelte-vitals ${args.join(' ')}\` expected exit 1, got ${code}: ${stderr}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+check('a non-project directory exits 2', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'cli-e2e-nonproject-'));
+  try {
+    const args = [dir];
+    const { code, signal, stderr } = runCli(args);
+    assert.equal(signal, null, `killed by signal ${signal} (stderr: ${stderr})`);
+    assert.equal(code, 2, `\`svelte-vitals ${args.join(' ')}\` expected exit 2, got ${code}: ${stderr}`);
+    assert.match(stderr, /No SvelteKit project found/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+check('--help exits 0', () => {
+  const { code, signal, stdout, stderr } = runCli(['--help']);
+  assert.equal(signal, null, `killed by signal ${signal} (stderr: ${stderr})`);
+  assert.equal(code, 0, `\`svelte-vitals --help\` expected exit 0, got ${code}: ${stderr}`);
+  assert.match(stdout, /svelte-vitals — a deterministic SvelteKit code-health scanner/);
+});
+
+check('--reporter json stdout parses as JSON when findings exist', () => {
+  const dir = makeWarningOnlyProject();
+  try {
+    const args = [dir, '--reporter', 'json'];
+    const { code, signal, stdout, stderr } = runCli(args);
+    assert.equal(signal, null, `killed by signal ${signal} (stderr: ${stderr})`);
+    assert.equal(code, 0, `\`svelte-vitals ${args.join(' ')}\` expected exit 0, got ${code}: ${stderr}`);
+    const report = JSON.parse(stdout);
+    assert.equal(typeof report.score, 'number');
+    assert.ok(report.score < 100, `expected an imperfect score, got ${report.score}`);
+    assert.ok(report.categories && typeof report.categories === 'object');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+let failed = 0;
+for (const [name, fn] of checks) {
+  try {
+    fn();
+    console.log(`  ok   ${name}`);
+  } catch (err) {
+    failed++;
+    console.error(`  FAIL ${name}\n       ${err.stack ?? err.message}`);
+  }
+}
+
+if (failed > 0) {
+  console.error(`cli-e2e: ${failed} of ${checks.length} checks failed`);
+  process.exit(1);
+}
+console.log(`cli-e2e: ${checks.length} checks passed`);


### PR DESCRIPTION
Phase 0 of the gunshi migration plan (#448, `docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md`): record the CLI's user-visible contracts before any gunshi code exists, so migration diffs are judged against pinned behavior. Also pays down audit backlog 2608-TEST-01/03 (bin.ts in-process seam + built-dist gate-flag E2E) — the suite stands on its own merits regardless of the migration.

## The seam

`bin.ts` (139 lines) is now a 14-line entry; the full dispatch lives in a new `src/cli.ts` as `runCli(argv, io?) → { code, exit: 'natural' | 'immediate' }`. Two deliberate shapes:

- **A separate module, not an export from bin.ts** — `bin.ts` ends in `void main()`, so importing a seam from it would execute the CLI against vitest's argv; and an `import.meta.url` entry guard was rejected because npm/pnpm bin shims are symlinks (a realpath check would silently break the published binary).
- **`exit` discriminator instead of a bare number** — today's code uses three exit mechanisms deliberately (natural drain for `docs`/`explain`/help/version to avoid truncating pipe writes; immediate exit for `install`/`ci`/argv errors, which may hold prompt/timer handles; flush-then-immediate for the analyzer, whose report is the largest write). Unifying them is not provably safe, so the thin entry reproduces each path's exact mechanism.

**Behavior preservation verified two ways**: floor-smoke 8/8 unchanged on the branch, and a coordinator byte-comparison of main's rebuilt dist vs this branch's dist across 12 command surfaces (help ×5, version, docs list/show/redirect, explain list/error, flag-guard errors, rules×category conflict) — exit codes, stdout, and stderr all byte-identical.

## The pins

- **Help goldens** (`help-golden.test.ts`, 6 snapshots): root/docs/explain/install/ci `--help` + `--version` (digits normalized). When gunshi's generated format lands in Phase 2, the snapshot diff IS the review surface.
- **Contract matrix** (`cli-contract.test.ts`, 16 cells / 10 classes): the #397/#383 flag-guard class, `docs`-vs-`./docs` dispatch, `docs show` redirect, sub-command error surfaces — bin-level representatives, with `resolve-args.test.ts` still owning the exhaustive matrix.
- **Gate-flag E2E** (`scripts/cli-e2e.mjs`, Node builtins only, 7 checks): the built `bin.js` on generated fixtures — clean→0, `--fail-on warning`→1, `--min-health`→1, non-project→2, `--reporter json` stdout parses. Wired into CI's `test` job after the floor-smoke step (dist already built); the `floor-smoke` job is untouched.

## Two Phase-2 inputs discovered and pinned as-is (reality, not the doc)

1. `ci <unknown-subcommand>` prints its help to **stdout** and exits 2 — contradicting the design doc's "stdout empty on every exit-2 path" invariant. Pinned with a comment; either the code or the doc moves in Phase 2.
2. Unknown flags are **silently ignored** (`util.parseArgs` strict:false passthrough). gunshi will likely reject them — an explicit Phase 2 decision point, now impossible to change by accident.

No changeset — tests, an internal behavior-preserving refactor, and CI wiring only. Full suite 2,549 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved CLI command dispatch, argument handling, help, version, documentation, explanation, installation, and CI commands.
  * Added consistent exit-code behavior and support for structured JSON output.
  * Improved diagnostics and output handling across CLI operations.

* **Bug Fixes**
  * Improved validation for conflicting options, invalid projects, and missing paths.

* **Tests**
  * Added comprehensive end-to-end coverage for CLI flags, subcommands, errors, reporting, and help output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->