### PR TITLE
fix(cli): emit one completion candidate per flag — collapse multi-line descriptions and restore --no-* text

### DIFF
--- a/.changeset/curly-plums-drum.md
+++ b/.changeset/curly-plums-drum.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': patch
+---
+
+fix: shell completion now emits exactly one candidate per flag. Multi-line flag descriptions (e.g. `install --client`) no longer leak their continuation lines as bogus candidates, and `--no-color`/`--no-animation`/`--no-suppressions` now show their real descriptions instead of the bare stripped key.

--- a/packages/cli/src/gunshi/complete.ts
+++ b/packages/cli/src/gunshi/complete.ts
@@ -19,14 +19,34 @@ const SUPPORTED_SHELLS = ['bash', 'zsh', 'fish', 'powershell'] as const;
  * camelCase key like `noSuppressions` is offered verbatim as `--noSuppressions` — which the real
  * CLI does not parse — instead of `--no-suppressions`; a `hidden: true` entry like install's
  * obsolete `scope` is still offered). Mirrors an args record into a completion-safe copy —
- * key-corrected, hidden entries dropped — never a second copy of the flags/descriptions
- * themselves, which stay the imported consts from each surface's own module.
+ * key-corrected, hidden entries dropped, multi-line descriptions collapsed to one line (a raw
+ * `\n` inside a candidate's description breaks the line-oriented `value\tdescription` protocol,
+ * turning each continuation line into its own bogus candidate) — never a second copy of the
+ * flags/descriptions themselves, which stay the imported consts from each surface's own module.
+ *
+ * Separately: the plugin resolves a `no-*` key's OWN description by stripping the prefix and
+ * looking up the base key in this same args record (confirmed empirically — its `localizable()`
+ * does this unconditionally, independent of the `toKebab` workaround above, which only sidesteps
+ * gunshi's *help renderer* doing the same stripping). None of `no-suppressions`/`no-color`/
+ * `no-animation` has a real base flag, so the plugin falls back to printing the bare stripped key
+ * ("color") instead of our description. A `type: 'positional'` phantom entry under the stripped
+ * name satisfies that lookup without becoming a real candidate itself: bomb.sh/tab only lists
+ * `.options` entries (registered from non-positional schemas) as flag candidates, and this
+ * phantom carries no completion handler, so it contributes none of its own.
  */
 function forCompletion(args: Args): Args {
   const out: Record<string, ArgSchema> = {};
   for (const [key, schema] of Object.entries(args)) {
     if (schema.hidden) continue;
-    out[schema.type === 'positional' || !schema.toKebab ? key : kebabnize(key)] = schema;
+    const outKey = schema.type === 'positional' || !schema.toKebab ? key : kebabnize(key);
+    const description = schema.description?.replace(/\s*\n\s*/g, ' ');
+    out[outKey] = description === schema.description ? schema : { ...schema, description };
+  }
+  for (const [key, schema] of Object.entries(out)) {
+    const stripped = key.startsWith('no-') ? key.slice(3) : undefined;
+    if (stripped && !(stripped in out)) {
+      out[stripped] = { type: 'positional', required: false, description: schema.description };
+    }
   }
   return out;
 }

--- a/packages/cli/test/gunshi-complete.test.ts
+++ b/packages/cli/test/gunshi-complete.test.ts
@@ -11,6 +11,8 @@ import { join } from 'node:path';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { runCli } from '../src/cli.js';
 import { runCompleteCliGunshi } from '../src/gunshi/complete.js';
+import { ROOT_ARGS } from '../src/gunshi/analyze.js';
+import { INSTALL_ARGS } from '../src/gunshi/install.js';
 import { captureIO } from './helpers/capture-io.js';
 
 const SHELLS = ['bash', 'zsh', 'fish', 'powershell'] as const;
@@ -130,6 +132,32 @@ describe('complete -- <words>: candidate protocol the generated scripts call bac
 
   it("ci upgrade: only its real subset (no --force — it doesn't strip one, matches gunshi/ci.ts's CI_UPGRADE_ARGS)", async () => {
     expect(await candidates(['ci', 'upgrade', '--'])).toEqual(['--dry-run', '--help']);
+  });
+
+  /** Like `candidates()` but keeps the full `value\tdescription` line — needed to inspect description text and to catch a multi-line description's continuation lines leaking in as their own bogus, tab-less "candidates". */
+  async function candidateLines(words: string[]): Promise<string[]> {
+    const log = spyLog();
+    const code = await runCompleteCliGunshi(['complete', '--', ...words], captureIO());
+    expect(code).toBe(0);
+    return log.calls().split('\n');
+  }
+
+  it('install: every line is a real candidate or the trailing directive — a multi-line description (e.g. --client) never leaks its continuation lines as their own candidates', async () => {
+    const lines = await candidateLines(['install', '--']);
+    const directive = lines.at(-1)!;
+    expect(directive).toMatch(/^:\d+$/);
+    const body = lines.slice(0, -1).filter((l) => l.length > 0);
+    for (const line of body) expect(line).toContain('\t');
+    const nonHiddenFlags = Object.values(INSTALL_ARGS).filter((schema) => !('hidden' in schema && schema.hidden));
+    expect(body).toHaveLength(nonHiddenFlags.length);
+  });
+
+  it('root flags: --no-* candidates carry their real description, not the bare stripped key ("color"/"animation"/"suppressions")', async () => {
+    const lines = await candidateLines(['--']);
+    const descriptionOf = (flag: string) => lines.find((l) => l.startsWith(`${flag}\t`))?.slice(flag.length + 1);
+    expect(descriptionOf('--no-color')).toBe(ROOT_ARGS.noColor.description);
+    expect(descriptionOf('--no-animation')).toBe(ROOT_ARGS.noAnimation.description);
+    expect(descriptionOf('--no-suppressions')).toBe(ROOT_ARGS.noSuppressions.description);
   });
 });
 

