### PR TITLE
fix(core): match the compiler on ARIA attribute casing

### DIFF
--- a/.changeset/quiet-jars-look.md
+++ b/.changeset/quiet-jars-look.md
@@ -1,0 +1,20 @@
+---
+'@svelte-vitals/core': patch
+---
+
+Match the Svelte compiler on ARIA attribute casing.
+
+HTML attribute names are case-insensitive — the parser lowercases them, so `ARIA-LABEL` and `ROLE`
+reach the DOM as `aria-label` and `role`, and Svelte's own compiler judges them lowercased. The
+collector matched the source casing instead, so a typo written in capitals (`ARIA-LABLE`, `ROLE="bogus"`)
+was invisible to every ARIA rule while the compiler warned about it. Names are now matched
+case-insensitively and reported lowercased, as the compiler reports them.
+
+This widens detection: a project with an uppercase ARIA attribute or role that was silently
+unchecked may see new findings — the same ones `svelte-check` already reports.
+
+Recorded while here, with no behaviour change: this rule set deliberately follows the compiler over
+the letter of the ARIA spec where the two disagree. The spec lists `undefined` as a value for
+several boolean attributes and says a zero-length string should be treated as absent; the compiler
+rejects both, and so do we. A rule that disagreed with the build you run would be noise rather than
+a second opinion. The `a11y/invalid-aria-value` page now says so in both languages.

--- a/.changeset/quiet-jars-look.md
+++ b/.changeset/quiet-jars-look.md
@@ -4,14 +4,17 @@
 
 Match the Svelte compiler on ARIA attribute casing.
 
-HTML attribute names are case-insensitive — the parser lowercases them, so `ARIA-LABEL` and `ROLE`
-reach the DOM as `aria-label` and `role`, and Svelte's own compiler judges them lowercased. The
-collector matched the source casing instead, so a typo written in capitals (`ARIA-LABLE`, `ROLE="bogus"`)
-was invisible to every ARIA rule while the compiler warned about it. Names are now matched
-case-insensitively and reported lowercased, as the compiler reports them.
+HTML attribute names are case-insensitive: `ARIA-LABEL` and `ROLE` become `aria-label` and `role`
+during HTML parsing, and Svelte's own compiler judges them lowercased. The **Svelte AST keeps the
+source spelling**, though, and the attribute lookup matched it exactly — so an attribute written in
+capitals was read as a different attribute from the one it becomes in the browser. Lookups are now
+case-insensitive, and ARIA names are reported lowercased, as the compiler reports them.
 
-This widens detection: a project with an uppercase ARIA attribute or role that was silently
-unchecked may see new findings — the same ones `svelte-check` already reports.
+This corrects findings in both directions. A capitalised typo (`ARIA-LABLE`, `ROLE="bogus"`) was
+invisible while the compiler warned about it, so a project may see new findings — the same ones
+`svelte-check` already reports. A **valid** capitalised attribute was equally invisible, which
+produced false findings: `<button ARIA-LABEL="Save">` was reported as having no accessible name,
+and `<time DATETIME="…">` as missing its `datetime`. Those go away.
 
 Recorded while here, with no behaviour change: this rule set deliberately follows the compiler over
 the letter of the ARIA spec where the two disagree. The spec lists `undefined` as a value for

