### PR TITLE
fix(core): analyze components whose styles use a CSS dialect

### DIFF
--- a/.changeset/tricky-melons-shave.md
+++ b/.changeset/tricky-melons-shave.md
@@ -1,0 +1,13 @@
+---
+'@svelte-vitals/core': patch
+'svelte-vitals': patch
+---
+
+Fix analysis aborting on any project that writes its component styles in a CSS dialect.
+
+Svelte parses a `<style>` body as CSS whatever its `lang` attribute says, so a single
+`<style lang="scss">` block made a component unparseable — and one unparseable route file
+fails the whole run with exit 2. Projects using SCSS, Less, or Stylus could not be analyzed
+at all. Style bodies with a `lang` attribute are now blanked before parsing, preserving every
+byte offset so reported lines are unchanged; nothing in the analysis reads CSS. Genuinely
+malformed components still fail as before.

--- a/.changeset/tricky-melons-shave.md
+++ b/.changeset/tricky-melons-shave.md
@@ -11,3 +11,6 @@ fails the whole run with exit 2. Projects using SCSS, Less, or Stylus could not 
 at all. Style bodies with a `lang` attribute are now blanked before parsing, preserving every
 byte offset so reported lines are unchanged; nothing in the analysis reads CSS. Genuinely
 malformed components still fail as before.
+
+The rewrite is a retry, not a preprocessing step: a component that parses is never touched, so
+only sources that are already a hard failure can reach it.

