### PR TITLE
feat(core): recognise <aside> as a complementary landmark

### DIFF
--- a/.changeset/tidy-moons-tell.md
+++ b/.changeset/tidy-moons-tell.md
@@ -1,0 +1,25 @@
+---
+'@svelte-vitals/core': minor
+'svelte-vitals': minor
+'@svelte-vitals/vite': minor
+---
+
+Recognise `<aside>` as a `complementary` landmark, in both analysis modes.
+
+Only `main`, `header` and `footer` mapped to landmarks, so the scenario `a11y/top-level-landmark`
+exists for — a layout rendering its children inside `<main>` while the page contributes a
+complementary region — was undetectable in the markup people write. The docs even taught
+`<aside role="complementary">`, which Svelte's own compiler flags as a redundant role.
+
+Following the HTML accessibility mapping: an `<aside>` scoped to `<body>` or `<main>` is a
+`complementary` landmark; inside sectioning content (`<article>`, `<aside>`, `<nav>`, `<section>`)
+it is one only when it carries an `aria-label` or `aria-labelledby`.
+
+**This widens detection** — a route with a layout `<main>` and a page `<aside>` newly reports
+`a11y/top-level-landmark`. Projects with recorded suppressions for that rule may need a new entry;
+`--update-suppressions` records it.
+
+Also fixed while here: the per-file top-level approximation that decides whether a `<header>` or
+`<footer>` is a landmark was being applied to every non-`main` tag, so a landmark nested below the
+top level of its own file was dropped. It now applies to `<header>` and `<footer>` only, which is
+what it was always meant to mean.

