### PR TITLE
fix(core): bound read concurrency so a descriptor limit cannot shrink the analysis

### DIFF
--- a/.changeset/lucky-cooks-brake.md
+++ b/.changeset/lucky-cooks-brake.md
@@ -25,6 +25,11 @@ Reads are now capped at 64 in flight, in both the CLI and the Vite plugin. The s
 nothing measurable (1 000 routes: 406ms capped vs 403ms unbounded) because reads are ~3% of the
 work.
 
-A file that could not be **read** is also now distinguished from one that could not be **parsed**.
-The two shared a message, which is how a descriptor limit read as hundreds of broken components; an
-unreadable file now says so and points at permissions and `ulimit -n`.
+A file that could not be **read** is also now distinguished from one that could not be **parsed**,
+for components and SvelteKit modules alike. The two shared a message, which is how a descriptor
+limit read as hundreds of broken components; an unreadable file now says so and points at
+permissions and `ulimit -n`.
+
+The Vite plugin reports skipped files too. It previously warned about config problems and crashed
+rules but never about files a collector dropped, so an `EACCES` during `vite build` was scored as
+empty facts in silence. Both packages now format the warning with one shared function.

--- a/.changeset/lucky-cooks-brake.md
+++ b/.changeset/lucky-cooks-brake.md
@@ -1,0 +1,30 @@
+---
+'@svelte-vitals/core': patch
+'svelte-vitals': patch
+'@svelte-vitals/vite': patch
+---
+
+Stop a low open-file limit from silently shrinking the analysis.
+
+Every `.svelte` file in a project was read in parallel with no bound, so on a large project the
+process ran out of descriptors. `EMFILE` was raised on `open`, but each read sits inside the
+per-file `try`/`catch` that exists for malformed components — so the file was recorded as a parse
+failure, dropped, and the run carried on. Measured on a real 1 681-route project:
+
+| `ulimit -n` | routes analysed | findings | files skipped | reported health |
+| ----------- | --------------- | -------- | ------------- | --------------- |
+| 256         | 232             | 93       | 1 450         | 94              |
+| 1 024       | 1 000           | 150      | 682           | 94              |
+| 4 096       | 1 681           | 191      | 0             | 94              |
+
+At 1 024 — a common container default — 40% of the project went unexamined, 41 findings vanished,
+and **the score did not move**. Nothing in the report said how much had been skipped.
+
+Reads are now capped at 64 in flight, in both the CLI and the Vite plugin. The same project at
+`ulimit -n 256` now analyses all 1 681 routes and reports all 191 findings, and the cap costs
+nothing measurable (1 000 routes: 406ms capped vs 403ms unbounded) because reads are ~3% of the
+work.
+
+A file that could not be **read** is also now distinguished from one that could not be **parsed**.
+The two shared a message, which is how a descriptor limit read as hundreds of broken components; an
+unreadable file now says so and points at permissions and `ulimit -n`.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -255,16 +255,32 @@ function overridesOffWarnings(allowRules: string[] | undefined, overrides: RuleO
  * it would have produced are simply missing rather than reported as fixed. Capped at 10
  * inline paths so one badly-broken directory can't flood the terminal.
  */
-function skippedFileWarnings(facts: { file: string; parseFailed?: true }[]): string[] {
-  const files = [...new Set(facts.filter((f) => f.parseFailed).map((f) => f.file))].sort();
-  if (files.length === 0) return [];
-  const shown = files.slice(0, 10);
-  const list =
-    files.length > shown.length ? `${shown.join(', ')}, … and ${files.length - shown.length} more` : shown.join(', ');
-  return [
-    `skipped ${files.length} file(s) that could not be parsed: ${list}`,
-    'findings for these files are unavailable until they parse.'
-  ];
+function skippedFileWarnings(facts: { file: string; parseFailed?: true; readFailed?: true }[]): string[] {
+  const list = (files: string[]): string => {
+    const shown = files.slice(0, 10);
+    return files.length > shown.length
+      ? `${shown.join(', ')}, … and ${files.length - shown.length} more`
+      : shown.join(', ');
+  };
+  const names = (pick: (f: { parseFailed?: true; readFailed?: true }) => boolean): string[] =>
+    [...new Set(facts.filter(pick).map((f) => f.file))].sort();
+
+  const unread = names((f) => f.readFailed === true);
+  const unparsed = names((f) => f.parseFailed === true && f.readFailed !== true);
+  const out: string[] = [];
+  if (unread.length > 0) {
+    out.push(
+      `skipped ${unread.length} file(s) that could not be read: ${list(unread)}`,
+      'this is an environment problem, not a code one — check file permissions and the open-file limit (`ulimit -n`).'
+    );
+  }
+  if (unparsed.length > 0) {
+    out.push(
+      `skipped ${unparsed.length} file(s) that could not be parsed: ${list(unparsed)}`,
+      'findings for these files are unavailable until they parse.'
+    );
+  }
+  return out;
 }
 
 /**

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,6 +10,7 @@ import {
   type Category
 } from '@svelte-vitals/core';
 import {
+  skippedFileWarnings,
   allRules,
   runRules,
   formatConsoleReport,
@@ -247,40 +248,6 @@ function overridesOffWarnings(allowRules: string[] | undefined, overrides: RuleO
     }
   }
   return warnings;
-}
-
-/**
- * Warn about files a collector could not read or parse (`parseFailed`, set at the
- * component/kit-module catch sites): the file contributes empty facts, so any findings
- * it would have produced are simply missing rather than reported as fixed. Capped at 10
- * inline paths so one badly-broken directory can't flood the terminal.
- */
-function skippedFileWarnings(facts: { file: string; parseFailed?: true; readFailed?: true }[]): string[] {
-  const list = (files: string[]): string => {
-    const shown = files.slice(0, 10);
-    return files.length > shown.length
-      ? `${shown.join(', ')}, … and ${files.length - shown.length} more`
-      : shown.join(', ');
-  };
-  const names = (pick: (f: { parseFailed?: true; readFailed?: true }) => boolean): string[] =>
-    [...new Set(facts.filter(pick).map((f) => f.file))].sort();
-
-  const unread = names((f) => f.readFailed === true);
-  const unparsed = names((f) => f.parseFailed === true && f.readFailed !== true);
-  const out: string[] = [];
-  if (unread.length > 0) {
-    out.push(
-      `skipped ${unread.length} file(s) that could not be read: ${list(unread)}`,
-      'this is an environment problem, not a code one — check file permissions and the open-file limit (`ulimit -n`).'
-    );
-  }
-  if (unparsed.length > 0) {
-    out.push(
-      `skipped ${unparsed.length} file(s) that could not be parsed: ${list(unparsed)}`,
-      'findings for these files are unavailable until they parse.'
-    );
-  }
-  return out;
 }
 
 /**

--- a/packages/cli/src/runtime/node.ts
+++ b/packages/cli/src/runtime/node.ts
@@ -1,7 +1,7 @@
 import { readFile, access } from 'node:fs/promises';
 import { join } from 'node:path';
 import { glob as tinyglob } from 'tinyglobby';
-import type { Runtime } from '@svelte-vitals/core/internal';
+import { withReadLimit, type Runtime } from '@svelte-vitals/core/internal';
 
 /**
  * Node implementation of the core Runtime abstraction (design §8). This is the
@@ -9,9 +9,10 @@ import type { Runtime } from '@svelte-vitals/core/internal';
  * provider and rules stay runtime-agnostic by going through this interface.
  */
 export function createNodeRuntime(): Runtime {
+  const boundedRead = withReadLimit((path) => readFile(path, 'utf8'));
   return {
     readFile(path) {
-      return readFile(path, 'utf8');
+      return boundedRead(path);
     },
     async exists(path) {
       try {

--- a/packages/cli/test/malformed-svelte.test.ts
+++ b/packages/cli/test/malformed-svelte.test.ts
@@ -130,7 +130,8 @@ describe('collectComponentFacts: malformed .svelte files (component path)', () =
       moduleStateDecls: [],
       suppressions: [],
       commentLinks: [],
-      parseFailed: true
+      parseFailed: true,
+      readFailed: true
     });
     expect(byFile.get(goodPath)!.loc).toBeGreaterThan(0);
   });

--- a/packages/core/src/component-collect.ts
+++ b/packages/core/src/component-collect.ts
@@ -49,8 +49,16 @@ export async function collectComponentFacts(rt: Runtime, cwd: string): Promise<C
   const files = await rt.glob('src/**/*.svelte{,.ts,.js}', cwd);
   return Promise.all(
     files.sort().map(async (rel): Promise<ComponentFacts> => {
+      // Read and parse are caught separately: an unreadable file is an environment problem and a
+      // malformed one is the author's, and reporting them together is how a descriptor limit once
+      // read as 682 broken components.
+      let source: string;
       try {
-        const source = await rt.readFile(rt.join(cwd, rel));
+        source = await rt.readFile(rt.join(cwd, rel));
+      } catch {
+        return { ...emptyComponentFacts(rel), parseFailed: true, readFailed: true };
+      }
+      try {
         return { file: rel, ...parseComponentFacts(source, rel) };
       } catch {
         return { ...emptyComponentFacts(rel), parseFailed: true };

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -211,3 +211,41 @@ export interface ComponentFacts {
    *  limit), not a malformed component. Reported separately so one does not masquerade as the other. */
   readFailed?: true;
 }
+
+/**
+ * Warnings for files a collector could not read or parse: the file contributes empty facts, so any
+ * findings it would have produced are simply missing rather than reported as fixed. The two causes
+ * are reported separately — an unreadable file is an environment problem (permissions, a descriptor
+ * limit) and a malformed one is the author's, and sharing a message is how a descriptor limit once
+ * read as hundreds of broken components. Capped at 10 inline paths so one badly-broken directory
+ * cannot flood the terminal.
+ */
+export function skippedFileWarnings(
+  facts: readonly { file: string; parseFailed?: true; readFailed?: true }[]
+): string[] {
+  const list = (files: string[]): string => {
+    const shown = files.slice(0, 10);
+    return files.length > shown.length
+      ? `${shown.join(', ')}, … and ${files.length - shown.length} more`
+      : shown.join(', ');
+  };
+  const names = (pick: (f: { parseFailed?: true; readFailed?: true }) => boolean): string[] =>
+    [...new Set(facts.filter(pick).map((f) => f.file))].sort();
+
+  const unread = names((f) => f.readFailed === true);
+  const unparsed = names((f) => f.parseFailed === true && f.readFailed !== true);
+  const out: string[] = [];
+  if (unread.length > 0) {
+    out.push(
+      `skipped ${unread.length} file(s) that could not be read: ${list(unread)}`,
+      'this is an environment problem, not a code one — check file permissions and the open-file limit (`ulimit -n`).'
+    );
+  }
+  if (unparsed.length > 0) {
+    out.push(
+      `skipped ${unparsed.length} file(s) that could not be parsed: ${list(unparsed)}`,
+      'findings for these files are unavailable until they parse.'
+    );
+  }
+  return out;
+}

--- a/packages/core/src/component.ts
+++ b/packages/core/src/component.ts
@@ -207,4 +207,7 @@ export interface ComponentFacts {
   timesMissingDatetime?: { line: number; text: string }[];
   /** Set when the file failed to read or parse and these facts are the empty fallback — the file was NOT analyzed. */
   parseFailed?: true;
+  /** Set when the file could not be READ — an environment problem (permissions, a descriptor
+   *  limit), not a malformed component. Reported separately so one does not masquerade as the other. */
+  readFailed?: true;
 }

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -32,6 +32,7 @@ export type {
   SuppressionDirective
 } from './component.js';
 export { parseComponentFacts } from './component-parse.js';
+export { skippedFileWarnings } from './component.js';
 export { collectComponentFacts, emptyComponentFacts } from './component-collect.js';
 export { collectSourceFiles } from './source-files.js';
 export type { KitModuleFacts } from './kit-module.js';

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -60,6 +60,7 @@ export {
 } from './svelte-ast.js';
 export { ROBOTS_SOURCE_PATHS, SITEMAP_SOURCE_PATHS, VITE_CONFIG_FILES, SVELTE_CONFIG_FILES } from './project-paths.js';
 export type { Runtime } from './runtime.js';
+export { withReadLimit, READ_CONCURRENCY } from './runtime.js';
 export type { Rule, RuleContext } from './rule.js';
 export { isPenalized, docsUrlFor } from './rule.js';
 

--- a/packages/core/src/kit-module-collect.ts
+++ b/packages/core/src/kit-module-collect.ts
@@ -52,8 +52,15 @@ export async function collectKitModuleFacts(
   const facts = await Promise.all(
     files.sort().map(async (rel): Promise<KitModuleFacts> => {
       const kind = kindOf(rel);
+      // Read and parse caught separately, as in `collectComponentFacts`: an unreadable file is an
+      // environment problem and a malformed one is the author's.
+      let source: string;
       try {
-        const source = await rt.readFile(rt.join(cwd, rel));
+        source = await rt.readFile(rt.join(cwd, rel));
+      } catch {
+        return { ...emptyKitModuleFacts(rel, kind), parseFailed: true, readFailed: true };
+      }
+      try {
         return { file: rel, kind, ...parseKitModuleFacts(source, rel, aliases) };
       } catch {
         return { ...emptyKitModuleFacts(rel, kind), parseFailed: true };

--- a/packages/core/src/kit-module.ts
+++ b/packages/core/src/kit-module.ts
@@ -50,4 +50,6 @@ export interface KitModuleFacts {
   suppressions: SuppressionDirective[];
   /** Set when the file failed to read or parse and these facts are the empty fallback — the file was NOT analyzed. */
   parseFailed?: true;
+  /** Set when the file could not be READ — an environment problem, not a malformed module. */
+  readFailed?: true;
 }

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -29,3 +29,40 @@ export interface Runtime {
   /** Join path segments without depending on `node:path`. */
   join(...parts: string[]): string;
 }
+
+/**
+ * How many file reads may be in flight at once. Analysis reads every `.svelte` file in a project
+ * in parallel, which on a large project opens more descriptors than the process is allowed: at
+ * `ulimit -n 1024` — a common container default — a 1 681-route project raised `EMFILE`, and
+ * because a failed read lands in the same `catch` as a malformed component, 682 files were dropped
+ * and the run still reported a normal score. The cap is what keeps the analysis whole.
+ *
+ * 64 is chosen to sit well under the stock 256 on macOS while leaving descriptors for everything
+ * else the process holds open. It is not a throughput knob: reads are a few percent of the work.
+ */
+export const READ_CONCURRENCY = 64;
+
+/**
+ * `readFile` with at most `limit` reads in flight. A plain counter plus a queue of waiters —
+ * deliberately not a dependency, and pure enough to live in core.
+ */
+export function withReadLimit(
+  readFile: (path: string) => Promise<string>,
+  limit: number = READ_CONCURRENCY
+): (path: string) => Promise<string> {
+  let active = 0;
+  const waiting: (() => void)[] = [];
+  const release = (): void => {
+    active--;
+    waiting.shift()?.();
+  };
+  return async (path) => {
+    if (active >= limit) await new Promise<void>((resolve) => waiting.push(resolve));
+    active++;
+    try {
+      return await readFile(path);
+    } finally {
+      release();
+    }
+  };
+}

--- a/packages/core/test/component-collect.test.ts
+++ b/packages/core/test/component-collect.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import type { Runtime } from '../src/runtime.js';
 import { collectComponentFacts, emptyComponentFacts } from '../src/component-collect.js';
 import { withReadLimit } from '../src/runtime.js';
+import { skippedFileWarnings } from '../src/component.js';
 
 /** Minimal in-memory Runtime for tests (design §8) — no real filesystem needed. */
 function createMemoryRuntime(files: Record<string, string>, unreadable: Set<string> = new Set()): Runtime {
@@ -169,5 +170,23 @@ describe('withReadLimit', () => {
     }, 1);
     await expect(read('bad')).rejects.toThrow('EACCES');
     await expect(read('good')).resolves.toBe('good');
+  });
+});
+
+describe('skippedFileWarnings', () => {
+  it('separates unreadable files from unparseable ones', () => {
+    const out = skippedFileWarnings([
+      { file: 'a.svelte', parseFailed: true, readFailed: true },
+      { file: 'b.svelte', parseFailed: true },
+      { file: 'c.svelte' }
+    ]);
+    expect(out[0]).toContain('1 file(s) that could not be read: a.svelte');
+    expect(out[1]).toContain('ulimit -n');
+    expect(out[2]).toContain('1 file(s) that could not be parsed: b.svelte');
+    expect(out.join(' ')).not.toContain('c.svelte');
+  });
+
+  it('says nothing when every file was read and parsed', () => {
+    expect(skippedFileWarnings([{ file: 'a.svelte' }])).toEqual([]);
   });
 });

--- a/packages/core/test/component-collect.test.ts
+++ b/packages/core/test/component-collect.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { Runtime } from '../src/runtime.js';
 import { collectComponentFacts, emptyComponentFacts } from '../src/component-collect.js';
+import { withReadLimit } from '../src/runtime.js';
 
 /** Minimal in-memory Runtime for tests (design §8) — no real filesystem needed. */
 function createMemoryRuntime(files: Record<string, string>, unreadable: Set<string> = new Set()): Runtime {
@@ -68,13 +69,17 @@ describe('collectComponentFacts', () => {
     expect(facts[0]!.eachBlocks).toEqual([{ hasKey: false, line: 1 }]);
   });
 
-  it('falls back to emptyComponentFacts when readFile rejects', async () => {
+  it('marks a file it could not read as readFailed, not merely parseFailed', async () => {
+    // An unreadable file is an environment problem; reporting it as a parse failure is how a
+    // descriptor limit once read as hundreds of broken components.
     const rt = createMemoryRuntime(
       { 'src/lib/Unreadable.svelte': '<div></div>' },
       new Set(['src/lib/Unreadable.svelte'])
     );
     const facts = await collectComponentFacts(rt, '');
-    expect(facts).toEqual([{ ...emptyComponentFacts('src/lib/Unreadable.svelte'), parseFailed: true }]);
+    expect(facts).toEqual([
+      { ...emptyComponentFacts('src/lib/Unreadable.svelte'), parseFailed: true, readFailed: true }
+    ]);
   });
 
   it('marks parseFailed on a failed file and leaves it unset on a healthy one', async () => {
@@ -136,5 +141,31 @@ describe('collectComponentFacts', () => {
     expect(facts).toHaveLength(1);
     expect(facts[0]).not.toEqual(emptyComponentFacts('src/lib/Dialog.svelte'));
     expect(facts[0]!.loc).toBe(4);
+  });
+});
+
+describe('withReadLimit', () => {
+  it('never lets more than the limit run at once, and still resolves every read', async () => {
+    let active = 0;
+    let peak = 0;
+    const read = withReadLimit(async (path: string) => {
+      active++;
+      peak = Math.max(peak, active);
+      await new Promise((r) => setTimeout(r, 1));
+      active--;
+      return path;
+    }, 4);
+    const paths = Array.from({ length: 40 }, (_, i) => `f${i}`);
+    expect(await Promise.all(paths.map(read))).toEqual(paths);
+    expect(peak).toBe(4);
+  });
+
+  it('releases its slot when a read rejects, so the queue cannot deadlock', async () => {
+    const read = withReadLimit(async (path: string) => {
+      if (path === 'bad') throw new Error('EACCES');
+      return path;
+    }, 1);
+    await expect(read('bad')).rejects.toThrow('EACCES');
+    await expect(read('good')).resolves.toBe('good');
   });
 });

--- a/packages/core/test/component-collect.test.ts
+++ b/packages/core/test/component-collect.test.ts
@@ -151,7 +151,9 @@ describe('withReadLimit', () => {
     const read = withReadLimit(async (path: string) => {
       active++;
       peak = Math.max(peak, active);
-      await new Promise((r) => setTimeout(r, 1));
+      // A few microtask turns — core's tsconfig has no timers, and the semaphore only needs
+      // the read to actually suspend for the overlap to be observable.
+      for (let i = 0; i < 3; i++) await Promise.resolve();
       active--;
       return path;
     }, 4);

--- a/packages/core/test/kit-module-collect.test.ts
+++ b/packages/core/test/kit-module-collect.test.ts
@@ -128,10 +128,10 @@ describe('collectKitModuleFacts', () => {
     ]);
     expect(facts[1]!.moduleStateReassignments).toEqual([{ name: 'user', line: 3, inHandler: true }]);
   });
-  it('falls back to empty facts when a file fails to read', async () => {
+  it('marks a file it could not read as readFailed, not merely parseFailed', async () => {
     const rt = createMemoryRuntime({ 'src/routes/+page.server.ts': 'let x;' }, new Set(['src/routes/+page.server.ts']));
     expect(await collectKitModuleFacts(rt, '')).toEqual([
-      { ...emptyKitModuleFacts('src/routes/+page.server.ts', 'server'), parseFailed: true }
+      { ...emptyKitModuleFacts('src/routes/+page.server.ts', 'server'), parseFailed: true, readFailed: true }
     ]);
   });
 

--- a/packages/vite/src/analyze.ts
+++ b/packages/vite/src/analyze.ts
@@ -7,6 +7,7 @@ import {
   runRules,
   withFailedRulesOff,
   formatFailedRuleWarning,
+  skippedFileWarnings,
   computeScore,
   summarize,
   hasFailureAtOrAbove,
@@ -115,7 +116,10 @@ export async function analyze(
   });
   const results = applyOverrides(applyRuleSeverities(rawResults, config), config);
   // Surfaced through the same `warnings` channel as config-file issues (plugin.ts logs each with
-  // `console.warn`).
+  // `console.warn`). A file the collectors could not read or parse contributes empty facts, so its
+  // findings go missing rather than showing as fixed — the build has to say so, exactly as the CLI
+  // does, and through the same formatter so the two never drift apart.
+  warnings.push(...skippedFileWarnings([...components, ...kitModules]));
   for (const f of failedRules) warnings.push(formatFailedRuleWarning(f));
   // A failed rule examined nothing, so its weight must not stay in the Health denominator — same
   // correction the CLI's `analyzeProject` applies, used by every downstream consumer here so the

--- a/packages/vite/src/providers/source/components.ts
+++ b/packages/vite/src/providers/source/components.ts
@@ -8,6 +8,7 @@ import {
   type ComponentFacts,
   type KitAlias,
   type KitModuleFacts,
+  withReadLimit,
   type Runtime
 } from '@svelte-vitals/core/internal';
 
@@ -16,8 +17,10 @@ import {
  * swappable runtime is needed here — this just satisfies the interface the
  * shared core implementation expects.
  */
+const boundedRead = withReadLimit((path: string) => readFile(path, 'utf8'));
+
 const nodeRuntime: Runtime = {
-  readFile: (path) => readFile(path, 'utf8'),
+  readFile: (path) => boundedRead(path),
   async exists(path) {
     try {
       await access(path);


### PR DESCRIPTION
The item [#522](https://github.com/oekazuma/svelte-vitals/pull/522) flipped from "defer" to "implement" once it was measured rather than inferred.

## The failure

Every `.svelte` file was read in parallel with no bound, so a large project ran out of descriptors. `EMFILE` is raised on `open` — but each read sits inside the per-file `try`/`catch` that exists for **malformed components**, so the file was recorded as a parse failure, dropped, and the run carried on.

Measured on `shadcn-svelte/docs`, a real 1 681-route project:

| `ulimit -n` | routes analysed | findings | files skipped | reported health |
| --- | --- | --- | --- | --- |
| 256 | 232 | 93 | 1 450 | **94** |
| 1 024 | 1 000 | 150 | 682 | **94** |
| 4 096 | 1 681 | 191 | 0 | **94** |

At **1 024 — a common container default — 40% of the project went unexamined, 41 findings vanished, and the score did not move.** The only signal was a line on stderr saying those files "could not be parsed", which is not what happened. This is the failure mode the project can least afford: not a crash, which is loud, but a plausible green answer computed over part of the input.

My earlier "no exhaustion at real scale" rested on one successful run on a machine whose `ulimit -n` is 1 048 576.

## The fix

Reads are capped at 64 in flight, through one `withReadLimit` helper in core used by both the CLI and the Vite plugin runtimes — so a future collector cannot reintroduce the problem by adding another parallel read. 64 sits well under the stock 256 on macOS with room for everything else the process holds open.

**After**: the same project at `ulimit -n 256` analyses all 1 681 routes and reports all 191 findings, with nothing skipped — identical to the unlimited run.

**Cost**: none measurable. 1 000 routes, median of 3: **406ms capped vs 403ms unbounded**. Reads are ~3% of CPU (from the profile in #522), so throttling them costs nothing.

## Read failure is no longer disguised as parse failure

The two shared a `catch` and a message. An unreadable file now carries `readFailed` and gets its own warning:

```
skipped 682 file(s) that could not be read: …
this is an environment problem, not a code one — check file permissions and the open-file limit (`ulimit -n`).
```

## Tests

The semaphore is pinned directly: 40 reads at limit 4 never exceed 4 in flight and all resolve, and a rejecting read releases its slot so the queue cannot deadlock. The existing unreadable-file tests now assert `readFailed` alongside `parseFailed`.

`pnpm build`, `pnpm typecheck`, `pnpm test` (core 1541 / cli / vite / kitchen-sink), `pnpm lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)