### PR TITLE
chore(cli): stop exporting four internal-only types

### DIFF
--- a/packages/cli/src/install/targets.ts
+++ b/packages/cli/src/install/targets.ts
@@ -1,6 +1,6 @@
 import { WORKFLOW_PATH } from '../ci/workflow.js';
 
-export type ViteTargetId = 'vite-plugin' | 'vite-hooks';
+type ViteTargetId = 'vite-plugin' | 'vite-hooks';
 export type AgentTargetId = 'claude-skill' | 'cursor-rules' | 'claude-skill-improve';
 export type TargetId = ViteTargetId | AgentTargetId | 'config-file' | 'ci-workflow';
 export type TargetKind = 'vite' | 'agent' | 'config' | 'ci';

--- a/packages/cli/src/providers/source/adapters/index.ts
+++ b/packages/cli/src/providers/source/adapters/index.ts
@@ -4,8 +4,6 @@ import { svelteMetaTagsAdapter } from './svelte-meta-tags.js';
 import { svelteMetaTagsJsonLdAdapter } from './svelte-meta-tags-jsonld.js';
 import { svelteSeoAdapter } from './svelte-seo.js';
 
-export type { Adapter, AdapterResult } from './types.js';
-
 /** Built-in known-package adapters (design §11 layer 2). */
 const builtinAdapters: Adapter[] = [svelteMetaTagsAdapter, svelteMetaTagsJsonLdAdapter, svelteSeoAdapter];
 

--- a/packages/cli/src/providers/source/parse.ts
+++ b/packages/cli/src/providers/source/parse.ts
@@ -175,7 +175,7 @@ function collectComponents(node: WalkNode | WalkNode[] | null | undefined, acc: 
   }
 }
 
-export interface ParsedImage {
+interface ParsedImage {
   hasWidth: boolean;
   hasHeight: boolean;
   hasLoading: boolean;
@@ -187,7 +187,7 @@ export interface ParsedImage {
 }
 
 /** A page-body heading (<h1>–<h6>) parsed from one file (seo/single-h1). */
-export interface ParsedHeading {
+interface ParsedHeading {
   /** Heading level 1–6. */
   level: number;
   /** 1-based source line, or 0 if unknown. */


### PR DESCRIPTION
Post-gunshi final-audit follow-up: a knip sweep (entry-configured) found exactly four unused type exports — all pre-existing, none introduced by the migration:

- `adapters/index.ts` no longer re-exports `Adapter`/`AdapterResult` (every consumer imports them from `./types.js` directly; the barrel only ever serves `findAdapter`)
- `ViteTargetId` (`install/targets.ts`), `ParsedImage`/`ParsedHeading` (`providers/source/parse.ts`) drop their `export` keyword — each is referenced only within its own module (tsup's dts emit verified fine with the demotions)

Zero runtime change; full gates green (2,775 tests, lint, check:publish). No changeset — internal-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reduced the public API surface by keeping internal CLI types and parsing structures private.
  * Removed public access to adapter-related type definitions that are intended for internal use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->