--- a/docs/blume.translations.json
+++ b/docs/blume.translations.json
@@ -58,7 +58,7 @@
       "ja": "bbd2d7d3dbad907e"
     },
     "src/content/docs/rules/a11y/duplicate-landmark.md": {
-      "ja": "8e21257119851832"
+      "ja": "3edcce61226e649e"
     },
     "src/content/docs/rules/a11y/id-duplication.md": {
       "ja": "183e1f76d7e056e6"
@@ -91,7 +91,7 @@
       "ja": "e1beb61cdb9c6b2f"
     },
     "src/content/docs/rules/a11y/top-level-landmark.md": {
-      "ja": "b4429f8dec89a80e"
+      "ja": "a1832834ef24080f"
     },
     "src/content/docs/rules/a11y/unknown-aria-attribute.md": {
       "ja": "fbd9ae29b3202137"

--- a/docs/blume.translations.json
+++ b/docs/blume.translations.json
@@ -91,7 +91,7 @@
       "ja": "e1beb61cdb9c6b2f"
     },
     "src/content/docs/rules/a11y/top-level-landmark.md": {
-      "ja": "a1832834ef24080f"
+      "ja": "5aa1a96d29066046"
     },
     "src/content/docs/rules/a11y/unknown-aria-attribute.md": {
       "ja": "fbd9ae29b3202137"

--- a/docs/src/content/docs/ja/rules/a11y/duplicate-landmark.md
+++ b/docs/src/content/docs/ja/rules/a11y/duplicate-landmark.md
@@ -23,7 +23,7 @@ description: 1つのルートに main・banner・contentinfo ランドマーク�
 
 ```svelte +layout.svelte
 <header>すべてのルートに表示するナビゲーション</header>
-<main><slot /></main>
+<main>{@render children()}</main>
 <footer>すべてのルートに表示するフッター</footer>
 ```
 

--- a/docs/src/content/docs/ja/rules/a11y/top-level-landmark.md
+++ b/docs/src/content/docs/ja/rules/a11y/top-level-landmark.md
@@ -9,15 +9,17 @@ description: banner・main・complementary・contentinfo ランドマークは�
 
 ルートを構成するレイアウトチェーン（`+layout.svelte` から `+page.svelte` まで）と、そこから解決したローカルコンポーネントを合わせたときに、`banner`・`main`・`complementary`・`contentinfo` のいずれかのランドマークが、別のランドマークの内側にネストしてしまっているケースを検出します。
 
-代表的なケースは、レイアウトが子要素を `<main>` の中に描画し、ページが別のランドマーク、例えば `role="complementary"` の `<aside>` を描画する場合です。
+代表的なケースは、レイアウトが子要素を `<main>` の中に描画し、ページが別のランドマーク、例えば `<aside>` を描画する場合です。
 
 ```svelte +layout.svelte
-<header>サイトナビゲーション</header><main><slot /></main>
+<header>サイトナビゲーション</header><main>{@render children()}</main>
 ```
 
 ```svelte +page.svelte
-<h1>ページの本文</h1><aside role="complementary">関連リンク</aside>
+<h1>ページの本文</h1><aside>関連リンク</aside>
 ```
+
+`role` は不要です。`<body>` または `<main>` の直下にある裸の `<aside>` は `complementary` ランドマークになります。`<article>`・`<aside>`・`<nav>`・`<section>` といったセクショニングコンテンツの中では、`aria-label` か `aria-labelledby` を持つ場合にのみランドマークになります — これが HTML のアクセシビリティマッピングの規定です。
 
 どちらのファイル単体を見ても問題はありません。ファイル単位のマークアップ linter ではこれを検出できません。このネストは、レイアウトの `<main>` とページの `complementary` をファイルをまたいで合成して初めて存在するものだからです。
 
@@ -35,7 +37,7 @@ description: banner・main・complementary・contentinfo ランドマークは�
 すべてのランドマークがルートの最上位で合成されるよう、ネストしたランドマークを外に出します。
 
 ```svelte +layout.svelte
-<header>サイトナビゲーション</header><main><slot /></main>
+<header>サイトナビゲーション</header><main>{@render children()}</main>
 ```
 
 ```svelte +page.svelte

--- a/docs/src/content/docs/ja/rules/a11y/top-level-landmark.md
+++ b/docs/src/content/docs/ja/rules/a11y/top-level-landmark.md
@@ -42,7 +42,7 @@ description: banner・main・complementary・contentinfo ランドマークは�
 
 ```svelte +page.svelte
 <h1>ページの本文</h1>
-<aside role="complementary">関連リンク</aside>
+<aside>関連リンク</aside>
 <!-- +layout.svelte の <main> の下から外に出した -->
 ```
 

--- a/docs/src/content/docs/rules/a11y/duplicate-landmark.md
+++ b/docs/src/content/docs/rules/a11y/duplicate-landmark.md
@@ -23,7 +23,7 @@ Keep one `<main>`, one `<header>`/`role="banner"`, and one `<footer>`/`role="con
 
 ```svelte +layout.svelte
 <header>Site navigation, shown on every route</header>
-<main><slot /></main>
+<main>{@render children()}</main>
 <footer>Site footer, shown on every route</footer>
 ```
 

--- a/docs/src/content/docs/rules/a11y/top-level-landmark.md
+++ b/docs/src/content/docs/rules/a11y/top-level-landmark.md
@@ -9,15 +9,17 @@ description: A banner, main, complementary, or contentinfo landmark should not b
 
 Flags a `banner`, `main`, `complementary`, or `contentinfo` landmark that ends up nested inside another landmark once a route's composed layout chain (every `+layout.svelte` up to the route's `+page.svelte`) and its resolved local components are put together.
 
-The flagship case is a layout that renders its children inside `<main>` while the page contributes another landmark, e.g. an `<aside>` with `role="complementary"`:
+The flagship case is a layout that renders its children inside `<main>` while the page contributes another landmark, e.g. an `<aside>`:
 
 ```svelte +layout.svelte
-<header>Site navigation</header><main><slot /></main>
+<header>Site navigation</header><main>{@render children()}</main>
 ```
 
 ```svelte +page.svelte
-<h1>Page content</h1><aside role="complementary">Related links</aside>
+<h1>Page content</h1><aside>Related links</aside>
 ```
+
+No `role` is needed: a bare `<aside>` scoped to `<body>` or `<main>` is a `complementary` landmark. Inside sectioning content — `<article>`, `<aside>`, `<nav>`, `<section>` — it is one only when it has an `aria-label` or `aria-labelledby`, which is what the HTML accessibility mapping specifies.
 
 Nothing in either file alone is wrong — a file-scoped markup linter cannot see this, since the nesting only exists once the layout's `<main>` and the page's `complementary` are composed across files.
 
@@ -35,7 +37,7 @@ Assistive technology exposes `banner`, `main`, `complementary`, and `contentinfo
 Move the nested landmark out so every landmark composes at the top level of the route:
 
 ```svelte +layout.svelte
