### PR TITLE
fix(cli): keep every <link> per rel when composing a route's head

### DIFF
--- a/.changeset/link-tags-additive.md
+++ b/.changeset/link-tags-additive.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': patch
+---
+
+Source mode no longer collapses `<link>` tags that share a `rel`. The composed `<svelte:head>` used to keep only the last `<link>` per `rel` across the layout chain, so a page with two `rel="preload"` (font + stylesheet), both Google Fonts `rel="preconnect"` origins, or several `rel="alternate" hreflang` entries was analyzed with only one of them — a false "un-preconnected origin" finding for a correctly configured site, and skipped preload/hreflang checks. Every `<link>` except `rel="canonical"` (still page-overrides-layout) is now kept, like JSON-LD. Projects with baselines or recorded suppressions may see new Performance/SEO findings on links that were previously invisible.

--- a/packages/cli/src/providers/source/resolve.ts
+++ b/packages/cli/src/providers/source/resolve.ts
@@ -57,7 +57,7 @@ export const BROAD_KINDS: ParsedTag[] = [
   // meta-tag family a broad meta source implies (JsonLd has its own adapter).
 ];
 
-/** Stable identity for a tag (matches routes.ts keyOf). */
+/** Override key for singular tags in routes.ts's composed head (additive kinds never reach it). */
 export function tagKey(tag: ParsedTag): string {
   switch (tag.kind) {
     case 'title':

--- a/packages/cli/src/providers/source/routes.ts
+++ b/packages/cli/src/providers/source/routes.ts
@@ -264,10 +264,13 @@ async function resolveRoute(
   const files = chainFiles(pageRel, layouts);
   const chainOrder = new Map(files.map((f, i) => [f.rel, i]));
   const composed = new Map<string, HeadTag>();
-  // JSON-LD is additive, not a singleton (issue #443): every document survives, in
-  // chain order (root layout -> ... -> page) and source order within a file, unlike
-  // composed's override-by-kind semantics for title/meta/link.
-  const jsonldTags: HeadTag[] = [];
+  // Additive kinds survive in chain order (root layout -> ... -> page) and source order
+  // within a file, unlike composed's override-by-kind semantics for title/meta: JSON-LD
+  // (issue #443) and every <link> except canonical — preload/preconnect/alternate/icon/…
+  // legitimately repeat with the same rel. Canonical stays in `composed` because the
+  // broad-source fill below keys on `link:canonical`; if it were additive, a static
+  // canonical would sit next to a synthetic dynamic one and detection would degrade.
+  const additiveTags: HeadTag[] = [];
   let broadOwn = false;
   let broadInherited = false;
   const images: ImageInfo[] = [];
@@ -301,7 +304,7 @@ async function resolveRoute(
     const resolved = await resolveFileTags(rt, cwd, rel, parsed, config, MAX_DEPTH, new Set([rel]), cache, aliases);
     for (const tag of resolved.tags) {
       const stamped: HeadTag = { ...tag, presence: isPage ? 'own' : 'inherited', file: rel };
-      if (tag.kind === 'jsonld') jsonldTags.push(stamped);
+      if (tag.kind === 'jsonld' || (tag.kind === 'link' && tag.rel !== 'canonical')) additiveTags.push(stamped);
       else composed.set(tagKey(tag), stamped);
     }
     if (resolved.broad) {
@@ -327,7 +330,7 @@ async function resolveRoute(
 
   const route = deriveRoute(pageRel);
   return {
-    head: { route, source: 'static', tags: [...composed.values(), ...jsonldTags], file: pageRel },
+    head: { route, source: 'static', tags: [...composed.values(), ...additiveTags], file: pageRel },
     images: { route, images },
     headings: { route, headings, componentHeadings },
     a11y: {

--- a/packages/cli/test/source-provider.test.ts
+++ b/packages/cli/test/source-provider.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import {
+  performancePreconnect,
+  seoHreflang,
   seoJsonLdValidity,
   seoSingleH1,
   seoTitlePresence,
@@ -252,6 +254,76 @@ describe('collectRoutes JSON-LD additivity (issue #443)', () => {
     const results = await seoJsonLdValidity.check({ heads: [head!], project: defaultProject, config: defaultConfig });
     const finding = results.find((r) => r.message === 'JSON-LD is not valid JSON');
     expect(finding?.location).toBe('src/routes/+layout.svelte');
+  });
+});
+
+describe('collectRoutes <link> additivity', () => {
+  const links = (head: ResolvedHead, rel: string) => head.tags.filter((t) => t.kind === 'link' && t.rel === rel);
+
+  it('keeps two <link rel="preload"> with different `as` in one <svelte:head>', async () => {
+    const rt = createMemoryRuntime({
+      'src/routes/+page.svelte': `<svelte:head>
+  <link rel="preload" href="/font.woff2" as="font" crossorigin />
+  <link rel="preload" href="/app.css" as="style" />
+</svelte:head>`
+    });
+    const [head] = await collectHeads(rt, '');
+    expect(links(head!, 'preload').map((t) => t.as)).toEqual(['font', 'style']);
+  });
+
+  it('keeps both Google Fonts preconnects so performance/preconnect reports no missing origin', async () => {
+    const rt = createMemoryRuntime({
+      'src/routes/+page.svelte': `<svelte:head>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter" />
+  <link rel="preload" href="https://fonts.gstatic.com/s/inter.woff2" as="font" crossorigin />
+</svelte:head>`
+    });
+    const [head] = await collectHeads(rt, '');
+    expect(links(head!, 'preconnect')).toHaveLength(2);
+    const results = await performancePreconnect.check({
+      heads: [head!],
+      project: defaultProject,
+      config: defaultConfig
+    });
+    expect(results.map((r) => r.message)).toEqual(['Third-party origins are preconnected']);
+  });
+
+  it('keeps every hreflang alternate so seo/hreflang sees the full set', async () => {
+    const rt = createMemoryRuntime({
+      'src/routes/+page.svelte': `<svelte:head>
+  <link rel="alternate" hreflang="en" href="https://example.com/en" />
+  <link rel="alternate" hreflang="ja" href="https://example.com/ja" />
+</svelte:head>`
+    });
+    const [head] = await collectHeads(rt, '');
+    expect(links(head!, 'alternate').map((t) => t.hreflang)).toEqual(['en', 'ja']);
+    const results = await seoHreflang.check({ heads: [head!], project: defaultProject, config: defaultConfig });
+    expect(results.map((r) => r.message)).toEqual(['Multiple hreflang alternates with no x-default declared']);
+  });
+
+  it('keeps a layout preload (inherited) alongside a page preload (own)', async () => {
+    const rt = createMemoryRuntime({
+      'src/routes/+layout.svelte': `<svelte:head><link rel="preload" href="/font.woff2" as="font" crossorigin /></svelte:head>`,
+      'src/routes/+page.svelte': `<svelte:head><link rel="preload" href="/hero.jpg" as="image" /></svelte:head>`
+    });
+    const [head] = await collectHeads(rt, '');
+    const preloads = links(head!, 'preload');
+    expect(preloads).toHaveLength(2);
+    expect(preloads.find((t) => t.file === 'src/routes/+layout.svelte')?.presence).toBe('inherited');
+    expect(preloads.find((t) => t.file === 'src/routes/+page.svelte')?.presence).toBe('own');
+  });
+
+  it('still overrides the layout canonical with the page canonical (singular rel regression pin)', async () => {
+    const rt = createMemoryRuntime({
+      'src/routes/+layout.svelte': `<svelte:head><link rel="canonical" href="https://example.com/" /></svelte:head>`,
+      'src/routes/+page.svelte': `<svelte:head><link rel="canonical" href="https://example.com/page" /></svelte:head>`
+    });
+    const [head] = await collectHeads(rt, '');
+    const canonicals = links(head!, 'canonical');
+    expect(canonicals).toHaveLength(1);
+    expect(canonicals[0]?.presence).toBe('own');
   });
 });
 


### PR DESCRIPTION
## What

Source-mode head composition (`packages/cli/src/providers/source/routes.ts`) keyed `<link>` tags by `rel` alone via `tagKey()`, so within one route (own file or across the layout chain) only the **last** `<link>` per `rel` survived. Every `<link>` except `rel="canonical"` is now additive, joining the existing JSON-LD `additiveTags` list; `title`/`meta`/`link rel="canonical"` keep their page-overrides-layout semantics.

## Why

Realistic heads repeat a `rel`:

- two `rel="preconnect"` (fonts.googleapis.com + fonts.gstatic.com — the canonical Google Fonts fix) → only one registered, so `performance/preconnect` reported a **false** "used without a preconnect" for the other origin
- a font preload + a stylesheet preload → only one checked by `performance/preload-missing-as` / `performance/font-preload-crossorigin`
- several `rel="alternate" hreflang` → `seo/hreflang` never saw the full set

`canonical` stays in the override map on purpose: the broad-meta-source fill checks `composed.has('link:canonical')`, and making it additive would put a synthetic dynamic canonical next to a real static one and degrade detection (comment in code).

## Reviewer notes

- Rules already iterate all matching tags (`link-rule.ts`, `hreflang.ts`, `preconnect.ts`) — no core change needed.
- New tests in `packages/cli/test/source-provider.test.ts` (`collectRoutes <link> additivity`): two preloads with different `as`, both Google Fonts preconnects end-to-end through `performancePreconnect` (fails before the fix), two hreflang alternates through `seoHreflang`, layout+page preload presence, and a canonical override regression pin.
- Changeset (`svelte-vitals` patch) notes that projects with baselines/suppressions may see new Performance/SEO findings on links that were previously invisible.
- Same bug class remains for two dynamic-`src` `<script>` tags (`script:?` key) — deliberately left for a follow-up.
- Verified: `pnpm build && pnpm test`, `pnpm lint`, `pnpm typecheck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Source analysis now preserves multiple non-canonical `<link>` tags with the same relationship.
  * Duplicate preload, preconnect, and alternate hreflang links are now surfaced for analysis.
  * Canonical links continue to use page-over-layout override behavior.

* **Tests**
  * Added coverage for inherited and page-specific link tags, including canonical-link handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->