### PR TITLE
docs: promote code-fence filename comments to fence titles

### DIFF
--- a/docs/blume.translations.json
+++ b/docs/blume.translations.json
@@ -31,7 +31,7 @@
       "ja": "a207c44df41eeae6"
     },
     "src/content/docs/guides/(setup)/configuration.mdx": {
-      "ja": "8098a6f58709e085"
+      "ja": "4343c7be4d4b1789"
     },
     "src/content/docs/guides/(setup)/install.md": {
       "ja": "14aaece31b210bfc"
@@ -40,73 +40,73 @@
       "ja": "4405a6efd51689f4"
     },
     "src/content/docs/guides/(vite)/dev-dashboard.mdx": {
-      "ja": "5eae1f63436d3a5c"
+      "ja": "8582cf616a7e3e55"
     },
     "src/content/docs/guides/(vite)/meta.ts": {
       "ja": "72937c0224fde0f3"
     },
     "src/content/docs/guides/(vite)/plugin-mode.md": {
-      "ja": "ca97ae1f755177d1"
+      "ja": "627d8a3176a2250b"
     },
     "src/content/docs/index.mdx": {
       "ja": "a3f01994fadf8b04"
     },
     "src/content/docs/rules/a11y/accessible-name.md": {
-      "ja": "6ee67bce1783a262"
+      "ja": "8c913ec8421b502e"
     },
     "src/content/docs/rules/a11y/doctype.md": {
-      "ja": "93ff8a010a706cb4"
+      "ja": "bbd2d7d3dbad907e"
     },
     "src/content/docs/rules/a11y/duplicate-landmark.md": {
-      "ja": "559a472a0f07e7fb"
+      "ja": "f3bb464c559b0db5"
     },
     "src/content/docs/rules/a11y/id-duplication.md": {
-      "ja": "fb53643d4b690ae5"
+      "ja": "80220205c1843add"
     },
     "src/content/docs/rules/a11y/index.mdx": {
       "ja": "cec144067e19e1a6"
     },
     "src/content/docs/rules/a11y/interactive-nesting.md": {
-      "ja": "d8119b19ee2d4217"
+      "ja": "956cbb045d7b9b33"
     },
     "src/content/docs/rules/a11y/invalid-aria-value.md": {
-      "ja": "aa1fe8182de5e3b9"
+      "ja": "cc58b6327e880961"
     },
     "src/content/docs/rules/a11y/invalid-role.md": {
-      "ja": "498ed055dcba8476"
+      "ja": "9eb9b5f41c38eb58"
     },
     "src/content/docs/rules/a11y/label-has-control.md": {
-      "ja": "638c30deeca7732b"
+      "ja": "0ee96ff758bdd77e"
     },
     "src/content/docs/rules/a11y/no-missing-id-ref.md": {
-      "ja": "9d9dc49a02c0cf5b"
+      "ja": "c970fb617aa874cb"
     },
     "src/content/docs/rules/a11y/placeholder-label-option.md": {
-      "ja": "2cc87c215d5f7078"
+      "ja": "3490e4e6e92e8dc0"
     },
     "src/content/docs/rules/a11y/require-datetime.md": {
-      "ja": "fb607ebef6f2649d"
+      "ja": "d9848eb818d1e07b"
     },
     "src/content/docs/rules/a11y/required-aria-props.md": {
-      "ja": "b36b2390f96b8b8c"
+      "ja": "2e677954defd695a"
     },
     "src/content/docs/rules/a11y/top-level-landmark.md": {
-      "ja": "0ddf7251c2eeded3"
+      "ja": "f6c39158265010de"
     },
     "src/content/docs/rules/a11y/unknown-aria-attribute.md": {
-      "ja": "2a312bd56dc9361b"
+      "ja": "29430ede8f65fdfd"
     },
     "src/content/docs/rules/a11y/use-list.md": {
-      "ja": "ddb5a587f0c4995f"
+      "ja": "d22d3d2b7d3854cd"
     },
     "src/content/docs/rules/architecture/component-size.md": {
-      "ja": "e974eb20dbfa063d"
+      "ja": "4df82809cd185fb3"
     },
     "src/content/docs/rules/architecture/directory-naming.md": {
-      "ja": "a9089d94d3135beb"
+      "ja": "2f95fb58256bf88b"
     },
     "src/content/docs/rules/architecture/doc-link-target.md": {
-      "ja": "83275a32cc2f82d0"
+      "ja": "20cbc7305bf88d78"
     },
     "src/content/docs/rules/architecture/index.mdx": {
       "ja": "1fad1aa87d5e90e6"
@@ -115,241 +115,241 @@
       "ja": "e5fa126a50581272"
     },
     "src/content/docs/rules/architecture/private-scope-import.md": {
-      "ja": "fd01243248cbf0d0"
+      "ja": "6c1fa9d5e52850f6"
     },
     "src/content/docs/rules/architecture/prop-count.md": {
-      "ja": "65992b3e7bb38d02"
+      "ja": "68f773ec275139d2"
     },
     "src/content/docs/rules/architecture/reserved-directory-names.md": {
-      "ja": "5dfdfaf73d1ccc49"
+      "ja": "8b236bdf364619f9"
     },
     "src/content/docs/rules/architecture/reserved-name-placement.md": {
-      "ja": "6e69c3d0f8b9652a"
+      "ja": "6710038415e4806e"
     },
     "src/content/docs/rules/architecture/route-component-import.md": {
-      "ja": "bc783c57f4907a85"
+      "ja": "d665a10238021847"
     },
     "src/content/docs/rules/architecture/unit-entry-file.md": {
-      "ja": "4fa2833cf58a93f3"
+      "ja": "9c7e6ca07c482fb4"
     },
     "src/content/docs/rules/correctness/base-path-navigation.md": {
-      "ja": "54e6eb18d368b6a6"
+      "ja": "81cf93a1ee786fce"
     },
     "src/content/docs/rules/correctness/checkable-bind-value.md": {
-      "ja": "4b6a74254c789ff9"
+      "ja": "2fb2c42a11e3ef90"
     },
     "src/content/docs/rules/correctness/each-index-key.md": {
-      "ja": "1d18df11ca9ab2d4"
+      "ja": "0116981880c10453"
     },
     "src/content/docs/rules/correctness/each-key.md": {
-      "ja": "b628681dfc1185f0"
+      "ja": "c462be8c15156cb0"
     },
     "src/content/docs/rules/correctness/effect-as-derived.md": {
-      "ja": "82915e004288c705"
+      "ja": "db276055d8053ab9"
     },
     "src/content/docs/rules/correctness/effect-as-onmount.md": {
-      "ja": "9f7a6fcaea953706"
+      "ja": "065d4ade6756a7e3"
     },
     "src/content/docs/rules/correctness/index.mdx": {
       "ja": "71157f56573345ca"
     },
     "src/content/docs/rules/correctness/instance-browser-global.md": {
-      "ja": "d715a03c893bb7fd"
+      "ja": "cc74a6ba51979ede"
     },
     "src/content/docs/rules/correctness/meta.ts": {
       "ja": "9d00ecaa38f209ae"
     },
     "src/content/docs/rules/correctness/nonreactive-builtin-state.md": {
-      "ja": "92fb182ade3953e7"
+      "ja": "5c1401fd9f448a96"
     },
     "src/content/docs/rules/correctness/orphan-effect.md": {
-      "ja": "1b12e5afca0964ab"
+      "ja": "344bc319a9e8924e"
     },
     "src/content/docs/rules/correctness/orphan-lifecycle.md": {
-      "ja": "6a330ca8478bbe19"
+      "ja": "3fe0583ee50e0fe1"
     },
     "src/content/docs/rules/correctness/prop-mutation.md": {
-      "ja": "12279facf81394a2"
+      "ja": "7e3f46876a35d4ae"
     },
     "src/content/docs/rules/correctness/server-browser-global.md": {
-      "ja": "6fd3221e6c6f1e94"
+      "ja": "f77a7e5a632a19e2"
     },
     "src/content/docs/rules/correctness/stale-prop-derivation.md": {
-      "ja": "ed68d0f52c226da1"
+      "ja": "a5d9a1d365c26ce7"
     },
     "src/content/docs/rules/correctness/unmutated-state.md": {
-      "ja": "800008f7300bc4c1"
+      "ja": "8a084d8042944616"
     },
     "src/content/docs/rules/index.mdx": {
       "ja": "67acb953dfd73379"
     },
     "src/content/docs/rules/performance/font-preload-crossorigin.md": {
-      "ja": "f8c60d1838c6fdcf"
+      "ja": "39baf5dc36b078e9"
     },
     "src/content/docs/rules/performance/heavy-import.md": {
-      "ja": "436b8f593d9b6122"
+      "ja": "ba247cec1e12b2bb"
     },
     "src/content/docs/rules/performance/image-dimensions.md": {
-      "ja": "a7818cef83a797d2"
+      "ja": "2fe7999593b2bc0e"
     },
     "src/content/docs/rules/performance/image-loading-hint.md": {
-      "ja": "1ba4599144f6b7b1"
+      "ja": "67f228fe4286a558"
     },
     "src/content/docs/rules/performance/index.mdx": {
       "ja": "71738efa32049609"
     },
     "src/content/docs/rules/performance/lcp-image.md": {
-      "ja": "fd08923ca2eec6c9"
+      "ja": "fc74c476407152b9"
     },
     "src/content/docs/rules/performance/load-waterfall.md": {
-      "ja": "b1b85bdbb64c012c"
+      "ja": "09ebbe58028cb943"
     },
     "src/content/docs/rules/performance/meta.ts": {
       "ja": "323d1d8de8d3cbea"
     },
     "src/content/docs/rules/performance/minify-disabled.md": {
-      "ja": "97dd26eb27847c96"
+      "ja": "028c54c50d55aa36"
     },
     "src/content/docs/rules/performance/namespace-import.md": {
-      "ja": "5576d2d4a3c15768"
+      "ja": "717a8cd1b9a8728a"
     },
     "src/content/docs/rules/performance/preconnect.md": {
-      "ja": "af9c84b4e63350d1"
+      "ja": "78275d4c1e3670c9"
     },
     "src/content/docs/rules/performance/preload-missing-as.md": {
-      "ja": "efac1287b3312ce7"
+      "ja": "29fc718bf9fa7ccc"
     },
     "src/content/docs/rules/performance/render-blocking-script.md": {
-      "ja": "27cb8210488f644d"
+      "ja": "2c73c21919867dc4"
     },
     "src/content/docs/rules/performance/responsive-image.md": {
-      "ja": "ceabcc0e75243b1d"
+      "ja": "159853a8dfb31ead"
     },
     "src/content/docs/rules/performance/sequential-awaits.md": {
-      "ja": "744332e5e78e3575"
+      "ja": "001389b971b1b4a3"
     },
     "src/content/docs/rules/performance/state-raw.md": {
-      "ja": "a5f7aa6a71650a86"
+      "ja": "996875fc121523bb"
     },
     "src/content/docs/rules/security/handler-state-write.md": {
-      "ja": "2898c78e7dd09152"
+      "ja": "b162531dcfb60de3"
     },
     "src/content/docs/rules/security/index.mdx": {
       "ja": "eeaab3faeac155bf"
     },
     "src/content/docs/rules/security/javascript-url.md": {
-      "ja": "4a61fb37e0f48fc0"
+      "ja": "775d12f468887034"
     },
     "src/content/docs/rules/security/meta.ts": {
       "ja": "79f39784963e2d45"
     },
     "src/content/docs/rules/security/raw-html.md": {
-      "ja": "f28b7de4571f8835"
+      "ja": "489db60129454612"
     },
     "src/content/docs/rules/security/server-module-state.md": {
-      "ja": "abecdea8f11c8b54"
+      "ja": "1c0b966f5d159cb9"
     },
     "src/content/docs/rules/security/shared-state-import.md": {
-      "ja": "da4b3c85c97cc146"
+      "ja": "cc947a418698575c"
     },
     "src/content/docs/rules/seo/canonical-url.md": {
-      "ja": "91c73a1b498f2ffb"
+      "ja": "092e2e072e4b3061"
     },
     "src/content/docs/rules/seo/charset.md": {
-      "ja": "b06b3220b494663e"
+      "ja": "2e35c6797f3f3dd7"
     },
     "src/content/docs/rules/seo/description-length.md": {
-      "ja": "967308539295d428"
+      "ja": "4519b0015442aadc"
     },
     "src/content/docs/rules/seo/description-presence.md": {
-      "ja": "bb626b04ebf0a7ad"
+      "ja": "cbd54b29ec5f0e61"
     },
     "src/content/docs/rules/seo/duplicate-description.md": {
-      "ja": "cdcc605f4fa26416"
+      "ja": "ae8946f798e57fb2"
     },
     "src/content/docs/rules/seo/duplicate-title.md": {
-      "ja": "0fa82650f96d554a"
+      "ja": "e4698fdd6fb3d30f"
     },
     "src/content/docs/rules/seo/heading-level-skip.md": {
-      "ja": "a36f285988c7744a"
+      "ja": "c3caddc8e8d8570e"
     },
     "src/content/docs/rules/seo/hreflang.md": {
-      "ja": "a695380530a0e5c1"
+      "ja": "ba704af14db52a1e"
     },
     "src/content/docs/rules/seo/html-lang.md": {
-      "ja": "cbabccc5f3c286eb"
+      "ja": "ce4bd50188e6e740"
     },
     "src/content/docs/rules/seo/image-alt.md": {
-      "ja": "e15262424ef26fd6"
+      "ja": "b1238f65f53db401"
     },
     "src/content/docs/rules/seo/index.mdx": {
       "ja": "59bf332f6fbc5c3c"
     },
     "src/content/docs/rules/seo/indexability.md": {
-      "ja": "3467880b90e63693"
+      "ja": "683d3abff263a8d5"
     },
     "src/content/docs/rules/seo/json-ld-date-format.md": {
-      "ja": "286a0f500534c9ba"
+      "ja": "5070c78576af77c8"
     },
     "src/content/docs/rules/seo/json-ld-deprecated-type.md": {
-      "ja": "ab60ace9f7b96104"
+      "ja": "1120bffe426b2c84"
     },
     "src/content/docs/rules/seo/json-ld-placeholder.md": {
-      "ja": "02c4c309d2b68420"
+      "ja": "95ba5b621af2f012"
     },
     "src/content/docs/rules/seo/json-ld-relative-url.md": {
-      "ja": "79979f64b4833187"
+      "ja": "9c597b682ec616a2"
     },
     "src/content/docs/rules/seo/json-ld-required-props.md": {
-      "ja": "73256e2f6c83ca12"
+      "ja": "1ad5d19a1a2395b4"
     },
     "src/content/docs/rules/seo/json-ld-validity.md": {
-      "ja": "0263498bb86dec7f"
+      "ja": "51e0b7d9c6991fda"
     },
     "src/content/docs/rules/seo/json-ld.md": {
-      "ja": "455c6baea452b93d"
+      "ja": "87b8fa69ce4a5c43"
     },
     "src/content/docs/rules/seo/meta.ts": {
       "ja": "12edac06bc7f6265"
     },
     "src/content/docs/rules/seo/og-description.md": {
-      "ja": "7418edcc9451aab9"
+      "ja": "ae4486553d5d71b7"
     },
     "src/content/docs/rules/seo/og-image.md": {
-      "ja": "44f8f41710066b3f"
+      "ja": "98402bd02598b9d4"
     },
     "src/content/docs/rules/seo/og-title.md": {
-      "ja": "eeb3aa6d905d294b"
+      "ja": "209cf7140acbbc58"
     },
     "src/content/docs/rules/seo/og-url.md": {
-      "ja": "ad1fc0754268143f"
+      "ja": "8a23b4383b100a2b"
     },
     "src/content/docs/rules/seo/robots-txt.md": {
-      "ja": "a3c0d4fcfd24ce53"
+      "ja": "825bdf47bc050744"
     },
     "src/content/docs/rules/seo/single-h1.md": {
-      "ja": "e7f07d9e313d2ea7"
+      "ja": "fca9d96915504122"
     },
     "src/content/docs/rules/seo/sitemap-in-robots.md": {
-      "ja": "cc8f4cb4a18392a0"
+      "ja": "6b488a0ed558e344"
     },
     "src/content/docs/rules/seo/sitemap-xml.md": {
-      "ja": "88aa8c63271f6b94"
+      "ja": "be24ec5205d1d8dd"
     },
     "src/content/docs/rules/seo/ssr-disabled.md": {
-      "ja": "6a25d52feca23275"
+      "ja": "4a10c93c4be54248"
     },
     "src/content/docs/rules/seo/title-length.md": {
-      "ja": "e36ce39cd139d4e1"
+      "ja": "ec6063b64824f750"
     },
     "src/content/docs/rules/seo/title-presence.md": {
-      "ja": "b7071871df5e0e56"
+      "ja": "54da38c55288c885"
     },
     "src/content/docs/rules/seo/twitter-card.md": {
-      "ja": "4924df631def74c4"
+      "ja": "9056239a00cd98db"
     },
     "src/content/docs/rules/seo/viewport.md": {
-      "ja": "8752e1efd19ef5a6"
+      "ja": "0cc556fa77960387"
     }
   },
   "version": 1

