### PR TITLE
feat(core): suggest the closest schema.org type for small @type typos

### DIFF
--- a/.changeset/jsonld-typo-suggestions.md
+++ b/.changeset/jsonld-typo-suggestions.md
@@ -1,0 +1,5 @@
+---
+'@svelte-vitals/core': patch
+---
+
+seo/json-ld-validity's unknown-`@type` hint now also catches small typos, not just casing: a bare `@type` within edit distance 2 of a real schema.org type gets a `Did you mean 'X'?` suggestion (e.g. `Unknown @type 'Artcle'` now suggests `'Article'`). The free case-insensitive exact match still runs first; the typo scan only runs when that misses. Message-text-only change — finding keys, severities, and gates are untouched.

--- a/docs/src/content/docs/ja/rules/seo/json-ld-validity.md
+++ b/docs/src/content/docs/ja/rules/seo/json-ld-validity.md
@@ -11,7 +11,7 @@ description: ページの JSON-LD は、@context と @type を備えた妥当な
 
 ## 未知の型
 
-ドキュメントの `@context` が schema.org を指している場合、そのドキュメント内のすべての裸の `@type` 名 — ルートだけでなく、ネストしたエンティティ(`author`、`publisher`、`offers` など)や `@graph` メンバー内のものも含む — が schema.org の語彙と照合されます。完全一致・大文字小文字を区別した schema.org の型名でない場合、次のような検出結果になります: `Unknown @type 'article' — not a schema.org type. Did you mean 'Article'?`。この「Did you mean」の提案は、語彙内に大文字小文字違いの一致がある場合にのみ表示されます — 文字の欠落や余分な文字(`Artcle`)は大文字小文字の違いではないため、提案は表示されません。
+ドキュメントの `@context` が schema.org を指している場合、そのドキュメント内のすべての裸の `@type` 名 — ルートだけでなく、ネストしたエンティティ(`author`、`publisher`、`offers` など)や `@graph` メンバー内のものも含む — が schema.org の語彙と照合されます。完全一致・大文字小文字を区別した schema.org の型名でない場合、次のような検出結果になります: `Unknown @type 'article' — not a schema.org type. Did you mean 'Article'?`。この「Did you mean」の提案は、大文字小文字違い(`article`)だけでなく、最大 2 文字の欠落・追加・置換までの軽微なタイプミス(`Artcle`)にも、語彙内で最も近い schema.org の型名として表示されます — 語彙内にそれほど近い型名がない場合、提案なしの検出結果になります。
 
 IRI 形式(`https://schema.org/Article`)やプレフィックス形式(`schema:Article`)の `@type` は妥当な JSON-LD であり、このチェックの対象外です — 裸の名前のみが検査されます。
 

--- a/docs/src/content/docs/rules/seo/json-ld-validity.md
+++ b/docs/src/content/docs/rules/seo/json-ld-validity.md
@@ -11,7 +11,7 @@ For each static `<script type="application/ld+json">`, the content must parse as
 
 ## Unknown type
 
-When a document's `@context` is schema.org, every bare `@type` name in it — at the root, in nested entities (`author`, `publisher`, `offers`, …), and in `@graph` members — is checked against the schema.org vocabulary. A name that isn't an exact, case-sensitive schema.org type produces a finding: `Unknown @type 'article' — not a schema.org type. Did you mean 'Article'?` The suggestion only appears when a case-insensitive match exists in the vocabulary — a dropped or extra letter (`Artcle`) gets no suggestion, since that's not a case difference.
+When a document's `@context` is schema.org, every bare `@type` name in it — at the root, in nested entities (`author`, `publisher`, `offers`, …), and in `@graph` members — is checked against the schema.org vocabulary. A name that isn't an exact, case-sensitive schema.org type produces a finding: `Unknown @type 'article' — not a schema.org type. Did you mean 'Article'?` The suggestion covers casing mismatches (`article`) and small typos — up to 2 dropped, added, or substituted characters (`Artcle`) — against the closest schema.org name; when nothing in the vocabulary is that close, the finding has no suggestion.
 
 IRI (`https://schema.org/Article`) and prefixed (`schema:Article`) `@type` forms are valid JSON-LD and are never flagged — only bare names are checked.
 

--- a/docs/superpowers/specs/2026-08-09-jsonld-vocabulary-catalog-design.md
+++ b/docs/superpowers/specs/2026-08-09-jsonld-vocabulary-catalog-design.md
@@ -182,3 +182,13 @@ Follows the repo's committed-generated-file pattern (`packages/cli/src/docs/gene
   variants), so alias-vs-interface filtering alone does not produce a clean vocabulary. The
   generator's explicit exclusion list carries them (plus `WithActionConstraints`), and the sanity
   band still guards against wholesale shape changes.