--- a/packages/cli/src/providers/source/parse.ts
+++ b/packages/cli/src/providers/source/parse.ts
@@ -1,7 +1,7 @@
-import { parse } from 'svelte/compiler';
 import type { AST } from 'svelte/compiler';
 import type { BranchStep, HeadTag } from '@svelte-vitals/core/internal';
 import {
+  parseSvelte,
   CHILD_NODE_KEYS,
   lineOf,
   findAttr,
@@ -455,7 +455,7 @@ export interface ParsedFile {
 
 /** Parse a .svelte source into its layer-1 head tags, component usages, and imports. */
 export function parseFile(source: string, filename: string): ParsedFile {
-  const ast = parse(source, { modern: true, filename });
+  const ast = parseSvelte(source, filename);
   const heads: AST.SvelteHead[] = [];
   collectSvelteHeads(ast.fragment, heads);
   const components: ComponentUse[] = [];
@@ -479,7 +479,7 @@ export function parseFile(source: string, filename: string): ParsedFile {
  * <svelte:head> blocks (detection layer 1 — literal svelte:head, design §11).
  */
 export function parseHeadTags(source: string, filename: string): ParsedTag[] {
-  const ast = parse(source, { modern: true, filename });
+  const ast = parseSvelte(source, filename);
   const heads: AST.SvelteHead[] = [];
   collectSvelteHeads(ast.fragment, heads);
   return heads.flatMap(tagsFromHead);

--- a/packages/cli/test/malformed-svelte.test.ts
+++ b/packages/cli/test/malformed-svelte.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path';
 import { cpSync, mkdtempSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { collectComponentFacts, type Runtime } from '@svelte-vitals/core/internal';
+import { parseFile } from '../src/providers/source/parse.js';
 import { run } from '../src/index.js';
 import { createNodeRuntime } from '../src/runtime/node.js';
 
@@ -226,5 +227,16 @@ describe('run(): malformed .svelte files (route path)', () => {
     const code = await run({ cwd: malformedRouteProject, log: cap.log, errorLog: cap.errorLog, env: CLEAN_ENV });
     expect(code).toBe(2);
     expect(cap.err.join('\n')).toMatch(/^svelte-vitals:/);
+  });
+});
+
+describe('style blocks in a CSS dialect', () => {
+  it('parses the head of a component whose <style> is SCSS', () => {
+    const pf = parseFile(
+      `<svelte:head><title>About</title></svelte:head>` +
+        `<style lang="scss">\n  .a { color: red; // note\n    .b { color: blue; }\n  }\n</style>`,
+      'src/routes/+page.svelte'
+    );
+    expect(pf.headTags).toEqual([{ kind: 'title', text: 'About', value: 'static' }]);
   });
 });

--- a/packages/core/src/component-parse.ts
+++ b/packages/core/src/component-parse.ts
@@ -17,7 +17,16 @@ import type {
   UnnamedInteractiveFact
 } from './component.js';
 import { isRootRelativePath } from './base-path.js';
-import { CHILD_NODE_KEYS, lineOf, findAttr, attrTextOf, attrText, attrValueOf, textFromNodes } from './svelte-ast.js';
+import {
+  CHILD_NODE_KEYS,
+  lineOf,
+  findAttr,
+  attrTextOf,
+  attrText,
+  attrValueOf,
+  textFromNodes,
+  parseSvelte
+} from './svelte-ast.js';
 import { isInteractiveElement, isInteractiveContainer, type ElementAttr } from './rules/a11y/interactive.js';
 
 // The Svelte AST is structurally complex and only partially typed for our needs,
@@ -2504,7 +2513,7 @@ function parseModuleFacts(source: string, filename: string): ParsedFacts {
 export function parseComponentFacts(source: string, filename: string): ParsedFacts {
   if (MODULE_FILE_RE.test(filename)) return parseModuleFacts(source, filename);
 
-  const ast = parse(source, { modern: true, filename }) as Node;
+  const ast = parseSvelte(source, filename) as unknown as Node;
   const eachBlocks: EachBlockFact[] = [];
   collectEachBlocks(ast.fragment ?? ast, source, eachBlocks);
   const htmlTags: SourceSpan[] = [];

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -47,7 +47,8 @@ export {
   attrText,
   attrValue,
   attrValueOf,
-  attrTextOf
+  attrTextOf,
+  parseSvelte
 } from './svelte-ast.js';
 export { ROBOTS_SOURCE_PATHS, SITEMAP_SOURCE_PATHS, VITE_CONFIG_FILES, SVELTE_CONFIG_FILES } from './project-paths.js';
 export type { Runtime } from './runtime.js';

--- a/packages/core/src/svelte-ast.ts
+++ b/packages/core/src/svelte-ast.ts
@@ -1,5 +1,24 @@
-import type { AST } from 'svelte/compiler';
+import { parse, type AST } from 'svelte/compiler';
 import type { Value } from './types.js';
+
+/**
+ * `<style lang="scss">` and friends, with their bodies blanked to spaces of the same length.
+ * Svelte parses a `<style>` body as CSS whatever its `lang` says, so a preprocessor dialect makes
+ * the whole file unparseable — and one unparseable route file fails the entire run. Nothing here
+ * reads CSS, and blanking preserves every byte offset, so the substitution is invisible to callers.
+ */
+const PREPROCESSED_STYLE_RE = /(<style\b[^>]*\blang\s*=\s*['"]?[^'"\s>]+['"]?[^>]*>)([\s\S]*?)(<\/style>)/gi;
+
+/** Parse a `.svelte` source, tolerating style blocks written in a CSS dialect we never read. */
+export function parseSvelte(source: string, filename: string): AST.Root {
+  return parse(
+    source.replace(
+      PREPROCESSED_STYLE_RE,
+      (_m, open: string, body: string, close: string) => open + body.replace(/[^\n]/g, ' ') + close
+    ),
+    { modern: true, filename }
+  );
+}
 
 /** A template fragment's child node relevant to value classification: literal text or a `{expr}`. */
 type TextOrExpr = AST.Text | AST.ExpressionTag;

--- a/packages/core/src/svelte-ast.ts
+++ b/packages/core/src/svelte-ast.ts
@@ -2,22 +2,35 @@ import { parse, type AST } from 'svelte/compiler';
 import type { Value } from './types.js';
 
 /**
- * `<style lang="scss">` and friends, with their bodies blanked to spaces of the same length.
- * Svelte parses a `<style>` body as CSS whatever its `lang` says, so a preprocessor dialect makes
- * the whole file unparseable — and one unparseable route file fails the entire run. Nothing here
- * reads CSS, and blanking preserves every byte offset, so the substitution is invisible to callers.
+ * `<style lang="scss">` and friends. The leading `\s` before `lang` is what keeps `data-lang` out.
+ * This is a text scan, not a parse, so it can also match style-like text inside a script string or
+ * an attribute — which is why it only ever runs on a source Svelte has already refused.
  */
-const PREPROCESSED_STYLE_RE = /(<style\b[^>]*\blang\s*=\s*['"]?[^'"\s>]+['"]?[^>]*>)([\s\S]*?)(<\/style>)/gi;
+const PREPROCESSED_STYLE_RE = /(<style\b[^>]*\slang\s*=\s*['"]?[^'"\s>]+['"]?[^>]*>)([\s\S]*?)(<\/style>)/gi;
 
-/** Parse a `.svelte` source, tolerating style blocks written in a CSS dialect we never read. */
+/**
+ * Parse a `.svelte` source, tolerating style blocks written in a CSS dialect.
+ *
+ * Svelte parses a `<style>` body as CSS whatever its `lang` says, so one `<style lang="scss">`
+ * makes a component unparseable — and one unparseable route file fails the entire run. On failure
+ * the dialect bodies are blanked to spaces of the same length (nothing here reads CSS, and equal
+ * length keeps every byte offset, so reported lines are unchanged) and the parse is retried.
+ *
+ * The retry, not the substitution, is the design: a file that parses today is never rewritten, so
+ * the text scan's imprecision cannot reach it. A file that does not parse is already a hard failure,
+ * which the retry can only improve on.
+ */
 export function parseSvelte(source: string, filename: string): AST.Root {
-  return parse(
-    source.replace(
+  try {
+    return parse(source, { modern: true, filename });
+  } catch (err) {
+    const blanked = source.replace(
       PREPROCESSED_STYLE_RE,
       (_m, open: string, body: string, close: string) => open + body.replace(/[^\n]/g, ' ') + close
-    ),
-    { modern: true, filename }
-  );
+    );
+    if (blanked === source) throw err;
+    return parse(blanked, { modern: true, filename });
+  }
 }
 
 /** A template fragment's child node relevant to value classification: literal text or a `{expr}`. */

--- a/packages/core/test/svelte-ast.test.ts
+++ b/packages/core/test/svelte-ast.test.ts
@@ -150,4 +150,15 @@ describe('parseSvelte', () => {
   it('still throws on a genuinely malformed component', () => {
     expect(() => parseSvelte('<div>{#if x}</div>', 'src/routes/+page.svelte')).toThrow();
   });
+
+  it('leaves a source that already parses untouched, style-like text and all', () => {
+    // The blanking scan is text, not parse, so it could match inside a string or an attribute.
+    // It never runs on these: they parse on the first attempt.
+    const embedded = `<script>const s = '<style lang="scss">.a { color: red; }</style>';</script><p>x</p>`;
+    expect(() => parseSvelte(embedded, 'src/routes/+page.svelte')).not.toThrow();
+
+    const dataLang = `<p>x</p><style data-lang="scss">.a { color: red; }</style>`;
+    const ast = parseSvelte(dataLang, 'src/routes/+page.svelte');
+    expect(ast.css?.children.length).toBe(1);
+  });
 });

--- a/packages/core/test/svelte-ast.test.ts
+++ b/packages/core/test/svelte-ast.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { AST } from 'svelte/compiler';
 import {
+  parseSvelte,
   valueFromNodes,
   textFromNodes,
   attrText,
@@ -126,5 +127,27 @@ describe('lineOf', () => {
   it('returns 0 for an unknown/invalid offset', () => {
     expect(lineOf('abc', undefined)).toBe(0);
     expect(lineOf('abc', -1)).toBe(0);
+  });
+});
+
+describe('parseSvelte', () => {
+  // Svelte parses a <style> body as CSS whatever its `lang` says, so a preprocessor dialect made the
+  // whole file unparseable — and one unparseable route file fails the entire run.
+  const scss = `<h1 id="t">Hi</h1>\n<style lang="scss">\n  .a { color: red; // note\n    .b { color: blue; }\n  }\n</style>`;
+
+  it('parses a component whose style block is in a CSS dialect', () => {
+    const ast = parseSvelte(scss, 'src/routes/+page.svelte');
+    expect(ast.fragment.nodes.some((n) => n.type === 'RegularElement' && n.name === 'h1')).toBe(true);
+  });
+
+  it('leaves every offset where it was, so reported lines stay correct', () => {
+    const trailing = `${scss}\n<p>after</p>`;
+    const ast = parseSvelte(trailing, 'src/routes/+page.svelte');
+    const p = ast.fragment.nodes.find((n) => n.type === 'RegularElement' && n.name === 'p');
+    expect(lineOf(trailing, p!.start)).toBe(7);
+  });
+
+  it('still throws on a genuinely malformed component', () => {
+    expect(() => parseSvelte('<div>{#if x}</div>', 'src/routes/+page.svelte')).toThrow();
   });
 });


### PR DESCRIPTION
Found while assembling the ecosystem corpus for roadmap Phase B-3: `lissy93/networking-toolbox` (a real SvelteKit app) exits **2** with

```
svelte-vitals: Expected a valid CSS identifier
https://svelte.dev/e/css_expected_identifier
```

## Cause

Svelte parses a `<style>` body as CSS **whatever its `lang` attribute says**. A single `<style lang="scss">` block therefore makes the component unparseable, and one unparseable route file fails the entire run — a deliberate contract for malformed input (`packages/cli/src/providers/source/resolve.ts:33-36`), but these files are not malformed.

31 of that project's components hit it. Any SvelteKit project written with SCSS, Less, or Stylus **cannot be analyzed at all** today.

## Fix

A shared `parseSvelte()` in `packages/core/src/svelte-ast.ts` blanks the body of any `<style>` carrying a `lang` attribute to spaces of the same length, then parses. Nothing in the analysis reads CSS, and blanking preserves every byte offset, so reported lines are unchanged. All four `.svelte` parse sites — two in core, two in the CLI's source provider — now go through it, so the handling cannot be forgotten at a fifth.

Plain `<style>` is untouched: a CSS syntax error there is a real Svelte compile error, and the malformed-input contract still applies.

## Verified

`networking-toolbox` now exits 0 with 541 routes and all 88 rules reporting. The other seven corpus candidates were unaffected and stay green (`cobalt/web`, `kener`, `AdventureLog/frontend`, `VERT`, `CMSaasStarter`, `animotion`, `svelte-commerce`, plus `svelte.dev`, `shadcn-svelte/docs`, `joy-of-code`).

Three new tests: the dialect style block parses, offsets are preserved so a following element still reports line 7, and a genuinely malformed component still throws. Plus a CLI-side case proving the head pass tolerates it.

`pnpm build`, `pnpm typecheck`, `pnpm test` (core 1521 / cli 1213 / vite 250 / kitchen-sink 16), `pnpm lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved analysis of Svelte components containing SCSS, Less, Stylus, and other non-CSS style blocks.
  - Preserved source locations and line reporting when preprocessing style content.
  - Head content and component markup can now be analyzed reliably even when styles use alternate languages.
  - Components with genuinely malformed markup continue to report parsing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->