### PR TITLE
feat(cli): suggest the closest command or rule id on a mistyped name

### DIFF
--- a/.changeset/did-you-mean-suggestions.md
+++ b/.changeset/did-you-mean-suggestions.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': minor
+---
+
+A mistyped sub-command or rule id now gets a `did you mean …?` hint appended after the existing error message, on four surfaces: `svelte-vitals <mistyped-subcommand>` falling through to the root analyzer as a path that doesn't exist on disk (e.g. `svelte-vitals isntall`), `docs <unknown-subcommand>`, `ci <unknown-subcommand>`, and `explain <unknown-rule-id>`. The hint only appears when the typed token is close to a real name and, for the root analyzer, when the explicit path does not exist on disk — an existing path is always analyzed as asked, never redirected. Nothing about the existing error wording, exit codes, or stdout/stderr split changes; the hint is a new, additional line.

--- a/docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md
+++ b/docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md
@@ -400,3 +400,67 @@ pins en/ja byte-identity so a future edit can't translate one side without the o
 No changeset: doc-site content plus an internal generator/test/build-entry, zero change to any
 published package's runtime behavior or public export surface (`gunshi-registry` is a build
 artifact, not an `exports` entry).
+
+## Addendum (2026-08-11): `did you mean …?` suggestions via `@gunshi/plugin-suggestion`'s matcher, not its plugin
+
+Probed `@gunshi/plugin-suggestion@0.37.1` (added to the catalog, exact pin, alongside the other
+`gunshi`-family packages) to determine whether it could fire on any of this CLI's five real
+surfaces. It cannot, confirmed two ways — reading the pinned `gunshi` 0.37.1 source
+(`cliCore`/`resolveCommandTree` in `node_modules/gunshi/lib/core-*.js`) and a live probe reproducing
+this repo's exact bone wiring:
+
+- The plugin decorates gunshi's own `CommandNotFoundError`/`ArgsValidationError` rendering — it
+  detects nothing itself (its own README says so). Both error kinds are structurally unreachable
+  here: `fallbackToEntry: true` (every sub-commanded surface, i.e. `docs`) resolves an unmatched
+  first-level token straight to the entry command inside `resolveCommandTree` — `targetCommand` is
+  already truthy by the time `cliCore` checks whether to construct a `CommandNotFoundError`, so it
+  never is, at any `strict` setting. `stripUnknownFlags` (guard.ts) removes any undeclared flag
+  before gunshi's own parser ever sees the token, so `ArgsValidationError`'s `unknownOption` case
+  (which only fires when `cliOptions.strict` is true AND the parser actually saw the flag) is
+  equally unreachable — and no surface here sets `strict: true` regardless. A probe script wiring
+  `suggestion()` into a `docs`-shaped bone `cli()` call (subCommands + `fallbackToEntry: true`,
+  both `strict` settings) confirmed this empirically: the entry `run()` always received the
+  mismatched token as an ordinary positional, `ctx.validationError` always `undefined`. Flipping
+  `fallbackToEntry: false` (not this CLI's shape, tested only to see what the plugin _would_ have
+  produced) reproduces the OTHER already-recorded Phase-2 finding instead: `bone`'s decorator throws
+  a raw `Error` on any validation error, discarding the rendered/decorated message — so the plugin's
+  hint text is unreachable there too, for the same class of reason full `cli()` was rejected for in
+  Phase 2. `ci` doesn't run its sub-subcommand split through gunshi at all (a literal `args[0]`
+  compare, by design — see Phase 3 verdict above), so it was never a candidate either.
+- The package DOES export a reusable, non-hand-rolled matcher, unrelated to its plugin/error-hooking
+  half: `import { levenshtein, defineSuggestNames } from '@gunshi/plugin-suggestion'`.
+  `levenshtein(a, b): number` is a plain edit-distance function; `defineSuggestNames(options)`
+  is the plugin's own candidate-ranking factory (filter by `maxDistance`, sort by distance then
+  input order, cap at `maxSuggestions`) — the same one its `suggestion()` plugin builds internally.
+  `resolveSuggestionOptions` (translates partial user options to defaults: `maxDistance: 2`,
+  `maxSuggestions: 1`) is NOT exported, so the default threshold is reproduced by hand at the one
+  call site (`gunshi/guard.ts`'s `suggestClosest`) instead of imported — values only, not logic.
+
+Shape chosen: `suggestClosest(typed, candidates)` in `gunshi/guard.ts`, built once from
+`defineSuggestNames`, called directly from each surface's own existing error path — never wiring
+`suggestion()` into any `cli()` call, since (per above) it would be dead weight. Four surfaces:
+root `runAnalyzeCliGunshi` (a `did you mean` line appended after the `No SvelteKit project found`
+message, gated on the explicit path not existing on disk at all — an existing directory of that name
+is always analyzed, never redirected), `docs`'s and `ci`'s unknown-subcommand paths, and `explain`'s
+unknown-rule-id path (scanning 70+ ids per call is well under a millisecond — `defineSuggestNames`
+is a single filter+sort over the candidate list, no measurable cost). Every insertion is additive:
+the existing error line(s) print unchanged, in the same order, with the hint as one new line: right
+after the specific "unknown …" complaint (docs/explain), right before the unchanged `CI_HELP` block
+(`ci`, which has no per-token complaint line to append after), or as the sole new line (root, which
+had only the one message).
+
+Dependency footprint: `@gunshi/plugin-suggestion` depends on `@gunshi/plugin` and peer-depends on
+`@gunshi/plugin-i18n` (same non-optional-peer shape as `@gunshi/plugin-completion`, this doc's prior
+addendum) — both were already resolved into the lockfile by `@gunshi/plugin-completion`, so adding
+this package resolved **zero new packages** (confirmed via lockfile diff: only
+`@gunshi/plugin-suggestion` itself gained entries).
+
+Unlike `@gunshi/plugin-completion` (reached only via the dynamic `import()` behind `complete`),
+`suggestClosest` lives in `gunshi/guard.ts`, which `gunshi/analyze.ts` — the root analyzer,
+statically imported by `cli.ts` and therefore on every invocation's hot path, not behind a dynamic
+import — already imports. So this DOES add to the hot path, unlike the completion feature; measured
+rather than assumed: median of 10 runs of `node --input-type=module -e "import('@gunshi/plugin-
+suggestion')"` minus the bare `node -e "import('node:path')"` floor on the same machine is ~1 ms
+(the package is a single small file depending only on the already-resolved `@gunshi/plugin`), and
+`svelte-vitals --help` end to end still runs ~130 ms, in line with this doc's own pre-existing
+gunshi-adoption baseline (~157 ms) rather than measurably above it.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,6 +55,7 @@
     "@svelte-vitals/core": "workspace:*",
     "@clack/prompts": "catalog:",
     "@gunshi/plugin-completion": "catalog:",
+    "@gunshi/plugin-suggestion": "catalog:",
     "gunshi": "catalog:",
     "log-update": "catalog:",
     "magicast": "catalog:",

--- a/packages/cli/src/gunshi/analyze.ts
+++ b/packages/cli/src/gunshi/analyze.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { parseArgs } from 'node:util';
 import { cli } from 'gunshi/bone';
 import { define } from 'gunshi/definition';
@@ -8,7 +9,15 @@ import { parseRunArgs, resolveArgs, VALUE_FLAGS, type CliArgv } from '../resolve
 import { selectAppPrompt } from '../install/cli.js';
 import { consoleIO, type CliIO } from '../cli-io.js';
 import type { CliResult } from '../cli.js';
-import { guardArgs, splitAtTerminator, stripUnknownFlags } from './guard.js';
+import { guardArgs, splitAtTerminator, stripUnknownFlags, suggestClosest } from './guard.js';
+
+/**
+ * `runCli` (cli.ts)'s reserved first-token dispatch names, hand-kept in sync (five short, stable
+ * tokens) — used only for the `did-you-mean` hint below on an explicit path that resolves to
+ * nothing on disk, e.g. `svelte-vitals isntall`; an existing directory of the same name is always
+ * analyzed as-is, never redirected (see the `existsSync` check at its one call site).
+ */
+const KNOWN_TOP_LEVEL_SUBCOMMANDS = ['docs', 'explain', 'install', 'ci', 'complete'];
 
 const VERSION = readPackageVersion();
 
@@ -298,6 +307,18 @@ export async function runAnalyzeCliGunshi(args: string[], io: CliIO = consoleIO)
         return;
       }
 