+
+## Phase-2 note (2026-08-11): distance-1 suggestions shipped
+
+The Corrections section's deferred refinement — edit-distance typo suggestions, the one that makes
+`'Artcle'` → `'Article'` actually fire — is implemented: a bounded in-core Levenshtein (distance
+<= 2, single deterministic suggestion, constants matched to the CLI's did-you-mean UX) runs as a
+fallthrough after the case-insensitive map. Hand-rolled inside core deliberately: the CLI's
+matcher comes from `@gunshi/plugin-suggestion`, and core's zero-dep runtime-agnostic contract
+outranks the CLI-scoped reuse-gunshi preference. Supersession warnings remain the only open
+phase-2 candidate.

--- a/packages/core/src/rules/seo/json-ld-validity.ts
+++ b/packages/core/src/rules/seo/json-ld-validity.ts
@@ -10,6 +10,62 @@ const SCHEMA_ORG_CONTEXT_RE = /^https?:\/\/schema\.org\/?$/;
 const LOWERCASE_TO_CANONICAL: ReadonlyMap<string, string> = new Map(
   [...SCHEMA_ORG_TYPES].map((name) => [name.toLowerCase(), name])
 );
+/** Sorted once so `closestType`'s tie-break (first in sorted order) is deterministic and cheap to repeat. */
+const SORTED_TYPES: readonly string[] = [...SCHEMA_ORG_TYPES].sort();
+
+// Matches the CLI's own did-you-mean UX (packages/cli/src/gunshi/guard.ts: @gunshi/plugin-suggestion,
+// maxDistance 2, maxSuggestions 1) for consistency between the two surfaces.
+const MAX_SUGGEST_DISTANCE = 2;
+
+/**
+ * Levenshtein distance, capped: once a row's minimum exceeds `maxDistance` no cell can still land
+ * <= it (each further row can only add cost), so returning early there is a bound, not a heuristic.
+ * Hand-rolled rather than imported: the CLI already has this via `@gunshi/plugin-suggestion`, but
+ * that's a CLI argument-parsing framework's plugin — pulling it into `@svelte-vitals/core` would
+ * break core's runtime-agnostic-with-zero-deps contract (AGENTS.md "Core purity"), which is a
+ * harder rule than the CLI's own "reuse gunshi's matcher" preference, itself scoped to the CLI.
+ */
+function levenshteinWithin(a: string, b: string, maxDistance: number): number {
+  if (Math.abs(a.length - b.length) > maxDistance) return maxDistance + 1;
+  let prev = Array.from({ length: b.length + 1 }, (_, j) => j);
+  for (let i = 1; i <= a.length; i++) {
+    const curr = [i];
+    let rowMin = i;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      const v = Math.min(prev[j]! + 1, curr[j - 1]! + 1, prev[j - 1]! + cost);
+      curr.push(v);
+      if (v < rowMin) rowMin = v;
+    }
+    if (rowMin > maxDistance) return maxDistance + 1;
+    prev = curr;
+  }
+  return prev[b.length]!;
+}
+
+/**
+ * Closest catalog name within edit distance `MAX_SUGGEST_DISTANCE` of `name`, or undefined —
+ * the phase-2 typo hint (design doc's "Distance-1 typo suggestions" refinement, generalized to
+ * distance <= 2 to match the CLI's UX). Distance is computed case-insensitively (a typo and a
+ * casing slip are the same kind of user error), but the returned name keeps catalog casing. Ties
+ * broken by sorted catalog order — arbitrary but stable, so the same typo always suggests the same
+ * name. Only ever called after the free case-insensitive-exact-match check misses, and only on the
+ * rare unknown-@type path, so scanning the ~1,000-name catalog here is negligible.
+ */
+function closestType(name: string, catalog: readonly string[]): string | undefined {
+  const lower = name.toLowerCase();
+  let best: string | undefined;
+  let bestDistance = MAX_SUGGEST_DISTANCE + 1;
+  for (const candidate of catalog) {
+    if (Math.abs(candidate.length - name.length) > MAX_SUGGEST_DISTANCE) continue;
+    const d = levenshteinWithin(lower, candidate.toLowerCase(), MAX_SUGGEST_DISTANCE);
+    if (d < bestDistance) {
+      bestDistance = d;
+      best = candidate;
+    }
+  }
+  return bestDistance <= MAX_SUGGEST_DISTANCE ? best : undefined;
+}
 
 function isSchemaOrgContextValue(v: unknown): boolean {
   if (typeof v === 'string') return SCHEMA_ORG_CONTEXT_RE.test(v);
@@ -43,7 +99,7 @@ function unknownTypeNames(nodes: JsonLdNode[]): string[] {
 }
 
 function unknownTypeMessage(name: string): string {
-  const canonical = LOWERCASE_TO_CANONICAL.get(name.toLowerCase());
+  const canonical = LOWERCASE_TO_CANONICAL.get(name.toLowerCase()) ?? closestType(name, SORTED_TYPES);
   return canonical
     ? `Unknown @type '${name}' — not a schema.org type. Did you mean '${canonical}'?`
     : `Unknown @type '${name}' — not a schema.org type.`;

--- a/packages/core/test/seo-jsonld-rules.test.ts
+++ b/packages/core/test/seo-jsonld-rules.test.ts
@@ -64,12 +64,55 @@ describe('seo/json-ld-validity: unknown @type vocabulary', () => {
     expect(rs[0]?.message).toBe("Unknown @type 'article' — not a schema.org type. Did you mean 'Article'?");
   });
 
-  it('gives no suggestion for a typo that is not a case-only mismatch', async () => {
+  it('suggests the closest name for a distance-1 typo (dropped letter)', async () => {
     const rs = fails(
       await seoJsonLdValidity.check(ctx(headWithJsonLd('{"@context":"https://schema.org","@type":"Artcle"}')))
     );
     expect(rs).toHaveLength(1);
-    expect(rs[0]?.message).toBe("Unknown @type 'Artcle' — not a schema.org type.");
+    expect(rs[0]?.message).toBe("Unknown @type 'Artcle' — not a schema.org type. Did you mean 'Article'?");
+  });
+
+  it('suggests the closest name for a distance-2 typo (transposition)', async () => {
+    // measured: levenshtein('artilce', 'article') === 2
+    const rs = fails(
+      await seoJsonLdValidity.check(ctx(headWithJsonLd('{"@context":"https://schema.org","@type":"Artilce"}')))
+    );
+    expect(rs).toHaveLength(1);
+    expect(rs[0]?.message).toBe("Unknown @type 'Artilce' — not a schema.org type. Did you mean 'Article'?");
+  });
+
+  it('suggests the closest name for a distance-2 typo (dropped letters)', async () => {
+    // measured: levenshtein('artcl', 'article') === 2
+    const rs = fails(
+      await seoJsonLdValidity.check(ctx(headWithJsonLd('{"@context":"https://schema.org","@type":"Artcl"}')))
+    );
+    expect(rs).toHaveLength(1);
+    expect(rs[0]?.message).toBe("Unknown @type 'Artcl' — not a schema.org type. Did you mean 'Article'?");
+  });
+
+  it('gives no suggestion when nothing in the catalog is within distance 2', async () => {
+    // measured: closest catalog name to 'zebra999' is 'Library' at distance 5; to 'xyzzy' is 'City' at distance 4
+    const rs1 = fails(
+      await seoJsonLdValidity.check(ctx(headWithJsonLd('{"@context":"https://schema.org","@type":"Zebra999"}')))
+    );
+    expect(rs1[0]?.message).toBe("Unknown @type 'Zebra999' — not a schema.org type.");
+
+    const rs2 = fails(
+      await seoJsonLdValidity.check(ctx(headWithJsonLd('{"@context":"https://schema.org","@type":"xyzzy"}')))
+    );
+    expect(rs2[0]?.message).toBe("Unknown @type 'xyzzy' — not a schema.org type.");
+  });
+
+  it('breaks a distance tie by sorted catalog order', async () => {
+    // measured: 'bMRadioChannel' is distance 1 from both 'AMRadioChannel' and 'FMRadioChannel';
+    // 'AMRadioChannel' sorts first.
+    const rs = fails(
+      await seoJsonLdValidity.check(ctx(headWithJsonLd('{"@context":"https://schema.org","@type":"bMRadioChannel"}')))
+    );
+    expect(rs).toHaveLength(1);
+    expect(rs[0]?.message).toBe(
+      "Unknown @type 'bMRadioChannel' — not a schema.org type. Did you mean 'AMRadioChannel'?"
+    );
   });
 
   it('passes known types including a nested entity type, unchanged', async () => {


### PR DESCRIPTION
#421 phase 2, suggestions half: the unknown-`@type` hint now catches small typos, not just casing — `Unknown @type 'Artcle'` finally gains `Did you mean 'Article'?` (the design doc's own once-falsified example, now real; a dated phase-2 note records it).

- Bounded in-core Levenshtein (30 lines, early-exit at distance > 2, length-band skip), run only on the already-unknown path; ties broken deterministically by catalog order (pinned with a real tie: `bMRadioChannel` is distance 1 from both `AMRadioChannel` and `FMRadioChannel`). **Deliberately hand-rolled**: the CLI's matcher is `@gunshi/plugin-suggestion`, and core's zero-dep runtime-agnostic contract outranks the CLI-scoped reuse-gunshi preference — the rationale lives as a code comment. Constants match the CLI's did-you-mean UX (distance ≤ 2, single suggestion).
- Every test cell pinned from MEASURED distances against the committed 1,034-name catalog (`Artcle`→1, `Artilce`→2, `Artcl`→2; `Zebra999`/`xyzzy` measured at 5/4 → no hint). Coordinator mutation check: setting the threshold to 0 fails exactly the 4 new cells.
- Message-text-only change — finding keys, severities, detections, and gates untouched (message is not part of `findingKey`). Rule docs (en/ja) corrected: they asserted verbatim that `Artcle` gets no suggestion.

Changeset: `@svelte-vitals/core` patch. Full gates green (core 1,416 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added helpful “Did you mean” suggestions for unknown schema.org JSON-LD `@type` values, including casing differences and typos within two character edits.
  * Suggestions are deterministic and omitted when no sufficiently close match exists.

* **Documentation**
  * Clarified JSON-LD validation behavior for nested entities and `@graph` members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->