### PR TITLE
fix(cli): treat <link> rel/as keywords as case-insensitive

### DIFF
--- a/.changeset/link-rel-case-insensitive.md
+++ b/.changeset/link-rel-case-insensitive.md
@@ -1,0 +1,6 @@
+---
+'svelte-vitals': patch
+'@svelte-vitals/vite': patch
+---
+
+Treat `<link>` `rel` and `as` keywords as case-insensitive, as the HTML spec does. `<link rel="Canonical">` is now recognised by seo/canonical-url (and overrides a layout canonical instead of being added alongside it), and `rel="Preload"` is now seen by the preload rules, in both source and rendered-HTML analysis.

--- a/packages/cli/src/providers/source/parse.ts
+++ b/packages/cli/src/providers/source/parse.ts
@@ -115,9 +115,11 @@ function tagsFromHead(head: AST.SvelteHead): ParsedTag[] {
         ...(descText !== undefined ? { text: descText } : {})
       });
     } else if (node.name === 'link') {
-      const rel = attrText(attributes, 'rel');
+      // rel/as keywords are ASCII case-insensitive per the HTML spec; rules and the head
+      // composition compare them literally, so normalize once here.
+      const rel = attrText(attributes, 'rel')?.toLowerCase();
       const hasAs = findAttr(attributes, 'as') !== undefined;
-      const asLiteral = attrText(attributes, 'as'); // literal keyword, or undefined for dynamic/absent
+      const asLiteral = attrText(attributes, 'as')?.toLowerCase(); // literal keyword, or undefined for dynamic/absent
       const hasCrossorigin = findAttr(attributes, 'crossorigin') !== undefined;
       const hreflang = attrText(attributes, 'hreflang'); // literal (incl. '') or undefined for dynamic/absent
       const href = attrText(attributes, 'href'); // literal URL (for performance/preconnect origin analysis), or undefined

--- a/packages/cli/test/parse-link-attrs.test.ts
+++ b/packages/cli/test/parse-link-attrs.test.ts
@@ -24,6 +24,12 @@ describe('parse: link as/crossorigin (static)', () => {
     expect(link.as).toBeUndefined();
     expect(link.hasCrossorigin).toBeUndefined();
   });
+  it('lowercases mixed-case rel/as keywords (HTML treats them case-insensitively)', () => {
+    const tags = parseHeadTags(head('<link rel="Preload" href="/i.woff2" as="Font" crossorigin />'), 'x.svelte');
+    const link = tags.find((t) => t.kind === 'link')!;
+    expect(link.rel).toBe('preload');
+    expect(link.as).toBe('font');
+  });
   it('treats a mixed static/dynamic href="/base/{slug}" as non-literal, not a truncated prefix', () => {
     const tags = parseHeadTags(head('<link rel="preload" href="/base/{slug}" as="font" />'), 'x.svelte');
     const link = tags.find((t) => t.kind === 'link' && t.rel === 'preload')!;

--- a/packages/cli/test/source-provider.test.ts
+++ b/packages/cli/test/source-provider.test.ts
@@ -243,6 +243,17 @@ describe('collectRoutes JSON-LD additivity (issue #443)', () => {
     expect(head!.tags.filter((t) => t.kind === 'title')).toHaveLength(1);
   });
 
+  it('overrides a layout rel="canonical" with a page rel="Canonical" (rel is case-insensitive)', async () => {
+    const rt = createMemoryRuntime({
+      'src/routes/+layout.svelte': `<svelte:head><link rel="canonical" href="https://example.com/layout" /></svelte:head>`,
+      'src/routes/+page.svelte': `<svelte:head><link rel="Canonical" href="https://example.com/page" /></svelte:head>`
+    });
+    const [head] = await collectHeads(rt, '');
+    const canonicals = head!.tags.filter((t) => t.kind === 'link' && t.rel === 'canonical');
+    expect(canonicals).toHaveLength(1);
+    expect(canonicals[0]!.presence).toBe('own');
+  });
+
   it('attributes a broken layout jsonld finding to the layout file, not the page', async () => {
     const rt = createMemoryRuntime({
       'src/routes/+layout.svelte': `<svelte:head><script type="application/ld+json">{not valid json}</script></svelte:head>`,

--- a/packages/cli/test/source-provider.test.ts
+++ b/packages/cli/test/source-provider.test.ts
@@ -252,6 +252,7 @@ describe('collectRoutes JSON-LD additivity (issue #443)', () => {
     const canonicals = head!.tags.filter((t) => t.kind === 'link' && t.rel === 'canonical');
     expect(canonicals).toHaveLength(1);
     expect(canonicals[0]!.presence).toBe('own');
+    expect(canonicals[0]!.href).toBe('https://example.com/page');
   });
 
   it('attributes a broken layout jsonld finding to the layout file, not the page', async () => {

--- a/packages/vite/src/providers/rendered/parse-html.ts
+++ b/packages/vite/src/providers/rendered/parse-html.ts
@@ -169,9 +169,11 @@ export function parseHtmlHead(html: string): ParsedHtmlHead {
   }
 
   for (const link of head.querySelectorAll('link')) {
-    const rel = link.getAttribute('rel');
+    // rel/as keywords are ASCII case-insensitive per the HTML spec; the rules compare
+    // them literally, so normalize here (mirrors the source parser in packages/cli).
+    const rel = link.getAttribute('rel')?.toLowerCase();
     if (!rel) continue;
-    const asAttr = link.getAttribute('as'); // rendered HTML: literal string or undefined
+    const asAttr = link.getAttribute('as')?.toLowerCase(); // rendered HTML: literal string or undefined
     const hasCrossorigin = link.hasAttribute('crossorigin');
     const hreflang = link.getAttribute('hreflang');
     const href = link.getAttribute('href');

--- a/packages/vite/test/parse-html.test.ts
+++ b/packages/vite/test/parse-html.test.ts
@@ -62,6 +62,14 @@ describe('parse-html: link as/crossorigin', () => {
     expect(link.hasAs).toBe(true);
     expect(link.hasCrossorigin).toBe(true);
   });
+  it('lowercases mixed-case rel/as keywords', () => {
+    const { tags } = parseHtmlHead(
+      '<html><head><link rel="Preload" href="/i.woff2" as="Font"></head><body></body></html>'
+    );
+    const link = tags.find((t) => t.kind === 'link')!;
+    expect(link.rel).toBe('preload');
+    expect(link.as).toBe('font');
+  });
   it('leaves as/crossorigin unset when absent', () => {
     const { tags } = parseHtmlHead('<html><head><link rel="preload" href="/a.js"></head><body></body></html>');
     const link = tags.find((t) => t.kind === 'link' && t.rel === 'preload')!;


### PR DESCRIPTION
## Summary

Per the HTML spec, `<link>` `rel` and `as` keywords are ASCII case-insensitive, but every consumer compared them literally: the head composition in `routes.ts` (`tag.rel !== 'canonical'` additive check), `tagKey()` in `resolve.ts` (`link:${rel}`), and the rules `seo/canonical-url`, `seo/hreflang`, `performance/preload-missing-as`, `performance/font-preload-crossorigin`, `performance/preconnect`.

As a result `<link rel="Canonical">` was invisible to `seo/canonical-url` and was kept alongside a layout canonical instead of overriding it, and `rel="Preload"` skipped the preload rules.

## Changes

- `packages/cli/src/providers/source/parse.ts` — lowercase the static literal `rel` / `as` at extraction; dynamic values stay `undefined`.
- `packages/vite/src/providers/rendered/parse-html.ts` — same normalization in the rendered-HTML collector so both modes agree.
- Tests: mixed-case `rel`/`as` normalize (cli `parse-link-attrs`, vite `parse-html`); layout `rel="canonical"` + page `rel="Canonical"` → one canonical with presence `own` (cli `source-provider`).
- Changeset: patch for `svelte-vitals` and `@svelte-vitals/vite`.

## Notes for reviewers

- Only the two extraction sites above read `rel`/`as` (`grep -rnE "attrText\(attributes, '(rel|as)'\)|getAttribute\('(rel|as)'\)"`); the svelte-seo / svelte-meta-tags adapters hard-code lowercase `'canonical'`.
- Multi-token `rel="preload x"` splitting is out of scope.

## Verification

`pnpm build && pnpm test && pnpm lint && pnpm typecheck` all pass (core 1517 / cli 1204 / vite 249 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link metadata handling so `rel` and `as` values are recognized regardless of capitalization.
  * Canonical links and preload rules now work consistently in source and rendered HTML.
  * Corrected canonical-link precedence when page and layout metadata use different capitalization.

* **Tests**
  * Added coverage for mixed-case link attributes and canonical-link behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->