--- a/packages/cli/test/gunshi-complete.test.ts
+++ b/packages/cli/test/gunshi-complete.test.ts
@@ -158,6 +158,12 @@ describe('complete -- <words>: candidate protocol the generated scripts call bac
     expect(descriptionOf('--no-color')).toBe(ROOT_ARGS.noColor.description);
     expect(descriptionOf('--no-animation')).toBe(ROOT_ARGS.noAnimation.description);
     expect(descriptionOf('--no-suppressions')).toBe(ROOT_ARGS.noSuppressions.description);
+    // Pins that the phantom base-key entries forCompletion adds to satisfy the plugin's
+    // description lookup (see complete.ts's own doc comment) never surface as their own,
+    // nonexistent candidates — the real CLI has no --color/--animation/--suppressions flags.
+    for (const phantom of ['--color', '--animation', '--suppressions']) {
+      expect(lines.some((l) => l.startsWith(`${phantom}\t`))).toBe(false);
+    }
   });
 });
 


### PR DESCRIPTION
Two protocol-level bugs in the new shell completion (#456), both reproduced end to end on the built binary:

1. Multi-line arg descriptions (e.g. \`install --client\`) were passed through verbatim; every continuation line became its own bogus candidate — \`install --<TAB>\` offered ~33 prose fragments alongside 7 real flags. \`forCompletion\` now collapses descriptions to a single line (completion only; \`--help\` output is byte-identical, verified by diff).
2. \`--no-color\`/\`--no-animation\`/\`--no-suppressions\` showed a bare stripped key ("color") instead of their real descriptions: the completion plugin resolves a \`no-*\` key's description by looking up the stripped base key in the same args record. \`forCompletion\` now injects a phantom \`type: 'positional'\` entry under the stripped name carrying the real description — the completion engine lists only non-positional entries as flag candidates, so the phantom never surfaces (pinned by test: no \`--color\`/\`--animation\`/\`--suppressions\` candidates leak, and first-word candidates are unchanged). Descriptions remain sourced from \`ROOT_ARGS\` — no second copy. This deliberately relies on \`@gunshi/plugin-completion@0.37.1\` internals; the family is exact-pinned and its bumps are design-review events, and the new tests fail loudly if the behavior shifts.

Tests: two new in-process candidate-protocol tests (TDD-red proven via stash). Changeset: \`svelte-vitals\` patch. Plan: \`plans/049-completion-candidate-stream.md\` (advisor session 2026-08-12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell completion candidates by excluding hidden and invalid entries.
  * Preserved descriptions for negated options such as `--no-*`.
  * Normalized multiline descriptions for clearer completion output.
  * Preserved positional arguments and correctly handled option names incompatible with shell completion.

* **Tests**
  * Added coverage to verify valid completion candidates, trailing directives, and negated-option descriptions.

* **Chores**
  * Prepared a patch release for `svelte-vitals`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->