### PR TITLE
chore: mark completed audit backlog items with their PRs

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -84,13 +84,13 @@ improve スキルによる監査(2026-07-05、commit `1f6f233` 時点)から生�
 - **2608-TEST-07** `routeMatcher` が空白をグロブのプレースホルダーに使い、空白入りグロブが `.*` に化ける(再現済み、S)。 **済み (PR #433)**
 - **2608-SEC-02** `gen-action-pin.mjs` が GitHub API 応答を無検証で TS ソースに埋め込む(SHA/semver の形状ガード + JSON.stringify で S)。 **済み (PR #436)**
 - **2608-CORE-02** `config.overrides` がスコアの inventory(分母)に不可視(挙動と `config-apply.ts` の契約コメントが矛盾。分母を per-key にするか、コメントを直すかの設計判断が本体、M)。2608-CORE-05(JSON レポートの再現claim)はこれの従属。
-- **2608-TEST-05** kit alias(`$components` 等)が head タグの transitive 解決(`resolveComponentPath`)で無視され、SEO ルールが false positive を出す。設計書 2026-07-30 はこの経路を明示的にスコープ外にはしていない(characterization テスト先行で M)。
+- **2608-TEST-05** kit alias(`$components` 等)が head タグの transitive 解決(`resolveComponentPath`)で無視され、SEO ルールが false positive を出す。設計書 2026-07-30 はこの経路を明示的にスコープ外にはしていない(characterization テスト先行で M)。 **済み (PR #463)**
 - **2608-DEBT-01** `@svelte-vitals/vite` が `svelte-vitals`(CLI)に runtime 依存(@clack/prompts 等がプラグイン利用者に推移的インストールされる。19 行の rules-config.ts を core へ移すのが第一歩、M)。
 - **2608-PERF-01** dev dashboard の再解析で component/kit-module facts がキャッシュされない(`index.ts` の JSDoc が既知ギャップとして明記。M)。2608-PERF-02(exists メモ化)、2608-PERF-05(lineOf の行索引)も同系の S。
 - **2608-CLI-04/05** dev dashboard で config ファイル編集が反映されない(ESM キャッシュ)+ `SVELTE_VITALS_UI` の restart 競合(S–M)。
 - **2608-TEST-01/03** `bin.ts` に in-process テストの seam がない + ビルド済みバイナリで CI ゲートフラグ(--fail-on/--min-health)の exit code を検証する E2E がない(M)。
-- **2608-SEC-03/07** agent レポーターの Markdown エスケープ + コンソールへの制御文字除去(解析対象リポジトリ由来文字列のサニタイズ、S–M)。
-- **2608-CORE-06/07** `runRules` の rule 失敗隔離(`Promise.allSettled`)+ パース不能ファイルの観測可能なシグナル(S–M)。CORE-07(シグナル)は **済み (PR #437)**、CORE-06(rule 失敗隔離)が残。
+- **2608-SEC-03/07** agent レポーターの Markdown エスケープ + コンソールへの制御文字除去(解析対象リポジトリ由来文字列のサニタイズ、S–M)。 **済み (PR #465)**
+- **2608-CORE-06/07** `runRules` の rule 失敗隔離(`Promise.allSettled`)+ パース不能ファイルの観測可能なシグナル(S–M)。CORE-06(rule 失敗隔離)は **済み (PR #464)**、CORE-07(シグナル)は **済み (PR #437)** — 両方完了。
 - **2608-CLI-09/11** `ci`/`install` の未ガード readFile が exit 1 に化ける + stderr の flush 漏れ(S)。
 - **2608-DEPS-01/02/03** action-pin の Renovate 自動化、devEngines Node ピンの棚卸し(初回コミットから不動)、`@types/node` が公開フロア(22)より 2 メジャー上(各 S)。
 - **2608-DEBT-03/04/13** Node Runtime アダプタ 3 重実装、vite の config 優先順位マージの cli との二重実装、vite の console 直叩き(各 S)。


### PR DESCRIPTION
Marks three 2026-08-08 audit backlog items as done in plans/README.md, following the same post-merge bookkeeping pattern as #440:

- 2608-TEST-05 → #463
- 2608-SEC-03/07 → #465
- 2608-CORE-06 → #464 (CORE-06/07 line now fully closed)

Doc-only, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the 2026-08-08 audit candidate list to reflect completed findings.
  * Added references to the completed work for test, security, and core audit items.
  * Removed the completed core item from the list of remaining findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->