+      // Computed before the run — never after — so a coincidental match against something the
+      // analysis itself printed (a finding, a rule id) can't masquerade as a subcommand typo.
+      // Gated on the path not existing at all: an explicit path that IS a real directory is
+      // analyzed as the user asked, even if its name happens to resemble a subcommand.
+      // `options.cwd` is optional only in `RunOptions`'s general shape (embedding callers may omit
+      // it); `resolveArgs` itself always fills it in (`positional ?? process.cwd()`).
+      const explicitCwd = options.cwd ?? process.cwd();
+      const suggestedSubcommand =
+        options.explicitPath && !existsSync(explicitCwd)
+          ? suggestClosest(explicitCwd, KNOWN_TOP_LEVEL_SUBCOMMANDS)
+          : undefined;
+
       const code = await run({
         ...options,
         minHealth,
@@ -305,6 +326,12 @@ export async function runAnalyzeCliGunshi(args: string[], io: CliIO = consoleIO)
         log: io.log,
         errorLog: io.errorLog
       });
+      // `options.cwd` not existing on disk forces `detectProject` to throw `ProjectError` (every
+      // check it runs needs a file under that path), so this is the one message `run()` could have
+      // just printed — appended, never replacing it (design doc invariants).
+      if (suggestedSubcommand !== undefined && code === 2) {
+        io.errorLog(`svelte-vitals: did you mean \`svelte-vitals ${suggestedSubcommand}\`?`);
+      }
       // A write to a pipe is asynchronous, so `process.exit` can discard what has not drained — the report is
       // the largest thing this CLI writes and the first pipe buffer is 65,536 bytes. The empty write's callback
       // fires once the stream has flushed, so it's safe for the thin entry to call `process.exit` as soon as