--- a/docs/blume.translations.json
+++ b/docs/blume.translations.json
@@ -70,7 +70,7 @@
       "ja": "5e19d8be06bac323"
     },
     "src/content/docs/rules/a11y/invalid-aria-value.md": {
-      "ja": "c96e3f206ffe8283"
+      "ja": "723d6fb903fa8acc"
     },
     "src/content/docs/rules/a11y/invalid-role.md": {
       "ja": "3a6d4c0b70839249"

--- a/docs/src/content/docs/ja/rules/a11y/invalid-aria-value.md
+++ b/docs/src/content/docs/ja/rules/a11y/invalid-aria-value.md
@@ -19,6 +19,10 @@ description: aria-* 属性の値は、その属性に WAI-ARIA 仕様が定め�
 - **number**(例: `aria-valuenow`) — 有限の数値であること。
 - **string** / **id** / **idlist**(例: `aria-label`、`aria-activedescendant`) — どんなリテラルでも許可(静的にはチェックできない)。
 
+ARIA 仕様の字面からは意図的に 2 点ずらしています。いずれも、実際にビルドに使う Svelte コンパイラに合わせるためです。仕様はいくつかの boolean 属性に `undefined` を値として挙げ、長さ 0 の文字列は属性が無いものとして扱うべきだとしていますが、コンパイラはどちらも拒否し（`a11y_incorrect_aria_attribute_type_boolean`）、このルールも拒否します。自分のビルドと食い違うルールは、第二の意見ではなくただのノイズだからです。
+
+属性名と `role` 名は **大文字小文字を区別せず**に照合します（HTML が小文字化するため）。`ARIA-LABLE` はコンパイラと同じく `aria-lable` として報告されます。
+
 検出しないもの:
 
 - `aria-hidden="true"` — 有効な boolean。

--- a/docs/src/content/docs/rules/a11y/invalid-aria-value.md
+++ b/docs/src/content/docs/rules/a11y/invalid-aria-value.md
@@ -19,6 +19,10 @@ Only attributes the spec defines are checked here — an unrecognized name is `a
 - **number** (e.g. `aria-valuenow`) — must be a finite number.
 - **string** / **id** / **idlist** (e.g. `aria-label`, `aria-activedescendant`) — any literal is accepted; these can't be checked statically.
 
+Two deliberate divergences from the letter of the ARIA spec, both to match the Svelte compiler you build with. The spec lists `undefined` as a value for several boolean attributes, and says a zero-length string should be treated as an absent attribute; the compiler rejects both (`a11y_incorrect_aria_attribute_type_boolean`), and so does this rule. A rule that disagreed with your own build would be noise, not a second opinion.
+
+Attribute and `role` names are matched **case-insensitively**, since HTML lowercases them: `ARIA-LABLE` is reported as `aria-lable`, exactly as the compiler reports it.
+
 Not flagged:
 
 - `aria-hidden="true"` — a valid boolean.

--- a/packages/core/src/component-parse.ts
+++ b/packages/core/src/component-parse.ts
@@ -1116,13 +1116,13 @@ function collectAriaElements(node: Node, source: string, acc: AriaElementFact[])
   }
   if (!node || typeof node !== 'object') return;
   if (node.type === 'RegularElement' && Array.isArray(node.attributes)) {
-    // HTML attribute names are case-insensitive — the parser lowercases them, so `ARIA-LABEL` and
-    // `ROLE` reach the DOM as `aria-label` and `role`. Svelte's own compiler judges them lowercased
-    // too; matching the source casing would let a typo like `ARIA-LABLE` slip past both this rule
-    // and the reader's eye. The name is reported lowercased, as the compiler reports it.
-    const roleAttr = node.attributes.find(
-      (a: Node) => a?.type === 'Attribute' && typeof a.name === 'string' && a.name.toLowerCase() === 'role'
-    );
+    // HTML attribute names are case-insensitive, so `ARIA-LABEL` and `ROLE` become `aria-label` and
+    // `role` during HTML parsing — but the **Svelte AST keeps the source spelling**, which is why
+    // the normalisation has to happen here rather than being inherited. Svelte's own compiler
+    // judges them lowercased, so matching the source casing would let a typo like `ARIA-LABLE` slip
+    // past this rule while the build warned about it. The name is reported lowercased, as the
+    // compiler reports it.
+    const roleAttr = findAttr(node.attributes, 'role');
     const ariaAttrs = node.attributes.filter(
       (a: Node) => a?.type === 'Attribute' && typeof a.name === 'string' && a.name.toLowerCase().startsWith('aria-')
     );
@@ -1151,9 +1151,13 @@ function collectAriaElements(node: Node, source: string, acc: AriaElementFact[])
 /** This element's `Attribute` nodes (directives/spreads excluded) as `isInteractiveElement`'s
  *  input shape. */
 function elementAttrs(attributes: Node[]): ElementAttr[] {
-  return attributes
-    .filter((a: Node) => a?.type === 'Attribute' && typeof a.name === 'string')
-    .map((a: Node) => ({ name: a.name, ...classifyAttrValue(a.value) }));
+  return (
+    attributes
+      .filter((a: Node) => a?.type === 'Attribute' && typeof a.name === 'string')
+      // Lowercased for the same reason `findAttr` matches case-insensitively: `ROLE` and `TABINDEX`
+      // are the same attributes as `role` and `tabindex` once the document is parsed.
+      .map((a: Node) => ({ name: String(a.name).toLowerCase(), ...classifyAttrValue(a.value) }))
+  );
 }
 
 /**

--- a/packages/core/src/component-parse.ts
+++ b/packages/core/src/component-parse.ts
@@ -1116,9 +1116,15 @@ function collectAriaElements(node: Node, source: string, acc: AriaElementFact[])
   }
   if (!node || typeof node !== 'object') return;
   if (node.type === 'RegularElement' && Array.isArray(node.attributes)) {
-    const roleAttr = findAttr(node.attributes, 'role');
+    // HTML attribute names are case-insensitive — the parser lowercases them, so `ARIA-LABEL` and
+    // `ROLE` reach the DOM as `aria-label` and `role`. Svelte's own compiler judges them lowercased
+    // too; matching the source casing would let a typo like `ARIA-LABLE` slip past both this rule
+    // and the reader's eye. The name is reported lowercased, as the compiler reports it.
+    const roleAttr = node.attributes.find(
+      (a: Node) => a?.type === 'Attribute' && typeof a.name === 'string' && a.name.toLowerCase() === 'role'
+    );
     const ariaAttrs = node.attributes.filter(
-      (a: Node) => a?.type === 'Attribute' && typeof a.name === 'string' && a.name.startsWith('aria-')
+      (a: Node) => a?.type === 'Attribute' && typeof a.name === 'string' && a.name.toLowerCase().startsWith('aria-')
     );
     if (roleAttr || ariaAttrs.length > 0) {
       const inputType = node.name === 'input' ? attrText(node.attributes, 'type') : undefined;
@@ -1130,7 +1136,7 @@ function collectAriaElements(node: Node, source: string, acc: AriaElementFact[])
         ...(inputType !== undefined ? { inputType: inputType.toLowerCase() } : {}),
         ...(hasSpread ? { hasSpread: true as const } : {}),
         aria: ariaAttrs.map((a: Node) => ({
-          name: a.name,
+          name: String(a.name).toLowerCase(),
           line: lineOf(source, a.start ?? node.start),
           ...classifyAttrValue(a.value)
         }))

--- a/packages/core/src/svelte-ast.ts
+++ b/packages/core/src/svelte-ast.ts
@@ -105,9 +105,21 @@ export function lineOf(source: string, offset: unknown): number {
   return line;
 }
 
+/**
+ * An element's attribute by name, matched **case-insensitively**: HTML attribute names are, so
+ * `ARIA-LABEL` and `Type` are the same attributes as `aria-label` and `type` once the document is
+ * parsed. The Svelte AST keeps the source spelling, so the normalisation has to happen here.
+ *
+ * Only ever called with an HTML element's attributes. A component's props are case-**sensitive**
+ * (`<Foo titleTemplate>` is not `<Foo titletemplate>`) and are read through the adapters' own
+ * lookup, which must stay exact.
+ */
 export function findAttr(attributes: AST.Attribute[], name: string): AST.Attribute | undefined {
   if (!Array.isArray(attributes)) return undefined;
-  return attributes.find((a) => a?.type === 'Attribute' && a.name === name);
+  const wanted = name.toLowerCase();
+  return attributes.find(
+    (a) => a?.type === 'Attribute' && typeof a.name === 'string' && a.name.toLowerCase() === wanted
+  );
 }
 
 /** Value kind of a single attribute (e.g. a component prop). */

--- a/packages/core/test/component-parse.test.ts
+++ b/packages/core/test/component-parse.test.ts
@@ -1458,6 +1458,18 @@ describe('parseComponentFacts — unassociatedLabels (a11y/label-has-control)', 
 });
 
 describe('parseComponentFacts — ariaElements attribute casing', () => {
+  it('applies the same normalisation to every collector that reads an element attribute', () => {
+    // The fix is in the shared `findAttr`/`elementAttrs`, not in one collector: an uppercase
+    // `ARIA-LABEL` used to produce a false `a11y/accessible-name` finding, and an uppercase `ROLE`
+    // used to hide a nesting defect.
+    expect(parseComponentFacts('<button ARIA-LABEL="Save"></button>', 'C.svelte').unnamedInteractive ?? []).toEqual([]);
+    expect(parseComponentFacts('<div ROLE="button"><button>x</button></div>', 'C.svelte').interactiveNestings).toEqual([
+      { containerTag: 'div', containerRole: 'button', descendantTag: 'button', line: 1 }
+    ]);
+    expect(
+      parseComponentFacts('<time DATETIME="2026-08-14">last Tuesday</time>', 'C.svelte').timesMissingDatetime ?? []
+    ).toEqual([]);
+  });
   it('reads ARIA and ROLE case-insensitively and reports the lowercased name', () => {
     // HTML lowercases attribute names, and Svelte's compiler judges them lowercased — matching the
     // source casing let `ARIA-LABLE` past both this rule and the reader's eye.

--- a/packages/core/test/component-parse.test.ts
+++ b/packages/core/test/component-parse.test.ts
@@ -1457,6 +1457,22 @@ describe('parseComponentFacts — unassociatedLabels (a11y/label-has-control)', 
   });
 });
 
+describe('parseComponentFacts — ariaElements attribute casing', () => {
+  it('reads ARIA and ROLE case-insensitively and reports the lowercased name', () => {
+    // HTML lowercases attribute names, and Svelte's compiler judges them lowercased — matching the
+    // source casing let `ARIA-LABLE` past both this rule and the reader's eye.
+    const c = parseComponentFacts('<div ARIA-LABLE="x" ROLE="bogus">y</div>', 'C.svelte');
+    expect(c.ariaElements).toEqual([
+      {
+        tag: 'div',
+        line: 1,
+        role: { literal: 'bogus' },
+        aria: [{ name: 'aria-lable', line: 1, literal: 'x' }]
+      }
+    ]);
+  });
+});
+
 describe('parseComponentFacts — bulletTexts (a11y/use-list)', () => {
   it('skips text after an interpolation and text in verbatim elements', () => {
     // `{count} - results found` trims to `- results found`: a sentence tail, not a bullet.


### PR DESCRIPTION
The last two open items from the Phase B-4 review, both settled by one principle: **where the ARIA spec and the Svelte compiler disagree, follow the compiler** — a rule that contradicts the build you actually run is noise, not a second opinion.

I checked the compiler's behaviour rather than assuming it, by running each case through `svelte-autofixer`:

| input | Svelte compiler | svelte-vitals before |
| --- | --- | --- |
| `aria-hidden="undefined"` | warns | reports — **already agreed** |
| `aria-hidden=""` | warns ("cannot be empty") | reports — **already agreed** |
| `ARIA-LABLE="x"` | warns, as `aria-lable` | **silent** |
| `ROLE="bogus"` | warns | **silent** |
| `ARIA-LABEL="y"` | no warning | silent — correct |

So the `undefined` and empty-string questions resolve to **no change**: we were already aligned, and the review's suggestion to accept `undefined` per the spec would have introduced the disagreement. That is now recorded on the rule page in both languages, so the divergence from the spec reads as a decision rather than an oversight.

The casing gap is a real fix. HTML lowercases attribute names, so `ARIA-LABEL` and `ROLE` reach the DOM lowercased; the collector matched source casing, which let a capitalised typo past every ARIA rule while `svelte-check` flagged it. Names are now matched case-insensitively and reported lowercased, exactly as the compiler reports them.

## Verified

Driven through `runRules` against the built `dist`:

```
ARIA-LABLE="x"                → `aria-lable` is not a WAI-ARIA attribute
ROLE="bogus"                  → role="bogus" on <div> is not a WAI-ARIA role
Role="checkbox"               → missing required aria-checked
ARIA-LABEL="y"                → clean
aria-lable="x" (lowercase)    → unchanged
```

This **widens** detection — a project with an uppercase ARIA attribute or role that was silently unchecked may see new findings, the same ones its own build already reports. Called out first in the changeset.

`pnpm build`, `pnpm typecheck`, `pnpm test`, `pnpm lint`, `translate:check` all clean; one regression test on the fact shape.

With this, every Priority 1, 2 and 3 item from the a11y rule-validity review is either fixed or recorded as a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)