### PR TITLE
feat(cli): run the analyzer's argument parsing and dispatch on gunshi

### DIFF
--- a/.changeset/gunshi-analyzer-dispatch.md
+++ b/.changeset/gunshi-analyzer-dispatch.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': minor
+---
+
+The CLI's argument parsing and dispatch now run on gunshi (the root analyzer joins `docs` and `explain`), and the root `--help` output's options section is generated from the argument declarations instead of hand-maintained — its formatting changes shape once. Everything else is pinned unchanged by the characterization suite: flags and their meanings, exit codes, error wording, `--version` output, and reporter stdout are all byte-identical.

--- a/docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md
+++ b/docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md
@@ -193,3 +193,28 @@ per-flag `negatable: true` schema opt-in, not automatic. Measurements: gunshi 0.
 to a 53.8 kB tarball, and installs zero dependencies (args-tokens confirmed inlined). Import cost
 ≈5 ms — median of 10 runs of `node --input-type=module -e "import('gunshi')"` minus the bare
 `node -e 0` floor on the same machine — against the CLI's current ≈157 ms `--help` startup.
+
+## Correction (2026-08-10, phase-2b): unknown-flag passthrough was only partially verified
+
+Phase 1 gate (b)'s cell "unknown flags are silently ignored exactly as today" is falsified for
+one argv shape the spike never exercised: args-tokens treats any UNDECLARED option as
+string-like, so a positional immediately following it is consumed as that option's value —
+`node:util`'s `parseArgs(strict:false)` treats the same shape as boolean and leaves the
+positional alone. The spike exercised no unknown-flag-before-positional shapes on any surface —
+not "docs/explain have none to lose": `docs show <name>` and `explain <rule-id>` each have a
+declared positional too, and both were equally vulnerable (`docs show --typo config` regressed to
+"needs a topic name" instead of printing the topic, same class as the analyzer's
+`svelte-vitals --typo ./apps/web` silently analyzing the wrong directory). `stripUnknownFlags` is
+therefore shared (`guard.ts`) and applied to all three surfaces, parameterized per command by its
+family-wide known-flag set — every sub-command of a family must declare every family flag even if
+unused, since gunshi resolves each sub-command's args independently (`docs show` never reads
+`--json`, but must still declare it so gunshi doesn't treat it as unknown and swallow the topic
+name after it). A second, analyzer-only layer, `neutralizeBareDiffAndBaseline` (rewrites a bare
+`--diff`/`--baseline`, judged on original-argv adjacency, into a self-contained `=value` token so
+a stripped token can never expose a following positional to them), and a third, shared layer,
+`splitAtTerminator` (splits argv at the first literal `--` before guard/strip run at all, since
+neither understands the terminator and would otherwise reinterpret a post-`--` token that merely
+looks like a flag), round out the compensation. `--diff`/`--baseline` values themselves come from a
+shadow parse of the untouched original argv through the legacy `parseCliArgs` — the one remaining
+use of that parser on the migrated path, which Phase 3's deletion pass must absorb (inline the
+value-shape logic) before removing `cli-args.ts`.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,76 +1,7 @@
-import { run } from './index.js';
-import { readPackageVersion, readCoreVersion } from './version.js';
-import { parseRunArgs, resolveArgs } from './resolve-args.js';
-import { runInstallCli, selectAppPrompt, realIO } from './install/cli.js';
+import { runInstallCli, realIO } from './install/cli.js';
 import { runCiCli } from './ci/cli.js';
 import { consoleIO, type CliIO } from './cli-io.js';