--- a/packages/cli/src/gunshi/ci.ts
+++ b/packages/cli/src/gunshi/ci.ts
@@ -7,7 +7,7 @@ import { realIO } from '../install/cli.js';
 import { WORKFLOW_PATH, buildWorkflowYaml, planWorkflowWrite } from '../ci/workflow.js';
 import { upgradeActionPin } from '../ci/upgrade.js';
 import { ACTION_SHA, ACTION_VERSION } from '../ci/action-pin.generated.js';
-import { guardArgs, splitAtTerminator, stripUnknownFlags, stripAutoVersionLine } from './guard.js';
+import { guardArgs, splitAtTerminator, stripUnknownFlags, stripAutoVersionLine, suggestClosest } from './guard.js';
 
 /**
  * Frozen error-path text: printed verbatim on `ci`'s non-help exit-2 paths (bare `ci`, an unknown
@@ -256,6 +256,12 @@ export async function runCiCliGunshi(args: string[], io: InstallIO = realIO()): 
     return runCiUpgrade(args.slice(1), io, helpSource);
   }
   if (sub !== 'install') {
+    // A bare `ci` (sub undefined) has no typed token to match against — only a wrong sub-subcommand
+    // name gets a suggestion.
+    if (sub !== undefined) {
+      const hint = suggestClosest(sub, ['install', 'upgrade']);
+      if (hint) io.errorLog(`svelte-vitals: did you mean \`svelte-vitals ci ${hint}\`?`);
+    }
     // Declared movement (design doc invariants / this PR's changeset): stderr, not stdout — the
     // one exit-2 path that used to leave stdout non-empty for callers piping it.
     io.errorLog(CI_HELP);

--- a/packages/cli/src/gunshi/docs.ts
+++ b/packages/cli/src/gunshi/docs.ts
@@ -6,7 +6,7 @@ import { consoleIO, type CliIO } from '../cli-io.js';
 import { knownRuleIds } from '../rules-config.js';
 import { EMBEDDED_DOCS } from '../docs/generated.js';
 import { DOCS_HELP, knownTopicNames, renderList } from '../docs/cli.js';
-import { guardArgs, splitAtTerminator, stripUnknownFlags, stripAutoVersionLine } from './guard.js';
+import { guardArgs, splitAtTerminator, stripUnknownFlags, stripAutoVersionLine, suggestClosest } from './guard.js';
 
 /** docs declares no value-carrying flags today — see guard.ts's own doc comment for why the list is still passed explicitly. */
 const BOOLEAN_FLAGS = ['json', 'help'] as const;
