### PR TITLE
docs: record the gunshi phase-1 gate verdicts

### DIFF
--- a/docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md
+++ b/docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md
@@ -164,6 +164,17 @@ wording. `bone` (same `cliCore` dispatcher, empty plugin array — `subCommands`
 confirmed identical) avoids both classes structurally, at the cost of auto-usage text this
 migration replaces with hand-controlled text anyway.
 
+**LLM-assisted implementation (maintainer instruction, 2026-08-10): every phase that writes
+gunshi code MUST consult `@gunshi/docs`** — gunshi ships its guide and API reference as
+llms.txt-format markdown (`@gunshi/docs`, versioned in lockstep with gunshi, 0.37.1). Mechanism:
+add it to the workspace catalog as a devDependency at Phase 2 start (exact pin, bumped together
+with `gunshi` so the docs never describe a different version than the installed API), and every
+executor prompt for gunshi work points at `node_modules/@gunshi/docs/**.md` as the primary API
+reference — ahead of web fetches, which may describe a newer gunshi than the pinned one. (The
+package's `npx @gunshi/docs` auto-setup writes Claude Code skill files; the devDependency +
+explicit-pointer route is preferred here because executors run in disposable worktrees where a
+committed dependency is the only reliably present artifact.)
+
 Implementation facts Phase 2 must carry: `ctx.positionals` includes the matched sub-command's own
 path tokens (undocumented) — recover argv-after-subcommand with
 `ctx.positionals.slice(ctx.commandPath.length)`; boolean `--flag=false` is truthy to args-tokens

