### PR TITLE
refactor(cli): dispatch docs and explain through gunshi/bone

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,12 +53,14 @@
   "dependencies": {
     "@svelte-vitals/core": "workspace:*",
     "@clack/prompts": "catalog:",
+    "gunshi": "catalog:",
     "log-update": "catalog:",
     "magicast": "catalog:",
     "svelte": "catalog:",
     "tinyglobby": "catalog:"
   },
   "devDependencies": {
+    "@gunshi/docs": "catalog:",
     "@types/estree": "catalog:",
     "@types/node": "catalog:"
   }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,7 +3,6 @@ import { readPackageVersion, readCoreVersion } from './version.js';
 import { parseRunArgs, resolveArgs } from './resolve-args.js';
 import { runInstallCli, selectAppPrompt, realIO } from './install/cli.js';
 import { runCiCli } from './ci/cli.js';
-import { runExplainCli } from './explain.js';
 import { consoleIO, type CliIO } from './cli-io.js';
 
 const HELP = `svelte-vitals — a deterministic SvelteKit code-health scanner (SEO · performance · correctness · security · architecture)
@@ -77,9 +76,9 @@ export interface CliResult {
   code: number;
   /**
    * How `bin.ts`'s thin entry should terminate the process:
-   * - `'natural'` — set `process.exitCode` and return; the path is pure-sync and holds no
-   *   handles (`docs`/`explain`/`--help`/`--version`), so an explicit `process.exit` would
-   *   only risk truncating an unflushed pipe write for no benefit.
+   * - `'natural'` — set `process.exitCode` and return; the path is fully resolved and holds no
+   *   handles by the time it returns (`docs`/`explain`/`--help`/`--version`), so an explicit
+   *   `process.exit` would only risk truncating an unflushed pipe write for no benefit.
    * - `'immediate'` — call `process.exit(code)` right away. `install`/`ci` hold prompts/timers
    *   that could hang a natural exit; an argv-resolution error exits before any output large
    *   enough to need a flush; the analyzer path below has already awaited its own stdout flush
@@ -98,11 +97,12 @@ export async function runCli(argv: string[], io: CliIO = consoleIO): Promise<Cli
   if (argv[0] === 'docs') {
     // Loaded on demand: the bundled topics are ~20KB of string literals that the analysis path
     // — the one the I/O budget test and `pnpm bench` defend — would otherwise parse every run.
-    const { runDocsCli } = await import('./docs/cli.js');
-    return { code: runDocsCli(argv.slice(1), io), exit: 'natural' };
+    const { runDocsCliGunshi } = await import('./gunshi/docs.js');
+    return { code: await runDocsCliGunshi(argv.slice(1), io), exit: 'natural' };
   }
   if (argv[0] === 'explain') {
-    return { code: runExplainCli(argv.slice(1), io), exit: 'natural' };
+    const { runExplainCliGunshi } = await import('./gunshi/explain.js');
+    return { code: await runExplainCliGunshi(argv.slice(1), io), exit: 'natural' };
   }
   if (argv[0] === 'install') {
     return { code: await runInstallCli(argv.slice(1), io), exit: 'immediate' };

--- a/packages/cli/src/docs/cli.ts
+++ b/packages/cli/src/docs/cli.ts
@@ -4,7 +4,8 @@ import { consoleIO, type CliIO } from '../cli-io.js';
 import { knownRuleIds } from '../rules-config.js';
 import { EMBEDDED_DOCS } from './generated.js';
 
-const DOCS_HELP = `svelte-vitals docs — read the bundled guides without leaving the terminal
+/** Shared with the gunshi/bone port (src/gunshi/docs.ts) so the two dispatchers can't drift. */
+export const DOCS_HELP = `svelte-vitals docs — read the bundled guides without leaving the terminal
 
 Usage:
   svelte-vitals docs list [--json]     List every topic with a one-line description
@@ -20,12 +21,13 @@ network. The full docs site is at https://oekazuma.github.io/svelte-vitals.
 \`docs\` is a subcommand, so it wins over a directory of the same name: to analyze a directory
 called \`docs\`, write \`svelte-vitals ./docs\`.`;
 