-<header>Site navigation</header><main><slot /></main>
+<header>Site navigation</header><main>{@render children()}</main>
 ```
 
 ```svelte +page.svelte

--- a/docs/src/content/docs/rules/a11y/top-level-landmark.md
+++ b/docs/src/content/docs/rules/a11y/top-level-landmark.md
@@ -42,7 +42,7 @@ Move the nested landmark out so every landmark composes at the top level of the 
 
 ```svelte +page.svelte
 <h1>Page content</h1>
-<aside role="complementary">Related links</aside>
+<aside>Related links</aside>
 <!-- moved out from under +layout.svelte's <main> -->
 ```
 

--- a/packages/cli/src/providers/source/parse.ts
+++ b/packages/cli/src/providers/source/parse.ts
@@ -283,10 +283,15 @@ const LANDMARK_TAGS: Record<string, string | undefined> = { main: 'main', header
  */
 const ASIDE_DEMOTING_TAGS = new Set(['article', 'aside', 'nav', 'section']);
 
-/** An `aria-label`/`aria-labelledby` with any value — a literal or an expression, whose rendered
- *  value is unknowable but whose presence is the author saying the element is named. */
+/** An `aria-label`/`aria-labelledby` carrying a name: a non-blank literal, or an expression whose
+ *  rendered value is unknowable. An empty or whitespace-only literal names nothing. */
 function hasAccessibleName(attrs: AST.Attribute[]): boolean {
-  return ['aria-label', 'aria-labelledby'].some((name) => findAttr(attrs, name) !== undefined);
+  return ['aria-label', 'aria-labelledby'].some((name) => {
+    const attr = findAttr(attrs, name);
+    if (!attr) return false;
+    if (attrValueOf(attr) === 'dynamic') return true;
+    return (attrTextOf(attr) ?? '').trim().length > 0;
+  });
 }
 const IDREF_ATTR_SET = new Set(IDREF_ATTRS);
 

--- a/packages/cli/src/providers/source/parse.ts
+++ b/packages/cli/src/providers/source/parse.ts
@@ -274,6 +274,20 @@ export interface ParsedA11y {
 }
 
 const LANDMARK_TAGS: Record<string, string | undefined> = { main: 'main', header: 'banner', footer: 'contentinfo' };
+
+/**
+ * HTML-AAM: an `<aside>` scoped to `body` or `main` is a `complementary` landmark; scoped to
+ * sectioning content it is one only when it has an accessible name. `main` is deliberately absent
+ * — it is a scope in which an `aside` *is* a landmark, unlike the sectioning set that decides
+ * `<header>`/`<footer>`.
+ */
+const ASIDE_DEMOTING_TAGS = new Set(['article', 'aside', 'nav', 'section']);
+
+/** An `aria-label`/`aria-labelledby` with any value — a literal or an expression, whose rendered
+ *  value is unknowable but whose presence is the author saying the element is named. */
+function hasAccessibleName(attrs: AST.Attribute[]): boolean {
+  return ['aria-label', 'aria-labelledby'].some((name) => findAttr(attrs, name) !== undefined);
+}
 const IDREF_ATTR_SET = new Set(IDREF_ATTRS);
 
 /** Context threaded down the a11y walk: where in the template a node sits. */
@@ -283,6 +297,8 @@ interface A11yCtx {
   /** landmark ancestors, outermost first */
   landmarks: string[];
   elementDepth: number;
+  /** open `ASIDE_DEMOTING_TAGS` ancestors — an `<aside>` below one needs a name to be a landmark */
+  asideDemoting: number;
 }
 
 /**
@@ -387,9 +403,15 @@ function collectA11y(fragment: AST.Fragment, source: string): ParsedA11y {
     // ARIA fallback role lists (role="switch checkbox") resolve to the first supported token; a
     // non-literal or non-landmark role suppresses the tag mapping rather than falling through to it.
     const role = roleAttr ? splitTokens(attrTextOf(roleAttr))[0] : undefined;
-    const landmark = roleAttr ? (role && LANDMARK_ROLES.has(role) ? role : undefined) : LANDMARK_TAGS[node.name];
+    let landmark = roleAttr ? (role && LANDMARK_ROLES.has(role) ? role : undefined) : LANDMARK_TAGS[node.name];
+    if (!roleAttr && node.name === 'aside') {
+      landmark = ctx.asideDemoting === 0 || hasAccessibleName(attrs) ? 'complementary' : undefined;
+    }
     if (landmark) {
-      const headerFooter = !roleAttr && node.name !== 'main';
+      // Only `<header>`/`<footer>` carry the per-file top-level approximation: their landmark-ness
+      // depends on sectioning ancestry the composition cannot see. `<main>` and `<aside>` are
+      // landmarks wherever they sit, so tagging them would drop every nested one.
+      const headerFooter = !roleAttr && (node.name === 'header' || node.name === 'footer');
       emit(ctx, {
         kind: 'landmark',
         key: landmark,
@@ -431,11 +453,12 @@ function collectA11y(fragment: AST.Fragment, source: string): ParsedA11y {
     walk(node.fragment, {
       ...ctx,
       elementDepth: ctx.elementDepth + 1,
+      asideDemoting: ctx.asideDemoting + (literalTag && ASIDE_DEMOTING_TAGS.has(literalTag) ? 1 : 0),
       landmarks: landmark ? [...ctx.landmarks, landmark] : ctx.landmarks
     });
   };
 
-  walk(fragment, { path: [], repeatable: false, landmarks: [], elementDepth: 0 });
+  walk(fragment, { path: [], repeatable: false, landmarks: [], elementDepth: 0, asideDemoting: 0 });
   return { nodes, ...(slotInLandmark ? { slotInLandmark } : {}), unknowableContent };
 }
 

--- a/packages/cli/test/source-provider.test.ts
+++ b/packages/cli/test/source-provider.test.ts
@@ -425,6 +425,10 @@ describe('collectRoutes a11y composition', () => {
     expect(await nested('<div><aside>Related</aside></div>')).toEqual(['complementary']);
     expect(await nested('<article><aside>unnamed</aside></article>')).toEqual([]);
     expect(await nested('<article><aside aria-label="Notes">n</aside></article>')).toEqual(['complementary']);
+    // An empty or whitespace-only label names nothing; an expression's value is unknowable.
+    expect(await nested('<article><aside aria-label="">e</aside></article>')).toEqual([]);
+    expect(await nested('<article><aside aria-labelledby="   ">w</aside></article>')).toEqual([]);
+    expect(await nested('<article><aside aria-label={n}>d</aside></article>')).toEqual(['complementary']);
   });
 
   it('takes the max across exclusive branches, including across components', async () => {

--- a/packages/cli/test/source-provider.test.ts
+++ b/packages/cli/test/source-provider.test.ts
@@ -414,6 +414,19 @@ describe('collectRoutes a11y composition', () => {
     expect(a11y.fullyResolved).toBe(true);
   });
 
+  it('maps <aside> per HTML-AAM: complementary in body/main, demoted unnamed in sectioning content', async () => {
+    const nested = async (page: string) =>
+      (
+        await a11yOf({ 'src/routes/+layout.svelte': `<main><slot /></main>`, 'src/routes/+page.svelte': page })
+      ).nestedLandmarks.map((n) => n.kind);
+    // Depth inside the page does not matter: an <aside> is a landmark wherever it sits, unlike
+    // <header>/<footer>, whose landmark-ness depends on sectioning ancestry.
+    expect(await nested('<aside>Related</aside>')).toEqual(['complementary']);
+    expect(await nested('<div><aside>Related</aside></div>')).toEqual(['complementary']);
+    expect(await nested('<article><aside>unnamed</aside></article>')).toEqual([]);
+    expect(await nested('<article><aside aria-label="Notes">n</aside></article>')).toEqual(['complementary']);
+  });
+
   it('takes the max across exclusive branches, including across components', async () => {
     const a11y = await a11yOf({
       'src/routes/+page.svelte': `<script>import A from '$lib/A.svelte';import B from '$lib/B.svelte';</script>{#if x}<A />{:else}<B />{/if}`,

--- a/packages/vite/src/providers/rendered/parse-html.ts
+++ b/packages/vite/src/providers/rendered/parse-html.ts
@@ -64,8 +64,14 @@ export interface ParsedHtmlHead {
 // directly, unlike source mode's per-file topLevel approximation (routes.ts countsAsLandmark).
 const SECTIONING_TAGS = new Set(['article', 'aside', 'main', 'nav', 'section']);
 
+// HTML-AAM: an <aside> scoped to body or main is a complementary landmark; scoped to sectioning
+// content it is one only when it has an accessible name. `main` is absent on purpose — for an
+// <aside> it is a scope that keeps the landmark, unlike the set above.
+const ASIDE_DEMOTING_TAGS = new Set(['article', 'aside', 'nav', 'section']);
+
 interface A11yWalkCtx {
   sectioning: number;
+  asideDemoting: number;
   /** ancestor landmark kinds seen so far, outermost first */
   landmarks: string[];
 }
