### PR TITLE
feat(cli): add shell completion generated from the argument declarations

### DIFF
--- a/.changeset/shell-completion.md
+++ b/.changeset/shell-completion.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': minor
+---
+
+Shell completion: `svelte-vitals complete <bash|zsh|fish|powershell>` prints a completion script — sub-command names, every flag, and values for the enum-ish flags (`--reporter`, `--fail-on`, `--category`, `--treat-dynamic-as`). Completions are generated from the same argument declarations that drive parsing and `--help`, so they stay in sync with the CLI automatically. `complete` is a new reserved top-level token, alongside `docs`/`explain`/`install`/`ci` — it wins over a same-named directory, same as those four. No existing command, flag, or output changes, except the root `--help` Usage block, which now lists the new sub-command.

--- a/docs/src/content/docs/guides/(setup)/cli.md
+++ b/docs/src/content/docs/guides/(setup)/cli.md
@@ -331,6 +331,55 @@ that wants to read it structurally.
 An unknown rule id exits `2` and lists every known id, so a near-miss is easy to correct. Rule
 ids are matched exactly and are case-sensitive.
 
+## Shell completion
+
+```bash
+svelte-vitals complete <bash|zsh|fish|powershell>
+```
+
+Prints a completion script for the given shell: sub-command names (`docs`, `explain`, `install`,
+`ci install`/`ci upgrade`), every flag on each, and values for the enum-ish flags (`--reporter`,
+`--fail-on`, `--category`, `--treat-dynamic-as`). Generated from the same argument declarations
+that drive parsing and `--help`, so completions stay in sync with the CLI automatically.
+
+**Bash**
+
+```bash
+mkdir -p ~/.local/share/bash-completion/completions
+svelte-vitals complete bash > ~/.local/share/bash-completion/completions/svelte-vitals
+source ~/.bashrc
+```
+
+**Zsh**
+
+```bash
+mkdir -p ~/.zsh/completions
+echo 'fpath=(~/.zsh/completions $fpath)' >> ~/.zshrc
+echo 'autoload -U compinit && compinit' >> ~/.zshrc
+svelte-vitals complete zsh > ~/.zsh/completions/_svelte-vitals
+exec zsh
+```
+
+**Fish**
+
+```bash
+mkdir -p ~/.config/fish/completions
+svelte-vitals complete fish > ~/.config/fish/completions/svelte-vitals.fish
+```
+
+**PowerShell**
+
+```powershell
+svelte-vitals complete powershell >> $PROFILE
+. $PROFILE
+```
+
+Each script re-invokes `svelte-vitals` from the exact install location it was generated from —
+regenerate it after upgrading `svelte-vitals`, or after moving/reinstalling the package.
+
+`complete` is a subcommand, so it wins over a directory of the same name: to analyze a directory
+called `complete`, write `svelte-vitals ./complete`.
+
 ## Supported Svelte/SvelteKit versions
 
 Rules assume **Svelte 5+ (runes)** and **SvelteKit 2+**. If the analyzed project declares an

--- a/docs/src/content/docs/ja/guides/(setup)/cli.md
+++ b/docs/src/content/docs/ja/guides/(setup)/cli.md
@@ -305,6 +305,56 @@ npx svelte-vitals explain performance/heavy-import
 
 未知のルール ID を渡すと、既知の ID をすべて列挙して終了コード `2` で終了するため、綴り違いをすぐ修正できます。ルール ID は完全一致・大文字小文字を区別して照合されます。
 
+## シェル補完
+
+```bash
+svelte-vitals complete <bash|zsh|fish|powershell>
+```
+
+指定したシェル向けの補完スクリプトを出力します。サブコマンド名（`docs`、`explain`、`install`、
+`ci install`/`ci upgrade`）、それぞれのフラグ、そして列挙型のフラグ（`--reporter`、`--fail-on`、
+`--category`、`--treat-dynamic-as`）の値まで補完します。パースと `--help` を駆動しているのと同じ
+引数定義から生成されるため、補完は常に CLI と一致します。
+
+**Bash**
+
+```bash
+mkdir -p ~/.local/share/bash-completion/completions
+svelte-vitals complete bash > ~/.local/share/bash-completion/completions/svelte-vitals
+source ~/.bashrc
+```
+
+**Zsh**
+
+```bash
+mkdir -p ~/.zsh/completions
+echo 'fpath=(~/.zsh/completions $fpath)' >> ~/.zshrc
+echo 'autoload -U compinit && compinit' >> ~/.zshrc
+svelte-vitals complete zsh > ~/.zsh/completions/_svelte-vitals
+exec zsh
+```
+
+**Fish**
+
+```bash
+mkdir -p ~/.config/fish/completions
+svelte-vitals complete fish > ~/.config/fish/completions/svelte-vitals.fish
+```
+
+**PowerShell**
+
+```powershell
+svelte-vitals complete powershell >> $PROFILE
+. $PROFILE
+```
+
+各スクリプトは、生成された時点のインストール場所から `svelte-vitals` を再実行します。
+`svelte-vitals` をアップグレードしたとき、あるいはパッケージを移動・再インストールしたときは、
+スクリプトを再生成してください。
+
+`complete` はサブコマンドなので、同名のディレクトリより優先されます。`complete` という名前の
+ディレクトリを解析したい場合は `svelte-vitals ./complete` と書いてください。
+
 ## 対応する Svelte/SvelteKit バージョン
 
 ルールは **Svelte 5+（runes）** と **SvelteKit 2+** を前提としています。解析対象プロジェクトの

