### PR TITLE
chore: group the gunshi family in renovate and stop automerging its 0.x minors; drop the dead depType groups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,12 +21,8 @@
       "enabled": false
     },
     {
-      "groupName": "dependencies",
-      "matchDepTypes": ["dependencies"]
-    },
-    {
-      "groupName": "devDependencies",
-      "matchDepTypes": ["devDependencies"]
+      "groupName": "catalog",
+      "matchFileNames": ["pnpm-workspace.yaml"]
     },
     {
       "groupName": "linters",
@@ -43,6 +39,16 @@
     {
       "groupName": "build-tools",
       "matchPackageNames": ["tsup{/,}**", "vite{/,}**", "vitest{/,}**"]
+    },
+    {
+      "groupName": "gunshi",
+      "matchPackageNames": ["gunshi", "@gunshi/**"]
+    },
+    {
+      "groupName": "gunshi",
+      "matchPackageNames": ["gunshi", "@gunshi/**"],
+      "matchUpdateTypes": ["minor"],
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
Three Renovate config fixes from the 2026-08-12 audit:

1. **gunshi group**: the five gunshi packages are exact-pinned and mutually peer-locked at exact versions; without a group rule, a gunshi 0.38.0 release becomes five independent automerging PRs, and between merges the release-triggering \`main\` carries a mixed family that resolves two copies of a plugin instead of failing.
2. **Minor automerge off for that group**: the migration design doc (2026-08-10, §risks) records "any breaking bump treated as a design-review event, not a routine merge" — under 0.x the minor IS the breaking channel, yet the blanket automerge covered it. Patches stay automerged.
3. **Dead rules replaced**: the \`matchDepTypes: ["dependencies"]\`/\`["devDependencies"]\` groups never matched anything (every dep is catalog-managed; merged branch names like \`renovate/node-html-parser-9.x\` prove single-dep PRs shipped past them). Replaced with a \`matchFileNames: ["pnpm-workspace.yaml"]\` catalog group.

No changeset (internal config). Plan: \`plans/053-renovate-config.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)