@@ -205,6 +205,8 @@ export async function runDocsCliGunshi(args: string[], io: CliIO = consoleIO): P
         return;
       }
       io.errorLog(`svelte-vitals: unknown docs subcommand '${sub}'; expected list|show.`);
+      const hint = suggestClosest(sub, ['list', 'show']);
+      if (hint) io.errorLog(`svelte-vitals: did you mean \`svelte-vitals docs ${hint}\`?`);
       io.errorLog(DOCS_HELP);
       exitCode = 2;
     }

--- a/packages/cli/src/gunshi/explain.ts
+++ b/packages/cli/src/gunshi/explain.ts
@@ -5,7 +5,7 @@ import { explainRule, allRules } from '@svelte-vitals/core';
 import { consoleIO, type CliIO } from '../cli-io.js';
 import { knownRuleIds } from '../rules-config.js';
 import { renderRuleList, formatRuleExplanation } from '../explain.js';
-import { guardArgs, splitAtTerminator, stripUnknownFlags, stripAutoVersionLine } from './guard.js';
+import { guardArgs, splitAtTerminator, stripUnknownFlags, stripAutoVersionLine, suggestClosest } from './guard.js';
 
 /** explain declares no value-carrying flags today — see guard.ts's own doc comment for why the list is still passed explicitly. */
 const BOOLEAN_FLAGS = ['json', 'list', 'help'] as const;
