### PR TITLE
fix(cli): map internal dispatch crashes to exit 2; pin the ja --help path through the built binary

### DIFF
--- a/.changeset/silent-plums-jump.md
+++ b/.changeset/silent-plums-jump.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': patch
+---
+
+fix: an internal crash in the CLI's dispatch layer now exits 2 with a one-line `svelte-vitals:` diagnostic instead of exit 1 with a raw stack trace — exit 1 keeps meaning "a finding failed the gate".

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -11,4 +11,7 @@ async function main(): Promise<void> {
   }
 }
 
-void main();
+main().catch((err: unknown) => {
+  console.error(`svelte-vitals: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(2);
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -34,37 +34,44 @@ export async function runCli(
   io: CliIO = consoleIO,
   env: NodeJS.ProcessEnv = process.env
 ): Promise<CliResult> {
-  const locale = resolveLocale(env);
+  try {
+    const locale = resolveLocale(env);
 
-  if (argv[0] === 'complete') {
-    // Loaded on demand, same reasoning as `docs`/`explain` below. Passed the FULL argv, not
-    // `argv.slice(1)` — see gunshi/complete.ts's own doc comment for why this one branch differs.
-    const { runCompleteCliGunshi } = await import('./gunshi/complete.js');
-    return { code: await runCompleteCliGunshi(argv, io), exit: 'natural' };
-  }
-  if (argv[0] === 'docs') {
-    // Loaded on demand: the bundled topics are ~20KB of string literals that the analysis path
-    // — the one the I/O budget test and `pnpm bench` defend — would otherwise parse every run.
-    const { runDocsCliGunshi } = await import('./gunshi/docs.js');
-    return { code: await runDocsCliGunshi(argv.slice(1), io, locale), exit: 'natural' };
-  }
-  if (argv[0] === 'explain') {
-    const { runExplainCliGunshi } = await import('./gunshi/explain.js');
-    return { code: await runExplainCliGunshi(argv.slice(1), io, locale), exit: 'natural' };
-  }
-  if (argv[0] === 'install') {
-    const { runInstallCliGunshi } = await import('./gunshi/install.js');
-    return { code: await runInstallCliGunshi(argv.slice(1), io, locale), exit: 'immediate' };
-  }
-  if (argv[0] === 'ci') {
-    // ci's own IO is disk-backed (realIO()) for reading/writing the workflow file; only the
-    // log/errorLog sinks are swapped for the caller's, so a test-injected `io` still observes
-    // everything ci prints without having to fake the filesystem for paths that never touch it
-    // (--help, the error surfaces below).
-    const { runCiCliGunshi } = await import('./gunshi/ci.js');
-    const code = await runCiCliGunshi(argv.slice(1), { ...realIO(), log: io.log, errorLog: io.errorLog }, locale);
-    return { code, exit: 'immediate' };
-  }
+    if (argv[0] === 'complete') {
+      // Loaded on demand, same reasoning as `docs`/`explain` below. Passed the FULL argv, not
+      // `argv.slice(1)` — see gunshi/complete.ts's own doc comment for why this one branch differs.
+      const { runCompleteCliGunshi } = await import('./gunshi/complete.js');
+      return { code: await runCompleteCliGunshi(argv, io), exit: 'natural' };
+    }
+    if (argv[0] === 'docs') {
+      // Loaded on demand: the bundled topics are ~20KB of string literals that the analysis path
+      // — the one the I/O budget test and `pnpm bench` defend — would otherwise parse every run.
+      const { runDocsCliGunshi } = await import('./gunshi/docs.js');
+      return { code: await runDocsCliGunshi(argv.slice(1), io, locale), exit: 'natural' };
+    }
+    if (argv[0] === 'explain') {
+      const { runExplainCliGunshi } = await import('./gunshi/explain.js');
+      return { code: await runExplainCliGunshi(argv.slice(1), io, locale), exit: 'natural' };
+    }
+    if (argv[0] === 'install') {
+      const { runInstallCliGunshi } = await import('./gunshi/install.js');
+      return { code: await runInstallCliGunshi(argv.slice(1), io, locale), exit: 'immediate' };
+    }
+    if (argv[0] === 'ci') {
+      // ci's own IO is disk-backed (realIO()) for reading/writing the workflow file; only the
+      // log/errorLog sinks are swapped for the caller's, so a test-injected `io` still observes
+      // everything ci prints without having to fake the filesystem for paths that never touch it
+      // (--help, the error surfaces below).
+      const { runCiCliGunshi } = await import('./gunshi/ci.js');
+      const code = await runCiCliGunshi(argv.slice(1), { ...realIO(), log: io.log, errorLog: io.errorLog }, locale);
+      return { code, exit: 'immediate' };
+    }
 
-  return runAnalyzeCliGunshi(argv, io, locale);
+    return await runAnalyzeCliGunshi(argv, io, locale);
+  } catch (err) {
+    // Last-resort net: any throw that escapes the dispatchers above is an internal crash, not a
+    // failing finding — exit 2 keeps that distinction visible to a CI gate reading the exit code.
+    io.errorLog(`svelte-vitals: ${err instanceof Error ? err.message : String(err)}`);
+    return { code: 2, exit: 'natural' };
+  }
 }

--- a/packages/cli/test/cli-crash-exit.test.ts
+++ b/packages/cli/test/cli-crash-exit.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+import { captureIO } from './helpers/capture-io.js';
+
+// Any throw that escapes the dispatchers in `runCli` (e.g. gunshi's `cli()` or a locale-plugin
+// import) must map to exit 2, not propagate as an unhandled rejection. Stubbing the root
+// analyzer is the smallest way to force a throw past the dispatch layer end-to-end.
+vi.mock('../src/gunshi/analyze.js', () => ({
+  runAnalyzeCliGunshi: async () => {
+    throw new Error('synthetic dispatch crash (test)');
+  }
+}));
+
+const { runCli } = await import('../src/cli.js');
+
+describe('runCli crash isolation', () => {
+  it('maps a dispatch-layer throw to exit 2 with a one-line diagnostic', async () => {
+    const io = captureIO();
+    const result = await runCli(['some-path'], io);
+    expect(result).toEqual({ code: 2, exit: 'natural' });
+    expect(io.err).toMatch(/^svelte-vitals: synthetic dispatch crash \(test\)$/);
+    expect(io.err).not.toContain('\n');
+  });
+});

--- a/scripts/cli-e2e.mjs
+++ b/scripts/cli-e2e.mjs
@@ -191,3 +191,26 @@ test('CURSOR_AGENT (a non-Claude gunshi/std-env-recognized var) auto-selects the
   assert.match(stderr, /agent reporter auto-selected/);
   assert.match(stdout, /# svelte-vitals — fixes/);
 });
+
+/**
+ * Real end-to-end coverage for the ja `--help` path (docs/superpowers/specs/
+ * 2026-08-11-cli-ja-help-design.md): it crosses a dynamic `import('@gunshi/plugin-i18n')` and a
+ * bundler-produced locale chunk that no in-process vitest run exercises. `LANG` isn't in
+ * `CHILD_ENV_ALLOWLIST` (it would leak the host locale into every other check), so it's passed
+ * as an explicit per-check override, same as `CLAUDECODE`/`CURSOR_AGENT` above.
+ */
+test('--help under LANG=ja_JP.UTF-8 renders the Japanese help text', () => {
+  const { code, signal, stdout, stderr } = runCli(['--help'], { env: cleanEnv({ LANG: 'ja_JP.UTF-8' }) });
+  assert.equal(signal, null, `killed by signal ${signal} (stderr: ${stderr})`);
+  assert.equal(code, 0, `expected exit 0, got ${code}: ${stderr}`);
+  assert.match(stdout, /決定論的な SvelteKit/);
+  assert.match(stdout, /使用方法:/);
+});
+
+test('--help under a clean env stays English (no ja plumbing leak)', () => {
+  const { code, signal, stdout, stderr } = runCli(['--help'], { env: cleanEnv() });
+  assert.equal(signal, null, `killed by signal ${signal} (stderr: ${stderr})`);
+  assert.equal(code, 0, `expected exit 0, got ${code}: ${stderr}`);
+  assert.match(stdout, /a deterministic SvelteKit code-health scanner/);
+  assert.doesNotMatch(stdout, /使用方法:/);
+});


### PR DESCRIPTION
Two process-boundary gaps found by the 2026-08-12 audit:

1. **Crashes inverted the exit-code contract.** \`bin.ts\` ran \`void main()\` with no catch, so any throw escaping the dispatch layer terminated Node with exit 1 — the code that means "a finding failed the gate" — plus a raw stack trace. The docs explicitly tell agents "Exit 2 is never a pass". \`runCli\` now wraps its whole dispatch in try/catch (\`return await\` on the analyze branch, so rejections don't bypass it) and returns \`{ code: 2, exit: 'natural' }\` with a one-line \`svelte-vitals:\` diagnostic; \`bin.ts\` keeps a last-resort \`.catch\` → exit 2. Unit test forces a dispatch throw via \`vi.mock\` and pins the result.
2. **The ja \`--help\` feature had zero real-process coverage** — every ja test injected \`env\` in-process, while the ja branch crosses two dynamic imports and a bundler-produced locale chunk. Two new \`cli-e2e\` checks run the built binary with \`LANG=ja_JP.UTF-8\` (asserts \`使用方法:\`) and with a clean env (asserts English, no ja leak), pinning the env plumbing and the packaging in both directions.

Changeset: \`svelte-vitals\` patch. Existing exit-code e2e checks unchanged (proves the catch altered no reachable path). Plan: \`plans/051-exit2-and-ja-e2e.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CLI crashes now exit with status 2 and display a concise diagnostic instead of failing silently or propagating an error.
  * Exit status 1 remains reserved for findings that fail the configured gate.

* **Tests**
  * Added coverage for CLI crash handling.
  * Added end-to-end checks for localized Japanese help output and the default English output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->