--- a/docs/src/content/docs/guides/(setup)/configuration.mdx
+++ b/docs/src/content/docs/guides/(setup)/configuration.mdx
@@ -89,8 +89,7 @@ A weight of `0` is valid — it excludes that category from the Health average e
 case being routes that are intentionally not public (behind auth) and shouldn't be held to SEO
 metadata rules:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   overrides: [
     // Everything in the (app) route group: no SEO checks at all.
@@ -138,8 +137,7 @@ Semantics worth knowing:
 
 Beyond the bare severity string, a rule setting can be an object, `{ severity?, options? }`:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'architecture/prop-count': { options: { max: 10 } },
@@ -252,8 +250,7 @@ One exception: `--rules` and `--ignore` are selection, not configuration — eac
 
 `@svelte-vitals/vite` reads `svelte-vitals.config.*` the same way the CLI does, with no extra wiring. Both the build gate and the [live dashboard](/guides/dev-dashboard) resolve it from the project root (`cwd` passed to `svelteVitals({ ... })`, else the Vite config root), with the same per-field precedence: **plugin option > config file > built-in default**. `weights` included.
 
-```ts
-// vite.config.ts
+```ts vite.config.ts
 import { sveltekit } from '@sveltejs/kit/vite';
 import { svelteVitals } from '@svelte-vitals/vite';
 

--- a/docs/src/content/docs/guides/(vite)/dev-dashboard.mdx
+++ b/docs/src/content/docs/guides/(vite)/dev-dashboard.mdx
@@ -7,8 +7,7 @@ sidebar:
 
 `@svelte-vitals/vite`'s `svelteVitals()` plugin serves a live dashboard at `/__svelte-vitals/` during `vite dev` — a searchable, sortable route list with a detail pane for the selected route, or an "Overview" that aggregates every finding across the whole project. It updates in place as you work, and it's **on by default**; see [Disabling it](#disabling-it) to opt out.
 
-```js
-// vite.config.{js,ts}
+```js vite.config.{js,ts}
 import { svelteVitals } from '@svelte-vitals/vite';
 
 export default {
@@ -49,8 +48,7 @@ If the whole-project analysis fails (for example the dev server root is not a Sv
 
 On top of that static baseline, browsing your app refines the picture. Add the `svelteVitalsHandle` hook to `src/hooks.server.ts`:
 
-```ts
-// src/hooks.server.ts
+```ts src/hooks.server.ts
 import { svelteVitalsHandle } from '@svelte-vitals/vite/hooks';
 import { sequence } from '@sveltejs/kit/hooks';
 

--- a/docs/src/content/docs/guides/(vite)/plugin-mode.md
+++ b/docs/src/content/docs/guides/(vite)/plugin-mode.md
@@ -23,8 +23,7 @@ pnpm add -D @svelte-vitals/vite
 
 Add `svelteVitals` to your `vite.config.ts`:
 
-```ts
-// vite.config.ts
+```ts vite.config.ts
 import { sveltekit } from '@sveltejs/kit/vite';
 import { svelteVitals } from '@svelte-vitals/vite';
 

--- a/docs/src/content/docs/ja/guides/(setup)/configuration.mdx
+++ b/docs/src/content/docs/ja/guides/(setup)/configuration.mdx
@@ -87,8 +87,7 @@ svelte-vitals は次のファイルを、この優先順で**分析対象ディ�
 
 `rules` は全体に適用されます。`overrides` はマッチした箇所にだけルール設定を適用します。典型的なのは、意図的に非公開のルート（認証必須のページ）を SEO メタデータルールの対象外にしたいケースです：
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   overrides: [
     // (app) ルートグループ配下：SEO チェックを一切行わない。
@@ -118,8 +117,7 @@ glob の構文はあえて最小限に絞ってあります：`*` はパスセ�
 
 単なる重大度の文字列に加えて、ルール設定にはオブジェクト形式 `{ severity?, options? }` も指定できます：
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'architecture/prop-count': { options: { max: 10 } },
@@ -225,8 +223,7 @@ CLI の静的モードは、ルートの `<head>` と見出しを解決するた
 
 `@svelte-vitals/vite` は CLI と同じ方法で `svelte-vitals.config.*` を読み込みます。追加の配線は不要です。ビルドゲートと[ライブダッシュボード](/ja/guides/dev-dashboard)のどちらも、プロジェクトルート（`svelteVitals({ ... })` に渡す `cwd`、省略時は Vite の config root）から解決し、CLI と同じフィールド単位の優先順位を適用します: **プラグインオプション > 設定ファイル > 組み込みのデフォルト**。`weights` も含みます。
 
-```ts
-// vite.config.ts
+```ts vite.config.ts
 import { sveltekit } from '@sveltejs/kit/vite';
 import { svelteVitals } from '@svelte-vitals/vite';
 

--- a/docs/src/content/docs/ja/guides/(vite)/dev-dashboard.mdx
+++ b/docs/src/content/docs/ja/guides/(vite)/dev-dashboard.mdx
@@ -7,8 +7,7 @@ sidebar:
 
 `@svelte-vitals/vite` の `svelteVitals()` プラグインは、`vite dev` 中に `/__svelte-vitals/` でライブダッシュボードを配信します。検索と並び替えができるルート一覧と選択中ルートの詳細ペイン、あるいはプロジェクト全体の指摘を集約した「Overview」で構成され、作業に合わせてその場で更新されます。**デフォルトで有効**です。無効化する場合は[無効化する](#無効化する)を参照してください。
 
-```js
-// vite.config.{js,ts}
+```js vite.config.{js,ts}
 import { svelteVitals } from '@svelte-vitals/vite';
 
 export default {
@@ -47,8 +46,7 @@ dev サーバーの起動直後から、ダッシュボードは**プロジェ�
 
 この静的なベースラインを土台に、アプリを実際にブラウジングすると結果の精度が上がります。`src/hooks.server.ts` に `svelteVitalsHandle` フックを追加してください:
 
-```ts
-// src/hooks.server.ts
+```ts src/hooks.server.ts
 import { svelteVitalsHandle } from '@svelte-vitals/vite/hooks';
 import { sequence } from '@sveltejs/kit/hooks';
 

--- a/docs/src/content/docs/ja/guides/(vite)/plugin-mode.md
+++ b/docs/src/content/docs/ja/guides/(vite)/plugin-mode.md
@@ -23,8 +23,7 @@ pnpm add -D @svelte-vitals/vite
 
 `vite.config.ts` に `svelteVitals` を追加します：
 
-```ts
-// vite.config.ts
+```ts vite.config.ts
 import { sveltekit } from '@sveltejs/kit/vite';
 import { svelteVitals } from '@svelte-vitals/vite';
 

--- a/docs/src/content/docs/ja/rules/a11y/accessible-name.md
+++ b/docs/src/content/docs/ja/rules/a11y/accessible-name.md
@@ -41,8 +41,7 @@ description: ボタン・リンク・画像ボタンには、アクセシブル�
 
 このルールからは見えない別の方法（ラップしている label 要素など）で名前を与えている場合は、`<!-- svelte-vitals-disable-next-line a11y/accessible-name -->` で個別の要素を抑制するか、ルールを無効化してください:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/accessible-name': 'off'

--- a/docs/src/content/docs/ja/rules/a11y/doctype.md
+++ b/docs/src/content/docs/ja/rules/a11y/doctype.md
@@ -25,8 +25,7 @@ doctype がないとブラウザは互換モード（quirks mode）でレンダ�
 
 意図的な場合はルールを無効化してください:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/doctype': 'off'

--- a/docs/src/content/docs/ja/rules/a11y/duplicate-landmark.md
+++ b/docs/src/content/docs/ja/rules/a11y/duplicate-landmark.md
@@ -47,8 +47,7 @@ description: 1つのルートに main・banner・contentinfo ランドマーク�
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/duplicate-landmark': 'off'

--- a/docs/src/content/docs/ja/rules/a11y/id-duplication.md
+++ b/docs/src/content/docs/ja/rules/a11y/id-duplication.md
@@ -48,8 +48,7 @@ id が重複すると、id の存在意義そのものが壊れます。`<label 
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/id-duplication': 'off'

--- a/docs/src/content/docs/ja/rules/a11y/interactive-nesting.md
+++ b/docs/src/content/docs/ja/rules/a11y/interactive-nesting.md
@@ -48,8 +48,7 @@ description: インタラクティブな要素を、別のインタラクティ�
 
 ネストが意図的で、別の方法（`pointer-events` と合成フォーカストラップなど）で対処済みの場合は、`<!-- svelte-vitals-disable-next-line a11y/interactive-nesting -->` で個別の要素を抑制するか、ルールを無効化してください:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/interactive-nesting': 'off'

--- a/docs/src/content/docs/ja/rules/a11y/invalid-aria-value.md
+++ b/docs/src/content/docs/ja/rules/a11y/invalid-aria-value.md
@@ -42,8 +42,7 @@ description: aria-* 属性の値は、その属性に WAI-ARIA 仕様が定め�
 
 意図的に非標準な値を使う場合は、`<!-- svelte-vitals-disable-next-line a11y/invalid-aria-value -->` で個別の要素を抑制するか、ルールを無効化してください:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/invalid-aria-value': 'off'

--- a/docs/src/content/docs/ja/rules/a11y/invalid-role.md
+++ b/docs/src/content/docs/ja/rules/a11y/invalid-role.md
@@ -36,8 +36,7 @@ description: role 属性には、タイポでも抽象ロールでもない、�
 
 意図的に非標準なロールを使う場合は、`<!-- svelte-vitals-disable-next-line a11y/invalid-role -->` で個別の要素を抑制するか、ルールを無効化してください:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/invalid-role': 'off'

--- a/docs/src/content/docs/ja/rules/a11y/label-has-control.md
+++ b/docs/src/content/docs/ja/rules/a11y/label-has-control.md
@@ -39,8 +39,7 @@ description: label をフィールドと関連付けるには for 属性かラ�
 
 このルールからは見えない別の方法（コントロール側の `aria-labelledby` など）で関連付けている場合は、`<!-- svelte-vitals-disable-next-line a11y/label-has-control -->` で個別の要素を抑制するか、ルールを無効化してください:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/label-has-control': 'off'

--- a/docs/src/content/docs/ja/rules/a11y/no-missing-id-ref.md
+++ b/docs/src/content/docs/ja/rules/a11y/no-missing-id-ref.md
@@ -41,8 +41,7 @@ id とその参照先は別々のファイルにあることが珍しくあり�
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/no-missing-id-ref': 'off'

--- a/docs/src/content/docs/ja/rules/a11y/placeholder-label-option.md
+++ b/docs/src/content/docs/ja/rules/a11y/placeholder-label-option.md
@@ -48,8 +48,7 @@ required な `<select>` は、最初の option を初期状態の選択値とし
 
 最初の option が意図的にプレースホルダーではなく実際の値である場合は、`<!-- svelte-vitals-disable-next-line a11y/placeholder-label-option -->` で個別の要素を抑制するか、ルールを無効化してください:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/placeholder-label-option': 'off'

--- a/docs/src/content/docs/ja/rules/a11y/require-datetime.md
+++ b/docs/src/content/docs/ja/rules/a11y/require-datetime.md
@@ -37,8 +37,7 @@ description: time 要素のテキストは機械可読であるか、datetime �
 
 テキストが意図的に機械可読でない場合は、`<!-- svelte-vitals-disable-next-line a11y/require-datetime -->` で個別の要素を抑制するか、ルールを無効化してください:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/require-datetime': 'off'

--- a/docs/src/content/docs/ja/rules/a11y/required-aria-props.md
+++ b/docs/src/content/docs/ja/rules/a11y/required-aria-props.md
@@ -48,8 +48,7 @@ description: state や property 属性を要求するロールには、ネイテ
 
 必須プロパティを意図的に省略する場合は、`<!-- svelte-vitals-disable-next-line a11y/required-aria-props -->` で個別の要素を抑制するか、ルールを無効化してください:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/required-aria-props': 'off'

--- a/docs/src/content/docs/ja/rules/a11y/top-level-landmark.md
+++ b/docs/src/content/docs/ja/rules/a11y/top-level-landmark.md
@@ -58,8 +58,7 @@ description: banner・main・complementary・contentinfo ランドマークは�
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/top-level-landmark': 'off'

--- a/docs/src/content/docs/ja/rules/a11y/unknown-aria-attribute.md
+++ b/docs/src/content/docs/ja/rules/a11y/unknown-aria-attribute.md
@@ -35,8 +35,7 @@ description: aria-* 属性には、タイポではない実在の WAI-ARIA 属�
 
 意図的に非標準な属性を使う場合は、`<!-- svelte-vitals-disable-next-line a11y/unknown-aria-attribute -->` で個別の要素を抑制するか、ルールを無効化してください:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/unknown-aria-attribute': 'off'

--- a/docs/src/content/docs/ja/rules/a11y/use-list.md
+++ b/docs/src/content/docs/ja/rules/a11y/use-list.md
@@ -43,8 +43,7 @@ description: プレーンテキストに入力された行頭記号は、本物�
 
 その行頭記号がリストの代わりではなく意図的な地の文である場合は、`<!-- svelte-vitals-disable-next-line a11y/use-list -->` で個別の箇所を抑制するか、ルールを無効化してください:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/use-list': 'off'

--- a/docs/src/content/docs/ja/rules/architecture/component-size.md
+++ b/docs/src/content/docs/ja/rules/architecture/component-size.md
@@ -25,8 +25,7 @@ description: 大きくなりすぎたコンポーネントは分割しましょ�
 | ---------- | ------- | ---------: |
 | `max`      | integer |        200 |
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: { 'architecture/component-size': { options: { max: 300 } } }
 };
@@ -36,8 +35,7 @@ export default {
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line architecture/component-size -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'architecture/component-size': 'off'

--- a/docs/src/content/docs/ja/rules/architecture/directory-naming.md
+++ b/docs/src/content/docs/ja/rules/architecture/directory-naming.md
@@ -32,8 +32,7 @@ description: ディレクトリは、その場所に宣言した記法で名付�
 | `directories` | ディレクトリ glob → 記法の集合 のマップ | `{}`       |
 | `exclude`     | ディレクトリ glob のリスト              | `[]`       |
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: {
     'architecture/directory-naming': {
@@ -175,8 +174,7 @@ glob を狭めてください。除外は、その配下すべてをチェック
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line architecture/directory-naming -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'architecture/directory-naming': 'off'

--- a/docs/src/content/docs/ja/rules/architecture/doc-link-target.md
+++ b/docs/src/content/docs/ja/rules/architecture/doc-link-target.md
@@ -33,8 +33,7 @@ description: コメントに書かれたドキュメントリンクは、実在�
 各エントリは、**このプロジェクトのルートを表す URL プレフィックス**です。URL がいずれかで始まるリンクは、
 そのプレフィックスを取り除かれ、残りの部分が `src/` 配下のファイルの中から探されます。
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: {
     'architecture/doc-link-target': {
@@ -82,8 +81,7 @@ export default {
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line architecture/doc-link-target -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'architecture/doc-link-target': 'off'

--- a/docs/src/content/docs/ja/rules/architecture/private-scope-import.md
+++ b/docs/src/content/docs/ja/rules/architecture/private-scope-import.md
@@ -27,8 +27,7 @@ description: プライベートなディレクトリ内のユニットを、そ�
 
 各 glob は**プライベートなディレクトリ**にマッチし、その**親**が境界になります。親の内側にあるファイルはそこから import できますが、外側のファイルはできません。
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: {
     'architecture/private-scope-import': {
@@ -62,8 +61,7 @@ glob では `*` がパスセグメント内、`**` がセグメントをまた�
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line architecture/private-scope-import -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'architecture/private-scope-import': 'off'

--- a/docs/src/content/docs/ja/rules/architecture/prop-count.md
+++ b/docs/src/content/docs/ja/rules/architecture/prop-count.md
@@ -30,8 +30,7 @@ description: props が多すぎるコンポーネントは、担っている責�
 | ---------- | ------- | ---------: |
 | `max`      | integer |          6 |
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: { 'architecture/prop-count': { options: { max: 10 } } }
 };
@@ -41,8 +40,7 @@ export default {
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line architecture/prop-count -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'architecture/prop-count': 'off'

--- a/docs/src/content/docs/ja/rules/architecture/reserved-directory-names.md
+++ b/docs/src/content/docs/ja/rules/architecture/reserved-directory-names.md
@@ -38,8 +38,7 @@ description: ディレクトリの直下に置ける名前は、その位置に�
 | `anyCaseUnitScopes` | 起点 glob → 直下に置ける名前 のマップ（大文字小文字を問わないユニット用） | `{}`       |
 | `exclude`           | ディレクトリ glob のリスト                                                | `[]`       |
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: {
     'architecture/reserved-directory-names': {
@@ -188,8 +187,7 @@ options: {
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line architecture/reserved-directory-names -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'architecture/reserved-directory-names': 'off'

--- a/docs/src/content/docs/ja/rules/architecture/reserved-name-placement.md
+++ b/docs/src/content/docs/ja/rules/architecture/reserved-name-placement.md
@@ -36,8 +36,7 @@ description: 予約ディレクトリ名は、その名前について宣言し�
 | `anyCaseUnitPlacements`     | 予約名 → 直下に置ける**大文字小文字を問わないユニット**ディレクトリにマッチする glob のマップ | `{}`       |
 | `exclude`                   | ディレクトリ glob のリスト                                                                    | `[]`       |
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: {
     'architecture/reserved-name-placement': {
@@ -147,8 +146,7 @@ export default {
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line architecture/reserved-name-placement -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'architecture/reserved-name-placement': 'off'

--- a/docs/src/content/docs/ja/rules/architecture/route-component-import.md
+++ b/docs/src/content/docs/ja/rules/architecture/route-component-import.md
@@ -42,8 +42,7 @@ SvelteKit のルートエントリ —— `+page.svelte`、`+layout.svelte`、`+
 だけをデフォルトとして持たせています。プロジェクトが別の方法でサテライトファイルを示している
 場合は、自分のパターンを追加してください。
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: {
     'architecture/route-component-import': {
@@ -66,8 +65,7 @@ export default {
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line architecture/route-component-import -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'architecture/route-component-import': 'off'

--- a/docs/src/content/docs/ja/rules/architecture/unit-entry-file.md
+++ b/docs/src/content/docs/ja/rules/architecture/unit-entry-file.md
@@ -42,8 +42,7 @@ description: ユニットとして宣言したディレクトリには、同名�
 
 `exclude` はマップではなくリストで、その値は拡張子ではなくディレクトリの glob です。
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: {
     'architecture/unit-entry-file': {
@@ -141,8 +140,7 @@ finding として報告されます。そのため、この finding を抑制す
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line architecture/unit-entry-file -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'architecture/unit-entry-file': 'off'

--- a/docs/src/content/docs/ja/rules/correctness/base-path-navigation.md
+++ b/docs/src/content/docs/ja/rules/correctness/base-path-navigation.md
@@ -65,8 +65,7 @@ redirect(303, resolve('/login')); // load 関数や form action で
 
 ## 無効化
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/base-path-navigation': 'off'

--- a/docs/src/content/docs/ja/rules/correctness/checkable-bind-value.md
+++ b/docs/src/content/docs/ja/rules/correctness/checkable-bind-value.md
@@ -44,8 +44,7 @@ description: checkbox や radio の bind:value は DOM の value プロパティ
 
 ## 無効化
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/checkable-bind-value': 'off'

--- a/docs/src/content/docs/ja/rules/correctness/each-index-key.md
+++ b/docs/src/content/docs/ja/rules/correctness/each-index-key.md
@@ -36,8 +36,7 @@ index キーではアイテムの同一性が位置に従うため、並べ替�
 
 並べ替えも途中への挿入や削除も決して起きないと確実に言えるリストなら、`<!-- svelte-vitals-disable-next-line correctness/each-index-key -->` で個別に抑制するか、ルールを無効化してください:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/each-index-key': 'off'

--- a/docs/src/content/docs/ja/rules/correctness/each-key.md
+++ b/docs/src/content/docs/ja/rules/correctness/each-key.md
@@ -29,8 +29,7 @@ description: 動的なデータを回す {#each} にはキーを付けましょ�
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line correctness/each-key -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/each-key': 'off'

--- a/docs/src/content/docs/ja/rules/correctness/effect-as-derived.md
+++ b/docs/src/content/docs/ja/rules/correctness/effect-as-derived.md
@@ -70,8 +70,7 @@ description: 状態を代入するだけの $effect は $derived に置き換え
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line correctness/effect-as-derived -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/effect-as-derived': 'off'

--- a/docs/src/content/docs/ja/rules/correctness/effect-as-onmount.md
+++ b/docs/src/content/docs/ja/rules/correctness/effect-as-onmount.md
@@ -43,8 +43,7 @@ description: reactive 値を読まない $effect は、イベントハンドラ�
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line correctness/effect-as-onmount -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/effect-as-onmount': 'off'

--- a/docs/src/content/docs/ja/rules/correctness/instance-browser-global.md
+++ b/docs/src/content/docs/ja/rules/correctness/instance-browser-global.md
@@ -52,8 +52,7 @@ description: インスタンススクリプトは SSR 時にサーバーでも�
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line correctness/instance-browser-global -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/instance-browser-global': 'off'

--- a/docs/src/content/docs/ja/rules/correctness/nonreactive-builtin-state.md
+++ b/docs/src/content/docs/ja/rules/correctness/nonreactive-builtin-state.md
@@ -55,8 +55,7 @@ description: $state に入れた素の Map・Set・Date・URL・URLSearchParams 
 
 ## 無効化
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/nonreactive-builtin-state': 'off'

--- a/docs/src/content/docs/ja/rules/correctness/orphan-effect.md
+++ b/docs/src/content/docs/ja/rules/correctness/orphan-effect.md
@@ -26,8 +26,7 @@ description: コンポーネント初期化の外で作られた $effect はラ�
 
 ## 修正方法
 
-```ts
-// store.svelte.ts
+```ts store.svelte.ts
 class QuizStateManager {
   bookmarks = $state<string[]>([]);
   constructor() {
@@ -78,8 +77,7 @@ export const quizState = new QuizStateManager();
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line correctness/orphan-effect -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/orphan-effect': 'off'

--- a/docs/src/content/docs/ja/rules/correctness/orphan-lifecycle.md
+++ b/docs/src/content/docs/ja/rules/correctness/orphan-lifecycle.md
@@ -29,8 +29,7 @@ load/handler/`init` の本体の**内側で定義された関数**は、そこ�
 
 ## 修正方法
 
-```ts
-// +page.ts
+```ts +page.ts
 import { getContext } from 'svelte';
 
 export async function load({ fetch }) {
@@ -58,8 +57,7 @@ export async function load({ fetch }) {
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line correctness/orphan-lifecycle -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/orphan-lifecycle': 'off'

--- a/docs/src/content/docs/ja/rules/correctness/prop-mutation.md
+++ b/docs/src/content/docs/ja/rules/correctness/prop-mutation.md
@@ -79,8 +79,7 @@ Svelte の公式ドキュメントは明確に「`$bindable` でない限り pro
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line correctness/prop-mutation -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/prop-mutation': 'off'

--- a/docs/src/content/docs/ja/rules/correctness/server-browser-global.md
+++ b/docs/src/content/docs/ja/rules/correctness/server-browser-global.md
@@ -27,8 +27,7 @@ description: モジュールスコープや load・ハンドラで window や do
 
 ## 修正方法
 
-```ts
-// +page.ts
+```ts +page.ts
 export function load() {
   const stored = localStorage.getItem('filters'); // ❌ サーバーで ReferenceError
 
@@ -62,8 +61,7 @@ const stored = browser ? localStorage.getItem('filters') : null; // ✅
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line correctness/server-browser-global -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/server-browser-global': 'off'

--- a/docs/src/content/docs/ja/rules/correctness/stale-prop-derivation.md
+++ b/docs/src/content/docs/ja/rules/correctness/stale-prop-derivation.md
@@ -74,8 +74,7 @@ Svelte のガイダンスは、props を変わるものとして扱うよう求�
 
 ## 無効化
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/stale-prop-derivation': 'off'

--- a/docs/src/content/docs/ja/rules/correctness/unmutated-state.md
+++ b/docs/src/content/docs/ja/rules/correctness/unmutated-state.md
@@ -32,8 +32,7 @@ description: 一度も変更しない $state は、const（または $state.raw�
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line correctness/unmutated-state -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/unmutated-state': 'off'

--- a/docs/src/content/docs/ja/rules/performance/font-preload-crossorigin.md
+++ b/docs/src/content/docs/ja/rules/performance/font-preload-crossorigin.md
@@ -25,8 +25,7 @@ description: crossorigin を指定しないと、preload したフォントは�
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/font-preload-crossorigin': 'off'

--- a/docs/src/content/docs/ja/rules/performance/heavy-import.md
+++ b/docs/src/content/docs/ja/rules/performance/heavy-import.md
@@ -39,8 +39,7 @@ description: サイズが大きく、ツリーシェイクも効かないパッ�
 組み込みと同じキーを指定した場合は、パッケージはリストに残ったまま対処方法だけが置き換わります。
 `{ lodash: '社内ヘルパーを使う' }` はエントリを増やすのではなく、検出結果の文面を差し替えます。
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: {
     'performance/heavy-import': { options: { packages: { 'chart.js': 'import chart.js/auto' } } }
@@ -52,8 +51,7 @@ export default {
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line performance/heavy-import -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/heavy-import': 'off'

--- a/docs/src/content/docs/ja/rules/performance/image-dimensions.md
+++ b/docs/src/content/docs/ja/rules/performance/image-dimensions.md
@@ -25,8 +25,7 @@ width と height を明示していない `<img>` は、読み込み中にレイ
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/image-dimensions': 'off'

--- a/docs/src/content/docs/ja/rules/performance/image-loading-hint.md
+++ b/docs/src/content/docs/ja/rules/performance/image-loading-hint.md
@@ -25,8 +25,7 @@ description: <img> には loading 属性を明示します。
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/image-loading-hint': 'off'

--- a/docs/src/content/docs/ja/rules/performance/lcp-image.md
+++ b/docs/src/content/docs/ja/rules/performance/lcp-image.md
@@ -25,8 +25,7 @@ LCP となる最初の画像から `loading="lazy"` を外し、あわせて `fe
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/lcp-image': 'off'

--- a/docs/src/content/docs/ja/rules/performance/load-waterfall.md
+++ b/docs/src/content/docs/ja/rules/performance/load-waterfall.md
@@ -42,8 +42,7 @@ export async function load({ fetch }) {
 
 ## 無効化
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/load-waterfall': 'off'

--- a/docs/src/content/docs/ja/rules/performance/minify-disabled.md
+++ b/docs/src/content/docs/ja/rules/performance/minify-disabled.md
@@ -30,8 +30,7 @@ Vite はデフォルトでミニファイを行います（Vite 8 以降は oxc�
 
 オーバーライドを削除する（デフォルトでミニファイされます）か、本番ではミニファイが維持されるようにスコープを限定します:
 
-```ts
-// vite.config.ts
+```ts vite.config.ts
 import { defineConfig } from 'vite';
 
 export default defineConfig(({ mode }) => ({
@@ -53,8 +52,7 @@ Vite プラグインは解決済みの値で判定するため、実行された
 
 意図してミニファイせずに本番へ出している場合は、設定でルールを無効化してください:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/minify-disabled': 'off'

--- a/docs/src/content/docs/ja/rules/performance/namespace-import.md
+++ b/docs/src/content/docs/ja/rules/performance/namespace-import.md
@@ -31,8 +31,7 @@ named import なら確実にツリーシェイクでき、依存の使用範囲�
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line performance/namespace-import -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/namespace-import': 'off'

--- a/docs/src/content/docs/ja/rules/performance/preconnect.md
+++ b/docs/src/content/docs/ja/rules/performance/preconnect.md
@@ -32,8 +32,7 @@ description: ページが使うサードパーティのオリジンには、あ�
 Google Fonts のオリジンは引き続きチェックされ、以降の svelte-vitals リリースで組み込みリストが
 拡張されればその恩恵も受けられます。
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: {
     'performance/preconnect': { options: { origins: ['cdn.example.com'] } }
@@ -45,8 +44,7 @@ export default {
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/preconnect': 'off'

--- a/docs/src/content/docs/ja/rules/performance/preload-missing-as.md
+++ b/docs/src/content/docs/ja/rules/performance/preload-missing-as.md
@@ -25,8 +25,7 @@ description: <link rel="preload"> には as 属性を指定します。
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/preload-missing-as': 'off'

--- a/docs/src/content/docs/ja/rules/performance/render-blocking-script.md
+++ b/docs/src/content/docs/ja/rules/performance/render-blocking-script.md
@@ -28,8 +28,7 @@ description: head の <script src> で HTML の解析を止めないようにし
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/render-blocking-script': 'off'

--- a/docs/src/content/docs/ja/rules/performance/responsive-image.md
+++ b/docs/src/content/docs/ja/rules/performance/responsive-image.md
@@ -32,8 +32,7 @@ description: 大きな画像には srcset を用意しましょう。
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/responsive-image': 'off'

--- a/docs/src/content/docs/ja/rules/performance/sequential-awaits.md
+++ b/docs/src/content/docs/ja/rules/performance/sequential-awaits.md
@@ -29,8 +29,7 @@ const [a, b] = await Promise.all([fetchA(), fetchB()]);
 
 ## 無効化
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/sequential-awaits': 'off'

--- a/docs/src/content/docs/ja/rules/performance/state-raw.md
+++ b/docs/src/content/docs/ja/rules/performance/state-raw.md
@@ -50,8 +50,7 @@ Svelte 公式も、再代入しかしない大きなオブジェクトには `$s
 
 ## 無効化
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/state-raw': 'off'

--- a/docs/src/content/docs/ja/rules/security/handler-state-write.md
+++ b/docs/src/content/docs/ja/rules/security/handler-state-write.md
@@ -22,8 +22,7 @@ universal な `+page.ts`/`+layout.ts` の load も対象です。SSR 時はサ�
 
 ただし除外の条件はディレクトリだけではありません。svelte-vitals は対象モジュールを読み、export がインメモリコンテナで**ない**場合にのみ除外します。`new Map`/`Set`/`WeakMap`/`WeakSet`、あるいはオブジェクト・配列リテラルで初期化された export は自作ストア（リクエストごとに上書きされる単一の共有インスタンス）なので、`src/lib/server` 配下でも検出します。
 
-```ts
-// src/lib/server/store.ts
+```ts src/lib/server/store.ts
 export const db = new Map(); // handler から db.set(...) すると検出
 export const client = drizzle(url); // コンテナリテラルではないので除外
 ```
@@ -40,8 +39,7 @@ SvelteKit の状態管理ドキュメントが「NEVER DO THIS」と明記する
 
 保存せず、データを返します。
 
-```ts
-// +page.ts
+```ts +page.ts
 import { user } from '$lib/user';
 
 export async function load({ fetch }) {
@@ -58,8 +56,7 @@ export async function load({ fetch }) {
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line security/handler-state-write -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'security/handler-state-write': 'off'

--- a/docs/src/content/docs/ja/rules/security/javascript-url.md
+++ b/docs/src/content/docs/ja/rules/security/javascript-url.md
@@ -26,8 +26,7 @@ description: '属性に javascript: URL を使わないでください。'
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line security/javascript-url -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'security/javascript-url': 'off'

--- a/docs/src/content/docs/ja/rules/security/raw-html.md
+++ b/docs/src/content/docs/ja/rules/security/raw-html.md
@@ -35,8 +35,7 @@ description: '{@html} は HTML をエスケープせずに描画します。値�
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line security/raw-html -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'security/raw-html': 'off'

--- a/docs/src/content/docs/ja/rules/security/server-module-state.md
+++ b/docs/src/content/docs/ja/rules/security/server-module-state.md
@@ -22,8 +22,7 @@ SvelteKit のドキュメントは「サーバーでの共有状態を避けよ�
 
 ## 修正方法
 
-```ts
-// +page.server.ts
+```ts +page.server.ts
 let user; // ❌ このサーバーの全ユーザーで1つの変数
 
 export const actions = {
@@ -42,8 +41,7 @@ cookies/`locals` で認証し、ユーザー別データはデータベースへ
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line security/server-module-state -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'security/server-module-state': 'off'

--- a/docs/src/content/docs/ja/rules/security/shared-state-import.md
+++ b/docs/src/content/docs/ja/rules/security/shared-state-import.md
@@ -26,8 +26,7 @@ SvelteKit のルート/フックファイルの import のうち、解決先が�
 
 サーバーで実行されるコードでは共有モジュール状態に頼らず、`load` からデータを返して `page.data` か context API で渡します。
 
-```ts
-// +page.server.ts
+```ts +page.server.ts
 import { quizState } from '$lib/quiz.svelte.js'; // ❌ サーバー上では全ユーザーで1インスタンス
 
 export async function load({ locals }) {
@@ -41,8 +40,7 @@ export async function load({ locals }) {
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line security/shared-state-import -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'security/shared-state-import': 'off'

--- a/docs/src/content/docs/ja/rules/seo/canonical-url.md
+++ b/docs/src/content/docs/ja/rules/seo/canonical-url.md
@@ -27,8 +27,7 @@ canonical URL は、どの URL が正規かを検索エンジンに伝えます�
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/canonical-url': 'off'

--- a/docs/src/content/docs/ja/rules/seo/charset.md
+++ b/docs/src/content/docs/ja/rules/seo/charset.md
@@ -27,8 +27,7 @@ description: 文字エンコーディングは <meta charset> で宣言します
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/charset': 'off'

--- a/docs/src/content/docs/ja/rules/seo/description-length.md
+++ b/docs/src/content/docs/ja/rules/seo/description-length.md
@@ -33,8 +33,7 @@ description: meta description は 70〜160 文字に収めましょう。
 | `min`      | integer |         70 |
 | `max`      | integer |        160 |
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: { 'seo/description-length': { options: { min: 50, max: 155 } } }
 };
@@ -44,8 +43,7 @@ export default {
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/description-length': 'off'

--- a/docs/src/content/docs/ja/rules/seo/description-presence.md
+++ b/docs/src/content/docs/ja/rules/seo/description-presence.md
@@ -29,8 +29,7 @@ description: すべてのルートに <meta name="description"> が必要です�
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/description-presence': 'off'

--- a/docs/src/content/docs/ja/rules/seo/duplicate-description.md
+++ b/docs/src/content/docs/ja/rules/seo/duplicate-description.md
@@ -25,8 +25,7 @@ meta description が重複していると、ページごとの要約を検索エ
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/duplicate-description': 'off'

--- a/docs/src/content/docs/ja/rules/seo/duplicate-title.md
+++ b/docs/src/content/docs/ja/rules/seo/duplicate-title.md
@@ -25,8 +25,7 @@ description: <title> はルートごとに違う内容にしましょう。
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/duplicate-title': 'off'

--- a/docs/src/content/docs/ja/rules/seo/heading-level-skip.md
+++ b/docs/src/content/docs/ja/rules/seo/heading-level-skip.md
@@ -32,8 +32,7 @@ description: 見出しのレベルは飛ばさずに使いましょう。
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/heading-level-skip': 'off'

--- a/docs/src/content/docs/ja/rules/seo/hreflang.md
+++ b/docs/src/content/docs/ja/rules/seo/hreflang.md
@@ -36,8 +36,7 @@ hreflang コードが不正だと国際ターゲティングが機能せず、�
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/hreflang': 'off'

--- a/docs/src/content/docs/ja/rules/seo/html-lang.md
+++ b/docs/src/content/docs/ja/rules/seo/html-lang.md
@@ -25,8 +25,7 @@ description: app.html の <html> に lang 属性を設定しましょう。
 
 意図したとおりであれば、ルールを無効化してください:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/html-lang': 'off'

--- a/docs/src/content/docs/ja/rules/seo/image-alt.md
+++ b/docs/src/content/docs/ja/rules/seo/image-alt.md
@@ -26,8 +26,7 @@ description: <img> には alt 属性を付けます。
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/image-alt': 'off'

--- a/docs/src/content/docs/ja/rules/seo/indexability.md
+++ b/docs/src/content/docs/ja/rules/seo/indexability.md
@@ -27,8 +27,7 @@ noindex はページを検索結果から除外します。公開ルートに誤
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/indexability': 'off'

--- a/docs/src/content/docs/ja/rules/seo/json-ld-date-format.md
+++ b/docs/src/content/docs/ja/rules/seo/json-ld-date-format.md
@@ -23,8 +23,7 @@ schema.org の日付プロパティは ISO-8601 形式を前提としていま�
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/json-ld-date-format': 'off'

--- a/docs/src/content/docs/ja/rules/seo/json-ld-deprecated-type.md
+++ b/docs/src/content/docs/ja/rules/seo/json-ld-deprecated-type.md
@@ -21,8 +21,7 @@ Google がリッチリザルトの表示を廃止または制限した `@type`�
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/json-ld-deprecated-type': 'off'

--- a/docs/src/content/docs/ja/rules/seo/json-ld-placeholder.md
+++ b/docs/src/content/docs/ja/rules/seo/json-ld-placeholder.md
@@ -21,8 +21,7 @@ JSON-LD の値に残っている明らかなプレースホルダや定型文（
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/json-ld-placeholder': 'off'

--- a/docs/src/content/docs/ja/rules/seo/json-ld-relative-url.md
+++ b/docs/src/content/docs/ja/rules/seo/json-ld-relative-url.md
@@ -25,8 +25,7 @@ JSON-LD の既知の URL キー（`url`、`image`、`logo`、`sameAs`、`content
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/json-ld-relative-url': 'off'

--- a/docs/src/content/docs/ja/rules/seo/json-ld-required-props.md
+++ b/docs/src/content/docs/ja/rules/seo/json-ld-required-props.md
@@ -30,8 +30,7 @@ description: 認識できる @type には、リッチリザルトに必要なプ
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/json-ld-required-props': 'off'

--- a/docs/src/content/docs/ja/rules/seo/json-ld-validity.md
+++ b/docs/src/content/docs/ja/rules/seo/json-ld-validity.md
@@ -37,8 +37,7 @@ IRI 形式(`https://schema.org/Article`)やプレフィックス形式(`schema:A
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/json-ld-validity': 'off'

--- a/docs/src/content/docs/ja/rules/seo/json-ld.md
+++ b/docs/src/content/docs/ja/rules/seo/json-ld.md
@@ -33,8 +33,7 @@ JSON-LD 構造化データがあると、検索エンジンはそのページに
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/json-ld': 'off'

--- a/docs/src/content/docs/ja/rules/seo/og-description.md
+++ b/docs/src/content/docs/ja/rules/seo/og-description.md
@@ -27,8 +27,7 @@ og:description は、ソーシャルプレビューでタイトルの下に表�
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/og-description': 'off'

--- a/docs/src/content/docs/ja/rules/seo/og-image.md
+++ b/docs/src/content/docs/ja/rules/seo/og-image.md
@@ -27,8 +27,7 @@ description: <meta property="og:image"> タグはどのルートにも必要で�
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/og-image': 'off'

--- a/docs/src/content/docs/ja/rules/seo/og-title.md
+++ b/docs/src/content/docs/ja/rules/seo/og-title.md
@@ -27,8 +27,7 @@ description: <meta property="og:title"> タグはどのルートにも必要で�
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/og-title': 'off'

--- a/docs/src/content/docs/ja/rules/seo/og-url.md
+++ b/docs/src/content/docs/ja/rules/seo/og-url.md
@@ -27,8 +27,7 @@ og:url は、シェアやいいねをどの正規アドレスに帰属させる�
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/og-url': 'off'

--- a/docs/src/content/docs/ja/rules/seo/robots-txt.md
+++ b/docs/src/content/docs/ja/rules/seo/robots-txt.md
@@ -28,8 +28,7 @@ Sitemap: https://example.com/sitemap.xml
 
 意図したとおりであれば、ルールを無効化してください:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/robots-txt': 'off'

--- a/docs/src/content/docs/ja/rules/seo/single-h1.md
+++ b/docs/src/content/docs/ja/rules/seo/single-h1.md
@@ -37,8 +37,7 @@ description: <h1> は 1 ページにつき 1 つだけにしましょう。
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/single-h1': 'off'

--- a/docs/src/content/docs/ja/rules/seo/sitemap-in-robots.md
+++ b/docs/src/content/docs/ja/rules/seo/sitemap-in-robots.md
@@ -28,8 +28,7 @@ Sitemap: https://example.com/sitemap.xml
 
 意図したとおりであれば、ルールを無効化してください:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/sitemap-in-robots': 'off'

--- a/docs/src/content/docs/ja/rules/seo/sitemap-xml.md
+++ b/docs/src/content/docs/ja/rules/seo/sitemap-xml.md
@@ -28,8 +28,7 @@ description: プロジェクトに sitemap.xml を用意しましょう。
 
 意図したとおりであれば、ルールを無効化してください:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/sitemap-xml': 'off'

--- a/docs/src/content/docs/ja/rules/seo/ssr-disabled.md
+++ b/docs/src/content/docs/ja/rules/seo/ssr-disabled.md
@@ -28,8 +28,7 @@ export const ssr = false; // これが意図的なら suppression するかル�
 
 意図して完全な SPA にしている場合は、config でルールを無効化します：
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/ssr-disabled': 'off'
@@ -43,8 +42,7 @@ export default {
 
 個別に抑制するには、対象行の直前に `<!-- svelte-vitals-disable-next-line seo/ssr-disabled -->` を置きます。ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/ssr-disabled': 'off'

--- a/docs/src/content/docs/ja/rules/seo/title-length.md
+++ b/docs/src/content/docs/ja/rules/seo/title-length.md
@@ -30,8 +30,7 @@ description: <title> は 30〜60 文字に収めましょう。
 | `min`      | integer |         30 |
 | `max`      | integer |         60 |
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: { 'seo/title-length': { options: { min: 20, max: 40 } } }
 };
@@ -41,8 +40,7 @@ export default {
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/title-length': 'off'

--- a/docs/src/content/docs/ja/rules/seo/title-presence.md
+++ b/docs/src/content/docs/ja/rules/seo/title-presence.md
@@ -27,8 +27,7 @@ description: どのルートでも <title> が空にならないようにしま�
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/title-presence': 'off'

--- a/docs/src/content/docs/ja/rules/seo/twitter-card.md
+++ b/docs/src/content/docs/ja/rules/seo/twitter-card.md
@@ -25,8 +25,7 @@ twitter:card は、ページが X/Twitter で共有されたときの表示形�
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/twitter-card': 'off'

--- a/docs/src/content/docs/ja/rules/seo/viewport.md
+++ b/docs/src/content/docs/ja/rules/seo/viewport.md
@@ -25,8 +25,7 @@ viewport メタタグがないと、モバイルブラウザはページを固�
 
 既存の検出は suppressions ファイルに記録して抑制できます（`npx svelte-vitals --update-suppressions`）。`overrides` でルートやパス単位に絞るか、ルールごと無効化するには:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/viewport': 'off'

--- a/docs/src/content/docs/rules/a11y/accessible-name.md
+++ b/docs/src/content/docs/rules/a11y/accessible-name.md
@@ -41,8 +41,7 @@ Give the element visible text, a labelling attribute, or an `alt` on its icon im
 
 If the name is supplied some other way this rule can't see (e.g. a wrapping label element), silence a single element with `<!-- svelte-vitals-disable-next-line a11y/accessible-name -->`, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/accessible-name': 'off'

--- a/docs/src/content/docs/rules/a11y/doctype.md
+++ b/docs/src/content/docs/rules/a11y/doctype.md
@@ -25,8 +25,7 @@ Add `<!doctype html>` as the first line of `src/app.html`:
 
 If this is intentional, turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/doctype': 'off'

--- a/docs/src/content/docs/rules/a11y/duplicate-landmark.md
+++ b/docs/src/content/docs/rules/a11y/duplicate-landmark.md
@@ -47,8 +47,7 @@ When the two disagree, trust the rendered result — it reflects what ships to t
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/duplicate-landmark': 'off'

--- a/docs/src/content/docs/rules/a11y/id-duplication.md
+++ b/docs/src/content/docs/rules/a11y/id-duplication.md
@@ -48,8 +48,7 @@ When the two disagree, trust the rendered result — it reflects what ships to t
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/id-duplication': 'off'

--- a/docs/src/content/docs/rules/a11y/interactive-nesting.md
+++ b/docs/src/content/docs/rules/a11y/interactive-nesting.md
@@ -48,8 +48,7 @@ Restructure the markup so each interactive control is a sibling, not a descendan
 
 If the nesting is intentional and handled some other way (e.g. `pointer-events` and a synthetic focus trap), silence a single element with `<!-- svelte-vitals-disable-next-line a11y/interactive-nesting -->`, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/interactive-nesting': 'off'

--- a/docs/src/content/docs/rules/a11y/invalid-aria-value.md
+++ b/docs/src/content/docs/rules/a11y/invalid-aria-value.md
@@ -42,8 +42,7 @@ Use a value matching the attribute's WAI-ARIA type — `aria-hidden="true"` for 
 
 If a value is intentionally non-standard, silence a single element with `<!-- svelte-vitals-disable-next-line a11y/invalid-aria-value -->`, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/invalid-aria-value': 'off'

--- a/docs/src/content/docs/rules/a11y/invalid-role.md
+++ b/docs/src/content/docs/rules/a11y/invalid-role.md
@@ -36,8 +36,7 @@ Use a concrete WAI-ARIA role, or drop the attribute if the element's native sema
 
 If a role is intentionally non-standard, silence a single element with `<!-- svelte-vitals-disable-next-line a11y/invalid-role -->`, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/invalid-role': 'off'

--- a/docs/src/content/docs/rules/a11y/label-has-control.md
+++ b/docs/src/content/docs/rules/a11y/label-has-control.md
@@ -39,8 +39,7 @@ Point `for` at the control's `id`, or wrap the control inside the `<label>`:
 
 If the association is made some other way this rule can't see (e.g. `aria-labelledby` on the control), silence a single element with `<!-- svelte-vitals-disable-next-line a11y/label-has-control -->`, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/label-has-control': 'off'

--- a/docs/src/content/docs/rules/a11y/no-missing-id-ref.md
+++ b/docs/src/content/docs/rules/a11y/no-missing-id-ref.md
@@ -41,8 +41,7 @@ When the two disagree, trust the rendered result — it reflects what ships to t
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/no-missing-id-ref': 'off'

--- a/docs/src/content/docs/rules/a11y/placeholder-label-option.md
+++ b/docs/src/content/docs/rules/a11y/placeholder-label-option.md
@@ -48,8 +48,7 @@ Make the first `option` an empty placeholder:
 
 If the first option is intentionally a real, non-placeholder value, silence a single element with `<!-- svelte-vitals-disable-next-line a11y/placeholder-label-option -->`, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/placeholder-label-option': 'off'

--- a/docs/src/content/docs/rules/a11y/require-datetime.md
+++ b/docs/src/content/docs/rules/a11y/require-datetime.md
@@ -37,8 +37,7 @@ Add a `datetime` attribute with a machine-readable value:
 
 If the text is intentionally not machine-readable, silence a single element with `<!-- svelte-vitals-disable-next-line a11y/require-datetime -->`, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/require-datetime': 'off'

--- a/docs/src/content/docs/rules/a11y/required-aria-props.md
+++ b/docs/src/content/docs/rules/a11y/required-aria-props.md
@@ -48,8 +48,7 @@ Or use the native element that already supplies the state:
 
 If a required prop is intentionally omitted, silence a single element with `<!-- svelte-vitals-disable-next-line a11y/required-aria-props -->`, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/required-aria-props': 'off'

--- a/docs/src/content/docs/rules/a11y/top-level-landmark.md
+++ b/docs/src/content/docs/rules/a11y/top-level-landmark.md
@@ -58,8 +58,7 @@ When the two disagree, trust the rendered result — it reflects what ships to t
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/top-level-landmark': 'off'

--- a/docs/src/content/docs/rules/a11y/unknown-aria-attribute.md
+++ b/docs/src/content/docs/rules/a11y/unknown-aria-attribute.md
@@ -35,8 +35,7 @@ Use the correctly spelled, spec-defined attribute:
 
 If an attribute is intentionally non-standard, silence a single element with `<!-- svelte-vitals-disable-next-line a11y/unknown-aria-attribute -->`, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/unknown-aria-attribute': 'off'

--- a/docs/src/content/docs/rules/a11y/use-list.md
+++ b/docs/src/content/docs/rules/a11y/use-list.md
@@ -43,8 +43,7 @@ Use a list element instead:
 
 If the bullet character is intentional prose, not a stand-in for a list, silence a single occurrence with `<!-- svelte-vitals-disable-next-line a11y/use-list -->`, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'a11y/use-list': 'off'

--- a/docs/src/content/docs/rules/architecture/component-size.md
+++ b/docs/src/content/docs/rules/architecture/component-size.md
@@ -25,8 +25,7 @@ Extract sections into smaller, focused child components (and reusable `.svelte.t
 | ------ | ------- | ------: |
 | `max`  | integer |     200 |
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: { 'architecture/component-size': { options: { max: 300 } } }
 };
@@ -36,8 +35,7 @@ export default {
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line architecture/component-size -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'architecture/component-size': 'off'

--- a/docs/src/content/docs/rules/architecture/directory-naming.md
+++ b/docs/src/content/docs/rules/architecture/directory-naming.md
@@ -32,8 +32,7 @@ Rename the directory, or narrow the declaration that swept it in.
 | `directories` | map of directory glob → casing set | `{}`    |
 | `exclude`     | list of directory globs            | `[]`    |
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: {
     'architecture/directory-naming': {
@@ -174,8 +173,7 @@ both are true.
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line architecture/directory-naming -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'architecture/directory-naming': 'off'

--- a/docs/src/content/docs/rules/architecture/doc-link-target.md
+++ b/docs/src/content/docs/rules/architecture/doc-link-target.md
@@ -32,8 +32,7 @@ Point the link at the unit that exists now, or remove it.
 Each entry is a **URL prefix that stands for this project's root**. A link whose URL starts with one has
 that prefix stripped, and the remainder is looked up among the files under `src/`.
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: {
     'architecture/doc-link-target': {
@@ -79,8 +78,7 @@ where no inventory is built, it is silent.
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line architecture/doc-link-target -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'architecture/doc-link-target': 'off'

--- a/docs/src/content/docs/rules/architecture/private-scope-import.md
+++ b/docs/src/content/docs/rules/architecture/private-scope-import.md
@@ -27,8 +27,7 @@ Move the unit out of its private directory, up to the directory shared by all of
 
 Each glob matches a **private directory**, and its **parent** becomes the boundary: files inside the parent may import from it, files outside may not.
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: {
     'architecture/private-scope-import': {
@@ -62,8 +61,7 @@ An import that names a private directory itself, rather than a file inside it (f
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line architecture/private-scope-import -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'architecture/private-scope-import': 'off'

--- a/docs/src/content/docs/rules/architecture/prop-count.md
+++ b/docs/src/content/docs/rules/architecture/prop-count.md
@@ -30,8 +30,7 @@ A component with a large prop surface is usually doing too much; grouping relate
 | ------ | ------- | ------: |
 | `max`  | integer |       6 |
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: { 'architecture/prop-count': { options: { max: 10 } } }
 };
@@ -41,8 +40,7 @@ export default {
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line architecture/prop-count -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'architecture/prop-count': 'off'

--- a/docs/src/content/docs/rules/architecture/reserved-directory-names.md
+++ b/docs/src/content/docs/rules/architecture/reserved-directory-names.md
@@ -37,8 +37,7 @@ declaration — deciding to widen the set is a legitimate outcome, as long as it
 | `anyCaseUnitScopes` | map of root glob → allowed child names, for units of either case        | `{}`    |
 | `exclude`           | list of directory globs                                                 | `[]`    |
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: {
     'architecture/reserved-directory-names': {
@@ -181,8 +180,7 @@ Two things are never reported:
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line architecture/reserved-directory-names -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'architecture/reserved-directory-names': 'off'

--- a/docs/src/content/docs/rules/architecture/reserved-name-placement.md
+++ b/docs/src/content/docs/rules/architecture/reserved-name-placement.md
@@ -35,8 +35,7 @@ the name.
 | `anyCaseUnitPlacements`     | map of reserved name → globs matching a **unit directory of either case** it may sit directly under | `{}`    |
 | `exclude`                   | list of directory globs                                                                             | `[]`    |
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: {
     'architecture/reserved-name-placement': {
@@ -144,8 +143,7 @@ declaration from the tree.
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line architecture/reserved-name-placement -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'architecture/reserved-name-placement': 'off'

--- a/docs/src/content/docs/rules/architecture/route-component-import.md
+++ b/docs/src/content/docs/rules/architecture/route-component-import.md
@@ -40,8 +40,7 @@ one.** A `string-list` option adds to its default and never replaces it, so you 
 not shrink it — which is why it ships covering only the conventions that are common across the ecosystem.
 If your project marks satellite files another way, add your pattern:
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: {
     'architecture/route-component-import': {
@@ -64,8 +63,7 @@ export default {
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line architecture/route-component-import -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'architecture/route-component-import': 'off'

--- a/docs/src/content/docs/rules/architecture/unit-entry-file.md
+++ b/docs/src/content/docs/rules/architecture/unit-entry-file.md
@@ -42,8 +42,7 @@ never finds it, and reports a missing entry file for a directory that has one.
 
 `exclude` is a list, not a map, and its values are directory globs rather than extensions.
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: {
     'architecture/unit-entry-file': {
@@ -139,8 +138,7 @@ suppresses the other — they are different claims and both are true.
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line architecture/unit-entry-file -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'architecture/unit-entry-file': 'off'

--- a/docs/src/content/docs/rules/correctness/base-path-navigation.md
+++ b/docs/src/content/docs/rules/correctness/base-path-navigation.md
@@ -65,8 +65,7 @@ Not covered:
 
 ## Disabling
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/base-path-navigation': 'off'

--- a/docs/src/content/docs/rules/correctness/checkable-bind-value.md
+++ b/docs/src/content/docs/rules/correctness/checkable-bind-value.md
@@ -44,8 +44,7 @@ Only native `<input>` elements with a statically-literal `type` are covered. A d
 
 ## Disabling
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/checkable-bind-value': 'off'

--- a/docs/src/content/docs/rules/correctness/each-index-key.md
+++ b/docs/src/content/docs/rules/correctness/each-index-key.md
@@ -36,8 +36,7 @@ Key by a value that uniquely identifies the item:
 
 If a list provably never reorders and never has mid-list insertions or removals, you can silence a single block with `<!-- svelte-vitals-disable-next-line correctness/each-index-key -->`, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/each-index-key': 'off'

--- a/docs/src/content/docs/rules/correctness/each-key.md
+++ b/docs/src/content/docs/rules/correctness/each-key.md
@@ -29,8 +29,7 @@ Without a key, a reorder or an insert/remove makes Svelte add or remove nodes at
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line correctness/each-key -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/each-key': 'off'

--- a/docs/src/content/docs/rules/correctness/effect-as-derived.md
+++ b/docs/src/content/docs/rules/correctness/effect-as-derived.md
@@ -78,8 +78,7 @@ than switching to `$derived`.
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line correctness/effect-as-derived -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/effect-as-derived': 'off'

--- a/docs/src/content/docs/rules/correctness/effect-as-onmount.md
+++ b/docs/src/content/docs/rules/correctness/effect-as-onmount.md
@@ -43,8 +43,7 @@ If that's your case, suppress it with a
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line correctness/effect-as-onmount -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/effect-as-onmount': 'off'

--- a/docs/src/content/docs/rules/correctness/instance-browser-global.md
+++ b/docs/src/content/docs/rules/correctness/instance-browser-global.md
@@ -52,8 +52,7 @@ For anything `svelte/reactivity/window` doesn't cover, read the global in `onMou
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line correctness/instance-browser-global -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/instance-browser-global': 'off'

--- a/docs/src/content/docs/rules/correctness/nonreactive-builtin-state.md
+++ b/docs/src/content/docs/rules/correctness/nonreactive-builtin-state.md
@@ -55,8 +55,7 @@ Out of reach or out of scope:
 
 ## Disabling
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/nonreactive-builtin-state': 'off'

--- a/docs/src/content/docs/rules/correctness/orphan-effect.md
+++ b/docs/src/content/docs/rules/correctness/orphan-effect.md
@@ -26,8 +26,7 @@ Reactive effects can only be created while a component is initialising, or insid
 
 ## How to fix
 
-```ts
-// store.svelte.ts
+```ts store.svelte.ts
 class QuizStateManager {
   bookmarks = $state<string[]>([]);
   constructor() {
@@ -78,8 +77,7 @@ export const quizState = new QuizStateManager();
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line correctness/orphan-effect -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/orphan-effect': 'off'

--- a/docs/src/content/docs/rules/correctness/orphan-lifecycle.md
+++ b/docs/src/content/docs/rules/correctness/orphan-lifecycle.md
@@ -29,8 +29,7 @@ These functions require an active component context. Called without one, `getCon
 
 ## How to fix
 
-```ts
-// +page.ts
+```ts +page.ts
 import { getContext } from 'svelte';
 
 export async function load({ fetch }) {
@@ -58,8 +57,7 @@ For shared modules, expose a setup function that components call during init ins
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line correctness/orphan-lifecycle -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/orphan-lifecycle': 'off'

--- a/docs/src/content/docs/rules/correctness/prop-mutation.md
+++ b/docs/src/content/docs/rules/correctness/prop-mutation.md
@@ -79,8 +79,7 @@ Reassign the prop after mutating it to re-trigger reactivity — this is Svelte'
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line correctness/prop-mutation -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/prop-mutation': 'off'

--- a/docs/src/content/docs/rules/correctness/server-browser-global.md
+++ b/docs/src/content/docs/rules/correctness/server-browser-global.md
@@ -27,8 +27,7 @@ None of these globals exist in Node. A module-scope `window` read crashes the se
 
 ## How to fix
 
-```ts
-// +page.ts
+```ts +page.ts
 export function load() {
   const stored = localStorage.getItem('filters'); // ❌ ReferenceError on the server
 
@@ -62,8 +61,7 @@ const stored = browser ? localStorage.getItem('filters') : null; // ✅
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line correctness/server-browser-global -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/server-browser-global': 'off'

--- a/docs/src/content/docs/rules/correctness/stale-prop-derivation.md
+++ b/docs/src/content/docs/rules/correctness/stale-prop-derivation.md
@@ -74,8 +74,7 @@ The rule cannot know whether the parent ever changes the prop, but `$derived` co
 
 ## Disabling
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/stale-prop-derivation': 'off'

--- a/docs/src/content/docs/rules/correctness/unmutated-state.md
+++ b/docs/src/content/docs/rules/correctness/unmutated-state.md
@@ -32,8 +32,7 @@ A `$state` that is never mutated pays for reactivity — deep proxying and depen
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line correctness/unmutated-state -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'correctness/unmutated-state': 'off'

--- a/docs/src/content/docs/rules/performance/font-preload-crossorigin.md
+++ b/docs/src/content/docs/rules/performance/font-preload-crossorigin.md
@@ -25,8 +25,7 @@ Add `crossorigin` to the font preload:
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/font-preload-crossorigin': 'off'

--- a/docs/src/content/docs/rules/performance/heavy-import.md
+++ b/docs/src/content/docs/rules/performance/heavy-import.md
@@ -42,8 +42,7 @@ cover in a later release.
 Reusing a built-in key keeps the package on the list but replaces its advice, so
 `{ lodash: 'use our own helpers' }` rewords the finding rather than adding a second entry.
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: {
     'performance/heavy-import': { options: { packages: { 'chart.js': 'import chart.js/auto' } } }
@@ -55,8 +54,7 @@ export default {
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line performance/heavy-import -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/heavy-import': 'off'

--- a/docs/src/content/docs/rules/performance/image-dimensions.md
+++ b/docs/src/content/docs/rules/performance/image-dimensions.md
@@ -25,8 +25,7 @@ Add explicit `width` and `height` attributes to the `<img>`:
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/image-dimensions': 'off'

--- a/docs/src/content/docs/rules/performance/image-loading-hint.md
+++ b/docs/src/content/docs/rules/performance/image-loading-hint.md
@@ -25,8 +25,7 @@ Add `loading="lazy"` to offscreen `<img>` elements (leave the LCP/hero image eag
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/image-loading-hint': 'off'

--- a/docs/src/content/docs/rules/performance/lcp-image.md
+++ b/docs/src/content/docs/rules/performance/lcp-image.md
@@ -25,8 +25,7 @@ Remove `loading="lazy"` from the first/LCP image and consider `fetchpriority="hi
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/lcp-image': 'off'

--- a/docs/src/content/docs/rules/performance/load-waterfall.md
+++ b/docs/src/content/docs/rules/performance/load-waterfall.md
@@ -44,8 +44,7 @@ Only the literal dependent-chain shape is detected; chains hidden behind branche
 
 ## Disabling
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/load-waterfall': 'off'

--- a/docs/src/content/docs/rules/performance/minify-disabled.md
+++ b/docs/src/content/docs/rules/performance/minify-disabled.md
@@ -30,8 +30,7 @@ Vite minifies by default (`oxc` since Vite 8); turning it off is almost always a
 
 Remove the override (the default already minifies), or scope it so production keeps minification:
 
-```ts
-// vite.config.ts
+```ts vite.config.ts
 import { defineConfig } from 'vite';
 
 export default defineConfig(({ mode }) => ({
@@ -53,8 +52,7 @@ The Vite plugin judges the resolved value, so its verdict is exact for the build
 
 If unminified production output is intentional, turn the rule off in your config:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/minify-disabled': 'off'

--- a/docs/src/content/docs/rules/performance/namespace-import.md
+++ b/docs/src/content/docs/rules/performance/namespace-import.md
@@ -31,8 +31,7 @@ Named imports are reliably shakeable and make the dependency surface explicit. W
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line performance/namespace-import -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/namespace-import': 'off'

--- a/docs/src/content/docs/rules/performance/preconnect.md
+++ b/docs/src/content/docs/rules/performance/preconnect.md
@@ -32,8 +32,7 @@ Configured origins are **added to** the built-in list, not a replacement for it 
 checking the Google Fonts origins even after adding its own, and picks up any origin the built-in
 list grows to cover in a later svelte-vitals release.
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: {
     'performance/preconnect': { options: { origins: ['cdn.example.com'] } }
@@ -45,8 +44,7 @@ export default {
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/preconnect': 'off'

--- a/docs/src/content/docs/rules/performance/preload-missing-as.md
+++ b/docs/src/content/docs/rules/performance/preload-missing-as.md
@@ -25,8 +25,7 @@ Add an `as` attribute matching the resource type:
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/preload-missing-as': 'off'

--- a/docs/src/content/docs/rules/performance/render-blocking-script.md
+++ b/docs/src/content/docs/rules/performance/render-blocking-script.md
@@ -28,8 +28,7 @@ Add `defer` (or `type="module"`) / `async`:
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/render-blocking-script': 'off'

--- a/docs/src/content/docs/rules/performance/responsive-image.md
+++ b/docs/src/content/docs/rules/performance/responsive-image.md
@@ -32,8 +32,7 @@ Add a `srcset` (and `sizes`) so the browser can pick a right-sized image:
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/responsive-image': 'off'

--- a/docs/src/content/docs/rules/performance/sequential-awaits.md
+++ b/docs/src/content/docs/rules/performance/sequential-awaits.md
@@ -27,8 +27,7 @@ Static data flow cannot see side-effect ordering. If an earlier await performs s
 
 ## Disabling
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/sequential-awaits': 'off'

--- a/docs/src/content/docs/rules/performance/state-raw.md
+++ b/docs/src/content/docs/rules/performance/state-raw.md
@@ -50,8 +50,7 @@ Escape handling is conservative: any aliasing reference disqualifies, a whole-bi
 
 ## Disabling
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'performance/state-raw': 'off'

--- a/docs/src/content/docs/rules/security/handler-state-write.md
+++ b/docs/src/content/docs/rules/security/handler-state-write.md
@@ -20,8 +20,7 @@ The `src/lib/server` exemption applies to the **resolved** path, so it holds how
 
 The exemption is not the directory alone. svelte-vitals reads the target module and keeps the call exempt only when the export is _not_ an in-memory container. An export initialized to `new Map`/`Set`/`WeakMap`/`WeakSet`, or to an object or array literal, is a hand-rolled store — one shared instance overwritten per request — and is reported even under `src/lib/server`:
 
-```ts
-// src/lib/server/store.ts
+```ts src/lib/server/store.ts
 export const db = new Map(); // reported when a handler calls db.set(...)
 export const client = drizzle(url); // exempt — not a container literal
 ```
@@ -38,8 +37,7 @@ Not every promoted write is a leak, though. A rate limiter or memoization cache 
 
 Return the data instead of storing it:
 
-```ts
-// +page.ts
+```ts +page.ts
 import { user } from '$lib/user';
 
 export async function load({ fetch }) {
@@ -56,8 +54,7 @@ Per-user data belongs in cookies/`locals` plus a database; share loaded data wit
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line security/handler-state-write -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'security/handler-state-write': 'off'

--- a/docs/src/content/docs/rules/security/javascript-url.md
+++ b/docs/src/content/docs/rules/security/javascript-url.md
@@ -26,8 +26,7 @@ Use an event handler or a real URL:
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line security/javascript-url -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'security/javascript-url': 'off'

--- a/docs/src/content/docs/rules/security/raw-html.md
+++ b/docs/src/content/docs/rules/security/raw-html.md
@@ -35,8 +35,7 @@ A general-purpose HTML sanitizer is also the wrong tool for a non-HTML payload. 
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line security/raw-html -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'security/raw-html': 'off'

--- a/docs/src/content/docs/rules/security/server-module-state.md
+++ b/docs/src/content/docs/rules/security/server-module-state.md
@@ -22,8 +22,7 @@ SvelteKit's docs: "Avoid shared state on the server." A module variable on the s
 
 ## How to fix
 
-```ts
-// +page.server.ts
+```ts +page.server.ts
 let user; // ❌ one variable for every user of this server
 
 export const actions = {
@@ -42,8 +41,7 @@ Authenticate with cookies/`locals` and persist per-user data to a database. For 
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line security/server-module-state -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'security/server-module-state': 'off'

--- a/docs/src/content/docs/rules/security/shared-state-import.md
+++ b/docs/src/content/docs/rules/security/shared-state-import.md
@@ -26,8 +26,7 @@ On the browser each user gets their own module instance; on the server there is 
 
 Don't reach for shared module state in server-executed code — return data from `load` and pass it via `page.data` or the context API:
 
-```ts
-// +page.server.ts
+```ts +page.server.ts
 import { quizState } from '$lib/quiz.svelte.js'; // ❌ one instance for all users on the server
 
 export async function load({ locals }) {
@@ -41,8 +40,7 @@ If the module is genuinely client-only, restructure so server files don't import
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line security/shared-state-import -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'security/shared-state-import': 'off'

--- a/docs/src/content/docs/rules/seo/canonical-url.md
+++ b/docs/src/content/docs/rules/seo/canonical-url.md
@@ -27,8 +27,7 @@ Add `<link rel="canonical">` in `<svelte:head>`, or set the canonical prop on yo
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/canonical-url': 'off'

--- a/docs/src/content/docs/rules/seo/charset.md
+++ b/docs/src/content/docs/rules/seo/charset.md
@@ -27,8 +27,7 @@ Without a declared character encoding the browser must guess, which can render t
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/charset': 'off'

--- a/docs/src/content/docs/rules/seo/description-length.md
+++ b/docs/src/content/docs/rules/seo/description-length.md
@@ -30,8 +30,7 @@ A description that is too short under-uses the search snippet; one that is too l
 | `min`  | integer |      70 |
 | `max`  | integer |     160 |
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: { 'seo/description-length': { options: { min: 50, max: 155 } } }
 };
@@ -41,8 +40,7 @@ export default {
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/description-length': 'off'

--- a/docs/src/content/docs/rules/seo/description-presence.md
+++ b/docs/src/content/docs/rules/seo/description-presence.md
@@ -29,8 +29,7 @@ Add a `<meta name="description">` in `<svelte:head>`, or set the description on 
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/description-presence': 'off'

--- a/docs/src/content/docs/rules/seo/duplicate-description.md
+++ b/docs/src/content/docs/rules/seo/duplicate-description.md
@@ -25,8 +25,7 @@ Duplicate meta descriptions give search engines no per-page summary, so they are
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/duplicate-description': 'off'

--- a/docs/src/content/docs/rules/seo/duplicate-title.md
+++ b/docs/src/content/docs/rules/seo/duplicate-title.md
@@ -25,8 +25,7 @@ Duplicate titles across pages make them compete in search results and weaken eac
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/duplicate-title': 'off'

--- a/docs/src/content/docs/rules/seo/heading-level-skip.md
+++ b/docs/src/content/docs/rules/seo/heading-level-skip.md
@@ -32,8 +32,7 @@ When the two disagree, trust the rendered result — it reflects what ships to t
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/heading-level-skip': 'off'

--- a/docs/src/content/docs/rules/seo/hreflang.md
+++ b/docs/src/content/docs/rules/seo/hreflang.md
@@ -36,8 +36,7 @@ Validation covers a pragmatic subset of BCP-47 — language, optional script, op
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/hreflang': 'off'

--- a/docs/src/content/docs/rules/seo/html-lang.md
+++ b/docs/src/content/docs/rules/seo/html-lang.md
@@ -25,8 +25,7 @@ Set `<html lang="...">` in `src/app.html`:
 
 If this is intentional, turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/html-lang': 'off'

--- a/docs/src/content/docs/rules/seo/image-alt.md
+++ b/docs/src/content/docs/rules/seo/image-alt.md
@@ -26,8 +26,7 @@ An `<img>` with no `alt` attribute is invisible to image search and assistive te
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/image-alt': 'off'

--- a/docs/src/content/docs/rules/seo/indexability.md
+++ b/docs/src/content/docs/rules/seo/indexability.md
@@ -27,8 +27,7 @@ If this route should be indexed, remove `noindex` from its robots meta:
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/indexability': 'off'

--- a/docs/src/content/docs/rules/seo/json-ld-date-format.md
+++ b/docs/src/content/docs/rules/seo/json-ld-date-format.md
@@ -23,8 +23,7 @@ Schema.org date properties expect ISO-8601; other formats may be ignored or misp
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/json-ld-date-format': 'off'

--- a/docs/src/content/docs/rules/seo/json-ld-deprecated-type.md
+++ b/docs/src/content/docs/rules/seo/json-ld-deprecated-type.md
@@ -21,8 +21,7 @@ Verify the type's current rich-result status in Google's documentation; remove o
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/json-ld-deprecated-type': 'off'

--- a/docs/src/content/docs/rules/seo/json-ld-placeholder.md
+++ b/docs/src/content/docs/rules/seo/json-ld-placeholder.md
@@ -21,8 +21,7 @@ Replace the placeholder with the real value for the page.
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/json-ld-placeholder': 'off'

--- a/docs/src/content/docs/rules/seo/json-ld-relative-url.md
+++ b/docs/src/content/docs/rules/seo/json-ld-relative-url.md
@@ -25,8 +25,7 @@ Search engines need absolute URLs in structured data; a relative URL can't be re
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/json-ld-relative-url': 'off'

--- a/docs/src/content/docs/rules/seo/json-ld-required-props.md
+++ b/docs/src/content/docs/rules/seo/json-ld-required-props.md
@@ -30,8 +30,7 @@ Add the missing properties. For example, a `Product` needs `name`, plus at least
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/json-ld-required-props': 'off'

--- a/docs/src/content/docs/rules/seo/json-ld-validity.md
+++ b/docs/src/content/docs/rules/seo/json-ld-validity.md
@@ -37,8 +37,7 @@ Invalid JSON-LD — unparseable, missing `@context`/`@type`, or declaring a `@ty
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/json-ld-validity': 'off'

--- a/docs/src/content/docs/rules/seo/json-ld.md
+++ b/docs/src/content/docs/rules/seo/json-ld.md
@@ -33,8 +33,7 @@ Add a JSON-LD `<script>` inside `<svelte:head>` with literal JSON (Svelte emits 
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/json-ld': 'off'

--- a/docs/src/content/docs/rules/seo/og-description.md
+++ b/docs/src/content/docs/rules/seo/og-description.md
@@ -27,8 +27,7 @@ This rule was `warning` before the 2026-08-09 severity review. The [Open Graph p
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/og-description': 'off'

--- a/docs/src/content/docs/rules/seo/og-image.md
+++ b/docs/src/content/docs/rules/seo/og-image.md
@@ -27,8 +27,7 @@ Add `<meta property="og:image">`, or set `openGraph.images` on your meta compone
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/og-image': 'off'

--- a/docs/src/content/docs/rules/seo/og-title.md
+++ b/docs/src/content/docs/rules/seo/og-title.md
@@ -27,8 +27,7 @@ Add `<meta property="og:title">`, or set `openGraph.title` on your meta componen
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/og-title': 'off'

--- a/docs/src/content/docs/rules/seo/og-url.md
+++ b/docs/src/content/docs/rules/seo/og-url.md
@@ -27,8 +27,7 @@ This rule was `info` before the 2026-08-09 severity review, on the reasoning tha
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/og-url': 'off'

--- a/docs/src/content/docs/rules/seo/robots-txt.md
+++ b/docs/src/content/docs/rules/seo/robots-txt.md
@@ -28,8 +28,7 @@ Sitemap: https://example.com/sitemap.xml
 
 If this is intentional, turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/robots-txt': 'off'

--- a/docs/src/content/docs/rules/seo/single-h1.md
+++ b/docs/src/content/docs/rules/seo/single-h1.md
@@ -37,8 +37,7 @@ When the two disagree, trust the rendered result (`@svelte-vitals/vite`) — it 
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/single-h1': 'off'

--- a/docs/src/content/docs/rules/seo/sitemap-in-robots.md
+++ b/docs/src/content/docs/rules/seo/sitemap-in-robots.md
@@ -28,8 +28,7 @@ Sitemap: https://example.com/sitemap.xml
 
 If this is intentional, turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/sitemap-in-robots': 'off'

--- a/docs/src/content/docs/rules/seo/sitemap-xml.md
+++ b/docs/src/content/docs/rules/seo/sitemap-xml.md
@@ -28,8 +28,7 @@ Add `static/sitemap.xml` or a `src/routes/sitemap.xml/+server` endpoint:
 
 If this is intentional, turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/sitemap-xml': 'off'

--- a/docs/src/content/docs/rules/seo/ssr-disabled.md
+++ b/docs/src/content/docs/rules/seo/ssr-disabled.md
@@ -28,8 +28,7 @@ export const ssr = false; // fine — suppress or turn the rule off if this is d
 
 For a deliberate full SPA, disable the rule in your config:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/ssr-disabled': 'off'
@@ -43,8 +42,7 @@ or add `// svelte-vitals-disable-next-line seo/ssr-disabled` above the declarati
 
 Silence a single occurrence with `<!-- svelte-vitals-disable-next-line seo/ssr-disabled -->` on the line above it, or turn the rule off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/ssr-disabled': 'off'

--- a/docs/src/content/docs/rules/seo/title-length.md
+++ b/docs/src/content/docs/rules/seo/title-length.md
@@ -30,8 +30,7 @@ A title that is too short wastes the strongest on-page SEO signal; one that is t
 | `min`  | integer |      30 |
 | `max`  | integer |      60 |
 
-```js
-// svelte-vitals.config.js
+```js svelte-vitals.config.js
 export default {
   rules: { 'seo/title-length': { options: { min: 20, max: 40 } } }
 };
@@ -41,8 +40,7 @@ export default {
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/title-length': 'off'

--- a/docs/src/content/docs/rules/seo/title-presence.md
+++ b/docs/src/content/docs/rules/seo/title-presence.md
@@ -27,8 +27,7 @@ Add a `<title>` inside `<svelte:head>` (a dynamic title is fine), or set it via 
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/title-presence': 'off'

--- a/docs/src/content/docs/rules/seo/twitter-card.md
+++ b/docs/src/content/docs/rules/seo/twitter-card.md
@@ -25,8 +25,7 @@ twitter:card selects how the page renders when shared on X/Twitter; without it t
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/twitter-card': 'off'

--- a/docs/src/content/docs/rules/seo/viewport.md
+++ b/docs/src/content/docs/rules/seo/viewport.md
@@ -25,8 +25,7 @@ Add the viewport meta tag, typically in `src/app.html`:
 
 Record existing findings in the suppressions file (`npx svelte-vitals --update-suppressions`), scope the rule per route or path with `overrides`, or turn it off:
 
-```js
-// svelte-vitals.config.mjs
+```js svelte-vitals.config.mjs
 export default {
   rules: {
     'seo/viewport': 'off'


### PR DESCRIPTION
## Summary

Every ```js/```ts code block on the docs site that opened with a `// filename` comment (232 blocks across 182 pages, en + ja) now carries the filename as the **fence title**, which Blume renders as the code block's header with the language icon and copy button — e.g. ```` ```js svelte-vitals.config.mjs ```` instead of a comment as the first line.

The terminal-rendered CLI docs under `packages/cli/docs` deliberately keep the comment form: fence titles do not render in `svelte-vitals docs show` output.

## Test plan

- Docs site builds; `blume translate --check` reports 117 up to date (all touched en/ja pairs re-stamped)
- `pnpm lint` (oxfmt covers markdown) and the full test suite pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)