@@ -97,6 +103,9 @@ function collectA11y(root: HTMLElement): CollectedA11y {
       landmark = 'main';
     } else if ((tag === 'header' || tag === 'footer') && ctx.sectioning === 0) {
       landmark = tag === 'header' ? 'banner' : 'contentinfo';
+    } else if (tag === 'aside') {
+      const named = el.getAttribute('aria-label') !== undefined || el.getAttribute('aria-labelledby') !== undefined;
+      landmark = ctx.asideDemoting === 0 || named ? 'complementary' : undefined;
     }
 
     if (landmark) {
@@ -125,12 +134,13 @@ function collectA11y(root: HTMLElement): CollectedA11y {
     if (tag === 'template') return;
     const nextCtx: A11yWalkCtx = {
       sectioning: ctx.sectioning + (SECTIONING_TAGS.has(tag) ? 1 : 0),
+      asideDemoting: ctx.asideDemoting + (ASIDE_DEMOTING_TAGS.has(tag) ? 1 : 0),
       landmarks: landmark ? [...ctx.landmarks, landmark] : ctx.landmarks
     };
     for (const child of el.children) walk(child, nextCtx);
   };
 
-  for (const child of root.children) walk(child, { sectioning: 0, landmarks: [] });
+  for (const child of root.children) walk(child, { sectioning: 0, asideDemoting: 0, landmarks: [] });
   return { landmarks, nestedLandmarks, ids, idRefs };
 }
 