--- a/docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md
+++ b/docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md
@@ -250,3 +250,79 @@ has non-fatal guard-firing shapes (a bare trailing `--client` parses to legacy's
 genuinely dangerous ones (`--client --force` legacy-consumes `--force` as a literal string) — so
 install's fallback re-runs the _entire_ legacy pipeline (parse → help check → resolve → dispatch)
 rather than assuming a guard hit is always exit 2.
+
+## Addendum (2026-08-11): shell completion via `@gunshi/plugin-completion`
+
+Added `svelte-vitals complete <bash|zsh|fish|powershell>` (`packages/cli/src/gunshi/complete.ts`),
+wired as a sixth reserved top-level token in `runCli` (cli.ts), dispatched unsliced (see the
+file's own doc comment for why) and loaded lazily, same as `docs`/`explain`/`install`/`ci`.
+
+**The plugin never touches the five real gunshi surfaces — a dedicated, completion-only command
+tree instead.** Proven necessary, not merely simpler: temporarily wiring `completion()` into
+`docs.ts`'s own `cli()` call left the full characterization suite green (help-golden,
+cli-contract, both parity suites — 72 tests), but `docs complete` silently changed behavior —
+`complete` is a plugin-added sub-command, added automatically wherever the plugin is installed,
+so it shadowed the existing "unknown docs subcommand" exit-2 path with the plugin's own directive
+line on stdout, exit 0. None of the characterization suite's existing cases exercise the literal
+token `complete`, so this collision is real but was invisible to the suite — recorded here so a
+future attempt to fold completion into an existing surface's `cli()` call re-derives the same
+finding instead of re-discovering it. The completion tree (`buildCompletionTree` in complete.ts)
+is therefore a second, parallel set of `define()` calls, built fresh per invocation (race-safety,
+matching every other surface's convention) with no-op `run`s — `@gunshi/plugin-completion` only
+ever reads `.args`/`.subCommands` off them via its `onExtension` hook; the command that actually
+executes for a `complete` invocation is the `complete` sub-command the plugin adds itself via
+`ctx.addCommand`. Every arg schema in that tree is imported from the real surface's own exported
+`*_ARGS` const (`ROOT_ARGS`, `DOCS_ROOT_ARGS`/`DOCS_LIST_ARGS`/`DOCS_SHOW_ARGS`, `EXPLAIN_ARGS`,
+`INSTALL_ARGS`, `CI_ARGS`/`CI_UPGRADE_ARGS`) — hoisted from inline literals to module-level
+exports where they weren't already (docs.ts, explain.ts), never re-declared, so a flag added to a
+real surface is visible to completion automatically.
+
+Three empirical gotchas, confirmed against 0.37.1, none documented in `@gunshi/docs` or the
+plugin's own README:
+
+- **The entry command's own args vanish from completion when `cli()`'s `subCommands` option is
+  empty AT CALL TIME.** `createInitialSubCommands` only splices a copy of the entry command into
+  the internal subCommands map (flagged `.entry: true`, later found via `.find(cmd => cmd.entry)`
+  in the plugin's `onExtension`) when `options.subCommands` is already non-empty _before_ any
+  plugin's `setup()` runs; with zero declared subCommands, the plugin's own `addCommand('complete',
+...)` is the only entry in that map by the time `onExtension` reads it, so root-level flags
+  silently disappear instead of erroring. Not a concern for this tree (it always declares
+  `docs`/`explain`/`install`/`ci`), but real enough that an isolated repro (a bone `cli()` call
+  with no `subCommands` at all, plus the completion plugin, querying `--` for entry-level flags)
+  is worth keeping in mind before ever adding a leaner completion entry later.
+- **The registration loop has no `toKebab`/`hidden` awareness.** It reads `Object.entries(args)`
+  and registers each flag under the literal object key, with no schema-driven kebab-casing and no
+  hidden check. `ROOT_ARGS`'s `noSuppressions`/`noColor`/`noAnimation` (declared camelCase +
+  `toKebab: true` specifically to dodge a _different_ renderer quirk — see analyze.ts's own doc
+  comment) would complete as `--noSuppressions` etc., which the real CLI does not parse; install's
+  `scope` (`hidden: true`, kept parseable only so an unrecognized flag doesn't swallow a following
+  positional) would still be offered. `forCompletion()` in complete.ts compensates: kebab-cases a
+  `toKebab` key via `kebabnize` (imported from `gunshi/utils`, not reimplemented) and drops
+  `hidden` entries before handing the args to `define()`.
+- **Cosmetic wart, accepted rather than worked around:** the plugin's own description-localization
+  strips a literal `no-` prefix from an arg key before looking up its schema (treating it as an
+  auto-generated negation, the same class of behavior analyze.ts's doc comment already describes
+  for gunshi's _renderer_) — since `forCompletion()`'s kebab-cased key IS `no-suppressions` (not a
+  negation of a `suppressions` flag that doesn't exist), the lookup misses and falls back to the
+  stripped key itself as the "description": `--no-suppressions` completes with the one-word
+  description `suppressions` instead of its real description. The completion _value_ is correct;
+  only the description text is degraded. Not pinned by a test — pinning today's wrong-but-harmless
+  string would fail a future gunshi bump that fixes it, for no benefit (nothing here reads or
+  depends on the description text).
+
+**Dependency footprint correction.** The "exactly one package" framing in this doc's Verified
+Facts section describes core gunshi adoption and remains true for that decision; it does not
+extend to this optional feature. `@gunshi/plugin-completion` itself depends on `@gunshi/plugin`
+and `@bomb.sh/tab` (both real, newly-installed packages), and declares a **non-optional**
+`peerDependency` on `@gunshi/plugin-i18n` — no `peerDependenciesMeta` marks it optional at the npm
+metadata level, even though the plugin's own runtime plugin-dependency graph treats i18n as
+optional (`dependencies: [{ id: 'g:i18n', optional: true }]`) and this integration never imports
+or configures it. Net effect: `pnpm install` here resolved `@gunshi/plugin-i18n` into the lockfile
+solely to satisfy that peer declaration (confirmed via the lockfile diff — it is not physically
+linked into `packages/cli/node_modules`, so it adds resolution weight but not an import-time
+cost), and an npm end-user installing the published `svelte-vitals` package will get it
+auto-installed for real, since npm auto-installs unmet non-optional peers by default. Four new
+packages total reach some form of "installed" for this feature
+(`@gunshi/plugin-completion`, `@gunshi/plugin`, `@bomb.sh/tab`, `@gunshi/plugin-i18n`), not zero
+and not one; import cost is unaffected on the analyzer hot path either way, since `complete.ts` is
+reached only via a dynamic `import()` behind the new `complete` token.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,6 +53,7 @@
   "dependencies": {
     "@svelte-vitals/core": "workspace:*",
     "@clack/prompts": "catalog:",
+    "@gunshi/plugin-completion": "catalog:",
     "gunshi": "catalog:",
     "log-update": "catalog:",
     "magicast": "catalog:",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -24,6 +24,12 @@ export interface CliResult {
  * for why the caller still needs to pick between `process.exit` and `process.exitCode` per path.
  */
 export async function runCli(argv: string[], io: CliIO = consoleIO): Promise<CliResult> {
+  if (argv[0] === 'complete') {
+    // Loaded on demand, same reasoning as `docs`/`explain` below. Passed the FULL argv, not
+    // `argv.slice(1)` — see gunshi/complete.ts's own doc comment for why this one branch differs.
+    const { runCompleteCliGunshi } = await import('./gunshi/complete.js');
+    return { code: await runCompleteCliGunshi(argv, io), exit: 'natural' };
+  }
   if (argv[0] === 'docs') {
     // Loaded on demand: the bundled topics are ~20KB of string literals that the analysis path
     // — the one the I/O budget test and `pnpm bench` defend — would otherwise parse every run.

--- a/packages/cli/src/gunshi/analyze.ts
+++ b/packages/cli/src/gunshi/analyze.ts
@@ -47,7 +47,8 @@ const BOOLEAN_FLAGS = [
  * under their camelCase key, remapped back to the kebab name `resolveArgs` expects in `toCliArgv`
  * below.
  */
-const ROOT_ARGS = {
+/** Exported for gunshi/complete.ts — the completion tree's root args mirror this, never a second copy. */
+export const ROOT_ARGS = {
   'meta-components': { type: 'string', description: 'Comma-separated component names that emit head metadata' },
   'treat-dynamic-as': { type: 'string', description: 'pass | warn | fail (default: pass)' },
   route: { type: 'string', description: 'Only analyze routes matching this glob' },
@@ -158,6 +159,7 @@ Usage:
   svelte-vitals install          Set up the Vite integration, agent skills/rules, config file, or CI
   svelte-vitals ci install       Add a GitHub Actions PR gate (annotations + summary comment)
   svelte-vitals ci upgrade       Refresh the pinned @svelte-vitals/action in an existing workflow
+  svelte-vitals complete <shell> Print a shell completion script (bash, zsh, fish, powershell)
 
 ${optionsSection}
 

--- a/packages/cli/src/gunshi/ci.ts
+++ b/packages/cli/src/gunshi/ci.ts
@@ -38,12 +38,16 @@ Options:
 
 /** Shared by both `ci install` and `ci upgrade` — `ci upgrade` doesn't read `force` itself, but
  * this is also the generator source for the one combined `--help` text every entry point shares
- * (matching CI_HELP's own merged options list), so it declares the full family. */
-const CI_ARGS = {
+ * (matching CI_HELP's own merged options list), so it declares the full family. Exported for
+ * gunshi/complete.ts — the completion tree's ci args mirror these, never a second copy. */
+export const CI_ARGS = {
   force: { type: 'boolean', description: 'Overwrite an existing workflow file (install only)' },
   'dry-run': { type: 'boolean', description: 'Print the plan and exit without writing' },
   help: { type: 'boolean', short: 'h', description: 'Show this help' }
 } as const;
+/** `ci upgrade` only ever reads a subset of CI_ARGS (it has no `--force` to strip) — this is that
+ * subset's single source, shared by `runCiUpgrade`'s real dispatch and the completion tree. */
+export const CI_UPGRADE_ARGS = { 'dry-run': CI_ARGS['dry-run'], help: CI_ARGS.help } as const;
 const KNOWN_LONG_FLAGS = new Set(['force', 'dry-run', 'help']);
 const KNOWN_SHORT_FLAGS = new Set(['h']);
 
@@ -162,7 +166,7 @@ async function runCiUpgrade(
   let exitCode = 0;
   const upgradeCommand = define({
     name: 'upgrade',
-    args: { 'dry-run': CI_ARGS['dry-run'], help: CI_ARGS.help },
+    args: CI_UPGRADE_ARGS,
     run: async (ctx) => {
       if (ctx.values.help) {
         io.log(await buildCiHelpText(helpSource));

--- a/packages/cli/src/gunshi/complete.ts
+++ b/packages/cli/src/gunshi/complete.ts
@@ -1,0 +1,151 @@
+import { cli } from 'gunshi/bone';
+import { define, type ArgSchema, type Args } from 'gunshi/definition';
+import { kebabnize } from 'gunshi/utils';
+import completion from '@gunshi/plugin-completion';
+import { consoleIO, type CliIO } from '../cli-io.js';
+import { REPORTER_NAMES } from '../reporter-resolve.js';
+import { CATEGORIES, FAIL_ON_VALUES, TREAT_DYNAMIC_AS_VALUES } from '../resolve-args.js';
+import { ROOT_ARGS } from './analyze.js';
+import { DOCS_ROOT_ARGS, DOCS_LIST_ARGS, DOCS_SHOW_ARGS } from './docs.js';
+import { EXPLAIN_ARGS } from './explain.js';
+import { INSTALL_ARGS } from './install.js';
+import { CI_ARGS, CI_UPGRADE_ARGS } from './ci.js';
+
+const SUPPORTED_SHELLS = ['bash', 'zsh', 'fish', 'powershell'] as const;
+
+/**
+ * `@gunshi/plugin-completion` registers a flag directly off its declaring object's key, with no
+ * awareness of `toKebab`/`hidden` (confirmed empirically against 0.37.1: a `toKebab: true`
+ * camelCase key like `noSuppressions` is offered verbatim as `--noSuppressions` — which the real
+ * CLI does not parse — instead of `--no-suppressions`; a `hidden: true` entry like install's
+ * obsolete `scope` is still offered). Mirrors an args record into a completion-safe copy —
+ * key-corrected, hidden entries dropped — never a second copy of the flags/descriptions
+ * themselves, which stay the imported consts from each surface's own module.
+ */
+function forCompletion(args: Args): Args {
+  const out: Record<string, ArgSchema> = {};
+  for (const [key, schema] of Object.entries(args)) {
+    if (schema.hidden) continue;
+    out[schema.type === 'positional' || !schema.toKebab ? key : kebabnize(key)] = schema;
+  }
+  return out;
+}
+
+/** A completion value-handler for a fixed list, e.g. `--reporter`'s console/json/agent/... set. */
+function valueList(list: readonly string[], describe: Record<string, string> = {}) {
+  return { handler: () => list.map((value) => ({ value, description: describe[value] ?? '' })) };
+}
+
+/**
+ * Builds the completion-only command tree — mirrors the five real gunshi surfaces' `subCommands`
+ * shape (`docs list`/`show`, `ci install`/`upgrade`) using ONLY their exported `*_ARGS` consts, so
+ * a flag added to a real surface is visible here automatically and a flag never gets a second,
+ * drifting declaration. Every `run` is a no-op: `@gunshi/plugin-completion` never executes these
+ * commands — it only reads `.args`/`.subCommands` during its `onExtension` hook. The command
+ * actually dispatched for a `complete` invocation is the `complete` sub-command the plugin adds
+ * itself via `ctx.addCommand` (confirmed empirically — see `runCompleteCliGunshi` below).
+ *
+ * Built fresh per call, matching every other ported surface's race-safety convention (docs.ts's
+ * own doc comment): `completion()` closes over one `@bomb.sh/tab` `RootCommand` instance per call,
+ * so two concurrent invocations sharing a module-level plugin instance could race registering
+ * commands into it.
+ */
+function buildCompletionTree() {
+  const listCommand = define({ name: 'list', args: forCompletion(DOCS_LIST_ARGS), run: () => {} });
+  const showCommand = define({ name: 'show', args: forCompletion(DOCS_SHOW_ARGS), run: () => {} });
+  const docsCommand = define({
+    name: 'docs',
+    args: forCompletion(DOCS_ROOT_ARGS),
+    subCommands: { list: listCommand, show: showCommand },
+    run: () => {}
+  });
+  const explainCommand = define({ name: 'explain', args: forCompletion(EXPLAIN_ARGS), run: () => {} });
+  const installCommand = define({ name: 'install', args: forCompletion(INSTALL_ARGS), run: () => {} });
+  const ciInstallCommand = define({ name: 'install', args: forCompletion(CI_ARGS), run: () => {} });
+  const ciUpgradeCommand = define({ name: 'upgrade', args: forCompletion(CI_UPGRADE_ARGS), run: () => {} });
+  const ciCommand = define({
+    name: 'ci',
+    args: {},
+    subCommands: { install: ciInstallCommand, upgrade: ciUpgradeCommand },
+    run: () => {}
+  });
+  const rootCommand = define({ name: 'svelte-vitals', args: forCompletion(ROOT_ARGS), run: () => {} });
+
+  // Only the root analyzer's flags take a fixed, enum-ish value set worth completing — matches
+  // the descriptions already used in docs/src/content/docs/guides/(setup)/cli.md's flag tables.
+  const completionPlugin = completion({
+    config: {
+      entry: {
+        args: {
+          reporter: valueList(REPORTER_NAMES, {
+            console: 'Human-readable text output (default)',
+            json: 'Machine-readable JSON',
+            agent: 'Markdown remediation for AI coding agents',
+            sarif: 'SARIF v2.1 (GitHub Code Scanning / SAST)',
+            github: 'GitHub Actions annotation format',
+            html: 'Self-contained HTML report',
+            md: 'Compact Markdown summary for PR comments / job summaries'
+          }),
+          'fail-on': valueList(FAIL_ON_VALUES, {
+            critical: 'Fail only on critical findings',
+            warning: 'Fail on warning or critical findings',
+            info: 'Fail on any finding'
+          }),
+          category: valueList(CATEGORIES),
+          'treat-dynamic-as': valueList(TREAT_DYNAMIC_AS_VALUES, {
+            pass: 'Dynamic values pass (default)',
+            warn: 'Dynamic values produce a warning',
+            fail: 'Dynamic values are treated as missing'
+          })
+        }
+      }
+    }
+  });
+
+  return {
+    rootCommand,
+    subCommands: { docs: docsCommand, explain: explainCommand, install: installCommand, ci: ciCommand },
+    completionPlugin
+  };
+}
+
+/**
+ * gunshi/bone port wiring `@gunshi/plugin-completion` (design doc addendum, this PR). Unlike every
+ * other ported surface, `args` reaches `cli()` completely unguarded/unstripped: `--` here is not
+ * this CLI's own terminator convention — it is the plugin's own protocol marker separating
+ * "print a setup script for this shell" (`complete <shell>`) from "return completion candidates
+ * for these words" (`complete -- <word>...`, what the generated script itself calls back with) —
+ * and the plugin's `complete` command reads argv straight off `ctx._` (the raw array passed to
+ * `cli()`), never through args-tokens parsing. So `runCli` (cli.ts) hands this function the FULL
+ * argv, `complete` included — slicing it off like every other branch does would leave `ctx._[1]`
+ * pointing at the wrong token and the plugin would silently produce no output.
+ *
+ * `shell`/`--` are validated before `cli()` even runs: an unsupported or missing shell would
+ * otherwise reach the plugin's own `assert(...)` in `@bomb.sh/tab`'s `setup()` (an uncaught throw)
+ * or silently print just the bare directive line with no candidates — this CLI's only
+ * would-be-silent-failure surface otherwise.
+ */
+export async function runCompleteCliGunshi(args: string[], io: CliIO = consoleIO): Promise<number> {
+  const shell = args[1];
+  const isCallback = shell === '--';
+  const isKnownShell = typeof shell === 'string' && (SUPPORTED_SHELLS as readonly string[]).includes(shell);
+  if (!isCallback && !isKnownShell) {
+    io.errorLog(
+      shell === undefined
+        ? 'svelte-vitals: complete needs a shell name, e.g. `svelte-vitals complete zsh`.'
+        : `svelte-vitals: unknown shell '${shell}'.`
+    );
+    io.errorLog(`svelte-vitals: supported shells: ${SUPPORTED_SHELLS.join(', ')}.`);
+    return 2;
+  }
+
+  const { rootCommand, subCommands, completionPlugin } = buildCompletionTree();
+  await cli(args, rootCommand, {
+    name: 'svelte-vitals',
+    subCommands,
+    fallbackToEntry: true,
+    usageSilent: true,
+    plugins: [completionPlugin]
+  });
+  return 0;
+}

--- a/packages/cli/src/gunshi/docs.ts
+++ b/packages/cli/src/gunshi/docs.ts
@@ -11,12 +11,22 @@ import { guardArgs, splitAtTerminator, stripUnknownFlags, stripAutoVersionLine }
 /** docs declares no value-carrying flags today — see guard.ts's own doc comment for why the list is still passed explicitly. */
 const BOOLEAN_FLAGS = ['json', 'help'] as const;
 const HELP_ARG = { help: { type: 'boolean', short: 'h', description: 'Show this help' } } as const;
+const JSON_ARG = { json: { type: 'boolean', description: 'Machine-readable output (list only)' } } as const;
 /** Family-wide, not per-subcommand — see guard.ts's `stripUnknownFlags` doc comment: the legacy
  * runner parses `--json`/`-h`/`--help` in one flat pass, so `show` (which never reads `--json`
  * itself) still needs it declared below to keep gunshi's own per-command resolution from
  * mistaking it for an unknown flag and swallowing the positional after it. */
 const KNOWN_LONG_FLAGS = new Set(BOOLEAN_FLAGS);
 const KNOWN_SHORT_FLAGS = new Set(['h']);
+
+/** Exported for gunshi/complete.ts — the completion tree's docs args mirror these, never a second copy. */
+export const DOCS_ROOT_ARGS = { ...JSON_ARG, ...HELP_ARG } as const;
+export const DOCS_LIST_ARGS = { ...JSON_ARG, ...HELP_ARG } as const;
+export const DOCS_SHOW_ARGS = {
+  name: { type: 'positional', required: false },
+  ...JSON_ARG,
+  ...HELP_ARG
+} as const;
 
 /**
  * Hybrid `docs --help` text: hand-written header/usage/footer preserved verbatim from `DOCS_HELP`
@@ -89,7 +99,7 @@ export async function runDocsCliGunshi(args: string[], io: CliIO = consoleIO): P
 
   const listCommand = define({
     name: 'list',
-    args: { json: { type: 'boolean', description: 'Machine-readable output (list only)' }, ...HELP_ARG },
+    args: DOCS_LIST_ARGS,
     run: async (ctx) => {
       if (ctx.values.help) {
         io.log(await buildDocsHelpText(rootCommand));
@@ -123,19 +133,15 @@ export async function runDocsCliGunshi(args: string[], io: CliIO = consoleIO): P
 
   const showCommand = define({
     name: 'show',
-    args: {
-      // Left un-required on purpose: gunshi's own "required positional missing" validation
-      // error preempts this command's `run` entirely and can't be made to say
-      // "docs show needs a topic name, e.g. ...". Counting positionals ourselves reproduces
-      // the exact current wording instead.
-      name: { type: 'positional', required: false },
-      // Declared but unused here — see the family-wide KNOWN_LONG_FLAGS comment above. The legacy
-      // runner accepts `--json` on `show` too (a harmless no-op boolean); without this, gunshi's
-      // per-command resolution would treat `--json` as undeclared for `show` specifically and
-      // swallow the following positional (`docs show --json config` would lose `config`).
-      json: { type: 'boolean', description: 'Machine-readable output (list only)' },
-      ...HELP_ARG
-    },
+    // Left un-required on purpose: gunshi's own "required positional missing" validation error
+    // preempts this command's `run` entirely and can't be made to say "docs show needs a topic
+    // name, e.g. ...". Counting positionals ourselves reproduces the exact current wording
+    // instead. `json` is declared but unused here too — see the family-wide KNOWN_LONG_FLAGS
+    // comment above: the legacy runner accepts `--json` on `show` too (a harmless no-op
+    // boolean); without this, gunshi's per-command resolution would treat `--json` as undeclared
+    // for `show` specifically and swallow the following positional (`docs show --json config`
+    // would lose `config`).
+    args: DOCS_SHOW_ARGS,
     run: async (ctx) => {
       if (ctx.values.help) {
         io.log(await buildDocsHelpText(rootCommand));
@@ -181,7 +187,7 @@ export async function runDocsCliGunshi(args: string[], io: CliIO = consoleIO): P
     name: 'docs',
     // `json` declared but unused here too, for the same family-wide reason as `showCommand` — a
     // bare `docs --json <sub>` reaches this command's own resolution via `fallbackToEntry`.
-    args: { json: { type: 'boolean', description: 'Machine-readable output (list only)' }, ...HELP_ARG },
+    args: DOCS_ROOT_ARGS,
     subCommands: { list: listCommand, show: showCommand },
     run: async (ctx) => {
       if (ctx.values.help) {

--- a/packages/cli/src/gunshi/explain.ts
+++ b/packages/cli/src/gunshi/explain.ts
@@ -12,6 +12,13 @@ const BOOLEAN_FLAGS = ['json', 'list', 'help'] as const;
 const KNOWN_LONG_FLAGS = new Set(BOOLEAN_FLAGS);
 const KNOWN_SHORT_FLAGS = new Set(['h']);
 
+/** Exported for gunshi/complete.ts — the completion tree's `explain` args mirror this, never a second copy. */
+export const EXPLAIN_ARGS = {
+  list: { type: 'boolean', description: 'List every rule instead of explaining one' },
+  json: { type: 'boolean', description: 'Machine-readable output (works with --list and with a rule id)' },
+  help: { type: 'boolean', short: 'h', description: 'Show this help' }
+} as const;
+
 /**
  * Hybrid `explain --help` text — same technique as `gunshi/docs.ts`'s `buildDocsHelpText`: hand-
  * written header/usage/footer, OPTIONS generated from this command's own `args`, the auto-injected
@@ -56,15 +63,11 @@ export async function runExplainCliGunshi(args: string[], io: CliIO = consoleIO)
 
   const explainCommand = define({
     name: 'explain',
-    args: {
-      list: { type: 'boolean', description: 'List every rule instead of explaining one' },
-      json: { type: 'boolean', description: 'Machine-readable output (works with --list and with a rule id)' },
-      help: { type: 'boolean', short: 'h', description: 'Show this help' }
-      // No declared `id` positional: `ctx.positionals` is populated regardless of whether any arg
-      // declares `type: 'positional'` (docs.ts's own root command relies on the same fact), and a
-      // declared one wouldn't see `tail` (post-`--`) anyway — the rule id is read from the merged
-      // `positionals` below instead.
-    },
+    // No declared `id` positional: `ctx.positionals` is populated regardless of whether any arg
+    // declares `type: 'positional'` (docs.ts's own root command relies on the same fact), and a
+    // declared one wouldn't see `tail` (post-`--`) anyway — the rule id is read from the merged
+    // `positionals` below instead.
+    args: EXPLAIN_ARGS,
     run: async (ctx) => {
       // `tail` (post-`--`) never went through gunshi at all, so it's appended here rather than
       // being part of `ctx.positionals`.

--- a/packages/cli/src/gunshi/install.ts
+++ b/packages/cli/src/gunshi/install.ts
@@ -21,7 +21,8 @@ const BOOLEAN_FLAGS = ['yes', 'dry-run', 'force', 'refresh', 'help'] as const;
 const KNOWN_LONG_FLAGS = new Set<string>([...VALUE_FLAGS, ...BOOLEAN_FLAGS]);
 const KNOWN_SHORT_FLAGS = new Set(['y', 'h']);
 
-const INSTALL_ARGS = {
+/** Exported for gunshi/complete.ts — the completion tree's install args mirror this, never a second copy. */
+export const INSTALL_ARGS = {
   client: {
     type: 'string',
     description:

--- a/packages/cli/src/reporter-resolve.ts
+++ b/packages/cli/src/reporter-resolve.ts
@@ -2,16 +2,11 @@ import { getAgentProfile } from 'gunshi/agent';
 
 export type ReporterName = 'console' | 'json' | 'agent' | 'sarif' | 'github' | 'html' | 'md';
 
+/** Single source of truth for the `--reporter` value set — shared with completion's value handler (gunshi/complete.ts). */
+export const REPORTER_NAMES: readonly ReporterName[] = ['console', 'json', 'agent', 'sarif', 'github', 'html', 'md'];
+
 export function isReporterName(value: string | undefined): value is ReporterName {
-  return (
-    value === 'console' ||
-    value === 'json' ||
-    value === 'agent' ||
-    value === 'sarif' ||
-    value === 'github' ||
-    value === 'html' ||
-    value === 'md'
-  );
+  return REPORTER_NAMES.includes(value as ReporterName);
 }
 
 /**

--- a/packages/cli/src/resolve-args.ts
+++ b/packages/cli/src/resolve-args.ts
@@ -1,10 +1,24 @@
 import { parseArgs } from 'node:util';
-import type { Category } from '@svelte-vitals/core';
+import type { Category, Severity } from '@svelte-vitals/core';
 import type { RunOptions } from './index.js';
 import { findUnknownRuleIds, knownRuleIds } from './rules-config.js';
 import { isReporterName, type ReporterName } from './reporter-resolve.js';
 
-const CATEGORIES: Category[] = ['seo', 'performance', 'correctness', 'security', 'architecture'];
+/** Single source of truth for the `--category` value set — shared with completion's value handler (gunshi/complete.ts). */
+export const CATEGORIES: Category[] = ['seo', 'performance', 'correctness', 'security', 'architecture'];
+
+/** Single source of truth for `--fail-on` — shared with completion's value handler (gunshi/complete.ts). */
+export const FAIL_ON_VALUES: readonly Severity[] = ['critical', 'warning', 'info'];
+function isFailOnValue(value: unknown): value is Severity {
+  return typeof value === 'string' && (FAIL_ON_VALUES as readonly string[]).includes(value);
+}
+
+type TreatDynamicAs = 'pass' | 'warn' | 'fail';
+/** Single source of truth for `--treat-dynamic-as` — shared with completion's value handler (gunshi/complete.ts). */
+export const TREAT_DYNAMIC_AS_VALUES: readonly TreatDynamicAs[] = ['pass', 'warn', 'fail'];
+function isTreatDynamicAs(value: unknown): value is TreatDynamicAs {
+  return typeof value === 'string' && (TREAT_DYNAMIC_AS_VALUES as readonly string[]).includes(value);
+}
 
 /** Parsed argv: positionals under `_`, flag values as flat keys. */
 export interface CliArgv {
@@ -245,7 +259,8 @@ export function resolveArgs(argv: CliArgv): ResolvedArgs {
   const metaComponents = typeof argv['meta-components'] === 'string' ? toList(argv['meta-components']) : undefined;
 
   const treatRaw = argv['treat-dynamic-as'];
-  const treatDynamicAs = treatRaw === 'warn' || treatRaw === 'fail' || treatRaw === 'pass' ? treatRaw : undefined;
+  const treatDynamicAsValid = isTreatDynamicAs(treatRaw);
+  const treatDynamicAs = treatDynamicAsValid ? treatRaw : undefined;
   if (typeof treatRaw === 'string' && treatDynamicAs === undefined) {
     warnings.push(
       `svelte-vitals: unknown --treat-dynamic-as '${treatRaw}'; expected pass|warn|fail. Defaulting to 'pass'.`
@@ -294,7 +309,7 @@ export function resolveArgs(argv: CliArgv): ResolvedArgs {
   }
 
   const failOnRaw = argv['fail-on'];
-  const failOnValid = failOnRaw === 'warning' || failOnRaw === 'info' || failOnRaw === 'critical';
+  const failOnValid = isFailOnValue(failOnRaw);
   if (typeof failOnRaw === 'string' && !failOnValid) {
     warnings.push(
       `svelte-vitals: unknown --fail-on '${failOnRaw}'; expected critical|warning|info. No threshold applied.`

--- a/packages/cli/test/__snapshots__/help-golden.test.ts.snap
+++ b/packages/cli/test/__snapshots__/help-golden.test.ts.snap
@@ -134,6 +134,7 @@ Usage:
   svelte-vitals install          Set up the Vite integration, agent skills/rules, config file, or CI
   svelte-vitals ci install       Add a GitHub Actions PR gate (annotations + summary comment)
   svelte-vitals ci upgrade       Refresh the pinned @svelte-vitals/action in an existing workflow
+  svelte-vitals complete <shell> Print a shell completion script (bash, zsh, fish, powershell)
 
 OPTIONS:
   -h, --help                                     Show this help

--- a/packages/cli/test/gunshi-complete.test.ts
+++ b/packages/cli/test/gunshi-complete.test.ts
@@ -1,0 +1,192 @@
+// Shell completion (docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md addendum):
+// `@gunshi/plugin-completion` wired as a dedicated `complete` entry (src/gunshi/complete.ts),
+// dispatched by `runCli` (cli.ts) before the analyzer fallback, mirroring `docs`/`explain`/
+// `install`/`ci`. Unlike those four, `@bomb.sh/tab` (the plugin's completion engine) writes
+// candidates/scripts via raw `console.log`, bypassing the injected `CliIO` entirely — confirmed
+// empirically, so success paths here spy on `console.log` rather than `captureIO()`; only this
+// file's own pre-`cli()` shell-name guard (the failure paths) goes through `io.errorLog`.
+import { existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { runCli } from '../src/cli.js';
+import { runCompleteCliGunshi } from '../src/gunshi/complete.js';
+import { captureIO } from './helpers/capture-io.js';
+
+const SHELLS = ['bash', 'zsh', 'fish', 'powershell'] as const;
+
+/**
+ * Joins every `console.log` call's first argument — bombshell logs one line (or one full script)
+ * per call. `vi.spyOn` returns the SAME mock on repeat calls within a test (the property is
+ * already replaced), so this clears prior calls first — otherwise a second `spyLog()`/`candidates()`
+ * in the same `it` would see earlier queries' output too.
+ */
+function spyLog(): { calls: () => string; restore: () => void } {
+  const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  spy.mockClear();
+  return {
+    calls: () => spy.mock.calls.map((c) => String(c[0])).join('\n'),
+    restore: () => spy.mockRestore()
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('complete: missing/unknown shell is a fatal error, not silent', () => {
+  it('bare `complete` (no shell, no --) exits 2 with a naming error, stdout untouched', async () => {
+    const log = spyLog();
+    const io = captureIO();
+    const code = await runCompleteCliGunshi(['complete'], io);
+    expect(code).toBe(2);
+    expect(io.out).toBe('');
+    expect(io.err).toContain('complete needs a shell name');
+    expect(log.calls()).toBe('');
+  });
+
+  it('an unsupported shell name exits 2 naming the ones that ARE supported', async () => {
+    const io = captureIO();
+    const code = await runCompleteCliGunshi(['complete', 'tcsh'], io);
+    expect(code).toBe(2);
+    expect(io.out).toBe('');
+    expect(io.err).toContain("unknown shell 'tcsh'");
+    expect(io.err).toContain('bash, zsh, fish, powershell');
+  });
+});
+
+describe('complete <shell>: prints a non-empty setup script for every supported shell', () => {
+  for (const shell of SHELLS) {
+    it(shell, async () => {
+      const log = spyLog();
+      const io = captureIO();
+      const code = await runCompleteCliGunshi(['complete', shell], io);
+      expect(code).toBe(0);
+      expect(io.out).toBe('');
+      expect(io.err).toBe('');
+      expect(log.calls().length).toBeGreaterThan(100);
+      expect(log.calls()).toContain('svelte-vitals');
+    });
+  }
+});
+
+describe('complete -- <words>: candidate protocol the generated scripts call back with', () => {
+  /** Runs the candidate query and returns just the candidate values (drops descriptions and the trailing `:<directive>` line). */
+  async function candidates(words: string[]): Promise<string[]> {
+    const log = spyLog();
+    const code = await runCompleteCliGunshi(['complete', '--', ...words], captureIO());
+    expect(code).toBe(0);
+    return log
+      .calls()
+      .split('\n')
+      .filter((l) => l.includes('\t'))
+      .map((l) => l.split('\t')[0]!);
+  }
+
+  it('top-level: every sub-command family is offered', async () => {
+    expect(await candidates([''])).toEqual(['docs', 'explain', 'install', 'ci']);
+  });
+
+  it('root flags: a sample of real flags, kebab-cased even for toKebab camelCase keys', async () => {
+    const list = await candidates(['--']);
+    expect(list).toEqual(expect.arrayContaining(['--route', '--reporter', '--score', '--help']));
+    // Pins the toKebab fix (gunshi/complete.ts's `forCompletion`): the plugin registers flags off
+    // the raw object key with no `toKebab` awareness — ROOT_ARGS declares these three under
+    // camelCase keys precisely so gunshi's OWN renderer doesn't mis-render `--no-*` (analyze.ts's
+    // own doc comment); left unmirrored, completion would offer `--noSuppressions` etc. instead.
+    expect(list).toEqual(expect.arrayContaining(['--no-suppressions', '--no-color', '--no-animation']));
+  });
+
+  it('root flags: value completion for the enum-ish flags matches their real accepted values', async () => {
+    expect(await candidates(['--reporter', ''])).toEqual(['console', 'json', 'agent', 'sarif', 'github', 'html', 'md']);
+    expect(await candidates(['--fail-on', ''])).toEqual(['critical', 'warning', 'info']);
+    expect(await candidates(['--category', ''])).toEqual([
+      'seo',
+      'performance',
+      'correctness',
+      'security',
+      'architecture'
+    ]);
+    expect(await candidates(['--treat-dynamic-as', ''])).toEqual(['pass', 'warn', 'fail']);
+  });
+
+  it('docs: list/show sub-commands', async () => {
+    expect(await candidates(['docs', ''])).toEqual(['list', 'show']);
+  });
+
+  it('explain: --list/--json/--help', async () => {
+    expect(await candidates(['explain', '--'])).toEqual(['--list', '--json', '--help']);
+  });
+
+  it("install: every real flag, but never the hidden obsolete '--scope'", async () => {
+    const list = await candidates(['install', '--']);
+    expect(list).toEqual(['--client', '--app', '--yes', '--dry-run', '--force', '--refresh', '--help']);
+    expect(list).not.toContain('--scope');
+  });
+
+  it('ci install: force/dry-run/help', async () => {
+    expect(await candidates(['ci', 'install', '--'])).toEqual(['--force', '--dry-run', '--help']);
+  });
+
+  it("ci upgrade: only its real subset (no --force — it doesn't strip one, matches gunshi/ci.ts's CI_UPGRADE_ARGS)", async () => {
+    expect(await candidates(['ci', 'upgrade', '--'])).toEqual(['--dry-run', '--help']);
+  });
+});
+
+describe('runCli dispatch: `complete` is a new reserved top-level token, wired unsliced', () => {
+  it('routes through runCli with the full argv (complete included), exiting naturally', async () => {
+    const log = spyLog();
+    const io = captureIO();
+    const result = await runCli(['complete', 'zsh'], io);
+    expect(result).toEqual({ code: 0, exit: 'natural' });
+    expect(log.calls().length).toBeGreaterThan(100);
+  });
+
+  it('a directory literally named `complete` is shadowed, same as docs/explain/install/ci (declared, not a regression)', async () => {
+    const io = captureIO();
+    const result = await runCli(['complete', 'nonexistent-shell-name'], io);
+    expect(result.code).toBe(2);
+    expect(io.err).toContain("unknown shell 'nonexistent-shell-name'");
+  });
+});
+
+describe('spawn the built dist (skipped if `pnpm build` has not run)', () => {
+  const cliBin = join(import.meta.dirname, '..', 'dist', 'bin.js');
+  const has = existsSync(cliBin);
+
+  function run(args: string[]): { code: number; stdout: string; stderr: string } {
+    try {
+      const stdout = execFileSync(process.execPath, [cliBin, ...args], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe']
+      });
+      return { code: 0, stdout, stderr: '' };
+    } catch (err) {
+      const e = err as { status: number; stdout?: string; stderr?: string };
+      return { code: e.status, stdout: String(e.stdout ?? ''), stderr: String(e.stderr ?? '') };
+    }
+  }
+
+  it.skipIf(!has)('complete zsh exits 0 with a non-empty script through the packaged binary', () => {
+    const { code, stdout } = run(['complete', 'zsh']);
+    expect(code).toBe(0);
+    expect(stdout.length).toBeGreaterThan(100);
+    expect(stdout).toContain('svelte-vitals');
+  });
+
+  it.skipIf(!has)('complete -- resolves sub-command names through the packaged binary', () => {
+    const { code, stdout } = run(['complete', '--', '']);
+    expect(code).toBe(0);
+    expect(stdout).toContain('docs\t');
+    expect(stdout).toContain('explain\t');
+    expect(stdout).toContain('install\t');
+    expect(stdout).toContain('ci\t');
+  });
+
+  it.skipIf(!has)('an unsupported shell exits 2 with stdout empty through the packaged binary', () => {
+    const { code, stdout, stderr } = run(['complete', 'tcsh']);
+    expect(code).toBe(2);
+    expect(stdout).toBe('');
+    expect(stderr).toContain("unknown shell 'tcsh'");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     '@gunshi/docs':
       specifier: 0.37.1
       version: 0.37.1
+    '@gunshi/plugin-completion':
+      specifier: 0.37.1
+      version: 0.37.1
     '@sveltejs/kit':
       specifier: ^2.70.2
       version: 2.70.2
@@ -137,6 +140,9 @@ importers:
       '@clack/prompts':
         specifier: 'catalog:'
         version: 1.7.0
+      '@gunshi/plugin-completion':
+        specifier: 'catalog:'
+        version: 0.37.1(@gunshi/plugin-i18n@0.37.1)(cac@6.7.14)(citty@0.1.6)
       '@svelte-vitals/core':
         specifier: workspace:*
         version: link:../core
@@ -478,6 +484,21 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@bomb.sh/tab@0.0.19':
+    resolution: {integrity: sha512-dTRfo9Q9B+lbLG3JCu8a/AGQSfD2XXcFcnakQzVjSOX+VvR/s9zpsH8TlqV3iHqazniRn1Ypwd1hcRlXcu/4BA==}
+    hasBin: true
+    peerDependencies:
+      cac: ^6.7.14
+      citty: ^0.1.6 || ^0.2.0
+      commander: ^13.1.0 || ^14.0.0 || ^15.0.0
+    peerDependenciesMeta:
+      cac:
+        optional: true
+      citty:
+        optional: true
+      commander:
+        optional: true
 
   '@braidai/lang@1.1.2':
     resolution: {integrity: sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==}
@@ -1011,6 +1032,25 @@ packages:
   '@gunshi/docs@0.37.1':
     resolution: {integrity: sha512-LcLL1ekr8T9177bnEuz7n3f6qeEsupfyVBGSyznQIEKvEFhLleRQeKmA0J/f7EZnMw0aPpafB+Ji5BmDaJ6roQ==}
     hasBin: true
+
+  '@gunshi/plugin-completion@0.37.1':
+    resolution: {integrity: sha512-6FHJiLvFYB1/bOr8waRIpwvyzdL/51vrGJL0klAFOk5CbfWogsOrv3kR+wX9WTgJHYVZJeMafg7tsZCHftZm2w==}
+    engines: {node: '>= 22'}
+    peerDependencies:
+      '@gunshi/plugin-i18n': 0.37.1
+
+  '@gunshi/plugin-i18n@0.37.1':
+    resolution: {integrity: sha512-K5L5IDeaD5JIGEPn4Wcl0cXyPggmmtj4sSQwCsqzAYc30VfJu+BQscoEt7wIoJ3UR6gnjY7BJh5dxGcmBcUvaA==}
+    engines: {node: '>= 22'}
+    peerDependencies:
+      '@gunshi/plugin-global': 0.37.1
+    peerDependenciesMeta:
+      '@gunshi/plugin-global':
+        optional: true
+
+  '@gunshi/plugin@0.37.1':
+    resolution: {integrity: sha512-ljjBaL15jCwX6tEtWRdmAQ/y/svGcMZa5mVhMPgXFeQFQ++srK/x5dx8uchQFrE2MTqaFhMMjNK9AQowCyRv9A==}
+    engines: {node: '>= 22'}
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -6364,6 +6404,11 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@bomb.sh/tab@0.0.19(cac@6.7.14)(citty@0.1.6)':
+    optionalDependencies:
+      cac: 6.7.14
+      citty: 0.1.6
+
   '@braidai/lang@1.1.2': {}
 
   '@braintree/sanitize-url@7.1.2': {}
@@ -6808,6 +6853,22 @@ snapshots:
     dependencies:
       '@antfu/install-pkg': 1.1.0
       tinyexec: 1.2.4
+
+  '@gunshi/plugin-completion@0.37.1(@gunshi/plugin-i18n@0.37.1)(cac@6.7.14)(citty@0.1.6)':
+    dependencies:
+      '@bomb.sh/tab': 0.0.19(cac@6.7.14)(citty@0.1.6)
+      '@gunshi/plugin': 0.37.1
+      '@gunshi/plugin-i18n': 0.37.1
+    transitivePeerDependencies:
+      - cac
+      - citty
+      - commander
+
+  '@gunshi/plugin-i18n@0.37.1':
+    dependencies:
+      '@gunshi/plugin': 0.37.1
+
+  '@gunshi/plugin@0.37.1': {}
 
   '@hono/node-server@1.19.14(hono@4.12.26)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,6 +19,7 @@ catalog:
   '@types/node': ^24.13.3
   esm-env: ^1.2.2
   '@gunshi/docs': 0.37.1
+  '@gunshi/plugin-completion': 0.37.1
   gunshi: 0.37.1
   jsdom: ^30.0.1
   log-update: ^8.0.0


### PR DESCRIPTION
gunshi adoption item 1 (per the approved utilization plan): shell completion for bash/zsh/fish/PowerShell via `@gunshi/plugin-completion` (0.37.1, exact pin), surfaced as a new `svelte-vitals complete <shell>` command.

## Design (probe-driven)

The Phase-A compatibility probe found that wiring the plugin into an existing surface silently breaks behavior — on `docs`, the plugin's auto-added `complete` sub-command shadowed the "unknown docs subcommand" exit-2 path with a bare directive on stdout, exit 0. So the integration is a **dedicated sixth entry**: a completion-only `define()` tree mirroring all five real surfaces, dispatched by an exact-match `complete` branch in `runCli` (lazy-loaded; the analyzer hot path pays nothing), with no-op runners the plugin never executes. `docs complete` still errors exactly as before — verified.

**No second flag declaration anywhere**: the tree is built from the same exported `*_ARGS` consts that drive parsing and `--help`, and enum value completion (`--reporter`, `--fail-on`, `--category`, `--treat-dynamic-as`) reuses newly single-sourced value arrays (`REPORTER_NAMES` etc. — `isReporterName` now derives from the same array). Two plugin gotchas found and fixed: it reads raw object keys with no `toKebab`/`hidden` awareness, which would have leaked `--noSuppressions` and the hidden `--scope` — a `forCompletion()` transform normalizes both.

## What completes

Sub-command names (incl. nested `list`/`show`/`install`/`upgrade`), every flag per surface (context-correct: `ci upgrade` excludes `--force`), and enum values. Setup verified end-to-end in real bash and zsh shells against the built dist; fish/PowerShell instructions come from the plugin's README and are marked as such in the docs (en/ja).

## Honest dependency footprint (declared in the changeset + design-doc addendum)

Not one package: `@gunshi/plugin-completion` brings `@gunshi/plugin`, `@bomb.sh/tab`, and a non-optional peer dependency on `@gunshi/plugin-i18n` that installs even though this integration never uses it. All 0.37.1 lockstep, exact-pinned.

## Verification

Characterization suite: zero behavioral churn — the only golden change is one new Usage line in root `--help`. 20 new tests (tree shape, kebab/hidden normalization, value completion, dispatch precedence, spawn-based dist checks). Full gates green: 2,701 tests, e2e 10/10, smoke 8/8, check:publish 0. Rebased onto #455 (both touched `reporter-resolve.ts`; the delegation and the `REPORTER_NAMES` single-sourcing compose — full suite re-run post-rebase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `complete` command for Bash, Zsh, Fish, and PowerShell.
  * Added completion for commands, flags, subcommands, and supported option values.
  * Added shell-specific installation guidance and regeneration instructions.

* **Documentation**
  * Documented shell completion in English and Japanese CLI guides.
  * Updated command-line help to include the new completion command.

* **Tests**
  * Added coverage for completion scripts, command dispatch, invalid shells, nested options, and packaged execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->