--- a/docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md
+++ b/docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md
@@ -131,3 +131,43 @@ help-format movement declared explicitly (maintainer call on patch vs minor at P
    signal, and the characterization suite plus phase gates carry the 0.x risk.
 3. **Phase 0 approved first**: the characterization suite lands before any gunshi code, so the
    migration diffs are judged against pinned behavior.
+
+## Phase 1 verdict (2026-08-10) — all three gates pass; proceed to Phase 2 on `gunshi/bone`
+
+Spike branch: `spike/gunshi-phase1` (commit 7d97b97b, not merged; full narrative in its
+`packages/cli/SPIKE-FINDINGS.md`, 36 probe tests). Gate outcomes:
+
+- **(a) contracts — pass-with-wrapper.** The `docs` port reproduces every design-doc cell
+  byte-for-byte except `--help` (exit 0 holds; text differs, which decision 1 already accepts).
+  Mechanisms that make it work: exit codes travel through a per-invocation closure (`cli()`
+  discards non-string runner returns); `usageSilent: true` is a documented seam that routes every
+  internal gunshi write through a no-op, proven global-write-free by spies on
+  `console.*`/`process.std*.write`; `fallbackToEntry: true` lets unmatched sub-command tokens
+  reach our own runner so current wording is reproducible verbatim.
+- **(b) parsing — pass-with-wrapper.** args-tokens diverges from the #397/#383 guard in one real
+  way: an empty value (`--reporter=` / `--reporter ''`) is silently dropped instead of rejected —
+  post-parse detection is impossible (the value never appears), so the proven ~15-line wrapper
+  pre-scans raw argv with the same flag list and the same `--out-file -` exemption.
+  Flag-like-value consumption (`--reporter --score`) is structurally safe in args-tokens (keys off
+  the leading dash), `--out-file -`/`=-` match exactly, unknown flags are silently ignored exactly
+  as today, and the 0–100 `--min-health` range check was always ours.
+- **(c) in-process testability — pass, clean.** Injected-IO capture works with zero global
+  patching, matching the Phase-0 harness pattern.
+
+**Phase 2 builds on `gunshi/bone`, not full `cli()`.** Decided on spike evidence: `cli()`'s
+`global()` plugin force-installs `-h`/`-v` on every command with no opt-out (`options.plugins` is
+additive), silently hijacking `docs list -v` into printing `"unknown"` on stdout with exit 0 —
+a stdout-purity and control-flow regression against a flag the CLI never defined; and its
+decorator throws on any validation error while discarding the rendered message, leaving only
+gunshi's English fallback text — directly hostile to reproducing this repo's exact stderr
+wording. `bone` (same `cliCore` dispatcher, empty plugin array — `subCommands`/`fallbackToEntry`
+confirmed identical) avoids both classes structurally, at the cost of auto-usage text this
+migration replaces with hand-controlled text anyway.
+
+Implementation facts Phase 2 must carry: `ctx.positionals` includes the matched sub-command's own
+path tokens (undocumented) — recover argv-after-subcommand with
+`ctx.positionals.slice(ctx.commandPath.length)`; boolean `--flag=false` is truthy to args-tokens
+(keep `parseCliArgs`'s literal-'false' coercion where needed); `--no-color`-style negation is a
+per-flag `negatable: true` schema opt-in, not automatic. Measurements: gunshi 0.37.1 is 304 K
+unpacked in the store / 53.8 kB packed, zero installed dependencies (args-tokens confirmed
+inlined), and its import costs ≈5 ms against the CLI's current ≈157 ms `--help` startup.

--- a/docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md
+++ b/docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md
@@ -108,7 +108,10 @@ retain Phase 0's suite, record the outcome here as a dated addendum.
 
 ### Phase 2 — root analyzer + `explain`
 
-`define()` the analyzer's args; `cli()` with `subCommands` + `fallbackToEntry`;
+`define()` the analyzer's args; `cli()` with `subCommands` + `fallbackToEntry`
+(entry point superseded by the Phase 1 verdict below: `gunshi/bone` — the zero-plugin subpath
+export of the same pinned `gunshi` package, not a separate package; `subCommands`/`fallbackToEntry`
+come from the shared `cliCore` dispatcher and were verified identical under bone);
 `resolve-args.ts` keeps all domain validation. Full characterization suite must stay green
 except deliberately-updated help goldens. This phase changes user-visible surfaces, so it gets
 the independent fresh-context review treatment on top of the standard adversarial review.
@@ -134,8 +137,9 @@ help-format movement declared explicitly (maintainer call on patch vs minor at P
 
 ## Phase 1 verdict (2026-08-10) — all three gates pass; proceed to Phase 2 on `gunshi/bone`
 
-Spike branch: `spike/gunshi-phase1` (commit 7d97b97b, not merged; full narrative in its
-`packages/cli/SPIKE-FINDINGS.md`, 36 probe tests). Gate outcomes:
+Spike branch: `spike/gunshi-phase1` (commit 7d97b97b, pushed but never merged; read the full
+narrative with `git show spike/gunshi-phase1:packages/cli/SPIKE-FINDINGS.md` — the path does not
+exist on `main`; 36 probe tests). Gate outcomes:
 
 - **(a) contracts — pass-with-wrapper.** The `docs` port reproduces every design-doc cell
   byte-for-byte except `--help` (exit 0 holds; text differs, which decision 1 already accepts).
@@ -154,7 +158,8 @@ Spike branch: `spike/gunshi-phase1` (commit 7d97b97b, not merged; full narrative
 - **(c) in-process testability — pass, clean.** Injected-IO capture works with zero global
   patching, matching the Phase-0 harness pattern.
 
-**Phase 2 builds on `gunshi/bone`, not full `cli()`.** Decided on spike evidence: `cli()`'s
+**Phase 2 builds on `gunshi/bone` — the subpath export of the pinned `gunshi` package, not a
+separate npm package — instead of full `cli()`.** Decided on spike evidence: `cli()`'s
 `global()` plugin force-installs `-h`/`-v` on every command with no opt-out (`options.plugins` is
 additive), silently hijacking `docs list -v` into printing `"unknown"` on stdout with exit 0 —
 a stdout-purity and control-flow regression against a flag the CLI never defined; and its
@@ -177,8 +182,14 @@ committed dependency is the only reliably present artifact.)
 
 Implementation facts Phase 2 must carry: `ctx.positionals` includes the matched sub-command's own
 path tokens (undocumented) — recover argv-after-subcommand with
-`ctx.positionals.slice(ctx.commandPath.length)`; boolean `--flag=false` is truthy to args-tokens
-(keep `parseCliArgs`'s literal-'false' coercion where needed); `--no-color`-style negation is a
-per-flag `negatable: true` schema opt-in, not automatic. Measurements: gunshi 0.37.1 is 304 K
-unpacked in the store / 53.8 kB packed, zero installed dependencies (args-tokens confirmed
-inlined), and its import costs ≈5 ms against the CLI's current ≈157 ms `--help` startup.
+`ctx.positionals.slice(ctx.commandPath.length)`, and because that invariant is unsupported
+upstream, every ported command pins it with an explicit regression test so a gunshi bump that
+changes the shape fails as a named test, not a mystery; boolean `--flag=false` is truthy to
+args-tokens — `parseCliArgs`'s literal-'false' coercion moves into the same raw-argv pre-scan
+wrapper as the gate-(b) guard when `cli-args.ts` is deleted in Phase 3 (one shared normalization
+layer ahead of gunshi, never per-command re-implementations); `--no-color`-style negation is a
+per-flag `negatable: true` schema opt-in, not automatic. Measurements: gunshi 0.37.1 occupies 304 K on disk in the pnpm store (`du -sh`; the registry's
+`unpackedSize` metadata reports ~234 KB — filesystem block overhead accounts for the gap), packs
+to a 53.8 kB tarball, and installs zero dependencies (args-tokens confirmed inlined). Import cost
+≈5 ms — median of 10 runs of `node --input-type=module -e "import('gunshi')"` minus the bare
+`node -e 0` floor on the same machine — against the CLI's current ≈157 ms `--help` startup.


### PR DESCRIPTION
Phase 1 of the gunshi migration (#448 plan) is complete — this appends the dated verdict to the design doc. **All three gates pass; Phase 2 proceeds on `gunshi/bone`.**

- **(a) contracts — pass-with-wrapper**: the `docs` port reproduces every contract cell byte-for-byte (automated `toEqual` against the real CLI, not eyeballed); exit codes via a per-invocation closure, `usageSilent` as the documented no-global-writes seam, `fallbackToEntry` for verbatim unknown-subcommand wording.
- **(b) parsing — pass-with-wrapper**: one real args-tokens divergence (empty values silently dropped — undetectable post-parse, so the proven ~15-line raw-argv pre-scan restores the #397/#383 guard exactly); flag-like-value consumption is structurally *safer* than today; `--out-file -` and unknown-flag passthrough match exactly.
- **(c) testability — clean pass**: injected-IO capture with zero global patching, spy-proven.

**Entry-point decision, on spike evidence**: full `cli()`'s `global()` plugin force-injects `-h`/`-v` with no opt-out — `docs list -v` silently prints `"unknown"` (exit 0) instead of listing — and its decorator throws on any validation error while discarding the rendered message. `gunshi/bone` (same dispatcher, no plugins; `subCommands`/`fallbackToEntry` behave identically per test) avoids both classes structurally.

The addendum also carries the implementation gotchas Phase 2 needs (`ctx.positionals` includes sub-command path tokens; boolean `=false` coercion; per-flag `negatable`) and the measurements (304 K store / 53.8 kB packed / zero deps / ≈5 ms import vs ≈157 ms current `--help` startup).

Spike branch `spike/gunshi-phase1` is pushed for inspection (36 probe tests, full narrative in `packages/cli/SPIKE-FINDINGS.md`) and is NOT for merging.

Doc-only — no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the CLI migration design documentation with the results of Phase 1 validation.
  * Documented compatibility requirements for command contracts, argument parsing, positional values, boolean and negatable flags.
  * Added guidance for the next implementation phase, including version-specific documentation review and startup-cost considerations.
  * Clarified the planned use of a lower-level command dispatcher to preserve existing CLI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->