--- a/packages/vite/src/providers/rendered/parse-html.ts
+++ b/packages/vite/src/providers/rendered/parse-html.ts
@@ -104,7 +104,7 @@ function collectA11y(root: HTMLElement): CollectedA11y {
     } else if ((tag === 'header' || tag === 'footer') && ctx.sectioning === 0) {
       landmark = tag === 'header' ? 'banner' : 'contentinfo';
     } else if (tag === 'aside') {
-      const named = el.getAttribute('aria-label') !== undefined || el.getAttribute('aria-labelledby') !== undefined;
+      const named = ['aria-label', 'aria-labelledby'].some((a) => (el.getAttribute(a) ?? '').trim().length > 0);
       landmark = ctx.asideDemoting === 0 || named ? 'complementary' : undefined;
     }
 

--- a/packages/vite/test/parse-html.test.ts
+++ b/packages/vite/test/parse-html.test.ts
@@ -222,6 +222,20 @@ describe('parse-html: a11y capture (rendered landmark/id parity)', () => {
     expect(landmarks).toContain('banner');
   });
 
+  it('maps a bare <aside> scoped to body or main to complementary', () => {
+    expect(parseHtmlHead(doc('<aside>Related</aside>')).landmarks).toContain('complementary');
+    const inMain = parseHtmlHead(doc('<main><aside>Related</aside></main>'));
+    expect(inMain.landmarks).toContain('complementary');
+    expect(inMain.nestedLandmarks).toContainEqual({ kind: 'complementary', within: 'main' });
+  });
+
+  it('demotes an <aside> inside sectioning content unless it is named', () => {
+    expect(parseHtmlHead(doc('<article><aside>u</aside></article>')).landmarks).not.toContain('complementary');
+    expect(parseHtmlHead(doc('<article><aside aria-label="Notes">n</aside></article>')).landmarks).toContain(
+      'complementary'
+    );
+  });
+
   it('excludes #top by its decoded form and skips whitespace-only ids', () => {
     const { idRefs, ids } = parseHtmlHead(doc('<a href="#%74op">up</a><a href="#TOP">up</a><p id="   ">x</p>'));
     expect(idRefs).toEqual([]);

--- a/packages/vite/test/parse-html.test.ts
+++ b/packages/vite/test/parse-html.test.ts
@@ -234,6 +234,12 @@ describe('parse-html: a11y capture (rendered landmark/id parity)', () => {
     expect(parseHtmlHead(doc('<article><aside aria-label="Notes">n</aside></article>')).landmarks).toContain(
       'complementary'
     );
+    expect(parseHtmlHead(doc('<article><aside aria-label="">e</aside></article>')).landmarks).not.toContain(
+      'complementary'
+    );
+    expect(parseHtmlHead(doc('<article><aside aria-labelledby="  ">w</aside></article>')).landmarks).not.toContain(
+      'complementary'
+    );
   });
 
   it('excludes #top by its decoded form and skips whitespace-only ids', () => {


### PR DESCRIPTION
Fourth of the fixes from the Phase B-4 review record ([#511](https://github.com/oekazuma/svelte-vitals/pull/511)): its Priority 1 row 2, and **the only one that widens detection**.

## The rule's flagship scenario was undetectable

Only `main`, `header` and `footer` mapped to landmarks. So the exact case `a11y/top-level-landmark` exists for — a layout rendering its children inside `<main>` while the page contributes a complementary region — never fired for the markup people actually write:

```svelte
<!-- +layout.svelte -->  <main>{@render children()}</main>
<!-- +page.svelte -->    <aside>Related links</aside>
```

Worse, the docs taught the workaround as the correct shape: `<aside role="complementary">`, which **Svelte's own compiler flags** as `a11y_no_redundant_roles`. The page demonstrated the rule with markup Svelte warns about, while the markup a user would write was invisible.

## Following the HTML accessibility mapping

- `<aside>` scoped to `<body>` or `<main>` → `complementary`.
- `<aside>` inside sectioning content (`<article>`, `<aside>`, `<nav>`, `<section>`) → `complementary` **only when named** by `aria-label` or `aria-labelledby`.

Note `main` is deliberately absent from that demoting set: for an `<aside>` it is a scope that *keeps* the landmark, unlike the sectioning set that decides `<header>`/`<footer>`. Implemented identically in both walks — the CLI's source parse and the plugin's rendered-HTML parse.

## A second defect found while verifying

The first implementation looked right and behaved wrong: `<aside>` at the top of a page flagged, but `<div><aside>` was silent. The cause is older than this PR — the per-file `topLevel` approximation that decides whether a `<header>`/`<footer>` is a landmark was gated on `node.name !== 'main'`, i.e. **every non-`main` tag**, so any newly-mapped tag inherited it and a landmark nested below the top level of its own file was dropped. Now gated on `header`/`footer` explicitly, which is what the flag always meant.

## Verified end to end

Against a scratch SvelteKit project with a layout `<main>`:

| page body | result |
| --- | --- |
| `<aside>x</aside>` | `top-level-landmark` |
| `<div><aside>x</aside></div>` | `top-level-landmark` |
| `<article><aside>u</aside></article>` | silent — unnamed in sectioning content |
| `<article><aside aria-label="N">n</aside></article>` | `top-level-landmark` |
| `<section><aside>u</aside></section>` | silent |

Regression tests on both sides: route composition in `packages/cli/test/source-provider.test.ts`, rendered HTML in `packages/vite/test/parse-html.test.ts`.

## Migration

**This widens detection.** A route with a layout `<main>` and a page `<aside>` newly reports, so a project with recorded suppressions for `a11y/top-level-landmark` may need a new entry — `--update-suppressions` records it. Called out first in the changeset, which is `minor` across all three packages for that reason.

Docs rewritten in both languages to teach the bare `<aside>` and state the sectioning-content condition. The four deprecated `<slot />` snippets on the two landmark pages (a Priority 3 row, flagged by `svelte-autofixer`) became `{@render children()}` while I was in the files.

`pnpm build`, `pnpm typecheck`, `pnpm test` (core / cli 1213 / vite 252 / kitchen-sink all green), `pnpm lint`, `translate:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved accessibility analysis for `<aside>` elements, recognizing complementary landmarks based on nesting and accessible labels.
  * Expanded top-level landmark detection with more accurate handling for `<header>` and `<footer>` elements.

* **Documentation**
  * Updated English and Japanese accessibility guidance and examples for Svelte 5 syntax and `<aside>` landmark behavior.
  * Added release notes for the affected packages.

* **Bug Fixes**
  * Improved consistency between source and rendered HTML accessibility analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->