@@ -111,6 +111,8 @@ export async function runExplainCliGunshi(args: string[], io: CliIO = consoleIO)
       const info = explainRule(id);
       if (!info) {
         io.errorLog(`svelte-vitals: unknown rule id '${id}'.`);
+        const hint = suggestClosest(id, knownRuleIds());
+        if (hint) io.errorLog(`svelte-vitals: did you mean \`svelte-vitals explain ${hint}\`?`);
         io.errorLog(`svelte-vitals: known rule ids: ${knownRuleIds().join(', ')}.`);
         exitCode = 2;
         return;

--- a/packages/cli/src/gunshi/guard.ts
+++ b/packages/cli/src/gunshi/guard.ts
@@ -1,3 +1,5 @@
+import { defineSuggestNames, levenshtein } from '@gunshi/plugin-suggestion';
+
 /**
  * Raw-argv pre-scan that every gunshi-dispatched command runs before handing argv to gunshi's
  * own parser (Phase 1 spike gate (b), `docs/superpowers/specs/2026-08-10-gunshi-cli-migration-design.md`).
@@ -124,6 +126,36 @@ export function stripAutoVersionLine(generated: string): string {
     .split('\n')
     .filter((line) => !/^\s*-v, --version\b/.test(line))
     .join('\n');
+}
+
+/**
+ * `Did you mean …?` closest-match lookup for a mistyped sub-command or rule id, reusing
+ * `@gunshi/plugin-suggestion`'s own matcher (`defineSuggestNames`/`levenshtein`) instead of a
+ * hand-rolled edit-distance function — the plugin's own default threshold (distance <= 2, one
+ * suggestion), pinned here since `resolveSuggestionOptions` itself isn't exported.
+ *
+ * The plugin's OWN error-hooking (decorating gunshi's `CommandNotFoundError`/`ArgsValidationError`
+ * rendering) never fires on any surface in this CLI: `fallbackToEntry: true` resolves an unmatched
+ * sub-command straight to the entry command with no `CommandNotFoundError` ever constructed
+ * (confirmed against gunshi 0.37.1's `resolveCommandTree` — the `additionalValidationErrors.push`
+ * call is unreachable when `resolveAsEntry()` already returned a command), and `stripUnknownFlags`
+ * above removes any undeclared flag before gunshi's own parser sees it, so `ArgsValidationError`'s
+ * `unknownOption` case is equally unreachable. Every ported surface therefore calls this function
+ * directly from its own error path instead of wiring the plugin into `cli()`.
+ */
+const suggestNames = defineSuggestNames({
+  maxDistance: 2,
+  maxSuggestions: 1,
+  distance: levenshtein,
+  normalize: (v) => v,
+  // Unused by `defineSuggestNames` itself (only its own `suggestion()` plugin reads these, to
+  // decide which of gunshi's two error kinds to look at) — required by `ResolvedSuggestionOptions`
+  // regardless, so set to the plugin's own defaults.
+  includeOptions: true,
+  includeCommands: true
+});
+export function suggestClosest(typed: string, candidates: readonly string[]): string | undefined {
+  return suggestNames(typed, candidates)[0];
 }
 
 export function stripUnknownFlags(

--- a/packages/cli/test/__snapshots__/gunshi-ci.test.ts.snap
+++ b/packages/cli/test/__snapshots__/gunshi-ci.test.ts.snap
@@ -212,6 +212,34 @@ Done. Commit the workflow file and open a PR to see it in action.",
 }
 `;
 
+exports[`gunshi/bone ci — pinned behavior across the argv-shape matrix > isntall (typo of install, close enough for a did-you-mean hint) 1`] = `
+{
+  "code": 2,
+  "err": "svelte-vitals: did you mean \`svelte-vitals ci install\`?
+svelte-vitals ci — scaffold CI integration
+
+Usage:
+  svelte-vitals ci install [options]
+  svelte-vitals ci upgrade [--dry-run]
+
+Adds a GitHub Actions workflow (.github/workflows/svelte-vitals.yml) that calls the \`@svelte-vitals/action\`
+GitHub Action on pull requests: inline annotations, a job summary, and a sticky PR
+comment with the findings.
+
+\`ci upgrade\` rewrites only the pinned \`@svelte-vitals/action\` reference in an existing
+workflow to the pin bundled with this CLI, leaving the rest of the file (and any other
+pins, like actions/checkout) untouched. To pick up the latest pin, run
+\`npx svelte-vitals@latest ci upgrade\`.
+
+Options:
+  --force       Overwrite an existing workflow file (install only)
+  --dry-run     Print the plan and exit without writing
+  -h, --help    Show this help",
+  "out": "",
+  "wrote": false,
+}
+`;
+
 exports[`gunshi/bone ci — pinned behavior across the argv-shape matrix > no sub (bare ci) 1`] = `
 {
   "code": 2,

--- a/packages/cli/test/docs-cli.test.ts
+++ b/packages/cli/test/docs-cli.test.ts
@@ -120,6 +120,18 @@ describe('svelte-vitals docs — dispatch', () => {
     expect(err).toContain('list|show');
   });
 
+  it('a close typo of a real subcommand gets a did-you-mean hint (design doc addendum)', async () => {
+    const { code, err } = await docs(['lsit']);
+    expect(code).toBe(2);
+    expect(err).toContain("unknown docs subcommand 'lsit'");
+    expect(err).toContain('svelte-vitals: did you mean `svelte-vitals docs list`?');
+  });
+
+  it('"read" is far enough from both list/show that no hint is added (already exercised above, asserted explicitly)', async () => {
+    const { err } = await docs(['read', 'config']);
+    expect(err).not.toContain('did you mean');
+  });
+
   it('documents the escape hatch for a ./docs directory', async () => {
     expect((await docs(['--help'])).out).toContain('svelte-vitals ./docs');
   });

--- a/packages/cli/test/explain.test.ts
+++ b/packages/cli/test/explain.test.ts
@@ -107,6 +107,20 @@ describe('svelte-vitals explain', () => {
     expect(err).toContain("unknown rule id 'NOPE999'");
     expect(err).toContain('known rule ids:');
     expect(err).toContain('seo/title-presence');
+    // NOPE999 is nowhere near any real rule id — no did-you-mean hint (design doc addendum).
+    expect(err).not.toContain('did you mean');
+  });
+
+  it('a one-edit typo of a real rule id gets a did-you-mean hint (design doc addendum)', async () => {
+    const { code, err } = await explain(['seo/ssr-disable']);
+    expect(code).toBe(2);
+    expect(err).toContain("unknown rule id 'seo/ssr-disable'");
+    expect(err).toContain('svelte-vitals: did you mean `svelte-vitals explain seo/ssr-disabled`?');
+  });
+
+  it('the wrong-case rule id above is far enough (case-sensitive match) that it gets no hint either', async () => {
+    const { err } = await explain(['SEO/TITLE-PRESENCE']);
+    expect(err).not.toContain('did you mean');
   });
 
   it('exits 2 when no rule id is given', async () => {

--- a/packages/cli/test/gunshi-analyze.test.ts
+++ b/packages/cli/test/gunshi-analyze.test.ts
@@ -51,6 +51,41 @@ describe('root analyzer: single bone entry, no subCommands map', () => {
   });
 });
 
+// did-you-mean addendum (design doc): a mistyped sub-command name falls through to the root
+// analyzer as a path (cli.ts's dispatch is exact-match only) — gunshi/analyze.ts appends one hint
+// line to the existing not-a-project message when, and only when, the token resolves to nothing on
+// disk AND is within the shared matcher's default distance of a real sub-command name.
+describe('did-you-mean: a mistyped sub-command falling through to the analyzer path', () => {
+  const prevCwd = process.cwd();
+  afterEach(() => process.chdir(prevCwd));
+
+  it("svelte-vitals isntall: appends the hint after the existing 'No SvelteKit project found' message", async () => {
+    process.chdir(tmpProjectDir());
+    const { code, err } = await run(['isntall']);
+    expect(code).toBe(2);
+    expect(err).toContain('No SvelteKit project found');
+    expect(err).toContain('svelte-vitals: did you mean `svelte-vitals install`?');
+  });
+
+  it('svelte-vitals xyzzyplugh: garbage input past the default distance threshold gets no hint', async () => {
+    process.chdir(tmpProjectDir());
+    const { code, err } = await run(['xyzzyplugh']);
+    expect(code).toBe(2);
+    expect(err).toContain('No SvelteKit project found');
+    expect(err).not.toContain('did you mean');
+  });
+
+  it('an existing directory with a close name is analyzed as-is, never redirected to the hint', async () => {
+    const cwd = tmpProjectDir();
+    mkdirSync(join(cwd, 'isntall'));
+    process.chdir(cwd);
+    const { code, err } = await run(['isntall']);
+    expect(code).toBe(2);
+    expect(err).toContain('No SvelteKit project found');
+    expect(err).not.toContain('did you mean');
+  });
+});
+
 describe('unknown flags never swallow the analyzed path', () => {
   // args-tokens treats an UNDECLARED long/short option as string-like, consuming a following
   // positional as its own value — unlike node:util's parseArgs(strict:false), which treats the

--- a/packages/cli/test/gunshi-ci.test.ts
+++ b/packages/cli/test/gunshi-ci.test.ts
@@ -39,6 +39,8 @@ describe('gunshi/bone ci — pinned behavior across the argv-shape matrix', () =
     { name: '--help', args: ['--help'] },
     { name: '-h', args: ['-h'] },
     { name: 'bogus sub', args: ['bogus'] },
+    // did-you-mean addendum (design doc): a close typo of a real sub-subcommand name.
+    { name: 'isntall (typo of install, close enough for a did-you-mean hint)', args: ['isntall'] },
     { name: 'install', args: ['install'] },
     { name: 'install --dry-run', args: ['install', '--dry-run'] },
     { name: 'install --help', args: ['install', '--help'] },
@@ -76,5 +78,26 @@ describe('the declared movement: ci stdout→stderr on exit-2 paths', () => {
     expect(code).toBe(2);
     expect(out).toBe('');
     expect(err).toContain('Usage:');
+  });
+});
+
+// did-you-mean addendum (design doc): appended ahead of the existing CI_HELP dump, never replacing
+// it — CI_HELP has no per-token "unknown sub-subcommand 'x'" line of its own to append after.
+describe('did-you-mean: ci <bogus sub-subcommand>', () => {
+  it('a close typo of install gets a hint', async () => {
+    const { code, err } = await ci(['isntall']);
+    expect(code).toBe(2);
+    expect(err).toContain('svelte-vitals: did you mean `svelte-vitals ci install`?');
+    expect(err).toContain('Usage:'); // CI_HELP still prints in full — additive, not a replacement.
+  });
+
+  it('"bogus" is far enough from install/upgrade that no hint is added', async () => {
+    const { err } = await ci(['bogus']);
+    expect(err).not.toContain('did you mean');
+  });
+
+  it('a bare `ci` has no typed token to suggest against — no hint', async () => {
+    const { err } = await ci([]);
+    expect(err).not.toContain('did you mean');
   });
 });

--- a/packages/cli/test/gunshi-guard.test.ts
+++ b/packages/cli/test/gunshi-guard.test.ts
@@ -3,7 +3,7 @@
 // gate-(b) cells (spike-gunshi-parsing.test.ts) against the guard as actually shipped — driven by
 // the real `VALUE_FLAGS` import from resolve-args.ts, not a second hardcoded flag list.
 import { describe, it, expect } from 'vitest';
-import { guardArgs, splitAtTerminator, stripUnknownFlags } from '../src/gunshi/guard.js';
+import { guardArgs, splitAtTerminator, stripUnknownFlags, suggestClosest } from '../src/gunshi/guard.js';
 import { VALUE_FLAGS } from '../src/resolve-args.js';
 
 describe('guardArgs: value-carrying flags (using the real analyzer VALUE_FLAGS list)', () => {
@@ -121,5 +121,31 @@ describe('stripUnknownFlags', () => {
     // empty flag name, which is never in `knownLong`, so it drops without splitAtTerminator's
     // protection. Pinned so a future edit can't quietly "fix" this function instead.
     expect(stripUnknownFlags(['a', '--', 'b'], long, short)).toEqual(['a', 'b']);
+  });
+});
+
+// did-you-mean addendum (design doc): reuses @gunshi/plugin-suggestion's own exported matcher
+// (defineSuggestNames/levenshtein) at its own default threshold (distance <= 2, one suggestion) —
+// pinned directly here since none of the plugin's own error-hooking machinery ever runs in this
+// CLI (fallbackToEntry:true never constructs a CommandNotFoundError; unknown flags are stripped
+// before gunshi's parser ever sees them, so ArgsValidationError's unknownOption case is equally
+// unreachable) — see suggestClosest's own doc comment in guard.ts.
+describe('suggestClosest', () => {
+  const subcommands = ['docs', 'explain', 'install', 'ci', 'complete'];
+
+  it('a one-edit typo of a known name is suggested', () => {
+    expect(suggestClosest('isntall', subcommands)).toBe('install');
+  });
+
+  it('an exact match "suggests" itself (distance 0, still <= the threshold)', () => {
+    expect(suggestClosest('docs', subcommands)).toBe('docs');
+  });
+
+  it('unrelated input beyond the default distance threshold gets no suggestion', () => {
+    expect(suggestClosest('xyzzyplugh', subcommands)).toBeUndefined();
+  });
+
+  it('an empty candidate list never suggests', () => {
+    expect(suggestClosest('isntall', [])).toBeUndefined();
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ catalogs:
     '@gunshi/plugin-completion':
       specifier: 0.37.1
       version: 0.37.1
+    '@gunshi/plugin-suggestion':
+      specifier: 0.37.1
+      version: 0.37.1
     '@sveltejs/kit':
       specifier: ^2.70.2
       version: 2.70.2
@@ -143,6 +146,9 @@ importers:
       '@gunshi/plugin-completion':
         specifier: 'catalog:'
         version: 0.37.1(@gunshi/plugin-i18n@0.37.1)(cac@6.7.14)(citty@0.1.6)
+      '@gunshi/plugin-suggestion':
+        specifier: 'catalog:'
+        version: 0.37.1(@gunshi/plugin-i18n@0.37.1)
       '@svelte-vitals/core':
         specifier: workspace:*
         version: link:../core
@@ -1047,6 +1053,12 @@ packages:
     peerDependenciesMeta:
       '@gunshi/plugin-global':
         optional: true
+
+  '@gunshi/plugin-suggestion@0.37.1':
+    resolution: {integrity: sha512-za2LC8af64c4ruGmC+1f2gA1sDpcxt8gKzbxnlOIp0mInCaRvRMlLP4KyHm2NB3LkB98VOVwUSZ6G/lujWv2NA==}
+    engines: {node: '>= 22'}
+    peerDependencies:
+      '@gunshi/plugin-i18n': 0.37.1
 
   '@gunshi/plugin@0.37.1':
     resolution: {integrity: sha512-ljjBaL15jCwX6tEtWRdmAQ/y/svGcMZa5mVhMPgXFeQFQ++srK/x5dx8uchQFrE2MTqaFhMMjNK9AQowCyRv9A==}
@@ -6867,6 +6879,11 @@ snapshots:
   '@gunshi/plugin-i18n@0.37.1':
     dependencies:
       '@gunshi/plugin': 0.37.1
+
+  '@gunshi/plugin-suggestion@0.37.1(@gunshi/plugin-i18n@0.37.1)':
+    dependencies:
+      '@gunshi/plugin': 0.37.1
+      '@gunshi/plugin-i18n': 0.37.1
 
   '@gunshi/plugin@0.37.1': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,7 @@ catalog:
   esm-env: ^1.2.2
   '@gunshi/docs': 0.37.1
   '@gunshi/plugin-completion': 0.37.1
+  '@gunshi/plugin-suggestion': 0.37.1
   gunshi: 0.37.1
   jsdom: ^30.0.1
   log-update: ^8.0.0


### PR DESCRIPTION
gunshi adoption item 3 (per the approved utilization plan): `Did you mean …?` hints on mistyped sub-command names and rule ids.

## The probe verdict first (recorded as a design-doc addendum)

`@gunshi/plugin-suggestion`'s own hooking can never fire in this CLI — proven against gunshi 0.37.1's source and a live probe of our exact bone wiring: `fallbackToEntry: true` resolves unmatched tokens straight to the entry command (no `CommandNotFoundError` is ever constructed), and our shared strip layer removes undeclared flags before gunshi's parser sees them. So the integration uses the plugin's **exported matcher** (`defineSuggestNames` + `levenshtein` — no hand-rolled edit distance) called directly from our own error paths, with the plugin's default thresholds (distance ≤ 2, one suggestion) pinned at the single call site.

## The four surfaces (existing wording extended, never replaced)

- root: `svelte-vitals isntall` → the unchanged not-a-project error + ``did you mean `svelte-vitals install`?`` — suppressed whenever the token exists on disk (an existing path is analyzed as asked, never redirected)
- `docs lsit` → unchanged unknown-subcommand line + the hint, before the unchanged help dump
- `ci isntall` → the hint before the unchanged `CI_HELP`
- `explain seo/ssr-disable` → unchanged unknown-rule line + ``did you mean `svelte-vitals explain seo/ssr-disabled`?`` (matched across all 70+ rule ids)

Garbage input produces zero new output on all four surfaces (pinned both ways; coordinator byte-verified `docs bogus` identical to main).

## Footprint

`@gunshi/plugin-suggestion@0.37.1` (exact pin) resolves **zero new packages** — its dependency set was already present via the completion plugin. It sits on the analyzer path via `guard.ts`: measured ~1 ms import delta. All 2,701 pre-existing tests byte-unchanged; new unit + integration cells on all four surfaces; full gates green incl. e2e/smoke/check:publish. Changeset: `svelte-vitals` minor declaring exactly these appended hints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “Did you mean…?” suggestions for close typos in analyzer subcommands, CI commands, documentation commands, and rule IDs.
  - Preserved existing errors, exit codes, output streams, and directory analysis behavior.
  - Suggestions appear only when a likely match is found.

- **Tests**
  - Added coverage for close, distant, exact-match, wrong-case, and existing-path scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->