### PR TITLE
fix(cli): keep every head <script src> across the layout chain in source mode

### DIFF
--- a/.changeset/script-tags-additive.md
+++ b/.changeset/script-tags-additive.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': patch
+---
+
+Source mode no longer collapses `<script src>` tags that share a `src`. The composed `<svelte:head>` used to keep only the last `<script>` per `src` across the layout chain, so a page's `defer` copy of a script the layout loads synchronously masked the layout's render-blocking one, and `performance/render-blocking-script` reported nothing. Every head `<script src>` is now kept in chain order, like JSON-LD, and each blocking occurrence is reported at its own file. Projects with baselines or recorded suppressions may see new `performance/render-blocking-script` findings on layout scripts that were previously invisible.

--- a/packages/cli/src/providers/source/routes.ts
+++ b/packages/cli/src/providers/source/routes.ts
@@ -266,10 +266,12 @@ async function resolveRoute(
   const composed = new Map<string, HeadTag>();
   // Additive kinds survive in chain order (root layout -> ... -> page) and source order
   // within a file, unlike composed's override-by-kind semantics for title/meta: JSON-LD
-  // (issue #443) and every <link> except canonical — preload/preconnect/alternate/icon/…
-  // legitimately repeat with the same rel. Canonical stays in `composed` because the
-  // broad-source fill below keys on `link:canonical`; if it were additive, a static
-  // canonical would sit next to a synthetic dynamic one and detection would degrade.
+  // (issue #443), every <link> except canonical (preload/preconnect/alternate/icon/…
+  // legitimately repeat with the same rel), and <script src> (a layout's script and a page's
+  // same-src script both render, so a page-level `defer` copy must not mask the layout's
+  // blocking one). Canonical stays in `composed` because the broad-source fill below keys on
+  // `link:canonical`; if it were additive, a static canonical would sit next to a synthetic
+  // dynamic one and detection would degrade.
   const additiveTags: HeadTag[] = [];
   let broadOwn = false;
   let broadInherited = false;
@@ -304,7 +306,8 @@ async function resolveRoute(
     const resolved = await resolveFileTags(rt, cwd, rel, parsed, config, MAX_DEPTH, new Set([rel]), cache, aliases);
     for (const tag of resolved.tags) {
       const stamped: HeadTag = { ...tag, presence: isPage ? 'own' : 'inherited', file: rel };
-      if (tag.kind === 'jsonld' || (tag.kind === 'link' && tag.rel !== 'canonical')) additiveTags.push(stamped);
+      if (tag.kind === 'jsonld' || tag.kind === 'script' || (tag.kind === 'link' && tag.rel !== 'canonical'))
+        additiveTags.push(stamped);
       else composed.set(tagKey(tag), stamped);
     }
     if (resolved.broad) {

--- a/packages/cli/test/source-provider.test.ts
+++ b/packages/cli/test/source-provider.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import {
   performancePreconnect,
+  performanceRenderBlockingScript,
   seoHreflang,
   seoJsonLdValidity,
   seoSingleH1,
@@ -324,6 +325,50 @@ describe('collectRoutes <link> additivity', () => {
     const canonicals = links(head!, 'canonical');
     expect(canonicals).toHaveLength(1);
     expect(canonicals[0]?.presence).toBe('own');
+  });
+});
+
+describe('collectRoutes <script src> additivity', () => {
+  const scripts = (head: ResolvedHead) => head.tags.filter((t) => t.kind === 'script');
+
+  it('keeps a layout blocking script alongside the page copy of the same src with defer', async () => {
+    const rt = createMemoryRuntime({
+      'src/routes/+layout.svelte': `<svelte:head><script src="https://cdn.example/x.js"></script></svelte:head>`,
+      'src/routes/+page.svelte': `<svelte:head><script src="https://cdn.example/x.js" defer></script></svelte:head>`
+    });
+    const [head] = await collectHeads(rt, '');
+    expect(scripts(head!).map((t) => [t.file, t.presence, t.blocking ?? false])).toEqual([
+      ['src/routes/+layout.svelte', 'inherited', true],
+      ['src/routes/+page.svelte', 'own', false]
+    ]);
+    const results = await performanceRenderBlockingScript.check({
+      heads: [head!],
+      project: defaultProject,
+      config: defaultConfig
+    });
+    expect(results.map((r) => [r.message, r.location])).toEqual([
+      ['Render-blocking <script> (https://cdn.example/x.js) in <head>', 'src/routes/+layout.svelte']
+    ]);
+  });
+
+  it('keeps two same-src scripts in one <svelte:head>', async () => {
+    const rt = createMemoryRuntime({
+      'src/routes/+page.svelte': `<svelte:head>
+  <script src="/a.js"></script>
+  <script src="/a.js" async></script>
+</svelte:head>`
+    });
+    const [head] = await collectHeads(rt, '');
+    expect(scripts(head!).map((t) => t.blocking ?? false)).toEqual([true, false]);
+  });
+
+  it('models only literal src: dynamic src={expr} scripts produce no script tag', async () => {
+    const rt = createMemoryRuntime({
+      'src/routes/+page.svelte': `<script>let a = '/a.js'; let b = '/b.js';</script>
+<svelte:head><script src={a}></script><script src={b}></script></svelte:head>`
+    });
+    const [head] = await collectHeads(rt, '');
+    expect(scripts(head!)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## What

Source mode's composed `<svelte:head>` keyed `<script src>` tags by `src`, so only the last one per `src` across the layout chain survived. Scripts are now additive (like JSON-LD): every head `<script src>` is kept in chain order (root layout → … → page) with its own `file` and `presence`.

- `packages/cli/src/providers/source/routes.ts` — `jsonldTags` → `additiveTags`, condition extended to `tag.kind === 'script'`.
- `packages/cli/test/source-provider.test.ts` — new `collectRoutes <script src> additivity` block (3 tests).
- `.changeset/script-tags-additive.md` — `svelte-vitals` patch.

## Why

A page's `defer` copy of a script the layout loads synchronously replaced the layout tag, so `performance/render-blocking-script` reported nothing even though the layout's script is still render-blocking in the real page. Now each blocking occurrence is reported at its own file.

## Reviewer notes

- Dynamic `src={expr}` scripts are **not** affected: the parser only models literal `src` (`parse.ts`), so they never become tags in the first place. The new test pins that so nobody expects otherwise. Modeling them is a separate decision.
- `performance/preconnect` aggregates by host (`Map`/`Set`), so same-`src` duplicates don't double-report there.
- Only the two perf rules read script head tags (`render-blocking-script`, `preconnect`); both iterate all matching tags.
- Baselines / recorded suppressions may surface new `performance/render-blocking-script` findings on layout scripts that were previously masked (called out in the changeset).
- Verified: `pnpm build && pnpm test && pnpm lint && pnpm typecheck` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
