### PR TITLE
fix(vite): report performance/minify-disabled during a real SvelteKit vite build

### DIFF
--- a/.changeset/vite-minify-disabled-ssr-build.md
+++ b/.changeset/vite-minify-disabled-ssr-build.md
@@ -1,0 +1,5 @@
+---
+'@svelte-vitals/vite': patch
+---
+
+Fix `performance/minify-disabled` never reporting during a real SvelteKit `vite build`. The plugin captured `build.minify` only from the client build's resolved config, but SvelteKit runs the client build as a separate `vite.build()` with a fresh plugin instance, so the instance that analyzes the prerendered output never saw it. The plugin now reads the user's `build.minify` in its `config` hook — the same value SvelteKit forwards to the client build — so a `minify: false` in `vite.config.*` is reported (and gated) in build mode again, including projects whose routes are all `csr: false`.

--- a/packages/vite/src/minify-flag.ts
+++ b/packages/vite/src/minify-flag.ts
@@ -3,8 +3,9 @@ import { relative } from 'node:path';
 import { findMinifyDisabled, type Project } from '@svelte-vitals/core';
 
 /**
- * performance/minify-disabled fact from the RESOLVED Vite config — exact, so it also catches
- * function-form/conditional configs the CLI's literal-only static pass skips.
+ * performance/minify-disabled fact from the evaluated Vite user config (the value the plugin's
+ * `config` hook sees) — exact, so it also catches function-form/conditional configs the CLI's
+ * literal-only static pass skips.
  * The config source is re-parsed only to locate the line. `file` is never
  * fabricated: unset for an inline programmatic config (no `configFile` at
  * all), and always a posix-relative path to `root` (may start with `../` in

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -186,16 +186,23 @@ export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin | Plugin
   validateRulesOption(options.rules);
   validateOverridesOption(options.overrides, options.rules);
   let root = options.cwd ?? process.cwd();
-  let minifyFlag: { minify: unknown; configFile: string | undefined } | undefined;
+  let minify: unknown;
+  let configFile: string | undefined;
   const buildPlugin: Plugin = {
     name: 'svelte-vitals',
     apply: 'build',
     enforce: 'post',
+    config(userConfig) {
+      // Read the user's value here, not the resolved one: SvelteKit runs `vite build` as an
+      // SSR build whose resolved `build.minify` is forced to false, and its client build is a
+      // separate `vite.build({ configFile })` with a fresh plugin instance — so the instance
+      // whose closeBundle sees the prerendered dir never gets a client `configResolved`.
+      // This is the same source SvelteKit itself forwards to the client build.
+      minify = userConfig.build?.minify;
+    },
     configResolved(config) {
       if (!options.cwd) root = config.root;
-      // Vite <=7 resolves top-level build.minify to false whenever build.ssr is set —
-      // judge only the client build, which reflects user intent on every Vite version.
-      if (!config.build.ssr) minifyFlag = { minify: config.build.minify, configFile: config.configFile };
+      configFile = config.configFile;
     },
     async closeBundle() {
       const pagesDir = options.prerenderDir ? options.prerenderDir : join(root, DEFAULT_PRERENDER_DIR);
@@ -214,9 +221,7 @@ export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin | Plugin
 
       let result;
       try {
-        const viteMinifyDisabled = minifyFlag
-          ? await resolveMinifyDisabled(minifyFlag.minify, minifyFlag.configFile, root)
-          : undefined;
+        const viteMinifyDisabled = await resolveMinifyDisabled(minify, configFile, root);
         result = await analyze(
           resolved,
           root,

--- a/packages/vite/test/plugin-options.test.ts
+++ b/packages/vite/test/plugin-options.test.ts
@@ -66,4 +66,20 @@ describe('svelteVitals options', () => {
     await closeBundleOf(p)().catch(() => {});
     await expect(access(abs)).resolves.toBeUndefined();
   });
+
+  it('reports performance/minify-disabled from the plugin instance that only ever saw the SSR build', async () => {
+    // SvelteKit's client build is a separate `vite.build({ configFile })` with a fresh plugin
+    // instance; the instance whose closeBundle sees the prerendered dir is the outer SSR one,
+    // and its resolved SSR config carries no usable minify value.
+    const configFile = join(cwd, 'vite.config.ts');
+    await writeFile(configFile, `export default {\n  build: { minify: false }\n};\n`);
+    const p = svelteVitals({ cwd, ui: false, report: false, outFile: 'report.json' }) as Plugin;
+    const config = typeof p.config === 'function' ? p.config : p.config?.handler;
+    (config as (c: unknown, env: unknown) => void).call({}, { build: { minify: false, ssr: true } }, {});
+    const configResolved = typeof p.configResolved === 'function' ? p.configResolved : p.configResolved?.handler;
+    (configResolved as (c: unknown) => void).call({}, { root: cwd, configFile, build: { ssr: true, minify: false } });
+    await closeBundleOf(p)().catch(() => {});
+    const report = JSON.parse(await readFile(join(cwd, 'report.json'), 'utf8'));
+    expect(report.rules['performance/minify-disabled']).toEqual({ findings: 1, passed: 0 });
+  });
 });


### PR DESCRIPTION
## Summary

`performance/minify-disabled` never produced a finding in build mode: a real `vite build` on a SvelteKit project with `build: { minify: false }` in `vite.config.ts` reported `{ findings: 0, passed: 0 }` for the rule, while the CLI's static pass correctly reported 1 finding for the same file.

## Root cause

SvelteKit runs `vite build` as an **SSR build** and, inside its `writeBundle`, spawns the client build via a separate `vite.build({ configFile })`. That call re-evaluates `vite.config.ts`, so `svelteVitals()` runs again and produces a **fresh plugin instance / closure**.

The plugin captured `build.minify` in `configResolved` only when `!config.build.ssr` (client build), i.e. on the *second* instance. But the `closeBundle` that actually finds the prerendered directory and runs the analysis fires on the *outer SSR* instance, which only ever saw an `ssr: true` `configResolved` — so its `minifyFlag` was always `undefined` and the fact never reached `analyze()`. Projects with every route `csr: false` skip the client build entirely, so the old design could never have detected the case there.

## Fix

Read the user's `build.minify` in the plugin's `config` hook (the evaluated user config, before Vite applies the SSR default of `minify: false`) — this is the same value SvelteKit itself forwards to its client build (`initial_config.build?.minify`). `configFile` is taken from `configResolved` unconditionally. `closeBundle` now calls `resolveMinifyDisabled(minify, configFile, root)` directly (it already returns `undefined` unless `minify === false`).

## Verification

- New regression test in `packages/vite/test/plugin-options.test.ts` drives `config` → `configResolved(ssr: true)` → `closeBundle` on a single instance and asserts `performance/minify-disabled: { findings: 1, passed: 0 }`. Red before the fix (no `config` hook), green after.
- Real end-to-end check: a `vite build` of the `examples/kitchen-sink` project on `feat/kitchen-sink-example` against this branch's built `dist` now writes `rules['performance/minify-disabled'] = { findings: 1, passed: 0 }` in `svelte-vitals-report.json`.
- `pnpm build`, `pnpm -r typecheck`, `pnpm lint`, `pnpm -r test` all pass.

## Reviewer notes

- `feat/kitchen-sink-example` pins the buggy behavior (`performance/minify-disabled: 0`) in `examples/kitchen-sink/expected-findings.rendered.json`; whichever branch merges second must flip that expectation to `1`.
- The rule's docs-site page describes the plugin as judging the "resolved" value; that remains true from the user's perspective (function-form / conditional / inline programmatic configs are all evaluated before the `config` hook runs), so no docs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