-/** Mirrors `knownRuleIds()`. */
-function knownTopicNames(): string {
+/** Mirrors `knownRuleIds()`. Exported: shared with the gunshi/bone port. */
+export function knownTopicNames(): string {
   return EMBEDDED_DOCS.map((d) => d.name).join(', ');
 }
 
-function renderList(): string {
+/** Exported: shared with the gunshi/bone port. */
+export function renderList(): string {
   const width = Math.max(...EMBEDDED_DOCS.map((d) => d.name.length));
   const lines = EMBEDDED_DOCS.map((d) => `  ${d.name.padEnd(width)}  ${d.description}`);
   return [

--- a/packages/cli/src/explain.ts
+++ b/packages/cli/src/explain.ts
@@ -3,7 +3,8 @@ import { allRules, CATEGORIES, explainRule, type RuleOptionInfo } from '@svelte-
 import { consoleIO, type CliIO } from './cli-io.js';
 import { knownRuleIds } from './rules-config.js';
 
-const EXPLAIN_HELP = `svelte-vitals explain — print a rule's rationale, fix, and configurable options
+/** Shared with the gunshi/bone port (src/gunshi/explain.ts) so the two dispatchers can't drift. */
+export const EXPLAIN_HELP = `svelte-vitals explain — print a rule's rationale, fix, and configurable options
 
 Usage:
   svelte-vitals explain --list          List every rule id, grouped by category
@@ -45,8 +46,8 @@ function describeOptions(id: string, options: RuleOptionInfo[]): string {
   );
 }
 
-/** Render a rule's static metadata as the text `svelte-vitals explain` prints. */
-function formatRuleExplanation(info: NonNullable<ReturnType<typeof explainRule>>): string {
+/** Render a rule's static metadata as the text `svelte-vitals explain` prints. Exported: shared with the gunshi/bone port. */
+export function formatRuleExplanation(info: NonNullable<ReturnType<typeof explainRule>>): string {
   return (
     `${info.id} — ${info.title} (${info.severity}, ${info.category})\n\n` +
     `${info.rationale}\n\nDocs: ${info.docsUrl}` +
@@ -55,8 +56,8 @@ function formatRuleExplanation(info: NonNullable<ReturnType<typeof explainRule>>
   );
 }
 
-/** Every rule, grouped by category — the entry point into `explain`. */
-function renderRuleList(): string {
+/** Every rule, grouped by category — the entry point into `explain`. Exported: shared with the gunshi/bone port. */
+export function renderRuleList(): string {
   const sections = CATEGORIES.map((category) => {
     const rules = allRules.filter((r) => r.category === category);
     const width = Math.max(...rules.map((r) => r.id.length));

--- a/packages/cli/src/gunshi/docs.ts
+++ b/packages/cli/src/gunshi/docs.ts
@@ -1,0 +1,157 @@
+import { cli } from 'gunshi/bone';
+import { define } from 'gunshi/definition';
+import { docsUrlFor } from '@svelte-vitals/core';
+import { consoleIO, type CliIO } from '../cli-io.js';
+import { knownRuleIds } from '../rules-config.js';
+import { EMBEDDED_DOCS } from '../docs/generated.js';
+import { DOCS_HELP, knownTopicNames, renderList } from '../docs/cli.js';
+import { guardArgs } from './guard.js';
+
+/** docs declares no value-carrying flags today — see guard.ts's own doc comment for why the list is still passed explicitly. */
+const BOOLEAN_FLAGS = ['json', 'help'] as const;
+const HELP_ARG = { help: { type: 'boolean', short: 'h' } } as const;
+
+/**
+ * gunshi/bone port of `docs/cli.ts`'s dispatch (design doc: Phase 2a). `docs` is passed as its
+ * own `cli()` entry (not nested under a shared root) so an unmatched sub-command token reaches
+ * this file's own root `run()` via `fallbackToEntry` directly — reproducing
+ * `unknown docs subcommand '<x>'` verbatim without having to catch and re-render gunshi's own
+ * `CommandNotFoundError`, which is what nesting `docs` under a shared entry would require (that
+ * error only carries `commandPath`/`candidates` at the *intermediate* level, not the entry level;
+ * see the exit-code closure note below for the other half of why this shape was chosen).
+ *
+ * Exit codes have no return-value channel in gunshi (`executeCommand` discards a non-string
+ * runner return) — `exitCode` is the closure every `run` below sets instead. Commands are built
+ * fresh on every call (not module-level singletons) so concurrent invocations can't race across
+ * `cli()`'s internal `await`s and clobber each other's closure.
+ */
+export async function runDocsCliGunshi(args: string[], io: CliIO = consoleIO): Promise<number> {
+  const guard = guardArgs(args, [], BOOLEAN_FLAGS);
+  for (const e of guard.errors) io.errorLog(e);
+  if (guard.errors.length > 0) return 2;
+
+  let exitCode = 0;
+
+  const listCommand = define({
+    name: 'list',
+    args: { json: { type: 'boolean' }, ...HELP_ARG },
+    run: (ctx) => {
+      if (ctx.values.help) {
+        io.log(DOCS_HELP);
+        exitCode = 0;
+        return;
+      }
+      // ctx.positionals is NOT "args after `list`" — for a matched sub-command it's the raw
+      // top-level positional array with the command-path token(s) spliced in at the front
+      // (undocumented; see the regression test pinning this). Slicing off commandPath.length
+      // recovers "args after the sub-command name".
+      const extra = ctx.positionals.slice(ctx.commandPath.length);
+      if (extra.length > 0) {
+        // Accepting it would read as "list, filtered to config".
+        io.errorLog('svelte-vitals: docs list takes no arguments; use `docs show <name>` to read one.');
+        exitCode = 2;
+        return;
+      }
+      io.log(
+        ctx.values.json
+          ? JSON.stringify(
+              EMBEDDED_DOCS.map((d) => ({ name: d.name, title: d.title, description: d.description })),
+              null,
+              2
+            )
+          : renderList()
+      );
+      exitCode = 0;
+    }
+  });
+
+  const showCommand = define({
+    name: 'show',
+    args: {
+      // Left un-required on purpose: gunshi's own "required positional missing" validation
+      // error preempts this command's `run` entirely and can't be made to say
+      // "docs show needs a topic name, e.g. ...". Counting positionals ourselves reproduces
+      // the exact current wording instead.
+      name: { type: 'positional', required: false },
+      ...HELP_ARG
+    },
+    run: (ctx) => {
+      if (ctx.values.help) {
+        io.log(DOCS_HELP);
+        exitCode = 0;
+        return;
+      }
+      // `docs show a b` printing only `a` would misrepresent itself as "here are both".
+      const rest = ctx.positionals.slice(ctx.commandPath.length);
+      if (rest.length !== 1) {
+        io.errorLog(
+          rest.length === 0
+            ? 'svelte-vitals: docs show needs a topic name, e.g. `svelte-vitals docs show config`.'
+            : 'svelte-vitals: docs show takes one topic at a time.'
+        );
+        io.errorLog(`svelte-vitals: known topics: ${knownTopicNames()}.`);
+        exitCode = 2;
+        return;
+      }
+      const name = rest[0]!; // rest.length === 1, checked above
+      const doc = EMBEDDED_DOCS.find((d) => d.name === name);
+      if (!doc) {
+        // The agent reporter and web docs print rule ids as `<category>/<slug>` (and the web
+        // path as `rules/<category>/<slug>`); redirect those to `explain` instead of the
+        // generic "unknown topic" list, which does not include rule ids at all.
+        const ruleId = name.startsWith('rules/') ? name.slice('rules/'.length) : name;
+        if (knownRuleIds().includes(ruleId)) {
+          io.errorLog(`svelte-vitals: '${ruleId}' is a rule, not a docs topic.`);
+          io.errorLog(`svelte-vitals: rule detail: \`svelte-vitals explain ${ruleId}\`; web: ${docsUrlFor(ruleId)}`);
+          exitCode = 2;
+          return;
+        }
+        io.errorLog(`svelte-vitals: unknown docs topic '${name}'.`);
+        io.errorLog(`svelte-vitals: known topics: ${knownTopicNames()}.`);
+        exitCode = 2;
+        return;
+      }
+      io.log(doc.body);
+      exitCode = 0;
+    }
+  });
+
+  const rootCommand = define({
+    name: 'docs',
+    args: HELP_ARG,
+    subCommands: { list: listCommand, show: showCommand },
+    run: (ctx) => {
+      if (ctx.values.help) {
+        io.log(DOCS_HELP);
+        exitCode = 0;
+        return;
+      }
+      // fallbackToEntry (below) routes here both for a bare `docs` (ctx.omitted) and for an
+      // unrecognized first positional. ctx.commandPath is [] at the entry level, so no slicing
+      // is needed here (unlike list/show above, which are matched sub-commands).
+      const [sub] = ctx.positionals;
+      if (sub === undefined) {
+        io.errorLog(DOCS_HELP);
+        exitCode = 2;
+        return;
+      }
+      io.errorLog(`svelte-vitals: unknown docs subcommand '${sub}'; expected list|show.`);
+      io.errorLog(DOCS_HELP);
+      exitCode = 2;
+    }
+  });
+
+  await cli(guard.argv, rootCommand, {
+    name: 'svelte-vitals docs',
+    subCommands: { list: listCommand, show: showCommand },
+    fallbackToEntry: true,
+    // Routes every internal gunshi write (version/header/usage/validation-errors all check this
+    // before writing) through a no-op — gunshi never touches process.stdout/stderr directly.
+    // Nothing here currently produces such a write (no `version` is set, and `--help`/`-h` are
+    // this file's own declared args, not gunshi's), but it's the documented seam that keeps that
+    // true across a gunshi bump.
+    usageSilent: true
+  });
+
+  return exitCode;
+}

--- a/packages/cli/src/gunshi/explain.ts
+++ b/packages/cli/src/gunshi/explain.ts
@@ -1,0 +1,94 @@
+import { cli } from 'gunshi/bone';
+import { define } from 'gunshi/definition';
+import { explainRule, allRules } from '@svelte-vitals/core';
+import { consoleIO, type CliIO } from '../cli-io.js';
+import { knownRuleIds } from '../rules-config.js';
+import { EXPLAIN_HELP, renderRuleList, formatRuleExplanation } from '../explain.js';
+import { guardArgs } from './guard.js';
+
+/** explain declares no value-carrying flags today — see guard.ts's own doc comment for why the list is still passed explicitly. */
+const BOOLEAN_FLAGS = ['json', 'list', 'help'] as const;
+
+/**
+ * gunshi/bone port of `explain.ts`'s dispatch (design doc: Phase 2a). Unlike `docs`, this is a
+ * flat command with no sub-commands — `explain` is passed as its own `cli()` entry, so
+ * `ctx.commandPath` is always `[]` and `ctx.positionals` already IS "args after `explain`" with
+ * no path-token splicing to slice off (see the regression test pinning this alongside docs's
+ * real slice case). See docs.ts for the exit-code closure pattern this mirrors.
+ */
+export async function runExplainCliGunshi(args: string[], io: CliIO = consoleIO): Promise<number> {
+  const guard = guardArgs(args, [], BOOLEAN_FLAGS);
+  for (const e of guard.errors) io.errorLog(e);
+  if (guard.errors.length > 0) return 2;
+
+  let exitCode = 0;
+
+  const explainCommand = define({
+    name: 'explain',
+    args: {
+      list: { type: 'boolean' },
+      json: { type: 'boolean' },
+      help: { type: 'boolean', short: 'h' },
+      // Left un-required, same reasoning as docs show's `name` (gunshi/docs.ts): a missing rule
+      // id is reported with this command's own wording, not gunshi's required-positional error.
+      id: { type: 'positional', required: false }
+    },
+    run: (ctx) => {
+      if (ctx.values.help) {
+        io.log(EXPLAIN_HELP);
+        exitCode = 0;
+        return;
+      }
+
+      if (ctx.values.list) {
+        // Extra positionals reaching here would misrepresent themselves as "explaining that id".
+        if (ctx.positionals.slice(ctx.commandPath.length).length > 0) {
+          io.errorLog('svelte-vitals: explain --list takes no rule id; drop --list to explain one.');
+          exitCode = 2;
+          return;
+        }
+        io.log(
+          ctx.values.json
+            ? JSON.stringify(
+                allRules.map((r) => ({ id: r.id, category: r.category, severity: r.severity, title: r.title })),
+                null,
+                2
+              )
+            : renderRuleList()
+        );
+        exitCode = 0;
+        return;
+      }
+
+      const id = ctx.values.id;
+      if (id === undefined) {
+        io.errorLog(
+          'svelte-vitals: explain needs a rule id, e.g. `svelte-vitals explain seo/ssr-disabled`; `--list` shows them all.'
+        );
+        io.errorLog(`svelte-vitals: known rule ids: ${knownRuleIds().join(', ')}.`);
+        exitCode = 2;
+        return;
+      }
+
+      const info = explainRule(id);
+      if (!info) {
+        io.errorLog(`svelte-vitals: unknown rule id '${id}'.`);
+        io.errorLog(`svelte-vitals: known rule ids: ${knownRuleIds().join(', ')}.`);
+        exitCode = 2;
+        return;
+      }
+
+      io.log(ctx.values.json ? JSON.stringify(info, null, 2) : formatRuleExplanation(info));
+      exitCode = 0;
+    }
+  });
+
+  await cli(guard.argv, explainCommand, {
+    name: 'svelte-vitals explain',
+    // No writes this command can trigger currently rely on this (see docs.ts's identical note),
+    // kept for the same forward-compat reason.
+    usageSilent: true
+  });
+
+  return exitCode;
+}

--- a/packages/cli/src/gunshi/guard.ts
+++ b/packages/cli/src/gunshi/guard.ts
@@ -1,0 +1,63 @@
+/**
+ * Raw-argv pre-scan that every gunshi-dispatched command runs before handing argv to gunshi's
+ * own parser (Phase 1 spike gate (b), `docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md`).
+ * Two gaps gunshi's parser (args-tokens) has no post-parse fix for:
+ *
+ * - An empty value (`--flag=` / `--flag ''`) on a value-carrying flag is silently dropped from
+ *   `values` rather than surfaced as an error — there is no value left to inspect once gunshi has
+ *   parsed, so the check has to run on the raw tokens first.
+ * - Any explicit value on a declared boolean — including the literal string `'false'` — resolves
+ *   to `true`. `parseCliArgs` (cli-args.ts) special-cases `--flag=false` to mean off; reproducing
+ *   that means rewriting the token away before gunshi ever sees it.
+ *
+ * One function, parameterized by the flag lists the caller declares (never a second hardcoded
+ * copy of a flag list that already exists elsewhere — `valueFlags` for the root analyzer is
+ * `VALUE_FLAGS` from `resolve-args.ts`; `docs`/`explain` pass `[]`, since neither declares a
+ * value-carrying flag today).
+ */
+
+export interface GuardResult {
+  /** Fatal `--<flag> requires a value.` messages; empty when nothing was rejected. */
+  errors: string[];
+  /** `argv` with every `--<boolFlag>=false` token removed (equivalent to the flag never being passed). */
+  argv: string[];
+}
+
+/** A value token is bad if it's missing, empty, or dash-leading — `--out-file`'s literal `-` (stdout) is the one exception. */
+function isBadValue(flag: string, value: string | undefined): boolean {
+  return value === undefined || value === '' || (value.startsWith('-') && !(flag === 'out-file' && value === '-'));
+}
+
+export function guardArgs(argv: string[], valueFlags: readonly string[], booleanFlags: readonly string[]): GuardResult {
+  const errors: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i]!;
+    for (const flag of valueFlags) {
+      const eq = `--${flag}=`;
+      if (token === `--${flag}`) {
+        if (isBadValue(flag, argv[i + 1])) errors.push(`svelte-vitals: --${flag} requires a value.`);
+      } else if (token.startsWith(eq)) {
+        if (isBadValue(flag, token.slice(eq.length))) errors.push(`svelte-vitals: --${flag} requires a value.`);
+      }
+    }
+  }
+
+  // Duplicate boolean tokens are last-wins under the legacy parser (`util.parseArgs` overwrites
+  // on repetition, then cli-args.ts coerces a final literal 'false' to off) — so when a flag's
+  // LAST occurrence is `=false`, every token of that flag must go, not just the `=false` ones.
+  const offFlags = new Set(
+    booleanFlags.filter((flag) => {
+      let lastToken: string | undefined;
+      for (const t of argv) if (t === `--${flag}` || t === `--${flag}=false`) lastToken = t;
+      return lastToken === `--${flag}=false`;
+    })
+  );
+  const argvNormalized = argv.filter((token) => {
+    for (const flag of booleanFlags) {
+      if (token === `--${flag}=false` || (offFlags.has(flag) && token === `--${flag}`)) return false;
+    }
+    return true;
+  });
+
+  return { errors, argv: argvNormalized };
+}

--- a/packages/cli/src/resolve-args.ts
+++ b/packages/cli/src/resolve-args.ts
@@ -120,7 +120,9 @@ interface ResolvedArgs {
 // an empty string; either silently un-gates a CI run. Same stance as the
 // --baseline guard below, applied to every value-carrying flag. --diff is
 // exempt: bare/empty --diff deliberately defaults to HEAD (see parseRunArgs).
-const VALUE_FLAGS = [
+// Exported so gunshi/guard.ts's raw-argv pre-scan shares this exact list instead of
+// re-declaring it (gunshi's own parser can't reproduce the guard post-parse — see that file).
+export const VALUE_FLAGS = [
   'meta-components',
   'treat-dynamic-as',
   'route',

--- a/packages/cli/test/gunshi-docs-parity.test.ts
+++ b/packages/cli/test/gunshi-docs-parity.test.ts
@@ -1,0 +1,85 @@
+// Phase 2a of the gunshi migration (docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md):
+// the legacy `runDocsCli` (docs/cli.ts) stays in place and exported through Phase 3, so this file
+// runs the same argv through it and through the gunshi/bone port (gunshi/docs.ts, now what
+// `runCli(['docs', ...])` actually dispatches to) and asserts byte-for-byte equality — the same
+// comparison technique the Phase 1 spike used (spike-gunshi-docs.test.ts), extended with the
+// cells that only exist once help/`=false` are handled per-command instead of by a competing
+// renderer.
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { runDocsCli } from '../src/docs/cli.js';
+import { runDocsCliGunshi } from '../src/gunshi/docs.js';
+import { captureIO } from './helpers/capture-io.js';
+
+function legacy(args: string[]) {
+  const io = captureIO();
+  const code = runDocsCli(args, io);
+  return { code, out: io.out, err: io.err };
+}
+
+async function gunshi(args: string[]) {
+  const io = captureIO();
+  const code = await runDocsCliGunshi(args, io);
+  return { code, out: io.out, err: io.err };
+}
+
+describe('gunshi/bone docs reproduces the legacy docs CLI, byte for byte', () => {
+  const cells: { name: string; args: string[] }[] = [
+    { name: 'list', args: ['list'] },
+    { name: 'list --json', args: ['list', '--json'] },
+    { name: 'show config', args: ['show', 'config'] },
+    { name: 'show unknown', args: ['show', 'no-such-topic'] },
+    { name: 'show rule-id redirect', args: ['show', 'seo/title-presence'] },
+    { name: 'show rule-id redirect, rules/ prefix', args: ['show', 'rules/seo/title-presence'] },
+    { name: 'list extra-arg', args: ['list', 'extra-arg'] },
+    { name: 'show a b', args: ['show', 'a', 'b'] },
+    { name: 'show (no name)', args: ['show'] },
+    { name: 'no sub', args: [] },
+    { name: 'bogus sub', args: ['bogus'] },
+    { name: '--help', args: ['--help'] },
+    { name: '-h', args: ['-h'] },
+    { name: 'list --help (help wins over list logic, same as today)', args: ['list', '--help'] },
+    { name: 'show --help (help wins over show logic, same as today)', args: ['show', '--help'] },
+    { name: '-v (unrecognized, falls through to no-sub)', args: ['-v'] },
+    { name: 'list -v (unrecognized flag ignored, list still runs)', args: ['list', '-v'] },
+    { name: 'list --json=false (literal-false coercion)', args: ['list', '--json=false'] },
+    {
+      name: 'list --json --json=false (duplicate booleans are last-wins: off)',
+      args: ['list', '--json', '--json=false']
+    },
+    {
+      name: 'list --json=false --json (duplicate booleans are last-wins: on)',
+      args: ['list', '--json=false', '--json']
+    }
+  ];
+
+  for (const { name, args } of cells) {
+    it(`${name}: identical to the legacy CLI`, async () => {
+      expect(await gunshi(args)).toEqual(legacy(args));
+    });
+  }
+});
+
+describe('gate (c): in-process, injected IO, no process-global coupling', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('never calls console.log/console.error/process.stdout.write/process.stderr.write on any path exercised above', async () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const stdoutWrite = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await gunshi(['list']);
+    await gunshi(['show', 'config']);
+    await gunshi(['show', 'no-such-topic']);
+    await gunshi([]);
+    await gunshi(['bogus']);
+    await gunshi(['--help']);
+
+    expect(consoleLog).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(stdoutWrite).not.toHaveBeenCalled();
+    expect(stderrWrite).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/test/gunshi-explain-parity.test.ts
+++ b/packages/cli/test/gunshi-explain-parity.test.ts
@@ -1,0 +1,67 @@
+// Phase 2a of the gunshi migration (docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md):
+// same technique as gunshi-docs-parity.test.ts, for `explain` (explain.ts / gunshi/explain.ts).
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { runExplainCli } from '../src/explain.js';
+import { runExplainCliGunshi } from '../src/gunshi/explain.js';
+import { captureIO } from './helpers/capture-io.js';
+
+function legacy(args: string[]) {
+  const io = captureIO();
+  const code = runExplainCli(args, io);
+  return { code, out: io.out, err: io.err };
+}
+
+async function gunshi(args: string[]) {
+  const io = captureIO();
+  const code = await runExplainCliGunshi(args, io);
+  return { code, out: io.out, err: io.err };
+}
+
+describe('gunshi/bone explain reproduces the legacy explain CLI, byte for byte', () => {
+  const cells: { name: string; args: string[] }[] = [
+    { name: 'known rule id', args: ['seo/title-presence'] },
+    { name: 'configurable rule id', args: ['seo/title-length'] },
+    { name: '--json <id>', args: ['--json', 'seo/title-length'] },
+    { name: 'json --list', args: ['--list', '--json'] },
+    { name: '--list', args: ['--list'] },
+    { name: '--list extra-arg (rejected)', args: ['--list', 'extra-arg'] },
+    { name: 'no id', args: [] },
+    { name: 'unknown id', args: ['NOPE999'] },
+    { name: 'wrong-case id (exact match only)', args: ['SEO/TITLE-PRESENCE'] },
+    { name: 'id plus extra positionals (legacy ignores them)', args: ['seo/title-presence', 'extra'] },
+    { name: '--help', args: ['--help'] },
+    { name: '-h', args: ['-h'] },
+    { name: '--json=false (literal-false coercion)', args: ['--json=false', 'seo/title-length'] },
+    { name: '--list=false (literal-false coercion, falls through to no-id)', args: ['--list=false'] }
+  ];
+
+  for (const { name, args } of cells) {
+    it(`${name}: identical to the legacy CLI`, async () => {
+      expect(await gunshi(args)).toEqual(legacy(args));
+    });
+  }
+});
+
+describe('gate (c): in-process, injected IO, no process-global coupling', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('never calls console.log/console.error/process.stdout.write/process.stderr.write on any path exercised above', async () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const stdoutWrite = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await gunshi(['seo/title-presence']);
+    await gunshi(['--list']);
+    await gunshi(['NOPE999']);
+    await gunshi([]);
+    await gunshi(['--help']);
+
+    expect(consoleLog).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(stdoutWrite).not.toHaveBeenCalled();
+    expect(stderrWrite).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/test/gunshi-guard.test.ts
+++ b/packages/cli/test/gunshi-guard.test.ts
@@ -1,0 +1,75 @@
+// Phase 2a of the gunshi migration (docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md):
+// unit tests for the shared raw-argv pre-scan (gunshi/guard.ts), reproducing the Phase 1 spike's
+// gate-(b) cells (spike-gunshi-parsing.test.ts) against the guard as actually shipped — driven by
+// the real `VALUE_FLAGS` import from resolve-args.ts, not a second hardcoded flag list.
+import { describe, it, expect } from 'vitest';
+import { guardArgs } from '../src/gunshi/guard.js';
+import { VALUE_FLAGS } from '../src/resolve-args.js';
+
+describe('guardArgs: value-carrying flags (using the real analyzer VALUE_FLAGS list)', () => {
+  it('--reporter= (empty, inline) is rejected with the current wording', () => {
+    const { errors } = guardArgs(['--reporter='], VALUE_FLAGS, []);
+    expect(errors).toEqual(['svelte-vitals: --reporter requires a value.']);
+  });
+
+  it("--reporter '' (empty, split token) is rejected", () => {
+    const { errors } = guardArgs(['--reporter', ''], VALUE_FLAGS, []);
+    expect(errors).toEqual(['svelte-vitals: --reporter requires a value.']);
+  });
+
+  it('--reporter --score (flag-like value) is rejected with the current wording, not invalid-type', () => {
+    const { errors } = guardArgs(['--reporter', '--score'], VALUE_FLAGS, []);
+    expect(errors).toEqual(['svelte-vitals: --reporter requires a value.']);
+  });
+
+  it('--out-file - and --out-file=- are exempted (the documented stdout marker)', () => {
+    expect(guardArgs(['--out-file', '-'], VALUE_FLAGS, []).errors).toEqual([]);
+    expect(guardArgs(['--out-file=-'], VALUE_FLAGS, []).errors).toEqual([]);
+  });
+
+  it('--diff is not in VALUE_FLAGS, so a bare/dash-shaped --diff is never flagged here (parseRunArgs owns its default-ref rewrite)', () => {
+    expect(guardArgs(['--diff'], VALUE_FLAGS, []).errors).toEqual([]);
+    expect(guardArgs(['--diff', '--staged'], VALUE_FLAGS, []).errors).toEqual([]);
+  });
+
+  it('a well-formed run produces no errors', () => {
+    expect(guardArgs(['--reporter', 'json', '--min-health', '80'], VALUE_FLAGS, []).errors).toEqual([]);
+  });
+
+  it('an unrelated flag not in valueFlags is never checked', () => {
+    expect(guardArgs(['--bogus='], [], []).errors).toEqual([]);
+  });
+});
+
+describe('guardArgs: boolean --flag=false normalization', () => {
+  it('drops a --<boolFlag>=false token from argv entirely (equivalent to "not passed")', () => {
+    const { argv } = guardArgs(['--json=false', 'show', 'config'], [], ['json']);
+    expect(argv).toEqual(['show', 'config']);
+  });
+
+  it('leaves --<boolFlag>=true untouched — only the literal false coercion is special-cased', () => {
+    const { argv } = guardArgs(['--json=true'], [], ['json']);
+    expect(argv).toEqual(['--json=true']);
+  });
+
+  it('only drops the token for flags named in booleanFlags, not every =false', () => {
+    const { argv } = guardArgs(['--fail-on=false', '--json=false'], [], ['json']);
+    expect(argv).toEqual(['--fail-on=false']);
+  });
+
+  it('a well-formed run is untouched', () => {
+    const { argv } = guardArgs(['show', 'config'], [], ['json', 'help']);
+    expect(argv).toEqual(['show', 'config']);
+  });
+
+  it('duplicate tokens are last-wins: a trailing =false turns the flag off entirely', () => {
+    // Legacy parity: util.parseArgs overwrites on repetition, so `--json --json=false` is off.
+    const { argv } = guardArgs(['--json', '--json=false'], [], ['json']);
+    expect(argv).toEqual([]);
+  });
+
+  it('duplicate tokens are last-wins: a trailing bare flag stays on', () => {
+    const { argv } = guardArgs(['--json=false', '--json'], [], ['json']);
+    expect(argv).toEqual(['--json']);
+  });
+});

--- a/packages/cli/test/gunshi-positionals-slice-invariant.test.ts
+++ b/packages/cli/test/gunshi-positionals-slice-invariant.test.ts
@@ -1,0 +1,109 @@
+// Phase 2a of the gunshi migration (docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md):
+// pins gunshi's undocumented ctx.positionals/ctx.commandPath contract that both gunshi/docs.ts
+// and gunshi/explain.ts depend on (design doc, "Implementation facts Phase 2 must carry"): for a
+// matched sub-command, ctx.positionals is the raw top-level positional array with the matched
+// sub-command's own path token(s) spliced in at the front — NOT "args after the sub-command
+// name". `ctx.positionals.slice(ctx.commandPath.length)` is what recovers the latter. If a
+// gunshi bump changes this shape, THIS test should fail — not a downstream wording mismatch
+// three files away in a docs/explain contract test.
+//
+// The command trees below mirror gunshi/docs.ts and gunshi/explain.ts's actual shape (docs as a
+// bone entry with `list`/`show` sub-commands; explain as a bone entry with no sub-commands) so
+// the invariant is pinned against the same topology production code relies on.
+import { describe, it, expect } from 'vitest';
+import { cli } from 'gunshi/bone';
+import { define } from 'gunshi/definition';
+
+describe('gunshi/bone: ctx.positionals includes the matched sub-command path tokens', () => {
+  it('docs show config: positionals is ["show","config"], commandPath is ["show"] — slice(commandPath.length) recovers ["config"]', async () => {
+    let captured: { positionals: string[]; commandPath: string[] } | undefined;
+    const showCommand = define({
+      name: 'show',
+      args: { name: { type: 'positional', required: false } },
+      run: (ctx) => {
+        captured = { positionals: ctx.positionals, commandPath: ctx.commandPath };
+      }
+    });
+    const listCommand = define({ name: 'list', run: () => {} });
+    const docsCommand = define({
+      name: 'docs',
+      subCommands: { list: listCommand, show: showCommand },
+      run: () => {}
+    });
+
+    await cli(['show', 'config'], docsCommand, {
+      subCommands: { list: listCommand, show: showCommand },
+      fallbackToEntry: true,
+      usageSilent: true
+    });
+
+    expect(captured?.positionals).toEqual(['show', 'config']);
+    expect(captured?.commandPath).toEqual(['show']);
+    expect(captured?.positionals.slice(captured!.commandPath.length)).toEqual(['config']);
+  });
+
+  it('docs list extra: positionals is ["list","extra"], commandPath is ["list"] — slice recovers ["extra"]', async () => {
+    let captured: { positionals: string[]; commandPath: string[] } | undefined;
+    const listCommand = define({
+      name: 'list',
+      run: (ctx) => {
+        captured = { positionals: ctx.positionals, commandPath: ctx.commandPath };
+      }
+    });
+    const showCommand = define({ name: 'show', run: () => {} });
+    const docsCommand = define({
+      name: 'docs',
+      subCommands: { list: listCommand, show: showCommand },
+      run: () => {}
+    });
+
+    await cli(['list', 'extra'], docsCommand, {
+      subCommands: { list: listCommand, show: showCommand },
+      fallbackToEntry: true,
+      usageSilent: true
+    });
+
+    expect(captured?.positionals).toEqual(['list', 'extra']);
+    expect(captured?.positionals.slice(captured!.commandPath.length)).toEqual(['extra']);
+  });
+
+  it('explain <id>: commandPath is [] at the entry level — positionals already IS "args after explain", so the slice is a documented no-op, not a real recovery', async () => {
+    let captured: { positionals: string[]; commandPath: string[] } | undefined;
+    const explainCommand = define({
+      name: 'explain',
+      args: { id: { type: 'positional', required: false } },
+      run: (ctx) => {
+        captured = { positionals: ctx.positionals, commandPath: ctx.commandPath };
+      }
+    });
+
+    await cli(['seo/title-presence'], explainCommand, { usageSilent: true });
+
+    expect(captured?.commandPath).toEqual([]);
+    expect(captured?.positionals).toEqual(['seo/title-presence']);
+    expect(captured?.positionals.slice(captured!.commandPath.length)).toEqual(['seo/title-presence']);
+  });
+
+  it('docs bogus: an unmatched sub-command reaches the entry (docs root) via fallbackToEntry with commandPath [] — no slicing needed there either', async () => {
+    let captured: { positionals: string[]; commandPath: string[]; omitted: boolean } | undefined;
+    const listCommand = define({ name: 'list', run: () => {} });
+    const showCommand = define({ name: 'show', run: () => {} });
+    const docsCommand = define({
+      name: 'docs',
+      subCommands: { list: listCommand, show: showCommand },
+      run: (ctx) => {
+        captured = { positionals: ctx.positionals, commandPath: ctx.commandPath, omitted: ctx.omitted };
+      }
+    });
+
+    await cli(['bogus'], docsCommand, {
+      subCommands: { list: listCommand, show: showCommand },
+      fallbackToEntry: true,
+      usageSilent: true
+    });
+
+    expect(captured?.commandPath).toEqual([]);
+    expect(captured?.positionals).toEqual(['bogus']);
+    expect(captured?.omitted).toBe(false);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ catalogs:
     '@clack/prompts':
       specifier: ^1.7.0
       version: 1.7.0
+    '@gunshi/docs':
+      specifier: 0.37.1
+      version: 0.37.1
     '@sveltejs/kit':
       specifier: ^2.70.2
       version: 2.70.2
@@ -30,6 +33,9 @@ catalogs:
     esm-env:
       specifier: ^1.2.2
       version: 1.2.2
+    gunshi:
+      specifier: 0.37.1
+      version: 0.37.1
     jsdom:
       specifier: ^30.0.1
       version: 30.0.1
@@ -134,6 +140,9 @@ importers:
       '@svelte-vitals/core':
         specifier: workspace:*
         version: link:../core
+      gunshi:
+        specifier: 'catalog:'
+        version: 0.37.1
       log-update:
         specifier: 'catalog:'
         version: 8.0.0
@@ -147,6 +156,9 @@ importers:
         specifier: 'catalog:'
         version: 0.2.17
     devDependencies:
+      '@gunshi/docs':
+        specifier: 'catalog:'
+        version: 0.37.1
       '@types/estree':
         specifier: 'catalog:'
         version: 1.0.9
@@ -995,6 +1007,10 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@gunshi/docs@0.37.1':
+    resolution: {integrity: sha512-LcLL1ekr8T9177bnEuz7n3f6qeEsupfyVBGSyznQIEKvEFhLleRQeKmA0J/f7EZnMw0aPpafB+Ji5BmDaJ6roQ==}
+    hasBin: true
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -3570,6 +3586,10 @@ packages:
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
+
+  gunshi@0.37.1:
+    resolution: {integrity: sha512-C3t35z65PQpAHay/gzEu4J/7SNWXn2NhfC4RfZQPxyOqkPfDTizthxCPoSU48OazoVherCuCpFDKI1qcY425Gw==}
+    engines: {node: '>= 22'}
 
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
@@ -6784,6 +6804,11 @@ snapshots:
 
   '@exodus/bytes@1.15.1': {}
 
+  '@gunshi/docs@0.37.1':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      tinyexec: 1.2.4
+
   '@hono/node-server@1.19.14(hono@4.12.26)':
     dependencies:
       hono: 4.12.26
@@ -9319,6 +9344,8 @@ snapshots:
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
+
+  gunshi@0.37.1: {}
 
   h3@1.15.11:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,8 @@ catalog:
   '@types/estree': ^1.0.9
   '@types/node': ^24.13.3
   esm-env: ^1.2.2
+  '@gunshi/docs': 0.37.1
+  gunshi: 0.37.1
   jsdom: ^30.0.1
   log-update: ^8.0.0
   magicast: ^0.5.4


### PR DESCRIPTION
Phase 2a of the gunshi migration (#448 plan; Phase 1 verdict in the design doc). `docs` and `explain` now run through `gunshi/bone` — with **zero user-visible change**, which is this PR's contract: the Phase 0 characterization suite passes with zero golden churn, and the coordinator byte-compared main's rebuilt dist against this branch's dist across 14 command surfaces (docs list/json/show/errors/redirect/bogus/help, explain list/rule/error/help, root help/version) — exit codes, stdout, and stderr all identical.

## What's in

- **`gunshi: 0.37.1` (exact pin) as a cli runtime dependency**, plus `@gunshi/docs: 0.37.1` as the devDependency API reference (maintainer mandate — the executor consulted its `nested-sub-commands`/`CliOptions`/`CommandContext` pages, which document the `commandPath`/`callMode` semantics the Phase 1 spike had to reverse-engineer). The built analyzer path is untouched: `dist/bin.js` contains zero gunshi references — it ships only inside the lazily-imported docs/explain chunks.
- **`src/gunshi/guard.ts`** — the shared raw-argv pre-scan from the spike's gate (b): empty/dash-value rejection with current wording, `--out-file -` exemption, and boolean `--flag=false` normalization. Parameterized by caller-supplied flag lists (the real `VALUE_FLAGS` is imported by its tests; `docs`/`explain` pass `[]` because neither declares a value-carrying flag today — applying the analyzer's list to them would itself be a behavior change). One shared layer, per the design-doc rule.
- **`src/gunshi/docs.ts` / `explain.ts`** — bone ports sharing the legacy modules' *data* (help strings, pure renderers — now exported) while reimplementing dispatch on gunshi's `ctx`. Topology: two separate bone entries, not one nested tree — probed first: `fallbackToEntry` only works at the outer `cli()` level, so a nested `docs bogus` would throw `CommandNotFoundError` instead of reaching our runner with today's wording.
- **The `ctx.positionals` slice-invariant regression pins** required by the design doc (a gunshi bump that changes the undocumented shape fails as a named test).
- Help output is the current hand-written text (printed by our runners under bone) — the help-format movement is deliberately deferred to Phase 2b's changeset, keeping this PR movement-free.

## Verification

Legacy `runDocsCli`/`runExplainCli` remain in place and tested (deletion is Phase 3). Parity suites compare the gunshi ports against the legacy implementations cell-by-cell (mutation-checked: altering one error string fails exactly the parity cell). Full gates green: 2,598 tests, lint, typecheck, e2e 7/7 — executor additionally ran `pnpm smoke` (8/8) and `pnpm check:publish` (0).

No changeset — behavior is byte-identical; the user-visible movement lands with Phase 2b, which will also carry the independent fresh-context review for the whole migrated surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added updated `docs` and `explain` command handling with support for help, listings, JSON output, validation, and appropriate exit codes.
  * Improved command-line argument validation, including clearer handling of missing or invalid flag values.
* **Bug Fixes**
  * Preserved existing command behavior and output across supported scenarios.
  * Improved isolation of command output from global console and process streams.
* **Tests**
  * Added comprehensive coverage for command parity, argument validation, positional arguments, and injected I/O behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->