-
-const HELP = `svelte-vitals — a deterministic SvelteKit code-health scanner (SEO · performance · correctness · security · architecture)
-
-Usage:
-  svelte-vitals [path] [options]
-  svelte-vitals docs list        List the bundled guides (docs show <name> prints one)
-  svelte-vitals explain --list   List every rule (explain <rule-id> explains one)
-  svelte-vitals install          Set up the Vite integration, agent skills/rules, config file, or CI
-  svelte-vitals ci install       Add a GitHub Actions PR gate (annotations + summary comment)
-  svelte-vitals ci upgrade       Refresh the pinned @svelte-vitals/action in an existing workflow
-
-Options:
-  --meta-components <names>   Comma-separated component names that emit head metadata
-  --treat-dynamic-as <mode>   pass | warn | fail (default: pass)
-  --route <glob>              Only analyze routes matching this glob
-  --diff [ref]                Report only findings in files changed vs ref (default HEAD; e.g. --diff main)
-  --staged                    Report only findings in files staged for commit (pre-commit gate)
-  --baseline <ref>            Report only findings not present at ref (compare against e.g. origin/main)
-  --update-suppressions       Write svelte-vitals-suppressions.json accepting all current findings (introduce gates on legacy projects)
-  --no-suppressions           Ignore svelte-vitals-suppressions.json for this run
-  --by-route                  Show per-route score breakdown in console output
-  --reporter <fmt>            console | json | agent | sarif | github | html | md (auto: agent under AI-agent envs, github under GitHub Actions)
-  --out-file <path>           Output path for --reporter html (default: svelte-vitals-report.html; '-' for stdout)
-  --fail-on <severity>        Fail (exit 1) when any finding reaches this severity: critical | warning | info
-  --min-health <0-100>        Fail (exit 1) when the combined Health score is below this value
-  --rules <ids>               Comma-separated rule ids to enable (all others disabled)
-  --ignore <ids>              Comma-separated rule ids to disable
-  --category <cats>           Comma-separated categories to analyze: seo | performance | correctness | security | architecture
-  --weights <pairs>           Per-category Health weight overrides, e.g. seo=2,performance=1 (unlisted categories default to 1)
-  --score                     Print only the combined Health score (works with --min-health for gating)
-  --no-color                  Disable ANSI color in console output
-  --no-animation               Disable the Health-score reveal animation and mascot on an interactive terminal
-  --verbose                    Show every finding uncapped and ungrouped (default: capped, grouped by rule)
-  -h, --help                  Show this help
-  -v, --version               Show version
-
-Config file:
-  svelte-vitals.config.{mjs,js,ts} in the analyzed directory; flags override it.
-
-Exit codes:
-  0  no failing findings
-  1  critical finding present (or --fail-on threshold reached)
-  2  execution error (not a SvelteKit project / internal error)
-
-If you are an AI agent:
-  - \`svelte-vitals docs list\` then \`docs show <name>\` — the guides ship inside this CLI, so
-    they match this exact version and need no network. Read those before searching the web.
-  - \`--reporter agent\` gives every failing finding a location, a concrete fix and an acceptance
-    check; it is auto-selected when an agent environment is detected. \`--reporter json\` is the
-    structured form.
-  - \`--diff\` scopes the report to what you just changed; \`--staged\` is the pre-commit gate.
-  - \`svelte-vitals explain <rule-id>\` says why a rule exists and which options it takes, before
-    you decide to turn it off.
-  - Do NOT reach for \`--update-suppressions\` to make a run pass: it accepts every current
-    finding into a committed file and un-gates CI for all of them. Fix the findings, or scope
-    the run with \`--diff\`. Only a human should decide to accept a backlog.
-  - Exit 2 is never a pass — it means the analysis did not run. Read stderr.
-  - Analysis never prompts when stdout is not a TTY: where it would have asked, it exits 2
-    naming the flag to pass. \`install\` is the exception — non-interactively it skips its
-    confirmation and writes, so pass \`--dry-run\` first if you need to see the plan.`;
-
-const VERSION = readPackageVersion();
-
-/** Monorepo app picker (design doc 2026-07-08-monorepo-app-picker-design.md): single-select via @clack/prompts, same style as the `install` wizard. */
-function selectApp(apps: string[]): Promise<string | null> {
-  return selectAppPrompt(apps, 'Multiple SvelteKit apps found — which one should svelte-vitals analyze?');
-}
+import { runAnalyzeCliGunshi } from './gunshi/analyze.js';
 
 export interface CliResult {
   code: number;
@@ -88,10 +19,10 @@ export interface CliResult {
 }
 
 /**
- * CLI dispatch: routes `docs`/`explain`/`install`/`ci` subcommands, otherwise parses argv,
- * resolves it into `run()` options, executes the analysis, and computes the exit code. Never
- * calls `process.exit` itself — see `CliResult.exit` for why the caller still needs to pick
- * between `process.exit` and `process.exitCode` per path.
+ * CLI dispatch: routes `docs`/`explain`/`install`/`ci` subcommands, otherwise hands off to the
+ * root analyzer (`gunshi/analyze.ts`), which resolves argv into `run()` options, executes the
+ * analysis, and computes the exit code. Never calls `process.exit` itself — see `CliResult.exit`
+ * for why the caller still needs to pick between `process.exit` and `process.exitCode` per path.
  */
 export async function runCli(argv: string[], io: CliIO = consoleIO): Promise<CliResult> {
   if (argv[0] === 'docs') {
@@ -116,39 +47,5 @@ export async function runCli(argv: string[], io: CliIO = consoleIO): Promise<Cli
     return { code, exit: 'immediate' };
   }
 
-  const parsed = parseRunArgs(argv);
-
-  if (parsed.help) {
-    io.log(HELP);
-    return { code: 0, exit: 'natural' };
-  }
-  if (parsed.version) {
-    // Printing the resolved core version alongside the CLI's own lets users compare
-    // it directly against the `@svelte-vitals/vite` live dashboard's "core vX.Y.Z" line —
-    // the two packages are versioned independently and can drift (see docs).
-    io.log(`${VERSION} (core ${readCoreVersion()})`);
-    // stdout stays exactly the version string so it can be parsed; the pointer goes to stderr.
-    // An agent that runs only `--version` and never `--help` still learns the guides exist.
-    io.errorLog('svelte-vitals: run `svelte-vitals docs list` for the bundled guides.');
-    return { code: 0, exit: 'natural' };
-  }
-
-  const { options, warnings, errors, minHealth } = resolveArgs(parsed);
-  for (const w of warnings) io.errorLog(w);
-  for (const e of errors) io.errorLog(e);
-  if (!options) return { code: 2, exit: 'immediate' };
-
-  const code = await run({
-    ...options,
-    minHealth,
-    selectApp,
-    log: io.log,
-    errorLog: io.errorLog
-  });
-  // A write to a pipe is asynchronous, so `process.exit` can discard what has not drained — the report is
-  // the largest thing this CLI writes and the first pipe buffer is 65,536 bytes. The empty write's callback
-  // fires once the stream has flushed, so it's safe for the thin entry to call `process.exit` as soon as
-  // this resolves.
-  await new Promise((resolve) => process.stdout.write('', resolve));
-  return { code, exit: 'immediate' };
+  return runAnalyzeCliGunshi(argv, io);
 }

--- a/packages/cli/src/gunshi/analyze.ts
+++ b/packages/cli/src/gunshi/analyze.ts
@@ -1,0 +1,314 @@
+import { cli } from 'gunshi/bone';
+import { define } from 'gunshi/definition';
+import { generate } from 'gunshi/generator';
+import { run } from '../index.js';
+import { readPackageVersion, readCoreVersion } from '../version.js';
+import { parseRunArgs, resolveArgs, VALUE_FLAGS } from '../resolve-args.js';
+import { parseCliArgs, type CliArgv } from '../cli-args.js';
+import { selectAppPrompt } from '../install/cli.js';
+import { consoleIO, type CliIO } from '../cli-io.js';
+import type { CliResult } from '../cli.js';
+import { guardArgs, splitAtTerminator, stripUnknownFlags } from './guard.js';
+
+const VERSION = readPackageVersion();
+
+/** Monorepo app picker (design doc 2026-07-08-monorepo-app-picker-design.md): single-select via @clack/prompts, same style as the `install` wizard. */
+function selectApp(apps: string[]): Promise<string | null> {
+  return selectAppPrompt(apps, 'Multiple SvelteKit apps found — which one should svelte-vitals analyze?');
+}
+
+/**
+ * Every boolean flag the analyzer declares, kebab-cased — mirrors `parseRunArgs`'s own
+ * `boolean: [...]` list (resolve-args.ts) so guard.ts's last-wins `--flag=false` normalization
+ * covers exactly the same set gunshi will parse as booleans.
+ */
+const BOOLEAN_FLAGS = [
+  'by-route',
+  'staged',
+  'score',
+  'verbose',
+  'update-suppressions',
+  'no-suppressions',
+  'no-color',
+  'no-animation',
+  'help',
+  'version'
+] as const;
+
+/**
+ * gunshi's renderer treats ANY arg key literally starting with `no-` as an auto-generated
+ * negation of a base flag (stripping the prefix and looking up `ctx.args[stripped]`), regardless
+ * of whether `negatable: true` was set — confirmed empirically (`node_modules/@gunshi/docs` does
+ * not document this). For `no-suppressions`/`no-color`/`no-animation`, that base flag doesn't
+ * exist, so the renderer falls back to printing the stripped key itself ("suppressions", "color",
+ * "animation") instead of our description. Declaring these three under a camelCase key + `toKebab:
+ * true` sidesteps the string-prefix check entirely while still parsing/rendering as `--no-*` on
+ * the command line (`toKebab` affects both, per ArgSchema's docs) — `ctx.values` then carries them
+ * under their camelCase key, remapped back to the kebab name `resolveArgs` expects in `toCliArgv`
+ * below.
+ */
+const ROOT_ARGS = {
+  'meta-components': { type: 'string', description: 'Comma-separated component names that emit head metadata' },
+  'treat-dynamic-as': { type: 'string', description: 'pass | warn | fail (default: pass)' },
+  route: { type: 'string', description: 'Only analyze routes matching this glob' },
+  diff: {
+    type: 'string',
+    description: 'Report only findings in files changed vs ref (default HEAD; e.g. --diff main)'
+  },
+  staged: { type: 'boolean', description: 'Report only findings in files staged for commit (pre-commit gate)' },
+  baseline: {
+    type: 'string',
+    description: 'Report only findings not present at ref (compare against e.g. origin/main)'
+  },
+  'update-suppressions': {
+    type: 'boolean',
+    description:
+      'Write svelte-vitals-suppressions.json accepting all current findings (introduce gates on legacy projects)'
+  },
+  noSuppressions: {
+    type: 'boolean',
+    toKebab: true,
+    description: 'Ignore svelte-vitals-suppressions.json for this run'
+  },
+  'by-route': { type: 'boolean', description: 'Show per-route score breakdown in console output' },
+  reporter: {
+    type: 'string',
+    description:
+      'console | json | agent | sarif | github | html | md (auto: agent under AI-agent envs, github under GitHub Actions)'
+  },
+  'out-file': {
+    type: 'string',
+    description: "Output path for --reporter html (default: svelte-vitals-report.html; '-' for stdout)"
+  },
+  'fail-on': {
+    type: 'string',
+    description: 'Fail (exit 1) when any finding reaches this severity: critical | warning | info'
+  },
+  'min-health': {
+    type: 'string',
+    description: 'Fail (exit 1) when the combined Health score is below this value (0-100)'
+  },
+  rules: { type: 'string', description: 'Comma-separated rule ids to enable (all others disabled)' },
+  ignore: { type: 'string', description: 'Comma-separated rule ids to disable' },
+  category: {
+    type: 'string',
+    description: 'Comma-separated categories to analyze: seo | performance | correctness | security | architecture'
+  },
+  weights: {
+    type: 'string',
+    description: 'Per-category Health weight overrides, e.g. seo=2,performance=1 (unlisted categories default to 1)'
+  },
+  score: { type: 'boolean', description: 'Print only the combined Health score (works with --min-health for gating)' },
+  noColor: { type: 'boolean', toKebab: true, description: 'Disable ANSI color in console output' },
+  noAnimation: {
+    type: 'boolean',
+    toKebab: true,
+    description: 'Disable the Health-score reveal animation and mascot on an interactive terminal'
+  },
+  verbose: {
+    type: 'boolean',
+    description: 'Show every finding uncapped and ungrouped (default: capped, grouped by rule)'
+  },
+  help: { type: 'boolean', short: 'h', description: 'Show this help' },
+  version: { type: 'boolean', short: 'v', description: 'Show version' }
+} as const;
+
+/** Long flag names gunshi is declared to recognize, kebab-cased as they appear on argv — see `stripUnknownFlags`. */
+const KNOWN_LONG_FLAGS = new Set<string>([
+  ...Object.keys(ROOT_ARGS).filter((k) => k !== 'noColor' && k !== 'noAnimation' && k !== 'noSuppressions'),
+  'no-color',
+  'no-animation',
+  'no-suppressions'
+]);
+const KNOWN_SHORT_FLAGS = new Set(['h', 'v']);
+
+/**
+ * Rewrites a bare `--diff`/`--baseline` (follower missing or dash-leading, judged on THIS argv's
+ * own adjacency — called with the original argv, before anything strips a token that sat between
+ * them and a real value) into a self-contained `--flag=value` token. Purely for the copy of argv
+ * gunshi parses: gunshi's own diff/baseline values are discarded either way —
+ * `shadowParseDiffAndBaseline`, run separately against the untouched original argv, stays the sole
+ * source of truth for both. Without this, `guard.ts`'s `stripUnknownFlags` removing an unknown
+ * flag that sat between a bare `--diff`/`--baseline` and a following positional would expose that
+ * positional to gunshi's own (otherwise-discarded) parse, which consumes it as the flag's value
+ * instead of leaving it as the analyzed path. The value gunshi lands on doesn't matter (`HEAD` for
+ * diff, empty for baseline): either is dropped in favor of the shadow parse.
+ */
+function neutralizeBareDiffAndBaseline(argv: string[]): string[] {
+  return argv.map((token, i) => {
+    const bare = (argv[i + 1] ?? '--').startsWith('-');
+    if (token === '--diff' && bare) return '--diff=HEAD';
+    if (token === '--baseline' && bare) return '--baseline=';
+    return token;
+  });
+}
+
+/** Builds the hybrid `--help` text: hand-written header/usage + sub-commands stay prose (gunshi has no subCommands map here to generate them from); the options list is generated from `ROOT_ARGS`. */
+async function buildHelpText(rootCommand: Parameters<typeof generate>[1]): Promise<string> {
+  const generated = await generate(null, rootCommand, { name: 'svelte-vitals', renderHeader: null });
+  const optionsIndex = generated.indexOf('OPTIONS:');
+  const optionsSection = optionsIndex === -1 ? generated.trimEnd() : generated.slice(optionsIndex).trimEnd();
+
+  return `svelte-vitals — a deterministic SvelteKit code-health scanner (SEO · performance · correctness · security · architecture)
+
+Usage:
+  svelte-vitals [path] [options]
+  svelte-vitals docs list        List the bundled guides (docs show <name> prints one)
+  svelte-vitals explain --list   List every rule (explain <rule-id> explains one)
+  svelte-vitals install          Set up the Vite integration, agent skills/rules, config file, or CI
+  svelte-vitals ci install       Add a GitHub Actions PR gate (annotations + summary comment)
+  svelte-vitals ci upgrade       Refresh the pinned @svelte-vitals/action in an existing workflow
+
+${optionsSection}
+
+Config file:
+  svelte-vitals.config.{mjs,js,ts} in the analyzed directory; flags override it.
+
+Exit codes:
+  0  no failing findings
+  1  critical finding present (or --fail-on threshold reached)
+  2  execution error (not a SvelteKit project / internal error)
+
+If you are an AI agent:
+  - \`svelte-vitals docs list\` then \`docs show <name>\` — the guides ship inside this CLI, so
+    they match this exact version and need no network. Read those before searching the web.
+  - \`--reporter agent\` gives every failing finding a location, a concrete fix and an acceptance
+    check; it is auto-selected when an agent environment is detected. \`--reporter json\` is the
+    structured form.
+  - \`--diff\` scopes the report to what you just changed; \`--staged\` is the pre-commit gate.
+  - \`svelte-vitals explain <rule-id>\` says why a rule exists and which options it takes, before
+    you decide to turn it off.
+  - Do NOT reach for \`--update-suppressions\` to make a run pass: it accepts every current
+    finding into a committed file and un-gates CI for all of them. Fix the findings, or scope
+    the run with \`--diff\`. Only a human should decide to accept a backlog.
+  - Exit 2 is never a pass — it means the analysis did not run. Read stderr.
+  - Analysis never prompts when stdout is not a TTY: where it would have asked, it exits 2
+    naming the flag to pass. \`install\` is the exception — non-interactively it skips its
+    confirmation and writes, so pass \`--dry-run\` first if you need to see the plan.`;
+}
+
+/**
+ * `--diff`/`--baseline` are exempt from `guardArgs`'s VALUE_FLAGS class (design doc: `--diff`
+ * defaults rather than rejects; `--baseline` gets its own dedicated `resolveArgs` wording) but
+ * gunshi's args-tokens drops ANY missing/empty/flag-following value on a string arg to
+ * `undefined` (not just the empty-value case VALUE_FLAGS guards against) — confirmed empirically
+ * for both flags. Re-parsing just these two with the same `node:util`-backed parser
+ * `resolveArgs`'s checks were built against reproduces today's exact value shapes (`true` for a
+ * bare trailing flag, `''` for `--flag=`, a consumed flag-like token for `--flag --other`)
+ * without touching `resolve-args.ts` at all. Takes the ORIGINAL argv, not the
+ * `stripUnknownFlags`-adjusted copy fed to gunshi: `--baseline --typo main` needs `--typo` still
+ * present so `parseCliArgs` consumes it (dash-prefixed) as baseline's value and `resolveArgs`
+ * rejects it, exactly as `parseRunArgs` does today — dropping `--typo` first would let `main`
+ * become baseline's value instead, turning today's fatal error into a silent pass.
+ */
+function shadowParseDiffAndBaseline(argv: string[]): { diff: unknown; baseline: unknown } {
+  const patched = argv.map((a, i) => (a === '--diff' && (argv[i + 1] ?? '--').startsWith('-') ? '--diff=HEAD' : a));
+  const legacy = parseCliArgs(patched, { string: ['diff', 'baseline'] });
+  return { diff: legacy.diff, baseline: legacy.baseline };
+}
+
+/** Adapts gunshi's parsed result into the `CliArgv` shape `resolveArgs` consumes, unchanged. */
+function toCliArgv(values: Record<string, unknown>, positionals: string[], rawArgs: string[]): CliArgv {
+  const { diff, baseline } = shadowParseDiffAndBaseline(rawArgs);
+  return {
+    _: positionals,
+    ...values,
+    'no-color': values.noColor,
+    'no-animation': values.noAnimation,
+    'no-suppressions': values.noSuppressions,
+    diff,
+    baseline
+  };
+}
+
+/**
+ * gunshi/bone port of the root analyzer's dispatch (design doc: Phase 2b). A single entry with no
+ * `subCommands` map — `runCli` (cli.ts) keeps its own exact-match branches for `docs`/`explain`/
+ * `install`/`ci`, so an unmatched first token (`./docs`, a path) reaches this file's `run()`
+ * directly. See docs.ts/explain.ts for the exit-code closure and injected-`CliIO` pattern this
+ * mirrors.
+ */
+export async function runAnalyzeCliGunshi(args: string[], io: CliIO = consoleIO): Promise<CliResult> {
+  // `--` must be split off before any of guard/neutralize/strip run: none of them understands the
+  // terminator, so a post-`--` token that merely looks like a flag (`<path> -- --score`) would
+  // otherwise get reinterpreted as a real one — `tail` is appended verbatim to the positional
+  // channel below, never touched by anything flag-shaped again.
+  const { head, tail } = splitAtTerminator(args);
+  // Pre-neutralizing (not `head` itself — VALUE_FLAGS never includes diff/baseline, so guard's own
+  // error detection is unaffected either way) keeps a bare `--diff`/`--baseline`'s adjacency
+  // judged on the true pre-`--` argv, before guard's own `--flag=false` stripping could shift what
+  // sits next to them.
+  const guard = guardArgs(neutralizeBareDiffAndBaseline(head), VALUE_FLAGS, BOOLEAN_FLAGS);
+  const argvForGunshi = stripUnknownFlags(guard.argv, KNOWN_LONG_FLAGS, KNOWN_SHORT_FLAGS);
+
+  let result: CliResult = { code: 0, exit: 'natural' };
+
+  const rootCommand = define({
+    name: 'svelte-vitals',
+    args: ROOT_ARGS,
+    run: async (ctx) => {
+      if (ctx.values.help) {
+        io.log(await buildHelpText(rootCommand));
+        result = { code: 0, exit: 'natural' };
+        return;
+      }
+      if (ctx.values.version) {
+        // Printing the resolved core version alongside the CLI's own lets users compare
+        // it directly against the `@svelte-vitals/vite` live dashboard's "core vX.Y.Z" line —
+        // the two packages are versioned independently and can drift (see docs).
+        io.log(`${VERSION} (core ${readCoreVersion()})`);
+        // stdout stays exactly the version string so it can be parsed; the pointer goes to stderr.
+        // An agent that runs only `--version` and never `--help` still learns the guides exist.
+        io.errorLog('svelte-vitals: run `svelte-vitals docs list` for the bundled guides.');
+        result = { code: 0, exit: 'natural' };
+        return;
+      }
+
+      if (guard.errors.length > 0) {
+        // gunshi's parser can't reject these post-parse (guard.ts's own doc comment) — fall back
+        // to the exact legacy parse/validate pair so the printed diagnostics (guard's own wording
+        // PLUS resolveArgs' enum/range checks, which also fire against the same raw value) match
+        // byte-for-byte, in the same order, as today.
+        const { warnings, errors } = resolveArgs(parseRunArgs(args));
+        for (const w of warnings) io.errorLog(w);
+        for (const e of errors) io.errorLog(e);
+        result = { code: 2, exit: 'immediate' };
+        return;
+      }
+
+      // `tail` (post-`--`) never went through gunshi — it was split off above and stays out of
+      // `ctx.positionals` entirely, so it's appended here, verbatim, as node's `parseArgs` would.
+      const argv = toCliArgv(ctx.values as Record<string, unknown>, [...(ctx.positionals as string[]), ...tail], args);
+      const { options, warnings, errors, minHealth } = resolveArgs(argv);
+      for (const w of warnings) io.errorLog(w);
+      for (const e of errors) io.errorLog(e);
+      if (!options) {
+        result = { code: 2, exit: 'immediate' };
+        return;
+      }
+
+      const code = await run({
+        ...options,
+        minHealth,
+        selectApp,
+        log: io.log,
+        errorLog: io.errorLog
+      });
+      // A write to a pipe is asynchronous, so `process.exit` can discard what has not drained — the report is
+      // the largest thing this CLI writes and the first pipe buffer is 65,536 bytes. The empty write's callback
+      // fires once the stream has flushed, so it's safe for the thin entry to call `process.exit` as soon as
+      // this resolves.
+      await new Promise((resolve) => process.stdout.write('', resolve));
+      result = { code, exit: 'immediate' };
+    }
+  });
+
+  await cli(argvForGunshi, rootCommand, {
+    name: 'svelte-vitals',
+    // Routes every internal gunshi write through a no-op — see docs.ts's identical note; bone has
+    // no renderer plugin installed so nothing here currently relies on it, kept for forward-compat.
+    usageSilent: true
+  });
+
+  return result;
+}

--- a/packages/cli/src/gunshi/docs.ts
+++ b/packages/cli/src/gunshi/docs.ts
@@ -5,11 +5,17 @@ import { consoleIO, type CliIO } from '../cli-io.js';
 import { knownRuleIds } from '../rules-config.js';
 import { EMBEDDED_DOCS } from '../docs/generated.js';
 import { DOCS_HELP, knownTopicNames, renderList } from '../docs/cli.js';
-import { guardArgs } from './guard.js';
+import { guardArgs, splitAtTerminator, stripUnknownFlags } from './guard.js';
 
 /** docs declares no value-carrying flags today — see guard.ts's own doc comment for why the list is still passed explicitly. */
 const BOOLEAN_FLAGS = ['json', 'help'] as const;
 const HELP_ARG = { help: { type: 'boolean', short: 'h' } } as const;
+/** Family-wide, not per-subcommand — see guard.ts's `stripUnknownFlags` doc comment: the legacy
+ * runner parses `--json`/`-h`/`--help` in one flat pass, so `show` (which never reads `--json`
+ * itself) still needs it declared below to keep gunshi's own per-command resolution from
+ * mistaking it for an unknown flag and swallowing the positional after it. */
+const KNOWN_LONG_FLAGS = new Set(BOOLEAN_FLAGS);
+const KNOWN_SHORT_FLAGS = new Set(['h']);
 
 /**
  * gunshi/bone port of `docs/cli.ts`'s dispatch (design doc: Phase 2a). `docs` is passed as its
@@ -26,9 +32,28 @@ const HELP_ARG = { help: { type: 'boolean', short: 'h' } } as const;
  * `cli()`'s internal `await`s and clobber each other's closure.
  */
 export async function runDocsCliGunshi(args: string[], io: CliIO = consoleIO): Promise<number> {
-  const guard = guardArgs(args, [], BOOLEAN_FLAGS);
+  // `--` must be split off before guard/strip run — see guard.ts's `splitAtTerminator` doc
+  // comment. `tail` is appended verbatim to every positional read below.
+  const { head, tail } = splitAtTerminator(args);
+  const guard = guardArgs(head, [], BOOLEAN_FLAGS);
   for (const e of guard.errors) io.errorLog(e);
   if (guard.errors.length > 0) return 2;
+  const argvForGunshi = stripUnknownFlags(guard.argv, KNOWN_LONG_FLAGS, KNOWN_SHORT_FLAGS);
+
+  // Legacy's `[sub, ...rest] = argv._` picks the sub-command from ONE merged positional list, in
+  // argv order regardless of `--` — so `docs -- list` still sees `sub === 'list'`. gunshi can't:
+  // only `head` ever reaches its own sub-command matching (`tail` never goes through `cli()` at
+  // all), so when head has no positional of its own, gunshi immediately falls back to root's
+  // `run()` — which can only report "unknown subcommand", never actually dispatch to `list`/
+  // `show`'s own logic. Promoting the one matching token out of `tail` into the head argv lets
+  // gunshi's real matching route to it. Gated on head having NO positional at all (not merely a
+  // non-matching one): if head already attempted a positional, THAT is what `argv._[0]` would
+  // have been under the legacy parser, and tail is left alone — root's fallback below already
+  // merges it in for that "unknown subcommand" wording.
+  const headHasPositional = argvForGunshi.some((t) => !t.startsWith('-'));
+  const promoted = !headHasPositional && (tail[0] === 'list' || tail[0] === 'show');
+  const finalArgv = promoted ? [...argvForGunshi, tail[0]!] : argvForGunshi;
+  const tailRest = promoted ? tail.slice(1) : tail;
 
   let exitCode = 0;
 
@@ -44,8 +69,9 @@ export async function runDocsCliGunshi(args: string[], io: CliIO = consoleIO): P
       // ctx.positionals is NOT "args after `list`" — for a matched sub-command it's the raw
       // top-level positional array with the command-path token(s) spliced in at the front
       // (undocumented; see the regression test pinning this). Slicing off commandPath.length
-      // recovers "args after the sub-command name".
-      const extra = ctx.positionals.slice(ctx.commandPath.length);
+      // recovers "args after the sub-command name"; `tail` (post-`--`) never went through gunshi
+      // at all, so it's appended here rather than being part of that slice.
+      const extra = [...ctx.positionals.slice(ctx.commandPath.length), ...tailRest];
       if (extra.length > 0) {
         // Accepting it would read as "list, filtered to config".
         io.errorLog('svelte-vitals: docs list takes no arguments; use `docs show <name>` to read one.');
@@ -73,6 +99,11 @@ export async function runDocsCliGunshi(args: string[], io: CliIO = consoleIO): P
       // "docs show needs a topic name, e.g. ...". Counting positionals ourselves reproduces
       // the exact current wording instead.
       name: { type: 'positional', required: false },
+      // Declared but unused here — see the family-wide KNOWN_LONG_FLAGS comment above. The legacy
+      // runner accepts `--json` on `show` too (a harmless no-op boolean); without this, gunshi's
+      // per-command resolution would treat `--json` as undeclared for `show` specifically and
+      // swallow the following positional (`docs show --json config` would lose `config`).
+      json: { type: 'boolean' },
       ...HELP_ARG
     },
     run: (ctx) => {
@@ -82,7 +113,7 @@ export async function runDocsCliGunshi(args: string[], io: CliIO = consoleIO): P
         return;
       }
       // `docs show a b` printing only `a` would misrepresent itself as "here are both".
-      const rest = ctx.positionals.slice(ctx.commandPath.length);
+      const rest = [...ctx.positionals.slice(ctx.commandPath.length), ...tailRest];
       if (rest.length !== 1) {
         io.errorLog(
           rest.length === 0
@@ -118,7 +149,9 @@ export async function runDocsCliGunshi(args: string[], io: CliIO = consoleIO): P
 
   const rootCommand = define({
     name: 'docs',
-    args: HELP_ARG,
+    // `json` declared but unused here too, for the same family-wide reason as `showCommand` — a
+    // bare `docs --json <sub>` reaches this command's own resolution via `fallbackToEntry`.
+    args: { json: { type: 'boolean' }, ...HELP_ARG },
     subCommands: { list: listCommand, show: showCommand },
     run: (ctx) => {
       if (ctx.values.help) {
@@ -129,7 +162,7 @@ export async function runDocsCliGunshi(args: string[], io: CliIO = consoleIO): P
       // fallbackToEntry (below) routes here both for a bare `docs` (ctx.omitted) and for an
       // unrecognized first positional. ctx.commandPath is [] at the entry level, so no slicing
       // is needed here (unlike list/show above, which are matched sub-commands).
-      const [sub] = ctx.positionals;
+      const [sub] = [...ctx.positionals, ...tailRest];
       if (sub === undefined) {
         io.errorLog(DOCS_HELP);
         exitCode = 2;
@@ -141,7 +174,7 @@ export async function runDocsCliGunshi(args: string[], io: CliIO = consoleIO): P
     }
   });
 
-  await cli(guard.argv, rootCommand, {
+  await cli(finalArgv, rootCommand, {
     name: 'svelte-vitals docs',
     subCommands: { list: listCommand, show: showCommand },
     fallbackToEntry: true,

--- a/packages/cli/src/gunshi/explain.ts
+++ b/packages/cli/src/gunshi/explain.ts
@@ -4,10 +4,12 @@ import { explainRule, allRules } from '@svelte-vitals/core';
 import { consoleIO, type CliIO } from '../cli-io.js';
 import { knownRuleIds } from '../rules-config.js';
 import { EXPLAIN_HELP, renderRuleList, formatRuleExplanation } from '../explain.js';
-import { guardArgs } from './guard.js';
+import { guardArgs, splitAtTerminator, stripUnknownFlags } from './guard.js';
 
 /** explain declares no value-carrying flags today — see guard.ts's own doc comment for why the list is still passed explicitly. */
 const BOOLEAN_FLAGS = ['json', 'list', 'help'] as const;
+const KNOWN_LONG_FLAGS = new Set(BOOLEAN_FLAGS);
+const KNOWN_SHORT_FLAGS = new Set(['h']);
 
 /**
  * gunshi/bone port of `explain.ts`'s dispatch (design doc: Phase 2a). Unlike `docs`, this is a
@@ -17,9 +19,13 @@ const BOOLEAN_FLAGS = ['json', 'list', 'help'] as const;
  * real slice case). See docs.ts for the exit-code closure pattern this mirrors.
  */
 export async function runExplainCliGunshi(args: string[], io: CliIO = consoleIO): Promise<number> {
-  const guard = guardArgs(args, [], BOOLEAN_FLAGS);
+  // `--` must be split off before guard/strip run — see guard.ts's `splitAtTerminator` doc
+  // comment. `tail` is appended verbatim to the positional read below.
+  const { head, tail } = splitAtTerminator(args);
+  const guard = guardArgs(head, [], BOOLEAN_FLAGS);
   for (const e of guard.errors) io.errorLog(e);
   if (guard.errors.length > 0) return 2;
+  const argvForGunshi = stripUnknownFlags(guard.argv, KNOWN_LONG_FLAGS, KNOWN_SHORT_FLAGS);
 
   let exitCode = 0;
 
@@ -28,12 +34,16 @@ export async function runExplainCliGunshi(args: string[], io: CliIO = consoleIO)
     args: {
       list: { type: 'boolean' },
       json: { type: 'boolean' },
-      help: { type: 'boolean', short: 'h' },
-      // Left un-required, same reasoning as docs show's `name` (gunshi/docs.ts): a missing rule
-      // id is reported with this command's own wording, not gunshi's required-positional error.
-      id: { type: 'positional', required: false }
+      help: { type: 'boolean', short: 'h' }
+      // No declared `id` positional: `ctx.positionals` is populated regardless of whether any arg
+      // declares `type: 'positional'` (docs.ts's own root command relies on the same fact), and a
+      // declared one wouldn't see `tail` (post-`--`) anyway — the rule id is read from the merged
+      // `positionals` below instead.
     },
     run: (ctx) => {
+      // `tail` (post-`--`) never went through gunshi at all, so it's appended here rather than
+      // being part of `ctx.positionals`.
+      const positionals = [...ctx.positionals, ...tail];
       if (ctx.values.help) {
         io.log(EXPLAIN_HELP);
         exitCode = 0;
@@ -42,7 +52,7 @@ export async function runExplainCliGunshi(args: string[], io: CliIO = consoleIO)
 
       if (ctx.values.list) {
         // Extra positionals reaching here would misrepresent themselves as "explaining that id".
-        if (ctx.positionals.slice(ctx.commandPath.length).length > 0) {
+        if (positionals.length > 0) {
           io.errorLog('svelte-vitals: explain --list takes no rule id; drop --list to explain one.');
           exitCode = 2;
           return;
@@ -60,7 +70,7 @@ export async function runExplainCliGunshi(args: string[], io: CliIO = consoleIO)
         return;
       }
 
-      const id = ctx.values.id;
+      const id = positionals[0];
       if (id === undefined) {
         io.errorLog(
           'svelte-vitals: explain needs a rule id, e.g. `svelte-vitals explain seo/ssr-disabled`; `--list` shows them all.'
@@ -83,7 +93,7 @@ export async function runExplainCliGunshi(args: string[], io: CliIO = consoleIO)
     }
   });
 
-  await cli(guard.argv, explainCommand, {
+  await cli(argvForGunshi, explainCommand, {
     name: 'svelte-vitals explain',
     // No writes this command can trigger currently rely on this (see docs.ts's identical note),
     // kept for the same forward-compat reason.

--- a/packages/cli/src/gunshi/guard.ts
+++ b/packages/cli/src/gunshi/guard.ts
@@ -61,3 +61,75 @@ export function guardArgs(argv: string[], valueFlags: readonly string[], boolean
 
   return { errors, argv: argvNormalized };
 }
+
+/**
+ * Splits argv at the first literal `--` token — the shell's own "stop parsing flags" convention,
+ * honored natively by `node:util`'s `parseArgs` (what every legacy runner in this CLI is built
+ * on). `head` is everything before it, still subject to every pre-parse layer (guard, strip,
+ * gunshi itself). `tail` is everything after it (the `--` itself dropped) and must never be
+ * treated as a flag again by anything — the caller appends it verbatim to whatever positional
+ * channel it tracks. Absent, `head` is the whole argv and `tail` is empty.
+ *
+ * Every gunshi-dispatched command splits BEFORE calling `guardArgs`/`stripUnknownFlags`: neither
+ * of those understands `--`, so left unsplit they mistake a post-`--` token that merely looks like
+ * a flag (`<path> -- --score`) for a real one — `stripUnknownFlags` even drops the bare `--` token
+ * itself (an unknown "long flag" named `''`), which is what let gunshi's own parser see the
+ * unescaped tokens afterward and reinterpret them.
+ */
+export function splitAtTerminator(argv: string[]): { head: string[]; tail: string[] } {
+  const i = argv.indexOf('--');
+  return i === -1 ? { head: argv, tail: [] } : { head: argv.slice(0, i), tail: argv.slice(i + 1) };
+}
+
+/**
+ * gunshi's parser (args-tokens) treats any UNDECLARED long/short option as string-like: a
+ * positional immediately following it gets consumed as that option's own value instead of
+ * staying a positional (confirmed empirically — `node:util`'s `parseArgs(strict:false)`, which
+ * every legacy runner in this CLI uses, treats the same shape as boolean and leaves the
+ * positional alone). Left unhandled, a typo'd flag right before a declared positional (an
+ * analyzed path, `docs show <name>`, `explain <rule-id>`) would silently swallow it instead of
+ * just being ignored — breaking the "unknown flags are silently ignored" contract for that one
+ * argv shape. Stripped here, before gunshi ever parses: the token is dropped, its follower is
+ * never touched, so the follower surfaces as a positional exactly as the legacy parser would
+ * leave it.
+ *
+ * A grouped short like `-hx` mixes a known flag with an unknown one — node's parseArgs
+ * (strict:false) expands the group and keeps the known members, dropping only the unrecognized
+ * ones; reproduced here by filtering characters instead of testing the whole token. A single
+ * unknown short (`-x`) is the same case with zero survivors. `-5`/`-digit` gets no special
+ * exemption: node never treats it as a positional-preserving case either (an undeclared short is
+ * an undeclared short), so it drops like any other unknown short.
+ *
+ * `knownLong`/`knownShort` are the flag names this specific command recognizes ACROSS ITS WHOLE
+ * FAMILY (every sub-command's own flags, for a command with sub-commands) — not just the ones the
+ * particular sub-command handling a given invocation happens to read. The legacy runners parse
+ * every command's args in one flat `parseCliArgs` call, so e.g. `docs show --json config` sees
+ * `--json` as a harmless known boolean and keeps `config` as the positional even though `show`
+ * itself never reads `--json`; each gunshi sub-command must declare every family-wide flag in its
+ * own `args` too (even unused) so gunshi's own per-command resolution doesn't re-trigger the same
+ * swallow bug this function exists to prevent.
+ */
+export function stripUnknownFlags(
+  argv: string[],
+  knownLong: ReadonlySet<string>,
+  knownShort: ReadonlySet<string>
+): string[] {
+  const out: string[] = [];
+  for (const token of argv) {
+    if (token.startsWith('--')) {
+      const name = token.slice(2).split('=')[0]!;
+      if (knownLong.has(name)) out.push(token);
+      continue;
+    }
+    if (token.startsWith('-') && token !== '-') {
+      const survivors = token
+        .slice(1)
+        .split('')
+        .filter((c) => knownShort.has(c));
+      if (survivors.length > 0) out.push(`-${survivors.join('')}`);
+      continue;
+    }
+    out.push(token);
+  }
+  return out;
+}

--- a/packages/cli/test/__snapshots__/help-golden.test.ts.snap
+++ b/packages/cli/test/__snapshots__/help-golden.test.ts.snap
@@ -135,30 +135,30 @@ Usage:
   svelte-vitals ci install       Add a GitHub Actions PR gate (annotations + summary comment)
   svelte-vitals ci upgrade       Refresh the pinned @svelte-vitals/action in an existing workflow
 
-Options:
-  --meta-components <names>   Comma-separated component names that emit head metadata
-  --treat-dynamic-as <mode>   pass | warn | fail (default: pass)
-  --route <glob>              Only analyze routes matching this glob
-  --diff [ref]                Report only findings in files changed vs ref (default HEAD; e.g. --diff main)
-  --staged                    Report only findings in files staged for commit (pre-commit gate)
-  --baseline <ref>            Report only findings not present at ref (compare against e.g. origin/main)
-  --update-suppressions       Write svelte-vitals-suppressions.json accepting all current findings (introduce gates on legacy projects)
-  --no-suppressions           Ignore svelte-vitals-suppressions.json for this run
-  --by-route                  Show per-route score breakdown in console output
-  --reporter <fmt>            console | json | agent | sarif | github | html | md (auto: agent under AI-agent envs, github under GitHub Actions)
-  --out-file <path>           Output path for --reporter html (default: svelte-vitals-report.html; '-' for stdout)
-  --fail-on <severity>        Fail (exit 1) when any finding reaches this severity: critical | warning | info
-  --min-health <0-100>        Fail (exit 1) when the combined Health score is below this value
-  --rules <ids>               Comma-separated rule ids to enable (all others disabled)
-  --ignore <ids>              Comma-separated rule ids to disable
-  --category <cats>           Comma-separated categories to analyze: seo | performance | correctness | security | architecture
-  --weights <pairs>           Per-category Health weight overrides, e.g. seo=2,performance=1 (unlisted categories default to 1)
-  --score                     Print only the combined Health score (works with --min-health for gating)
-  --no-color                  Disable ANSI color in console output
-  --no-animation               Disable the Health-score reveal animation and mascot on an interactive terminal
-  --verbose                    Show every finding uncapped and ungrouped (default: capped, grouped by rule)
-  -h, --help                  Show this help
-  -v, --version               Show version
+OPTIONS:
+  -h, --help                                     Show this help
+  -v, --version                                  Show version
+  --meta-components <meta-components>            Comma-separated component names that emit head metadata
+  --treat-dynamic-as <treat-dynamic-as>          pass | warn | fail (default: pass)
+  --route <route>                                Only analyze routes matching this glob
+  --diff <diff>                                  Report only findings in files changed vs ref (default HEAD; e.g. --diff main)
+  --staged                                       Report only findings in files staged for commit (pre-commit gate)
+  --baseline <baseline>                          Report only findings not present at ref (compare against e.g. origin/main)
+  --update-suppressions                          Write svelte-vitals-suppressions.json accepting all current findings (introduce gates on legacy projects)
+  --no-suppressions                              Ignore svelte-vitals-suppressions.json for this run
+  --by-route                                     Show per-route score breakdown in console output
+  --reporter <reporter>                          console | json | agent | sarif | github | html | md (auto: agent under AI-agent envs, github under GitHub Actions)
+  --out-file <out-file>                          Output path for --reporter html (default: svelte-vitals-report.html; '-' for stdout)
+  --fail-on <fail-on>                            Fail (exit 1) when any finding reaches this severity: critical | warning | info
+  --min-health <min-health>                      Fail (exit 1) when the combined Health score is below this value (0-100)
+  --rules <rules>                                Comma-separated rule ids to enable (all others disabled)
+  --ignore <ignore>                              Comma-separated rule ids to disable
+  --category <category>                          Comma-separated categories to analyze: seo | performance | correctness | security | architecture
+  --weights <weights>                            Per-category Health weight overrides, e.g. seo=2,performance=1 (unlisted categories default to 1)
+  --score                                        Print only the combined Health score (works with --min-health for gating)
+  --no-color                                     Disable ANSI color in console output
+  --no-animation                                 Disable the Health-score reveal animation and mascot on an interactive terminal
+  --verbose                                      Show every finding uncapped and ungrouped (default: capped, grouped by rule)
 
 Config file:
   svelte-vitals.config.{mjs,js,ts} in the analyzed directory; flags override it.

--- a/packages/cli/test/gunshi-analyze.test.ts
+++ b/packages/cli/test/gunshi-analyze.test.ts
@@ -1,0 +1,177 @@
+// Phase 2b of the gunshi migration (docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md):
+// analyzer-specific regressions the shared cli-contract.test.ts/help-golden.test.ts suites don't
+// already pin — see gunshi/analyze.ts's own doc comments for why each of these exists.
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { cli } from 'gunshi/bone';
+import { define } from 'gunshi/definition';
+import { runCli } from '../src/cli.js';
+import { captureIO } from './helpers/capture-io.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const unitEntryFixtureDir = join(here, 'fixtures', 'unit-entry-project');
+
+async function run(args: string[]) {
+  const io = captureIO();
+  const result = await runCli(args, io);
+  return { ...result, out: io.out, err: io.err };
+}
+
+const dirs: string[] = [];
+function tmpProjectDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'svelte-vitals-gunshi-analyze-'));
+  dirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  while (dirs.length > 0) {
+    const dir = dirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('root analyzer: single bone entry, no subCommands map', () => {
+  it('ctx.commandPath is always [] and ctx.positionals needs no slicing (mirrors explain.ts, not docs.ts)', async () => {
+    let captured: { positionals: string[]; commandPath: string[] } | undefined;
+    const cmd = define({
+      name: 'probe',
+      args: {},
+      run: (ctx) => {
+        captured = { positionals: ctx.positionals, commandPath: ctx.commandPath };
+      }
+    });
+    await cli(['./apps/web'], cmd, { name: 'probe' });
+    expect(captured?.commandPath).toEqual([]);
+    expect(captured?.positionals).toEqual(['./apps/web']);
+  });
+});
+
+describe('unknown flags never swallow the analyzed path', () => {
+  // args-tokens treats an UNDECLARED long/short option as string-like, consuming a following
+  // positional as its own value — unlike node:util's parseArgs(strict:false), which treats the
+  // same shape as boolean and leaves the positional alone (verified against both parsers).
+  // gunshi/analyze.ts's stripUnknownFlags removes the unrecognized token before gunshi ever sees
+  // it, so the follower always survives. cli-contract.test.ts's own 'unknown flag is silently
+  // ignored' cell already pins the flag-before-path shape end to end; these add the reverse order
+  // and a short-flag typo.
+  it('an unknown flag after the path leaves the path alone', async () => {
+    const dir = tmpProjectDir();
+    const { code, err } = await run([dir, '--nonsense-flag']);
+    expect(code).toBe(2);
+    expect(err).not.toContain('nonsense-flag');
+    expect(err).toContain('No SvelteKit project found');
+  });
+
+  it('an unknown short flag before the path leaves the path alone', async () => {
+    const dir = tmpProjectDir();
+    const { code, err } = await run(['-x', dir]);
+    expect(code).toBe(2);
+    expect(err).not.toContain('-x');
+    expect(err).toContain('No SvelteKit project found');
+  });
+
+  it('a grouped short (-hv) keeps every known member — help wins, matching node:util strict:false', async () => {
+    const { code, out } = await run(['-hv']);
+    expect(code).toBe(0);
+    expect(out).toContain('svelte-vitals — a deterministic SvelteKit code-health scanner');
+  });
+
+  it("-5 <path>: a digit-shaped unknown short is dropped like any other, not exempted — the path is analyzed, not swallowed as -5's value", async () => {
+    const dir = tmpProjectDir();
+    const { code, err } = await run(['-5', dir]);
+    expect(code).toBe(2);
+    expect(err).toContain('No SvelteKit project found');
+  });
+
+  it('--baseline --typo main: the unknown flag survives into the baseline shadow-parse, so it is still rejected as the (dash-prefixed) ref', async () => {
+    // resolveArgs returns before ever reading the positional on this path (a fatal error short-
+    // circuits before `cwd` is computed), so there's no separate observable surface for "the
+    // positional wasn't lost" here — the fix's positional-preservation is pinned by the --diff
+    // case below instead, which does reach cwd.
+    const { code, err } = await run(['--baseline', '--typo', 'main']);
+    expect(code).toBe(2);
+    expect(err).toContain('--baseline requires a git ref');
+  });
+});
+
+describe('neutralizeBareDiffAndBaseline: a stripped unknown flag never exposes a positional to a bare --diff/--baseline', () => {
+  // Before the fix: stripUnknownFlags removing --typo left `unitEntryFixtureDir` sitting directly
+  // after a bare --diff/--baseline in the argv gunshi parses, so gunshi consumed it as the flag's
+  // own value instead of leaving it as the analyzed-path positional — the run silently fell back
+  // to process.cwd() instead. Chdir to an empty tmpdir first so a lost positional is observable
+  // (process.cwd() would then deterministically fail project detection) and a preserved one is
+  // equally observable (the fixture project would be found and actually analyzed).
+  const prevCwd = process.cwd();
+  afterEach(() => process.chdir(prevCwd));
+
+  it('--diff --typo <path>: the path survives as the positional, exactly like parseRunArgs', async () => {
+    process.chdir(tmpProjectDir());
+    const { code, err } = await run(['--diff', '--typo', unitEntryFixtureDir]);
+    expect(err).not.toContain('No SvelteKit project found');
+    expect(code).not.toBe(2);
+  });
+
+  it('a bare --diff alone is unaffected — still defaults to HEAD, still fails project detection the same way', async () => {
+    process.chdir(tmpProjectDir());
+    const { code, err } = await run(['--diff']);
+    expect(code).toBe(2);
+    expect(err).toContain('No SvelteKit project found');
+  });
+
+  it('--diff main (value form, no interfering unknown flag): main is still consumed as the ref, not the path', async () => {
+    process.chdir(tmpProjectDir());
+    const { code, err } = await run([unitEntryFixtureDir, '--diff', 'main']);
+    // The explicit fixture path (before --diff) is the positional; 'main' is diff's value either
+    // way — this only guards that neutralizing bare occurrences didn't also touch this shape.
+    expect(err).not.toContain('No SvelteKit project found');
+    expect(code).not.toBe(2);
+  });
+});
+
+describe('-- terminator: everything after it is a literal positional, never a flag again', () => {
+  // Before splitAtTerminator ran ahead of guard/strip: stripUnknownFlags treated the bare `--`
+  // itself as an unknown long flag (name '') and dropped it, so gunshi never saw the terminator
+  // and re-parsed what followed as real flags.
+  // Both cells assert reporter-agnostically (out non-empty, never a bare score number) — the
+  // reporter auto-detects from the environment (github under GITHUB_ACTIONS, agent under agent
+  // envs), so a format-specific marker like 'Health:' would fail on CI while passing locally.
+  it('<fixture> -- --score: --score is a literal positional, not reactivated — full report, not a bare number', async () => {
+    const { code, out } = await run([unitEntryFixtureDir, '--', '--score']);
+    expect(code).toBe(1);
+    expect(out).not.toMatch(/^\d+$/);
+    expect(out.length).toBeGreaterThan(0);
+  });
+
+  it('<fixture> -- --reporter: nothing silent — a full report prints, not a bare exit 2', async () => {
+    // Before the fix: guardArgs fired on the post-`--` `--reporter` token (missing value), then
+    // the wording fallback re-parsed via parseRunArgs, which honors `--` and found no error — so
+    // nothing printed at all, yet the guard branch still forced exit 2.
+    const { code, out } = await run([unitEntryFixtureDir, '--', '--reporter']);
+    expect(code).not.toBe(2);
+    expect(out.length).toBeGreaterThan(0);
+  });
+});
+
+describe('--score --score=false: last-wins through the real dispatch path', () => {
+  it('a trailing =false turns --score off (falls through to the normal reporter path)', async () => {
+    const dir = tmpProjectDir();
+    const { code, err } = await run([dir, '--score', '--score=false']);
+    // --score off means no "--score overrides --reporter" warning path is even reachable here;
+    // the run still fails on project detection, proving --score itself did not stay on (a
+    // literal score run prints only a number, never this message).
+    expect(code).toBe(2);
+    expect(err).toContain('No SvelteKit project found');
+  });
+});
+
+describe('--help wins over a guard-detected error (help is checked before the guard fallback)', () => {
+  it('--help --reporter= prints help and exits 0, exactly like today', async () => {
+    const { code, out, err } = await run(['--help', '--reporter=']);
+    expect(code).toBe(0);
+    expect(out).toContain('svelte-vitals — a deterministic SvelteKit code-health scanner');
+    expect(err).toBe('');
+  });
+});

--- a/packages/cli/test/gunshi-docs-parity.test.ts
+++ b/packages/cli/test/gunshi-docs-parity.test.ts
@@ -49,6 +49,33 @@ describe('gunshi/bone docs reproduces the legacy docs CLI, byte for byte', () =>
     {
       name: 'list --json=false --json (duplicate booleans are last-wins: on)',
       args: ['list', '--json=false', '--json']
+    },
+    // Phase 2b (docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md): an unknown
+    // flag directly before a declared positional wasn't covered above — none of the existing
+    // cells put one there. args-tokens treats an undeclared option as string-like and would
+    // otherwise consume `config`/`--typo` as that option's own value.
+    { name: 'show --typo config (unknown long flag before the positional)', args: ['show', '--typo', 'config'] },
+    {
+      name: 'show --json config (a family-known, show-unused flag stays harmless)',
+      args: ['show', '--json', 'config']
+    },
+    { name: 'show -x config (unknown short flag before the positional)', args: ['show', '-x', 'config'] },
+    { name: 'show -- --typo (terminator: a literal, unknown topic name)', args: ['show', '--', '--typo'] },
+    { name: '-- --typo (terminator on bare docs, --typo becomes the sub)', args: ['--', '--typo'] },
+    { name: '--json bogus (family-known flag unused by the root fallback)', args: ['--json', 'bogus'] },
+    // Tail-promotion: legacy's `argv._[0]` picks the sub-command from ONE merged positional list
+    // regardless of `--`, so a sub-command name after the terminator still dispatches for real —
+    // not the generic "unknown docs subcommand" a bare fallback would print.
+    { name: '-- list (sub-command name promoted out of the tail)', args: ['--', 'list'] },
+    { name: '-- show config (promoted sub-command, topic stays in the tail)', args: ['--', 'show', 'config'] },
+    { name: '-- show (promoted sub-command, no topic left in the tail)', args: ['--', 'show'] },
+    {
+      name: '--json -- list (head flag parses normally, tail sub-command still promotes)',
+      args: ['--json', '--', 'list']
+    },
+    {
+      name: 'bogus -- list (head already has a positional — not promoted, "bogus" is still sub)',
+      args: ['bogus', '--', 'list']
     }
   ];
 

--- a/packages/cli/test/gunshi-explain-parity.test.ts
+++ b/packages/cli/test/gunshi-explain-parity.test.ts
@@ -32,7 +32,13 @@ describe('gunshi/bone explain reproduces the legacy explain CLI, byte for byte',
     { name: '--help', args: ['--help'] },
     { name: '-h', args: ['-h'] },
     { name: '--json=false (literal-false coercion)', args: ['--json=false', 'seo/title-length'] },
-    { name: '--list=false (literal-false coercion, falls through to no-id)', args: ['--list=false'] }
+    { name: '--list=false (literal-false coercion, falls through to no-id)', args: ['--list=false'] },
+    // Phase 2b (docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md): an unknown
+    // flag directly before the rule-id positional — args-tokens would otherwise consume the id as
+    // that undeclared flag's own value.
+    { name: '--typo <id> (unknown long flag before the positional)', args: ['--typo', 'seo/title-presence'] },
+    { name: '-x <id> (unknown short flag before the positional)', args: ['-x', 'seo/title-presence'] },
+    { name: '-- --typo (terminator: a literal, unknown rule id)', args: ['--', '--typo'] }
   ];
 
   for (const { name, args } of cells) {

--- a/packages/cli/test/gunshi-guard.test.ts
+++ b/packages/cli/test/gunshi-guard.test.ts
@@ -3,7 +3,7 @@
 // gate-(b) cells (spike-gunshi-parsing.test.ts) against the guard as actually shipped — driven by
 // the real `VALUE_FLAGS` import from resolve-args.ts, not a second hardcoded flag list.
 import { describe, it, expect } from 'vitest';
-import { guardArgs } from '../src/gunshi/guard.js';
+import { guardArgs, splitAtTerminator, stripUnknownFlags } from '../src/gunshi/guard.js';
 import { VALUE_FLAGS } from '../src/resolve-args.js';
 
 describe('guardArgs: value-carrying flags (using the real analyzer VALUE_FLAGS list)', () => {
@@ -71,5 +71,55 @@ describe('guardArgs: boolean --flag=false normalization', () => {
   it('duplicate tokens are last-wins: a trailing bare flag stays on', () => {
     const { argv } = guardArgs(['--json=false', '--json'], [], ['json']);
     expect(argv).toEqual(['--json']);
+  });
+});
+
+describe('splitAtTerminator', () => {
+  it('splits at the first -- , excluding it from both halves', () => {
+    expect(splitAtTerminator(['a', '--', 'b', 'c'])).toEqual({ head: ['a'], tail: ['b', 'c'] });
+  });
+
+  it('no -- present: everything is head, tail is empty', () => {
+    expect(splitAtTerminator(['a', 'b'])).toEqual({ head: ['a', 'b'], tail: [] });
+  });
+
+  it('only the FIRST -- terminates; a second one is a literal tail token', () => {
+    expect(splitAtTerminator(['a', '--', 'b', '--', 'c'])).toEqual({ head: ['a'], tail: ['b', '--', 'c'] });
+  });
+
+  it('-- as the very first token: empty head, everything else is tail', () => {
+    expect(splitAtTerminator(['--', 'a', 'b'])).toEqual({ head: [], tail: ['a', 'b'] });
+  });
+});
+
+describe('stripUnknownFlags', () => {
+  const long = new Set(['json', 'help']);
+  const short = new Set(['h']);
+
+  it('drops an unrecognized long flag, keeping its follower untouched', () => {
+    expect(stripUnknownFlags(['--typo', 'config'], long, short)).toEqual(['config']);
+  });
+
+  it('keeps a known long flag and a plain value unchanged', () => {
+    expect(stripUnknownFlags(['--json', 'config'], long, short)).toEqual(['--json', 'config']);
+  });
+
+  it('drops an unrecognized short flag entirely', () => {
+    expect(stripUnknownFlags(['-x', 'config'], long, short)).toEqual(['config']);
+  });
+
+  it('a grouped short keeps known members, drops unknown ones', () => {
+    expect(stripUnknownFlags(['-hx'], long, short)).toEqual(['-h']);
+  });
+
+  it('a digit-shaped short gets no exemption — dropped like any other unknown short', () => {
+    expect(stripUnknownFlags(['-5', 'config'], long, short)).toEqual(['config']);
+  });
+
+  it('the bare -- token itself is left alone here (splitAtTerminator must run first, not this)', () => {
+    // stripUnknownFlags has no `--` awareness — `--` matches `token.startsWith('--')` with an
+    // empty flag name, which is never in `knownLong`, so it drops without splitAtTerminator's
+    // protection. Pinned so a future edit can't quietly "fix" this function instead.
+    expect(stripUnknownFlags(['a', '--', 'b'], long, short)).toEqual(['a', 'b']);
   });
 });


### PR DESCRIPTION
Phase 2b of the gunshi migration (#448 plan): the root analyzer — the CLI's main surface — now parses and dispatches through `gunshi/bone`, joining `docs`/`explain` (#451). **One declared movement: the root `--help` output.** Everything else is byte-identical, verified by the coordinator against main's dist across 13 surfaces (version, five flag-error cells, unknown-flag-with-path, `--score`, `--reporter json`, duplicate-boolean last-wins, docs/explain, help) — 12 same, the 13th is the declared help change.

## The help movement (design-doc decision 1)

Root `--help` is now **hybrid**: the options section is generated by `gunshi/generator` from the `define()` declarations — flag descriptions live in one place, killing the hand-maintained help-drift class this migration exists for — while the curated prose (header, sub-command usage, `Config file:`, `Exit codes:`, and the whole `If you are an AI agent:` block) is preserved verbatim. Exactly one snapshot key changed.

## A Phase-1 verdict falsified, found and fixed

args-tokens treats any UNDECLARED option as string-like: a following positional is consumed as its value (`node:util parseArgs(strict:false)` leaves it alone). The spike couldn't see this — `docs`/`explain` have no free-form positional — but on the analyzer, `svelte-vitals --typo ./apps/web` would have silently analyzed the wrong directory. Two pre-parse layers compensate: `stripUnknownFlags` (drops unknown tokens, node-style grouped-short expansion) and `neutralizeBareDiffAndBaseline` (bare `--diff`/`--baseline`, judged on original-argv adjacency, become self-contained `=value` tokens so a stripped token can never expose a positional to them). A dated correction addendum records this in the design doc, including the one remaining legacy-parser use (the diff/baseline value shadow parse) that Phase 3's deletion pass must absorb.

Other implementation notes: the shared guard now runs with the real `VALUE_FLAGS` (last-wins boolean normalization from #451 included); `--no-*` flags dodge an undocumented renderer auto-negation quirk via camelCase keys + `toKebab` (accepted spellings unchanged, verified); domain validation stays entirely in `resolveArgs`, fed through a thin adapter; `--help`/`--version`/exit mechanics (flush-then-immediate) preserved.

## Verification

- `cli-contract.test.ts` 16/16 unchanged; only the root-help golden updated (single hunk vs the #451 merge).
- `pnpm e2e` 7/7 and `pnpm smoke` 8/8 against the built dist — the real analyzer now runs through gunshi in both.
- Full suite 2,612 green; io-budget untouched; core/vite untouched.
- Changeset: `svelte-vitals` **minor**, declaring the help-format change and the everything-else-is-pinned invariant.

An independent fresh-context review of the whole migrated surface (Phases 2a+2b vs the last pre-gunshi release) follows as a comment before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Migrated the default analysis CLI to the new command-line framework.
  * Added generated root-level help and version output.
  * Improved handling of analyzer options, paths, grouped flags, and repeated score options.
  * Preserved existing behavior for documentation, explanation, installation, and CI commands.

* **Bug Fixes**
  * Corrected argument handling around unknown flags and `--` separators.
  * Preserved expected behavior for bare `--diff` and `--baseline` options.

* **Tests**
  * Added regression coverage for CLI parsing, output, validation, cleanup, and exit codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->