### PR TITLE
docs: decide the 1.0 public surface (roadmap Phase A-1)

### DIFF
--- a/docs/superpowers/specs/2026-08-16-v1-public-surface.md
+++ b/docs/superpowers/specs/2026-08-16-v1-public-surface.md
@@ -1,0 +1,168 @@
+# Design: the 1.0 public surface
+
+Phase A-1 of `2026-08-16-v1-roadmap.md`. Decides, surface by surface, what 1.0's semver promise
+covers. Everything listed **frozen** may only change in a 2.0; everything listed **internal**
+carries no promise; everything listed **remove before 1.0** goes away while removal is still free.
+
+The classification rests on one measured fact: of `@svelte-vitals/core`'s ~50 export statements,
+**zero** are referenced by the docs site or by any package README — the package's own README says
+"most users don't depend on this directly". Core's exports are cli↔vite plumbing that had to be
+public only because they cross a package boundary.
+
+## The shape: a dedicated `internal` subpath
+
+`@svelte-vitals/core` gains a second entry point:
+
+```jsonc
+// packages/core/package.json
+"exports": {
+  ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" },
+  "./internal": { "types": "./dist/internal.d.ts", "import": "./dist/internal.js" }
+}
+```
+
+- `.` — the frozen surface below. Small, documented, semver-stable at 1.0.
+- `./internal` — everything cli and vite share. Its module doc states verbatim that it carries
+  **no semver guarantee and may change in any release, including patch**. `svelte-vitals` and
+  `@svelte-vitals/vite` import their plumbing from here; both are versioned in lockstep with core
+  through workspace ranges, so a breaking internal change is a same-PR change.
+
+This keeps internal refactors free after 1.0 (composition memoization, the seven-walk
+consolidation, and the a11y Phase 2/3 work all touch these signatures) without a major bump.
+
+## Frozen at 1.0
+
+### `svelte-vitals` (CLI)
+
+- **Binary behaviour**: every flag currently in `gunshi/*.ts` — root/analyze (`--meta-components`,
+  `--treat-dynamic-as`, `--route`, `--diff`, `--staged`, `--baseline`, `--update-suppressions`,
+  `--no-suppressions`, `--by-route`, `--reporter`, `--out-file`, `--fail-on`, `--min-health`,
+  `--rules`, `--ignore`, `--category`, `--weights`, `--score`, `--no-color`, `--no-animation`,
+  `--verbose`, `--help`, `--version`), and the `install` / `ci` / `explain` / `docs` sub-commands
+  with their flags. Adding flags stays minor; removing or repurposing one is 2.0.
+- **Exit codes**: `0` clean · `1` failing finding or threshold · `2` execution error.
+- **`defineConfig`** re-exported from `svelte-vitals` (the package users install). This is the only
+  programmatic export the docs teach.
+
+The rest of `packages/cli/src/index.ts`'s exports (`run`, `analyzeProject`, `applyScope`,
+`routeMatcher`, `loadConfigFile`, `findUnknownRuleIds`, …) are **internal**: no doc teaches them,
+and the CLI is documented as a binary. They keep working; they carry no promise. Recorded here so
+a future "programmatic API" is a deliberate 1.x addition, not an accident.
+
+### `@svelte-vitals/vite`
+
+- `svelteVitals(options)` and the `SvelteVitalsOptions` fields: `cwd`, `treatDynamicAs`,
+  `metaComponents`, `rules`, `overrides`, `failOn`, `weights`, `report`, `outFile`, `prerenderDir`,
+  `ui`.
+- `@svelte-vitals/vite/hooks`'s `svelteVitalsHandle(options)` and `SvelteVitalsHookOptions`
+  (`metaComponents`, `rules`).
+- The dev-dashboard route (`/__svelte-vitals/`) as a URL, not its HTML.
+
+### Configuration
+
+The config file schema in full: `treatDynamicAs`, `metaComponents`, `rules` (with the
+`'off' | Severity | { severity, options }` setting shapes), `failOn`, `weights`, `overrides`
+(`route` / `files` globs + `rules` keyed by rule id or category), and the documented precedence
+(CLI flag > config file > default, `--rules`/`--ignore` as selection exceptions). Config file
+discovery order and the `.ts`/`.mjs` support matrix are frozen too.
+
+### Rule identity and persisted data
+
+- **Rule ids** (`category/slug`) — they appear in configs, suppression files, CI annotations, and
+  published docs URLs. Renaming a rule after 1.0 needs a deprecation path, not a rename.
+- **`findingKey` = `id::route::location`** — the suppressions-file contract. `line` stays excluded.
+- **Suppressions file**: name `svelte-vitals-suppressions.json`, `{ version: 1, suppressions: [{ id, route?, location? }] }`.
+  The `version` field is the migration hatch; 1.0 promises to keep reading `1`.
+- **Inline directive**: `// svelte-vitals-disable-next-line [id[, id…]]` and its
+  `<!-- … -->` form, whole-line, applying to the next line.
+- **Docs URL shape**: `<docs-origin>/rules/<id>`. The origin itself is not frozen (a domain move
+  must stay possible); the path shape is, because `docsUrl` is persisted in JSON/SARIF output.
+
+### Report shapes
+
+- **JSON reporter** (`JsonReport`): frozen field-for-field as documented in the reporters guide —
+  `version, score, weights, categories, summary, rules{findings,passed}, routes[], siteIssues[],
+inventories, examined?`. Additive fields stay minor; removing or retyping one is 2.0.
+- **SARIF** stays valid SARIF 2.1.0; **GitHub** stays valid workflow commands. Both are frozen by
+  reference to their external specs, not to our own layout.
+- **agent / markdown / html** reporters are **human/agent-readable output, not schemas**: their
+  prose, ordering, and caps may change in any release. Stated explicitly so nobody parses them.
+
+### `@svelte-vitals/core`'s `.` entry (after the split)
+
+Only what a third-party integrator legitimately needs to read a report or drive the engine:
+
+- Contract types: `Config`, `RuleSetting`, `RuleSettingObject`, `RuleOverride`, `RuleOptions`,
+  `Severity`, `Category`, `CATEGORIES`, `TreatDynamicAs`, `Result`, `Detection`, `Presence`,
+  `Value`, `Scope`, `Fix`, `Project`.
+- `defineConfig`, `defaultConfig`, `defaultProject`.
+- `Rule`, `RuleContext`, `allRules`, `explainRule`, `RuleInfo`, `RuleOptionInfo`, `runRules`,
+  `isPenalized`, `docsUrlFor`.
+- Report building: `buildJsonReport`, `formatJsonReport`, `JsonReport`, `RuleEvidence`, and the
+  other `format*Report` functions.
+- Scoring: `computeScore`, `scoresByCategory`, `computeHealth` and their result types.
+- `Runtime` (the I/O injection interface — the documented way to run core in a non-Node host).
+
+## Internal (moves to `./internal`, no promise)
+
+Everything else in today's index: AST helpers (`CHILD_NODE_KEYS`, `lineOf`, `findAttr`,
+`attrText`/`attrValue`/`attrTextOf`/`attrValueOf`, `valueFromNodes`, `textFromNodes`), fact
+collection (`parseComponentFacts`, `collectComponentFacts`, `emptyComponentFacts`,
+`collectSourceFiles`, `ComponentFacts`, `SuppressionDirective`, the `*Fact` types, the kit-module
+family), config parsing (`findMinifyDisabled`, the svelte-config family, `project-paths` constants),
+the a11y composition helpers (`foldOccurrences`, `decodeFragmentId`, `splitTokens`,
+`isTopFragment`, `LANDMARK_ROLES`, `IDREF_ATTRS`, `BranchStep`, `A11yOccurrenceInfo`,
+`ResolvedA11y`), the provider boundary types (`HeadTag`, `ResolvedHead`, `HeadProvider`,
+`ImageInfo`, `ResolvedImages`, `HeadingInfo`, `ResolvedHeadings`), config application
+(`selectRules`, `applyRuleSeverities`, `applyOverrides`, `withFailedRulesOff`, …), rule-option
+plumbing (`resolveRuleOptions`, `validateRuleSetting`, `intOption`, …), reporter internals
+(`terminalSafe`, palette, app-shell rendering), and `summarize`/`classify`/`effectiveSeverity`.
+
+`ResolvedA11y` and friends being internal is the point: the a11y roadmap's remaining increments
+reshape them.
+
+## Remove before 1.0
+
+Exported today, imported by nothing in-repo and named in no doc — publishing them at 1.0 would
+freeze surface nobody uses:
+
+- Rule factories `headTagRule`, `imageRule`, `linkRule` (internal builders for ~20 concrete rules).
+- The ~90 individual rule functions (`seoTitlePresence` … `a11yNoMissingIdRef`). They are consumed
+  only in aggregate via `allRules`, and docs address rules by id. **This retires one of the
+  four registration places AGENTS.md mandates** — a simplification the rule-adding workflow has
+  wanted since the convention's "TypeScript won't catch a missed spot" warning. `allRules` and the
+  per-rule module files stay; only the index re-export list goes.
+- App-shell internals `buildHtmlDocument`, `scoreBand`, `BAND_COLOR`, `APP_SCRIPT`, `APP_STYLE`
+  (move to `./internal` where vite's UI needs them; drop the rest).
+- Overlapping/redundant: `compileOverrides` + `overrideMatches` (steps of `applyOverrides`),
+  `validateRuleOptions` (step of `validateRuleSetting`), `isMentionedAnywhere`, `settingOptions`,
+  `intOption`/`listOption`/`mapOption` (rule-authoring helpers used only inside core),
+  `parseKitModuleFacts`, `resolveRunesModuleSpecifier`, `ViteKitConfigResult`, `RawKitAliases`,
+  `FailedRule`, `Classification`, `ConsoleReportOptions`, `CompiledOverride`.
+
+`attrText`/`attrValue` vs `attrTextOf`/`attrValueOf` (same purpose, two call shapes) stay both —
+they are internal after the split, so the duplication costs nothing publicly and consolidating them
+is a free internal change later.
+
+## Enforcement
+
+A test in `packages/core/test/` reads `src/index.ts`'s export list and compares it to a committed
+`public-surface.json` (the frozen list above). A new name in `.` fails the build with "add it to
+the frozen surface or export it from ./internal instead". This is the same forcing function the
+docs-links and kitchen-sink meta-tests already apply.
+
+`check:publish` (attw/publint) must pass for both entry points.
+
+## Corrections this audit surfaced (fix before the freeze)
+
+- `docs/.../reporters.md` (en + ja) shows `"docsUrl": "https://svelte-vitals.dev/rules/…"` in the
+  JSON example, but `docsUrlFor` emits `https://oekazuma.github.io/svelte-vitals/rules/…`. The
+  example teaches a URL the tool never produces.
+- `SvelteVitalsOptions.overrides` is absent from the plugin-mode options table and the vite README,
+  the only plugin option with no doc coverage.
+
+## Sequencing
+
+The `.`/`./internal` split and the removals land **now** (0.x, free). The freeze — the enforcement
+test plus the "frozen" wording in the READMEs — lands last, in roadmap Phase E, so the a11y
+increments in Phase C can still reshape internal signatures on the way.

--- a/docs/superpowers/specs/2026-08-16-v1-public-surface.md
+++ b/docs/superpowers/specs/2026-08-16-v1-public-surface.md
@@ -125,9 +125,11 @@ is exactly this case.
 
 - **JSON reporter** (`JsonReport`): frozen field-for-field as documented in the reporters guide —
   `version, score, weights, categories, summary, rules{findings,passed}, routes[], siteIssues[],
-inventories, examined?`, closed over `Summary`, `Result`, `Detection`, `Presence`, `Value`,
-  `Scope`, `Fix`, `RuleEvidence`, `Category`, `Severity`, and the score result types. Additive
-  fields stay minor; removing or retyping one is 2.0.
+inventories, examined?`, closed over exactly `Summary`, `RuleEvidence`, `JsonIssue`, `Result`,
+  `Detection`, `Presence`, `Value`, `Fix`, `Category`, `Severity`, `Config`, and `ScoreModel`.
+  `ScoreModel` is named rather than "the scoring types": the neighbouring `ScoreOptions` carries
+  `rules?: Rule[]`, so freezing that group would drag `Rule` → `RuleContext` → `ResolvedA11y` back
+  into the promise. Additive fields stay minor; removing or retyping one is 2.0.
 - **SARIF** stays valid SARIF 2.1.0; **GitHub** stays valid workflow commands. Both are frozen by
   reference to their external specs, not to our own layout.
 - **agent / markdown / html** reporters are **human/agent-readable output, not schemas**: their
@@ -137,12 +139,11 @@ inventories, examined?`, closed over `Summary`, `Result`, `Detection`, `Presence
 
 - `defineConfig` and the config types it closes over: `Config`, `RuleSetting`, `RuleSettingObject`,
   `RuleOverride`, `RuleOptions`, `Severity`, `Category`, `CATEGORIES`, `TreatDynamicAs`.
-- `JsonReport` and the types it closes over (listed above), plus `Project` and `KitAlias`, which
-  `Result` reaches.
+- `JsonReport` and the types it closes over (listed above).
 
-Nothing else. The split's implementation must verify closure mechanically rather than by reading:
-`internal.ts` must not be reachable from `index.ts`, and the `.d.ts` for `index` must reference no
-symbol declared outside it.
+Nothing else — and specifically **not** `Project`, `KitAlias`, or `Scope`: no frozen type reaches
+them, `Project` grows a field per project-scoped rule, and `Scope` belongs to `Rule`. They are
+internal.
 
 ## Internal (moves to `./internal`, no promise)
 
@@ -186,7 +187,7 @@ free internal change later.
 
 One thing, and it is not a symbol:
 
-- **The hand-maintained rule re-export list in `index.ts`** (lines ~100-162). `internal.ts` uses
+- **The hand-maintained rule re-export list in `index.ts`** (`index.ts` lines ~71-162). `internal.ts` uses
   `export * from './rules/index.js'` instead. **This retires one of the four registration places
   AGENTS.md mandates** — the one its own "TypeScript won't catch a missed spot" warning is about —
   while every rule function stays importable, so no test changes meaning.
@@ -218,9 +219,17 @@ A test in `packages/core/test/` reads `src/index.ts`'s export list and compares 
 export it from ./internal instead". Same forcing function as the docs-links and kitchen-sink
 meta-tests.
 
-The type-closure property gets its own check: assert that `dist/index.d.ts` references no symbol
-it does not itself declare or import from within `.`. Closure is the invariant that makes the
-frozen list meaningful, and it is not preserved by review alone.
+The type-closure property gets its own check, and it must be phrased against what the bundler
+actually emits. `rollup-plugin-dts` **inlines** every reachable in-package declaration into
+`dist/index.d.ts`, so "references only what it declares" is self-satisfying by construction — an
+accidental drag-in of an internal type would inline silently and pass. The implementable form:
+
+1. `dist/index.d.ts` contains **zero** `import` statements (today's `import { AST } from 'svelte/compiler'` must not survive into `.`), and
+2. the set of identifiers it **declares** is a subset of `public-surface.json`.
+
+Check 2 is what catches a drag-in: pulling in `RuleContext` inlines `ResolvedA11y` et al. as new
+declarations, and the subset assertion fails. Closure is the invariant that makes the frozen list
+meaningful, and it is not preserved by review alone.
 
 ## Corrections this audit surfaced (fix before the freeze)
 

--- a/docs/superpowers/specs/2026-08-16-v1-public-surface.md
+++ b/docs/superpowers/specs/2026-08-16-v1-public-surface.md
@@ -127,6 +127,9 @@ is exactly this case.
   `version, score, weights, categories, summary, rules{findings,passed}, routes[], siteIssues[],
 inventories, examined?`, closed over exactly `Summary`, `RuleEvidence`, `JsonIssue`, `Result`,
   `Detection`, `Presence`, `Value`, `Fix`, `Category`, `Severity`, `Config`, and `ScoreModel`.
+  Every field listed above, and its meaning, is frozen; new fields may be added in a minor **only
+  as optional**, and consumers must ignore fields they do not know — a parser that rejects unknown
+  keys is relying on something 1.0 does not promise.
   `ScoreModel` is named rather than "the scoring types": the neighbouring `ScoreOptions` carries
   `rules?: Rule[]`, so freezing that group would drag `Rule` → `RuleContext` → `ResolvedA11y` back
   into the promise. Additive fields stay minor; removing or retyping one is 2.0.
@@ -200,12 +203,19 @@ nothing: an internal export carries no promise.
 
 ## Implementation notes for the split
 
-Mechanical, but three call sites need care:
+**Retarget per symbol, not per file.** `./internal` does not re-export `.`'s names, so a file that
+uses both keeps two import statements — and that is the desired end state: production code
+consuming `Config`, `defineConfig`, or `JsonReport` should keep importing them from the root, where
+it demonstrates the frozen surface. cli's `config-file.ts`, `suppressions.ts`, and vite's
+`ui/middleware.ts` import a mix today (`Config` alongside `isPenalized` / `renderAppShell`); each
+such line splits rather than moves wholesale.
 
-1. **Core's own tests** import from `../src/index.js` in ~50 files. Retarget to `../src/internal.js`
-   (or the owning module) — do not widen `.` to keep a test import compiling.
-2. **cli and vite tests** import from `@svelte-vitals/core` root. Retarget to
-   `@svelte-vitals/core/internal`. Same rule: a test import is never a reason to freeze a symbol.
+Three call sites need care:
+
+1. **Core's own tests** import from `../src/index.js` in ~50 files. Retarget the internal names to
+   `../src/internal.js` (or the owning module) — do not widen `.` to keep a test import compiling.
+2. **cli and vite tests** import from `@svelte-vitals/core` root. Same per-symbol split. A test
+   import is never a reason to freeze a symbol.
 3. **`index.ts` must not import from `internal.ts`, and vice versa.** Both re-export from the same
    underlying modules; neither re-exports the other, so there is no cycle and no risk of `.`
    accidentally re-exporting internal symbols through a barrel.
@@ -214,22 +224,28 @@ Mechanical, but three call sites need care:
 
 ## Enforcement
 
-A test in `packages/core/test/` reads `src/index.ts`'s export list and compares it to a committed
-`public-surface.json`. A new name in `.` fails the build with "add it to the frozen surface or
-export it from ./internal instead". Same forcing function as the docs-links and kitchen-sink
-meta-tests.
+`public-surface.json` holds **two** sets, because exports and declarations are not the same
+question:
 
-The type-closure property gets its own check, and it must be phrased against what the bundler
-actually emits. `rollup-plugin-dts` **inlines** every reachable in-package declaration into
-`dist/index.d.ts`, so "references only what it declares" is self-satisfying by construction — an
-accidental drag-in of an internal type would inline silently and pass. The implementable form:
+- `exports` — the names `.` re-exports, split `values` / `types`. This is the promise.
+- `closure` — every identifier allowed to be **declared** in `dist/index.d.ts`. A superset of
+  `exports`: `JsonIssue` is a non-exported type alias in `reporter/json.ts` that the bundler
+  inlines, so it is legal in the closure and must never become an export.
 
-1. `dist/index.d.ts` contains **zero** `import` statements (today's `import { AST } from 'svelte/compiler'` must not survive into `.`), and
-2. the set of identifiers it **declares** is a subset of `public-surface.json`.
+A test in `packages/core/test/` asserts three things:
 
-Check 2 is what catches a drag-in: pulling in `RuleContext` inlines `ResolvedA11y` et al. as new
-declarations, and the subset assertion fails. Closure is the invariant that makes the frozen list
-meaningful, and it is not preserved by review alone.
+1. `src/index.ts`'s export list equals `exports` (and the built `dist/index.js`'s runtime exports
+   equal `exports.values`, so a build that drops or adds a name fails too). A new name fails with
+   "add it to the frozen surface or export it from ./internal instead".
+2. `dist/index.d.ts` contains **zero** `import` statements — today's
+   `import { AST } from 'svelte/compiler'` must not survive into `.`.
+3. Every identifier `dist/index.d.ts` declares is in `closure`.
+
+Assertion 3 is what catches a type drag-in, and it needs the separate set to work: `rollup-plugin-dts`
+**inlines** every reachable in-package declaration, so "references only what it declares" is
+self-satisfying by construction — pulling in `RuleContext` would inline `ResolvedA11y` et al. as new
+declarations, which `closure` rejects while `exports` alone would not have noticed. Closure is the
+invariant that makes the frozen list meaningful, and it is not preserved by review alone.
 
 ## Corrections this audit surfaced (fix before the freeze)
 

--- a/docs/superpowers/specs/2026-08-16-v1-public-surface.md
+++ b/docs/superpowers/specs/2026-08-16-v1-public-surface.md
@@ -1,8 +1,8 @@
 # Design: the 1.0 public surface
 
 Phase A-1 of `2026-08-16-v1-roadmap.md`. Decides, surface by surface, what 1.0's semver promise
-covers. Everything listed **frozen** may only change in a 2.0; everything listed **internal**
-carries no promise; everything listed **remove before 1.0** goes away while removal is still free.
+covers. **Frozen** may only change in a 2.0; **internal** carries no promise; **removed** goes away
+while removal is still free.
 
 The classification rests on one measured fact: of `@svelte-vitals/core`'s ~50 export statements,
 **zero** are referenced by the docs site or by any package README — the package's own README says
@@ -27,8 +27,28 @@ public only because they cross a package boundary.
   `@svelte-vitals/vite` import their plumbing from here; both are versioned in lockstep with core
   through workspace ranges, so a breaking internal change is a same-PR change.
 
-This keeps internal refactors free after 1.0 (composition memoization, the seven-walk
-consolidation, and the a11y Phase 2/3 work all touch these signatures) without a major bump.
+`@svelte-vitals/vite` already ships a two-entry ESM build (`.` + `./hooks`) through the same
+tsup + publint/attw pipeline, so the mechanism is proven in-repo. `scripts/floor-smoke.mjs`
+resolves `dist/index.js` by path, which the split leaves intact.
+
+### The `.` entry is type-closed, and that is what makes it small
+
+A frozen export may not reference a type that is internal — otherwise a patch-legal change to the
+internal type silently breaks the frozen contract. Today's index fails this badly: `runRules`
+returns `FailedRule[]`; `RuleContext` embeds `ResolvedHead`, `ResolvedImages`, `ResolvedHeadings`,
+`ResolvedA11y`, `ComponentFacts`, `KitModuleFacts`; `Rule.options` is a `RuleOptionsSpec`;
+`formatConsoleReport` takes `ConsoleReportOptions`. Freezing any of those drags the entire engine
+into the promise — including `ResolvedA11y`, which roadmap Phase C exists to reshape.
+
+So `.` is scoped to the two jobs an outside caller actually has, and closed under both:
+
+1. **Authoring a config** — `defineConfig` and the `Config` type graph.
+2. **Reading a report** — the `JsonReport` type graph.
+
+Everything engine-side (`Rule`, `RuleContext`, `allRules`, `runRules`, `explainRule`, `Runtime`,
+the non-JSON `format*Report` functions, scoring functions) is **internal**. None of it is taught by
+any doc, and each can be promoted into `.` in a 1.x minor once a real consumer asks — promotion is
+additive, so nothing is lost by starting closed.
 
 ## Frozen at 1.0
 
@@ -39,10 +59,20 @@ consolidation, and the a11y Phase 2/3 work all touch these signatures) without a
   `--no-suppressions`, `--by-route`, `--reporter`, `--out-file`, `--fail-on`, `--min-health`,
   `--rules`, `--ignore`, `--category`, `--weights`, `--score`, `--no-color`, `--no-animation`,
   `--verbose`, `--help`, `--version`), and the `install` / `ci` / `explain` / `docs` sub-commands
-  with their flags. Adding flags stays minor; removing or repurposing one is 2.0.
+  with their flags. Adding flags stays minor; removing or repurposing one is 2.0. The list is
+  illustrative of scope, not the enforcement artifact — see Sequencing.
+- **Reporter names** (`--reporter` values) and the auto-detection contract: which environment
+  signals pick which default reporter is documented behaviour, so changing a signal's meaning is
+  2.0. Adding a reporter name is minor.
 - **Exit codes**: `0` clean · `1` failing finding or threshold · `2` execution error.
 - **`defineConfig`** re-exported from `svelte-vitals` (the package users install). This is the only
   programmatic export the docs teach.
+- **Scaffolding outputs**: the file paths `install` and `ci install` write (agent skill file,
+  config file, workflow file) and the fact that the scaffolded workflow pins the Action by a
+  generated version. Their _contents_ are not frozen — they are generated guidance, and both
+  commands are re-runnable.
+- **`docs show <topic>`**: the topic names are frozen (they appear in agent instructions); the
+  prose is not.
 
 The rest of `packages/cli/src/index.ts`'s exports (`run`, `analyzeProject`, `applyScope`,
 `routeMatcher`, `loadConfigFile`, `findUnknownRuleIds`, …) are **internal**: no doc teaches them,
@@ -58,13 +88,26 @@ a future "programmatic API" is a deliberate 1.x addition, not an accident.
   (`metaComponents`, `rules`).
 - The dev-dashboard route (`/__svelte-vitals/`) as a URL, not its HTML.
 
+### Package names and engines
+
+- The three published names (`svelte-vitals`, `@svelte-vitals/core`, `@svelte-vitals/vite`) and
+  their subpaths (`./internal`, `./hooks`).
+- **`engines.node`**: raising the floor to a Node line that is still in Long Term Support at the
+  time of the bump is a **minor**; dropping to an unsupported-by-us line or raising past current
+  LTS is 2.0. Stated because a Node floor is the most commonly disputed semver surface for a CLI
+  and AGENTS.md already treats the published floor as a promise to end users.
+
 ### Configuration
 
 The config file schema in full: `treatDynamicAs`, `metaComponents`, `rules` (with the
 `'off' | Severity | { severity, options }` setting shapes), `failOn`, `weights`, `overrides`
 (`route` / `files` globs + `rules` keyed by rule id or category), and the documented precedence
 (CLI flag > config file > default, `--rules`/`--ignore` as selection exceptions). Config file
-discovery order and the `.ts`/`.mjs` support matrix are frozen too.
+names, discovery order, and the `.ts`/`.mjs` support matrix are frozen too.
+
+**Adding a top-level config key, or a new option to an existing rule, is a minor** — the schema is
+frozen against removal and reinterpretation, not against growth. Phase C's component-mapping key
+is exactly this case.
 
 ### Rule identity and persisted data
 
@@ -82,7 +125,9 @@ discovery order and the `.ts`/`.mjs` support matrix are frozen too.
 
 - **JSON reporter** (`JsonReport`): frozen field-for-field as documented in the reporters guide —
   `version, score, weights, categories, summary, rules{findings,passed}, routes[], siteIssues[],
-inventories, examined?`. Additive fields stay minor; removing or retyping one is 2.0.
+inventories, examined?`, closed over `Summary`, `Result`, `Detection`, `Presence`, `Value`,
+  `Scope`, `Fix`, `RuleEvidence`, `Category`, `Severity`, and the score result types. Additive
+  fields stay minor; removing or retyping one is 2.0.
 - **SARIF** stays valid SARIF 2.1.0; **GitHub** stays valid workflow commands. Both are frozen by
   reference to their external specs, not to our own layout.
 - **agent / markdown / html** reporters are **human/agent-readable output, not schemas**: their
@@ -90,68 +135,92 @@ inventories, examined?`. Additive fields stay minor; removing or retyping one is
 
 ### `@svelte-vitals/core`'s `.` entry (after the split)
 
-Only what a third-party integrator legitimately needs to read a report or drive the engine:
+- `defineConfig` and the config types it closes over: `Config`, `RuleSetting`, `RuleSettingObject`,
+  `RuleOverride`, `RuleOptions`, `Severity`, `Category`, `CATEGORIES`, `TreatDynamicAs`.
+- `JsonReport` and the types it closes over (listed above), plus `Project` and `KitAlias`, which
+  `Result` reaches.
 
-- Contract types: `Config`, `RuleSetting`, `RuleSettingObject`, `RuleOverride`, `RuleOptions`,
-  `Severity`, `Category`, `CATEGORIES`, `TreatDynamicAs`, `Result`, `Detection`, `Presence`,
-  `Value`, `Scope`, `Fix`, `Project`.
-- `defineConfig`, `defaultConfig`, `defaultProject`.
-- `Rule`, `RuleContext`, `allRules`, `explainRule`, `RuleInfo`, `RuleOptionInfo`, `runRules`,
-  `isPenalized`, `docsUrlFor`.
-- Report building: `buildJsonReport`, `formatJsonReport`, `JsonReport`, `RuleEvidence`, and the
-  other `format*Report` functions.
-- Scoring: `computeScore`, `scoresByCategory`, `computeHealth` and their result types.
-- `Runtime` (the I/O injection interface — the documented way to run core in a non-Node host).
+Nothing else. The split's implementation must verify closure mechanically rather than by reading:
+`internal.ts` must not be reachable from `index.ts`, and the `.d.ts` for `index` must reference no
+symbol declared outside it.
 
 ## Internal (moves to `./internal`, no promise)
 
-Everything else in today's index: AST helpers (`CHILD_NODE_KEYS`, `lineOf`, `findAttr`,
-`attrText`/`attrValue`/`attrTextOf`/`attrValueOf`, `valueFromNodes`, `textFromNodes`), fact
-collection (`parseComponentFacts`, `collectComponentFacts`, `emptyComponentFacts`,
-`collectSourceFiles`, `ComponentFacts`, `SuppressionDirective`, the `*Fact` types, the kit-module
-family), config parsing (`findMinifyDisabled`, the svelte-config family, `project-paths` constants),
-the a11y composition helpers (`foldOccurrences`, `decodeFragmentId`, `splitTokens`,
-`isTopFragment`, `LANDMARK_ROLES`, `IDREF_ATTRS`, `BranchStep`, `A11yOccurrenceInfo`,
-`ResolvedA11y`), the provider boundary types (`HeadTag`, `ResolvedHead`, `HeadProvider`,
-`ImageInfo`, `ResolvedImages`, `HeadingInfo`, `ResolvedHeadings`), config application
-(`selectRules`, `applyRuleSeverities`, `applyOverrides`, `withFailedRulesOff`, …), rule-option
-plumbing (`resolveRuleOptions`, `validateRuleSetting`, `intOption`, …), reporter internals
-(`terminalSafe`, palette, app-shell rendering), and `summarize`/`classify`/`effectiveSeverity`.
+Everything else in today's index, without exception. Named here only where a reader would expect a
+different answer:
+
+- The engine: `Rule`, `RuleContext`, `allRules`, `runRules`, `FailedRule`, `explainRule`,
+  `RuleInfo`, `RuleOptionInfo`, `isPenalized`, `docsUrlFor`, `Runtime`.
+- Report machinery other than the JSON types: `buildJsonReport`, `formatJsonReport`, every other
+  `format*Report`, `ConsoleReportOptions`, `terminalSafe`, the palette, the app-shell renderers
+  (`buildHtmlDocument`, `scoreBand`, `BAND_COLOR`, `APP_SCRIPT`, `APP_STYLE` — vite's dashboard and
+  its tests consume these), scoring functions, `summarize`, `classify`, `Classification`,
+  `effectiveSeverity`.
+- Fact collection and AST helpers: `CHILD_NODE_KEYS`, `lineOf`, `findAttr`, the `attr*` family,
+  `valueFromNodes`, `textFromNodes`, `parseComponentFacts`, `collectComponentFacts`,
+  `emptyComponentFacts`, `collectSourceFiles`, `ComponentFacts`, `SuppressionDirective`, the
+  `*Fact` types, and the **whole** kit-module family — `parseKitModuleFacts`,
+  `resolveRunesModuleSpecifier`, and `resolveRepoLocalPath` (which cli's source resolver imports
+  and an earlier draft of this spec left unclassified).
+- Config plumbing: `findMinifyDisabled`, the svelte-config family, `project-paths` constants,
+  `selectRules`, `applyRuleSeverities`, `applyOverrides`, `compileOverrides`, `overrideMatches`,
+  `CompiledOverride`, `withFailedRulesOff`, `isMentionedAnywhere`, `resolveRuleOptions`,
+  `validateRuleSetting`, `validateRuleOptions`, `settingOptions`, `intOption`, `listOption`,
+  `mapOption`.
+- The a11y composition helpers (`foldOccurrences`, `decodeFragmentId`, `splitTokens`,
+  `isTopFragment`, `LANDMARK_ROLES`, `IDREF_ATTRS`, `BranchStep`, `A11yOccurrenceInfo`,
+  `ResolvedA11y`), the provider boundary types (`HeadTag`, `ResolvedHead`, `HeadProvider`,
+  `ImageInfo`, `ResolvedImages`, `HeadingInfo`, `ResolvedHeadings`), and the rule factories
+  `headTagRule`, `imageRule`, `linkRule`.
+- The ~90 individual rule functions (`seoTitlePresence` … `a11yNoMissingIdRef`) — ~30 core tests
+  and 3 cli tests import them by name.
 
 `ResolvedA11y` and friends being internal is the point: the a11y roadmap's remaining increments
 reshape them.
 
-## Remove before 1.0
-
-Exported today, imported by nothing in-repo and named in no doc — publishing them at 1.0 would
-freeze surface nobody uses:
-
-- Rule factories `headTagRule`, `imageRule`, `linkRule` (internal builders for ~20 concrete rules).
-- The ~90 individual rule functions (`seoTitlePresence` … `a11yNoMissingIdRef`). They are consumed
-  only in aggregate via `allRules`, and docs address rules by id. **This retires one of the
-  four registration places AGENTS.md mandates** — a simplification the rule-adding workflow has
-  wanted since the convention's "TypeScript won't catch a missed spot" warning. `allRules` and the
-  per-rule module files stay; only the index re-export list goes.
-- App-shell internals `buildHtmlDocument`, `scoreBand`, `BAND_COLOR`, `APP_SCRIPT`, `APP_STYLE`
-  (move to `./internal` where vite's UI needs them; drop the rest).
-- Overlapping/redundant: `compileOverrides` + `overrideMatches` (steps of `applyOverrides`),
-  `validateRuleOptions` (step of `validateRuleSetting`), `isMentionedAnywhere`, `settingOptions`,
-  `intOption`/`listOption`/`mapOption` (rule-authoring helpers used only inside core),
-  `parseKitModuleFacts`, `resolveRunesModuleSpecifier`, `ViteKitConfigResult`, `RawKitAliases`,
-  `FailedRule`, `Classification`, `ConsoleReportOptions`, `CompiledOverride`.
-
 `attrText`/`attrValue` vs `attrTextOf`/`attrValueOf` (same purpose, two call shapes) stay both —
-they are internal after the split, so the duplication costs nothing publicly and consolidating them
-is a free internal change later.
+internal after the split, so the duplication costs nothing publicly and consolidating them is a
+free internal change later.
+
+## Removed
+
+One thing, and it is not a symbol:
+
+- **The hand-maintained rule re-export list in `index.ts`** (lines ~100-162). `internal.ts` uses
+  `export * from './rules/index.js'` instead. **This retires one of the four registration places
+  AGENTS.md mandates** — the one its own "TypeScript won't catch a missed spot" warning is about —
+  while every rule function stays importable, so no test changes meaning.
+
+Nothing else is deleted. An earlier draft listed ~20 symbols as "imported by nothing in-repo";
+that was measured against `src/` only and is false — `packages/core/test` (≈50 files),
+`packages/cli/test` (3 files importing rule functions), and `packages/vite/test` (4 files importing
+`APP_SCRIPT` / `buildHtmlDocument`) all import them. Reclassifying instead of deleting costs
+nothing: an internal export carries no promise.
+
+## Implementation notes for the split
+
+Mechanical, but three call sites need care:
+
+1. **Core's own tests** import from `../src/index.js` in ~50 files. Retarget to `../src/internal.js`
+   (or the owning module) — do not widen `.` to keep a test import compiling.
+2. **cli and vite tests** import from `@svelte-vitals/core` root. Retarget to
+   `@svelte-vitals/core/internal`. Same rule: a test import is never a reason to freeze a symbol.
+3. **`index.ts` must not import from `internal.ts`, and vice versa.** Both re-export from the same
+   underlying modules; neither re-exports the other, so there is no cycle and no risk of `.`
+   accidentally re-exporting internal symbols through a barrel.
+
+`check:publish` (publint + attw `--profile esm-only`) must pass for both entry points.
 
 ## Enforcement
 
 A test in `packages/core/test/` reads `src/index.ts`'s export list and compares it to a committed
-`public-surface.json` (the frozen list above). A new name in `.` fails the build with "add it to
-the frozen surface or export it from ./internal instead". This is the same forcing function the
-docs-links and kitchen-sink meta-tests already apply.
+`public-surface.json`. A new name in `.` fails the build with "add it to the frozen surface or
+export it from ./internal instead". Same forcing function as the docs-links and kitchen-sink
+meta-tests.
 
-`check:publish` (attw/publint) must pass for both entry points.
+The type-closure property gets its own check: assert that `dist/index.d.ts` references no symbol
+it does not itself declare or import from within `.`. Closure is the invariant that makes the
+frozen list meaningful, and it is not preserved by review alone.
 
 ## Corrections this audit surfaced (fix before the freeze)
 
@@ -163,6 +232,11 @@ docs-links and kitchen-sink meta-tests already apply.
 
 ## Sequencing
 
-The `.`/`./internal` split and the removals land **now** (0.x, free). The freeze — the enforcement
-test plus the "frozen" wording in the READMEs — lands last, in roadmap Phase E, so the a11y
-increments in Phase C can still reshape internal signatures on the way.
+The `.`/`./internal` split and the re-export removal land **now** (0.x, free). The freeze — the
+enforcement artifact plus the "frozen" wording in the READMEs — lands last, in roadmap Phase E, so
+the a11y increments in Phase C can still reshape internal signatures on the way.
+
+Consequence: **the enumerations in this document are the decision, not the artifact.** Phases C-D
+add flags, config keys, and rule ids. At Phase E, `public-surface.json` and the flag list are
+re-derived from the code as it stands, and this document is what says which _kind_ of thing belongs
+in them.


### PR DESCRIPTION
Phase A-1 of the v1.0 roadmap: decide, surface by surface, what the 1.0 semver promise covers. Design doc only — no code changes.

## The decision

`@svelte-vitals/core` splits into two entry points:

- `.` — frozen, and **type-closed**: `defineConfig` + the `Config` type graph, and the `JsonReport` type graph. Nothing else.
- `./internal` — everything cli and vite share, with an explicit "no semver guarantee, may change in any patch" statement.

Type-closure is what keeps `.` small. A frozen export may not reference an internal type, or a patch-legal change to that type silently breaks the promise. Today's index fails this: `runRules` returns `FailedRule[]`, `RuleContext` embeds `ResolvedA11y`/`ComponentFacts`/…, `formatConsoleReport` takes `ConsoleReportOptions`. Freezing the engine would freeze exactly the types roadmap Phase C exists to reshape — so the whole engine starts internal and can be promoted additively in a 1.x minor if a real consumer asks.

The classification rests on one measured fact: zero of core's ~50 exports are referenced by the docs site or any package README.

## Also decided

CLI flags, reporter names + auto-detection, exit codes, scaffolding paths, `docs show` topic names; plugin options; package names and the `engines.node` bump policy; the full config schema with an explicit additive-is-minor rule; rule ids, `findingKey`, the suppressions file, inline directive syntax, docs URL shape; JSON/SARIF/GitHub report shapes (and that agent/markdown/html are output, not schemas).

Only one thing is *removed*: the hand-maintained rule re-export list in `index.ts`, replaced by `export *` in `internal.ts` — which retires one of the four rule-registration places AGENTS.md mandates, without changing any import's meaning.

## Enforcement

A committed `public-surface.json` compared against `src/index.ts`'s exports, plus a closure check phrased against what the bundler actually emits: `dist/index.d.ts` must contain zero import statements, and the identifiers it declares must be a subset of the frozen list. (Naive "references only what it declares" is vacuous — rollup-plugin-dts inlines everything reachable.)

## Sequencing

The split and the removal land now, on 0.x. The freeze itself lands in roadmap Phase E, so Phase C's a11y increments can still reshape internal signatures. The enumerations here are the decision, not the artifact — `public-surface.json` is re-derived from code at Phase E.

Two doc corrections surfaced by the audit are recorded for fixing before the freeze: `reporters.md` shows a `docsUrl` origin the tool never emits, and `SvelteVitalsOptions.overrides` has no doc coverage.

The spec went through two rounds of adversarial review; the second returned APPROVE, and its three remaining minors (name `ScoreModel` rather than "the scoring types"; drop `Project`/`KitAlias`/`Scope`, which nothing frozen reaches; make the closure check implementable) are folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a design specification defining the planned 1.0 public API surface.
  * Documented which interfaces are public, frozen, or internal.
  * Clarified package entry points, type boundaries, enforcement checks, and implementation sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->