### PR TITLE
fix(cli): match a --route glob written with a leading slash

### DIFF
--- a/.changeset/olive-camels-tell.md
+++ b/.changeset/olive-camels-tell.md
@@ -1,0 +1,11 @@
+---
+'svelte-vitals': patch
+---
+
+Fix `--route` selecting nothing when the glob is written with a leading slash.
+
+Routes were matched with their leading slash stripped but the glob was not, so
+`--route "/blog/**"` — the form the CLI guide documents, and the form every route the tool
+prints is written in — matched no route at all. The run reported zero findings and exited 0,
+so a CI job scoped to a subtree looked green while checking nothing. The glob is now
+normalized the same way the route is; both `/blog/**` and `blog/**` select the same routes.

--- a/examples/kitchen-sink/test/e2e-static.test.ts
+++ b/examples/kitchen-sink/test/e2e-static.test.ts
@@ -83,9 +83,13 @@ describe('kitchen-sink e2e (static mode)', () => {
 
   it('exits 1 on the gallery (critical present) and 0 on clean routes', () => {
     expect(exitCode).toBe(1);
-    const clean = execFileSync(process.execPath, [bin, appDir, '--route', '/clean', '--reporter', 'json'], {
+    const clean = execFileSync(process.execPath, [bin, appDir, '--route', '/clean/**', '--reporter', 'json'], {
       encoding: 'utf8'
     });
-    expect(JSON.parse(clean).rules).toBeDefined();
+    // Assert the scope selected something before asserting it is clean: a glob that matches no
+    // route also produces zero findings, which is how a broken `--route` passes for a canary.
+    const report = JSON.parse(clean) as { routes: { route: string; issues: unknown[] }[] };
+    expect(report.routes.length).toBeGreaterThan(1);
+    expect(report.routes.flatMap((r) => r.issues)).toEqual([]);
   });
 });

--- a/examples/kitchen-sink/test/e2e-static.test.ts
+++ b/examples/kitchen-sink/test/e2e-static.test.ts
@@ -86,10 +86,12 @@ describe('kitchen-sink e2e (static mode)', () => {
     const clean = execFileSync(process.execPath, [bin, appDir, '--route', '/clean/**', '--reporter', 'json'], {
       encoding: 'utf8'
     });
-    // Assert the scope selected something before asserting it is clean: a glob that matches no
-    // route also produces zero findings, which is how a broken `--route` passes for a canary.
+    // Assert the scope both selected and filtered before asserting it is clean. A glob matching no
+    // route produces zero findings, and a `--route` ignored entirely returns the whole gallery —
+    // either way an unguarded canary passes while checking nothing it claims to.
     const report = JSON.parse(clean) as { routes: { route: string; issues: unknown[] }[] };
     expect(report.routes.length).toBeGreaterThan(1);
+    expect(report.routes.map((r) => r.route).every((r) => r.startsWith('/clean'))).toBe(true);
     expect(report.routes.flatMap((r) => r.issues)).toEqual([]);
   });
 });

--- a/packages/cli/src/route-matcher.ts
+++ b/packages/cli/src/route-matcher.ts
@@ -3,7 +3,11 @@
 // can use it without importing `index.ts` (which imports `collect-all.ts`).
 export function routeMatcher(glob: string | undefined): (route: string) => boolean {
   if (!glob) return () => true;
+  // Routes are matched without their leading slash, so the glob loses its too — every route the
+  // tool prints starts with one, so `--route "/blog/**"` is the form a user copies, and matching
+  // it against `blog/...` would silently select nothing and exit 0 on an unchecked project.
   const body = glob
+    .replace(/^\//, '')
     .replace(/[.+^${}()|[\]\\]/g, '\\$&')
     .replace(/\*\*/g, '\0') // globstar placeholder (not a literal space: a glob can contain one)
     .replace(/\*/g, '[^/]*') // single-segment wildcard (placeholder untouched)

--- a/packages/cli/test/route-matcher.test.ts
+++ b/packages/cli/test/route-matcher.test.ts
@@ -41,4 +41,13 @@ describe('routeMatcher', () => {
     expect(m('/blog/my-post')).toBe(false);
     expect(m('/blog/myXpost')).toBe(false);
   });
+
+  it('accepts a glob written with a leading slash, as every printed route is', () => {
+    // The documented example was `--route "/blog/**"`, which matched nothing and exited 0 —
+    // a scoped CI run that checked no route at all.
+    expect(routeMatcher('/blog/**')('/blog/hello')).toBe(true);
+    expect(routeMatcher('/blog/**')('/about')).toBe(false);
+    expect(routeMatcher('/')('/')).toBe(true);
+    expect(routeMatcher('/**')('/anything/deep')).toBe(true);
+  });
 });


### PR DESCRIPTION
Found during the roadmap Phase B-4 a11y rule-validity review, outside its scope.

`routeMatcher` stripped the leading slash from the **route** but not from the **glob**, so a glob written the way every printed route is written matched nothing:

```bash
svelte-vitals --route "/blog/**"
```

That is the form [the CLI guide documents](docs/src/content/docs/guides/(setup)/cli.md), and it selected **zero routes**, reported zero findings, and **exited 0**. A CI job scoped to a subtree looked green while checking nothing.

Measured on `examples/kitchen-sink` before the fix:

| glob | routes selected |
| --- | --- |
| `"/gallery/a11y/**"` | **0** (exit 0) |
| `"gallery/a11y/**"` | 4 |

## Fix

Normalize the glob the same way the route already is. Both forms now select the same routes; no other matching behaviour changes.

## The canary that could not have caught it

`examples/kitchen-sink/test/e2e-static.test.ts` guarded the clean routes with `--route /clean` and then asserted only that `rules` was defined — which a zero-match glob satisfies. It now asserts the scope selected more than one route **before** asserting those routes are issue-free, so a broken `--route` fails there instead of passing.

Verified the canary is genuinely clean under the fix: `--route "/clean/**"` selects `/clean`, `/clean/form`, `/clean/list` with **no route issues**; the four findings in that report are the app-shell/config site issues the gallery plants on purpose (`seo/html-lang`, `seo/sitemap-in-robots`, `performance/minify-disabled`, `a11y/doctype`).

## Verification

`pnpm build`, `pnpm typecheck`, `pnpm test` (core 84 / cli 91 / vite 29 / kitchen-sink 3 files, all passing), `pnpm lint` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Route glob filters now handle leading slashes consistently.
  * Both `/blog/**` and `blog/**` patterns correctly select matching routes.
  * Matching works for root, nested, and scoped paths.

* **Tests**
  * Expanded coverage verifies route selection and confirms selected routes are reported without issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->