### PR TITLE
docs: record the v1.0 roadmap

### DIFF
--- a/docs/superpowers/specs/2026-08-15-a11y-parity-roadmap.md
+++ b/docs/superpowers/specs/2026-08-15-a11y-parity-roadmap.md
@@ -49,6 +49,9 @@ template declaration tags are invisible to the script-scope correctness facts
 
 ## Queued increments
 
+All of these are pre-1.0 work — see `2026-08-16-v1-roadmap.md` for the ordering and the
+reason (schema/findingKey/directive changes must precede the 1.0 freeze).
+
 1. **Pretender-style component mapping** — a config surface declaring what an unresolvable
    (node_modules) component renders as (`{ "Link": "a" }`; the component-to-element mapping file-scoped
    linters rely on is prior art). This is the single highest-leverage unlock: it widens `no-missing-id-ref`'s closed

--- a/docs/superpowers/specs/2026-08-16-v1-roadmap.md
+++ b/docs/superpowers/specs/2026-08-16-v1-roadmap.md
@@ -1,0 +1,86 @@
+# v1.0 roadmap — everything lands before the tag
+
+Policy: **1.0 is a declaration of stability, not a feature milestone.** Every change we can
+foresee — including the a11y increments previously scoped as "1.x" — ships on 0.x, where
+schema, findingKey, and rule-behaviour changes cost nothing. After 1.0 each of those is a
+major bump or a compatibility shim. Low visibility today is the asset being spent.
+
+The order below is a dependency order, not a priority ranking: items that change public
+surface come first so everything downstream is measured against the final shape.
+
+## Phase A — public surface, decided and frozen last (but designed first)
+
+1. **API inventory & freeze list.** Enumerate what 1.0 promises: config schema (file + plugin
+   options + `overrides` + rule options), the JSON/agent/sarif/github report shapes, exit codes,
+   `findingKey` (`id::route::location` — the suppressions-file contract), inline directive
+   syntax, and `@svelte-vitals/core`'s public exports (recent additions like `foldOccurrences`,
+   `splitTokens`, `isTopFragment` must be either committed to or made internal). Output: a
+   `docs/superpowers/specs/2026-xx-v1-public-surface.md` listing each surface as **frozen** /
+   **internal** / **removed-before-1.0**, and a `check:publish`-style test that fails when a
+   non-listed core export appears. Do this first so every item below is designed against the
+   final surface; do the actual freeze commit last.
+2. **Health score semantics.** Six categories, equal weights by default — confirm or change
+   now; the number's meaning cannot move after 1.0. Record in the score-semantics design.
+
+## Phase B — reliability net (the 1.0 confidence work)
+
+3. **Ecosystem CI.** Scheduled job cloning a small set of real OSS SvelteKit apps and
+   asserting only "no crash, exit ∈ {0,1}, report parses" — never counts. This is what turns
+   the recent run of dogfooding discoveries (link/script collapse, minify flag, a11y directive)
+   from lucky finds into a standing net. Highest confidence-per-effort item on this list.
+4. **a11y rule-validity review** at the standard of `2026-08-09-v1-rule-validity-review.md`:
+   the 15 rules were shipped after that review, so their premises, severities, message
+   mechanics, and doc claims need the same primary-source pass. Also re-check the review's
+   remaining P2 items still open after `#428` (single-h1 folklore wording, hreflang x-default
+   arm framing, the three correctness message-mechanics corrections).
+5. **Performance measurement, once.** Run `pnpm bench` (synthetic sizes) and
+   `pnpm bench --target examples/kitchen-sink`, record numbers, and decide each bench-gated item
+   (composition memoization, seven-walk consolidation, fs concurrency cap): implement or record
+   "not needed at 1.0 scale". A decision either way is the deliverable.
+
+## Phase C — a11y increments (all of them, pre-1.0)
+
+Ordered so each step's schema/key decisions are settled before the next builds on them.
+
+6. **Pretender-style component mapping** — config declaring what an unresolvable component
+   renders as (`{ "Link": "a" }`). New config key → schema decision → belongs before the freeze.
+   Widens `no-missing-id-ref`'s closed world; the "better than file-scoped linters" claim
+   depends on this.
+7. **Shell-id duplication** — merge `app.html` ids into the composed `ids` map. Requires the
+   findingKey-for-out-of-route-location decision, which is exactly why it must precede the
+   freeze.
+8. **Inline suppression directives for route-scoped findings** — parity with component rules;
+   the directive syntax is frozen public surface, so any extension lands here.
+9. **Phase 2 element-level spec data** — `permitted-contents` (full), `invalid-attr`, generic
+   `required-attr`, `deprecated-element`/`-attr`, `ineffective-attr`, plus the three
+   aria-query-only gaps from the current-generation linter delta (`disallowed-props`,
+   `implicit-role`, `deprecated-props/-role`). Data-source decision (own dataset vs published
+   data-only package) is a dependency decision — 1.0 must not inherit a data source we'd swap.
+10. **Phase 3 config-driven rules** — `required-element`, `disallowed-element` and the
+    selector-scoped configuration question. Config-schema-affecting → pre-freeze.
+11. **Small-rule pool** — `no-consecutive-br`, `no-empty-palpable-content`,
+    `table-row-column-alignment`, `no-ambiguous-navigable-target-names`, `neighbor-popovers`,
+    and the adjacent-category candidates (`correct-aspect-ratio`, `srcset-sizes-constraint`
+    → Performance; `link-types`, `head-element-order` → SEO). Each is a normal rule increment
+    (docs en/ja, kitchen-sink sample enforced by the meta-test).
+
+## Phase D — known-limitation sweep
+
+12. Every review-deferred minor becomes either a fix or a documented limitation: empty
+    `<select required>` flagged, `<aside>`/`<nav>` not landmark-mapped, source-mode
+    `SECTIONING_TAGS` omitting `main` (masked today), bare `aria-valuenow`/empty tokenlist
+    passing, `/^P/` duration shape, `handleHttpError` policy in the example, unguarded
+    `readFileSync` in the build e2e. Nothing "known but unwritten" ships in 1.0.
+13. **Docs completeness pass**: every rule page states its Mode differences and known
+    limitations; guides carry no rule counts; en/ja stamped; embedded CLI docs in sync.
+
+## Phase E — the tag
+
+14. Freeze commit (Phase A's list becomes enforcement), changesets bumping all packages to
+    1.0.0 with a migration note for anything renamed/removed on the way, release.
+
+## Explicitly not in scope for 1.0
+
+Nothing currently foreseen is excluded — that is the policy. Anything discovered during
+Phases B–D that is a genuine new capability (not a fix, freeze, or already-recorded increment)
+gets recorded here for 1.x rather than expanding this list mid-flight.


### PR DESCRIPTION
## Summary

Records the v1.0 policy and the ordered work list in `docs/superpowers/specs/2026-08-16-v1-roadmap.md`.

**Policy**: 1.0 is a declaration of stability, not a feature milestone — every foreseeable change, including the a11y increments previously scoped as 1.x, ships on 0.x while schema, findingKey, and rule-behaviour changes are free. Nothing currently foreseen is excluded.

Order is dependency order: public-surface inventory first (so everything is designed against the final shape, frozen last), then the reliability net (Ecosystem CI, a11y rule-validity review, one performance measurement pass), then every a11y increment (pretender mapping, shell-id duplication, route-scoped inline directives, Phase 2 spec data, Phase 3 config-driven rules, the small-rule pool), then the known-limitation sweep, then the freeze + tag.

The a11y parity roadmap now points here for ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)