### PR TITLE
docs: design inline suppression for route-scoped findings (roadmap Phase C-3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,10 @@ install`/`ci upgrade` bundle into scaffolded workflows.
   run does — a CLI flag, a config key, an inline directive, a suppressions entry, an override. Each
   needs (1) a case in `examples/kitchen-sink/test/e2e-suppression.test.ts` asserting an **observable
   effect** on the real gallery, so it fails if the lever becomes a no-op, and (2) a runtime warning
-  when the lever selects nothing on a full run. The class this prevents is a lever that silently
+  when the lever selects nothing on a full run **and selecting nothing is never a legitimate
+  state**. Where it can be legitimate — an inline directive left behind after the code was fixed is
+  the worked example — the warning is opt-in instead, and the design records why. Guard (1) has no
+  exception. The class this prevents is a lever that silently
   does nothing while the run reports success — `--route "/blog/**"` matching zero routes and exiting
   0 was exactly this, and it passed a canary that asserted only that a report came back. Design
   record: `docs/superpowers/specs/2026-08-17-route-inline-suppression.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,14 @@ install`/`ci upgrade` bundle into scaffolded workflows.
   - Other prefixes in use: `feat(vite):`, `docs:`, `chore:`.
 - **Adding a rule**: create `packages/core/src/rules/<dir>/<slug>.ts` (the Performance directory is `perf/`, not `performance/`), then register it in **three** places, all in `packages/core/src/rules/index.ts`: the import, the `allRules` array, and the re-export block. (`packages/core/src/internal.ts` picks the rule up through `export * from './rules/index.js'` — there is no hand-maintained duplicate of this list any more.) Add rule docs under `docs/src/content/docs/rules/<id>.md` (en) and `docs/src/content/docs/ja/rules/<id>.md` (ja) — `packages/cli/test/docs-links.test.ts` fails the build if either is missing. (`<id>` already includes the category, e.g. `docs/src/content/docs/rules/performance/heavy-import.md` — note the docs tree uses `performance/` here, not the source tree's `perf/`.) Then regenerate the index pages with `pnpm --filter svelte-vitals run gen:rules-index && pnpm format` and commit them; `packages/cli/test/rules-index.test.mjs` fails the build if they are stale. **Never hard-code rule counts or ID ranges in READMEs/guides** (e.g. "CORRECT001–009" or "the two Performance rules") — such text rots on every new rule; refer to rule _categories_ instead. Rule IDs in guides are fine only as examples or sample output. Adding a new arm to an existing rule (rather than a new rule) inherits that rule's committed suppressions — the `id::route::location` key doesn't change, so existing entries keep matching the new arm's findings too — so the arm's changeset must call out that its findings can already be pre-suppressed in projects with recorded entries for that rule.
 - **Tests**: vitest, per-package `test/` directories; fixtures live under `test/fixtures/`.
+- **User-facing levers ship with two guards.** A lever is anything a user sets to change what the
+  run does — a CLI flag, a config key, an inline directive, a suppressions entry, an override. Each
+  needs (1) a case in `examples/kitchen-sink/test/e2e-suppression.test.ts` asserting an **observable
+  effect** on the real gallery, so it fails if the lever becomes a no-op, and (2) a runtime warning
+  when the lever selects nothing on a full run. The class this prevents is a lever that silently
+  does nothing while the run reports success — `--route "/blog/**"` matching zero routes and exiting
+  0 was exactly this, and it passed a canary that asserted only that a report came back. Design
+  record: `docs/superpowers/specs/2026-08-17-route-inline-suppression.md`.
 - **I/O budget**: `packages/cli/test/io-budget.test.ts` holds the collection phase
   (`packages/cli/src/collect-all.ts`) to a fixed number of `Runtime` calls. This is how
   analysis speed is defended in CI — wall-clock timings are far too noisy on shared

--- a/docs/superpowers/specs/2026-08-17-route-inline-suppression.md
+++ b/docs/superpowers/specs/2026-08-17-route-inline-suppression.md
@@ -1,0 +1,88 @@
+# Inline suppression for route-scoped findings — design
+
+Phase C-3 of `2026-08-16-v1-roadmap.md`. The a11y category design recorded this as a follow-up
+rather than half-implementing it (`2026-08-14-a11y-category-design.md`, "Inline suppressions"):
+`svelte-vitals-disable-next-line` is consumed by `fileRule` only, so a directive above a
+route-scoped finding does nothing. Verified: it does nothing **silently** — no warning, no error.
+
+The directive syntax is frozen surface at 1.0, so extending what it covers has to land before the
+freeze.
+
+## Why this first, among the Phase C items
+
+It is the only place where a user does the work the tool documents and is ignored without being
+told. A missed finding costs a defect; an escape hatch that silently fails costs trust, and the user
+has no way to tell it from "the rule ignored my code".
+
+## What a route-scoped finding already carries
+
+Static mode gives every route-scoped a11y finding a real source location — measured on the
+kitchen-sink gallery:
+
+```json
+{ "id": "a11y/id-duplication", "location": "src/lib/a11y/DupId.svelte", "line": 3 }
+```
+
+So the target of a directive is unambiguous: the file and line the finding already points at.
+That is what makes this a wiring problem rather than a semantics problem.
+
+## Decisions
+
+### 1. Which findings a directive can silence
+
+Any finding with a source `location` and a `line ≥ 1`. That is every route-scoped finding in static
+mode, and none in rendered mode, where findings anchor to the route and have no line — so the rule
+is "the directive silences a finding you can point at in a file", with no rule-by-rule list to
+maintain.
+
+### 2. Where the directives come from
+
+**The route composition, not `ctx.components`.** The obvious wiring is for a route rule to look up
+`ctx.components` for the file its finding names, but that breaks under `--route`: component facts
+are not collected then (`collect-all.ts` skips them), while route-scoped rules still run — measured,
+all four fire under `--route "gallery/a11y/**"`. A directive would work in a full run and silently
+stop working in a scoped one, which is the same class of failure this change exists to remove.
+
+The composition already reads and parses every chain file and every resolved local component. The
+directives are collected there and carried on `ResolvedA11y`, so route rules need no second source
+of truth and `--route` behaves like a full run.
+
+### 3. A suppressed finding becomes a PASS, not a silence
+
+`fileRule` filters suppressed findings **before** deciding PASS versus finding, so a file whose only
+finding is suppressed reports a pass. Route rules follow that, for one reason: a suppressed finding
+was checked. Making it vanish would put the route in the same bucket as a route the rule skipped —
+and the category average deliberately excludes skipped routes so an unchecked route cannot report a
+false 100. A suppressed route is checked and clean-by-decision; it belongs in the average.
+
+### 4. A directive in a shared component silences that finding on every route
+
+A component composed into twenty routes yields the same finding twenty times, at the same file and
+line. One directive silences all of them. This differs from the suppressions file, whose key is
+`id::route::location` and therefore per route.
+
+That is the right default — the markup is one place, and the author is annotating the markup, not
+twenty routes — but it is a real difference from the file-based mechanism and goes in the rule docs
+rather than being left for someone to discover.
+
+## Not in scope
+
+- **Rendered mode.** No source files, no lines, nothing to attach a directive to. The rule pages
+  already carry a Mode-differences block; this adds one line to it.
+- **A directive that names a route.** `svelte-vitals-disable-next-line a11y/id-duplication` is
+  whole-line and rule-scoped, and stays that way; per-route scoping is what the suppressions file
+  and `overrides` are for.
+- **`seo/single-h1` and other route-scoped rules outside a11y.** The wiring is general once the
+  directives ride on the composition, but each rule's findings must be checked to actually carry a
+  file and line before it is claimed. That is a follow-up, and the docs must not imply otherwise.
+
+## Testing
+
+1. A directive above the representative line silences the finding, and the rule reports a PASS for
+   that route rather than nothing.
+2. The same directive works under `--route`, which is the case the `ctx.components` wiring would
+   have broken.
+3. A directive naming a different rule id does not silence it.
+4. A directive in a component composed into two routes silences both.
+5. Rendered mode is unchanged — a directive in the source does not affect a build-mode finding.
+6. The existing component-scoped behaviour is untouched.

--- a/docs/superpowers/specs/2026-08-17-route-inline-suppression.md
+++ b/docs/superpowers/specs/2026-08-17-route-inline-suppression.md
@@ -32,6 +32,21 @@ That makes the criterion and the implementation the same sentence, which is the 
 **any rule that emits a line-anchored finding is covered by construction.** No per-rule list, no
 wiring step a new rule family can forget.
 
+**The stage is `applyOverrides(applyRuleSeverities(rawResults, config), config)`'s output**, in
+`analyzeProject` and in the plugin's `analyze`. Not "after `runRules`", which is ambiguous — three
+transforms sit between. Running last means a directive silences whatever survived config, and the
+one result set that scoring, `--fail-on`, the suppressions file, `--update-suppressions`, `--verbose`
+and every reporter consume is the suppressed one. Nothing upstream moves: `examined` still counts
+what the rule examined (it did examine), `failedRules` is untouched, and a rule an override already
+turned off never produces a result for a directive to act on.
+
+**PASS identity is one result per `(rule id, route)`, located at the first suppressed finding** in
+the order the results already arrive — which is the rule's own deterministic emission order, the
+same order `route-rule.ts` uses to pick its PASS anchor today (`first.file`, `line: 0`). A
+route-scoped rule can have findings in several files; the PASS carries one file because a PASS
+always has, and picking the first keeps it identical to the PASS the rule would have emitted had the
+markup been clean. `line` is 0, as every PASS's is.
+
 **The emitted PASS is built, not converted.** Flipping a finding's `detection` in place would leave
 its defect `message`, its `line`, and any `fix` attached to a passing result — and `--verbose`
 prints a passed result's message, so a green ✓ would read "Multiple `<h1>` (2)". The PASS is
@@ -59,6 +74,12 @@ A design for removing silent no-ops must not ship one.
 
 The union of every file this run parsed and collected directives from: component facts when they
 were collected, and the route composition's chain files and resolved local components always.
+
+**The index is scoped to what the run selected.** `collectAll` gathers every route and filters
+afterwards, so an index built before that filter would let a `--route` run read directives — and
+report unknown ids — from files no selected route composes. The index is built from the selected
+compositions and the components actually collected, so its contents and its warnings cover exactly
+what the run looked at.
 
 **The composition does not collect directives today** — `parseFile` never calls
 `collectSuppressions`; only the component and Kit-module fact collectors do. Collecting them during
@@ -146,6 +167,14 @@ by a test here rather than inherited by accident.
    for it is reported stale.
 10. Rendered mode is unchanged.
 11. Component-scoped behaviour is untouched.
+12. **Multi-file PASS identity**: a route whose rule has findings in two different files, both
+    suppressed, emits exactly one PASS, located at the first in emission order.
+13. **Ordering against config**: a finding that an `overrides` entry re-severities is still
+    suppressed by a directive, and a rule an override turned off produces nothing for a directive to
+    act on — the stage runs on the output of `applyOverrides(applyRuleSeverities(...))`.
+14. **Index scope**: a `--route` run does not read directives, or report unknown directive ids, from
+    a file no selected route composes.
+15. `examined` counts are unchanged by suppression — the rule did examine what it examined.
 
 ## Recurrence prevention
 
@@ -154,11 +183,22 @@ stops working.
 
 **A meta-test that no lever ships untested.** `examples/kitchen-sink/test/e2e-suppression.test.ts`
 already pins nine disable surfaces against the real gallery, each asserting an observable effect.
-Route-scoped directives join it. To make "every lever has a case" enforceable rather than
-aspirational, a meta-test enumerates the CLI flags from the gunshi arg declarations — already
-machine-readable, since they generate the docs tables — and fails when a flag appears in no e2e test
-and in no exemption list with a recorded reason. This is the same forcing function as the `allRules`
-kitchen-sink coverage meta-test.
+Route-scoped directives join it.
+
+To make "every lever has a case" enforceable rather than aspirational, a meta-test enumerates the
+two lever families that **can** be enumerated and fails when a member appears in no e2e test and in
+no exemption list with a recorded reason:
+
+- **CLI flags**, from the gunshi arg declarations — already machine-readable, since they generate
+  the docs tables.
+- **Top-level config keys**, from `Object.keys(defaultConfig)` — `treatDynamicAs`, `metaComponents`,
+  `rules`, `failOn` today.
+
+The remaining lever kinds are not enumerable, because each is a single surface rather than a family:
+the inline directive, the suppressions file, and `overrides`. The meta-test therefore carries them
+as a hard-coded list of three required cases — a list that only grows when someone invents a new
+kind of lever, which is rare enough to catch in review, and which the AGENTS.md rule covers in
+prose. Claiming the enumeration covers them all would be its own silent gap.
 
 **A runtime warning when an input selects nothing**, for the cases where selecting nothing is never
 legitimate:

--- a/docs/superpowers/specs/2026-08-17-route-inline-suppression.md
+++ b/docs/superpowers/specs/2026-08-17-route-inline-suppression.md
@@ -1,88 +1,164 @@
-# Inline suppression for route-scoped findings — design
+# Inline suppression for line-anchored findings — design
 
 Phase C-3 of `2026-08-16-v1-roadmap.md`. The a11y category design recorded this as a follow-up
 rather than half-implementing it (`2026-08-14-a11y-category-design.md`, "Inline suppressions"):
 `svelte-vitals-disable-next-line` is consumed by `fileRule` only, so a directive above a
-route-scoped finding does nothing. Verified: it does nothing **silently** — no warning, no error.
+route-scoped finding does nothing — **silently**, with no warning.
 
-The directive syntax is frozen surface at 1.0, so extending what it covers has to land before the
-freeze.
+The directive syntax is frozen surface at 1.0 (`2026-08-16-v1-public-surface.md`), so extending
+what it covers has to land before the freeze.
 
-## Why this first, among the Phase C items
+## The class of defect this belongs to
 
-It is the only place where a user does the work the tool documents and is ignored without being
-told. A missed finding costs a defect; an escape hatch that silently fails costs trust, and the user
-has no way to tell it from "the rule ignored my code".
+A user-facing lever that silently does nothing while the run reports success. Verified instances in
+the last few days: this directive; `--route "/blog/**"` matching zero routes and exiting 0 (`#510`);
+descriptor exhaustion dropping 40% of a project with an unchanged score (`#525`); `a11y/doctype`
+never running in build mode (`#517`); uppercase `ARIA-LABEL` invisible to the collector (`#524`).
 
-## What a route-scoped finding already carries
-
-Static mode gives every route-scoped a11y finding a real source location — measured on the
-kitchen-sink gallery:
-
-```json
-{ "id": "a11y/id-duplication", "location": "src/lib/a11y/DupId.svelte", "line": 3 }
-```
-
-So the target of a directive is unambiguous: the file and line the finding already points at.
-That is what makes this a wiring problem rather than a semantics problem.
+That framing decides the shape of this design, because the obvious implementation reproduces the
+class. See "Why not per-family wiring".
 
 ## Decisions
 
-### 1. Which findings a directive can silence
+### 1. Suppression is central, over `Result`s, keyed by `(location, line)`
 
-Any finding with a source `location` and a `line ≥ 1`. That is every route-scoped finding in static
-mode, and none in rendered mode, where findings anchor to the route and have no line — so the rule
-is "the directive silences a finding you can point at in a file", with no rule-by-rule list to
-maintain.
+After `runRules`, every penalized result carrying a source `location` and a `line ≥ 1` is checked
+against a directive index and flipped to PASS if a directive on that file and line names its rule
+(or names nothing).
 
-### 2. Where the directives come from
+That makes the criterion and the implementation the same sentence, which is the whole point:
+**any rule that emits a line-anchored finding is covered by construction.** No per-rule list, no
+wiring step a new rule family can forget.
 
-**The route composition, not `ctx.components`.** The obvious wiring is for a route rule to look up
-`ctx.components` for the file its finding names, but that breaks under `--route`: component facts
-are not collected then (`collect-all.ts` skips them), while route-scoped rules still run — measured,
-all four fire under `--route "gallery/a11y/**"`. A directive would work in a full run and silently
-stop working in a scoped one, which is the same class of failure this change exists to remove.
+`fileRule` keeps its own early filter — it must, because it decides PASS versus finding before
+emitting, and a file whose only finding is suppressed has to report a pass rather than nothing. The
+central pass is idempotent with respect to it: a result `fileRule` already suppressed never reaches
+it.
 
-The composition already reads and parses every chain file and every resolved local component. The
-directives are collected there and carried on `ResolvedA11y`, so route rules need no second source
-of truth and `--route` behaves like a full run.
+### Why not per-family wiring
+
+The first draft of this design carried directives on `ResolvedA11y` and had route rules consult
+them. It stated the criterion as "any finding with a source location and a line" while shipping
+"the four a11y route rules", and the gap is not academic: `seo/single-h1`, `seo/heading-level-skip`
+and the `performance` image rules are route-scoped and emit static-mode findings with a file and a
+line that satisfy the stated criterion verbatim. A user would put a directive above a
+`performance/image-dimensions` finding — indistinguishable from an a11y finding in the report — and
+be silently ignored.
+
+A design for removing silent no-ops must not ship one.
+
+### 2. Where the directive index comes from
+
+The union of every file this run parsed and collected directives from: component facts when they
+were collected, and the route composition's chain files and resolved local components always.
+
+The union matters because the two sources are not the same set under every invocation. `--route`
+skips component-fact collection while route-scoped rules still run — measured, all four a11y route
+rules fire under `--route "gallery/a11y/**"` — so an index built only from component facts would
+work in a full run and silently stop working in a scoped one. That is the same failure this change
+exists to remove, one level down.
 
 ### 3. A suppressed finding becomes a PASS, not a silence
 
-`fileRule` filters suppressed findings **before** deciding PASS versus finding, so a file whose only
-finding is suppressed reports a pass. Route rules follow that, for one reason: a suppressed finding
-was checked. Making it vanish would put the route in the same bucket as a route the rule skipped —
-and the category average deliberately excludes skipped routes so an unchecked route cannot report a
-false 100. A suppressed route is checked and clean-by-decision; it belongs in the average.
+Matching `fileRule`. A suppressed finding **was checked**; making it vanish would put the route in
+the same bucket as one the rule skipped, and the category average deliberately excludes skipped
+routes so an unchecked route cannot report a false 100.
+
+**This diverges from the suppressions file, and the divergence is now on the record.** An inline
+suppression keeps the key in the score as a PASS; the suppressions file drops the result after
+scoring, so a route whose only result it was leaves the average entirely. Two mechanisms, two score
+effects, for the identical finding. The inline behaviour is the defensible one and `fileRule` has
+worked this way since it shipped, so the file-based mechanism is what would have to move — that is
+a separate decision, recorded here rather than silently inherited.
 
 ### 4. A directive in a shared component silences that finding on every route
 
-A component composed into twenty routes yields the same finding twenty times, at the same file and
-line. One directive silences all of them. This differs from the suppressions file, whose key is
-`id::route::location` and therefore per route.
+A component composed into twenty routes yields the same finding twenty times at the same file and
+line; one directive silences all of them. The suppressions file, keyed `id::route::location`, is
+per route.
 
-That is the right default — the markup is one place, and the author is annotating the markup, not
-twenty routes — but it is a real difference from the file-based mechanism and goes in the rule docs
-rather than being left for someone to discover.
+That is the right default — the author is annotating one piece of markup, not twenty routes — but
+it is a real difference and goes in the docs rather than being discovered.
+
+### 5. A directive naming an unknown rule id warns
+
+`collectSuppressions` accepts any token matching the rule-id shape, and `isSuppressed` compares by
+string, so `a11y/id-duplicaton` suppresses nothing and says nothing. That is an instance of the
+class this design is about, inside the mechanism it is extending, so it is fixed here: an id that
+matches no registered rule is reported the way an unknown `--rules` id already is.
+
+Note the asymmetry with the next item: an unknown id is **never** a legitimate state, while a
+directive that matches no finding often is.
+
+### 6. A directive that matches no finding stays silent by default
+
+The author fixed the code and left the comment; a rule is turned off in config; a `--route` run
+does not reach that file. All legitimate. Reporting them by default is how a warning gets muted.
+
+Unused-directive reporting is therefore opt-in — `--report-unused-directives`, following eslint's
+precedent — and for a line-anchored directive "used" is aggregated across every route before it is
+judged, since one directive can serve many routes.
+
+### 7. `--update-suppressions` interaction, pinned
+
+An inline-suppressed finding is not penalized, so `writeSuppressions` does not record it, and an
+existing entry for it becomes stale and is reported by the stale-entry warning that already ships.
+This falls out of the ordering rather than needing new code — but the parent design fixed
+key/suppression semantics deliberately rather than leaving them to the implementer, so it is pinned
+by a test here rather than inherited by accident.
 
 ## Not in scope
 
-- **Rendered mode.** No source files, no lines, nothing to attach a directive to. The rule pages
-  already carry a Mode-differences block; this adds one line to it.
-- **A directive that names a route.** `svelte-vitals-disable-next-line a11y/id-duplication` is
-  whole-line and rule-scoped, and stays that way; per-route scoping is what the suppressions file
-  and `overrides` are for.
-- **`seo/single-h1` and other route-scoped rules outside a11y.** The wiring is general once the
-  directives ride on the composition, but each rule's findings must be checked to actually carry a
-  file and line before it is claimed. That is a follow-up, and the docs must not imply otherwise.
+- **Rendered mode.** Build-mode findings anchor to the prerendered HTML file with `line: 0`, so the
+  `line ≥ 1` criterion excludes them and there is no source line for a directive to sit above. (The
+  first draft said they anchor "to the route", which is wrong — they carry the HTML file path.)
+- **A directive that names a route.** The syntax stays whole-line and rule-scoped; per-route scoping
+  is what the suppressions file and `overrides` are for.
 
 ## Testing
 
-1. A directive above the representative line silences the finding, and the rule reports a PASS for
-   that route rather than nothing.
-2. The same directive works under `--route`, which is the case the `ctx.components` wiring would
-   have broken.
-3. A directive naming a different rule id does not silence it.
-4. A directive in a component composed into two routes silences both.
-5. Rendered mode is unchanged — a directive in the source does not affect a build-mode finding.
-6. The existing component-scoped behaviour is untouched.
+1. A directive above a route-scoped finding silences it, and the rule reports a PASS for that route
+   rather than nothing.
+2. The same under `--route` — the case the per-family wiring would have broken.
+3. A directive above a **non-a11y** route-scoped finding (`seo/single-h1`) silences it too, which is
+   what makes decision 1's criterion true rather than aspirational.
+4. A bare directive with no rule ids silences a route-scoped finding.
+5. Partial suppression: one of two surplus representatives suppressed leaves the other firing and
+   emits no PASS.
+6. A directive at the unpenalized first occurrence does nothing — the documented no-op, pinned.
+7. A directive in a component composed into two routes silences both.
+8. A directive naming a different rule id does not silence it; one naming an unknown id warns.
+9. `--update-suppressions` does not record an inline-suppressed finding, and a pre-existing entry
+   for it is reported stale.
+10. Rendered mode is unchanged.
+11. Component-scoped behaviour is untouched.
+
+## Recurrence prevention
+
+Two guards, because the class has two failure modes: a lever that never worked, and a lever that
+stops working.
+
+**A meta-test that no lever ships untested.** `examples/kitchen-sink/test/e2e-suppression.test.ts`
+already pins nine disable surfaces against the real gallery, each asserting an observable effect.
+Route-scoped directives join it. To make "every lever has a case" enforceable rather than
+aspirational, a meta-test enumerates the CLI flags from the gunshi arg declarations — already
+machine-readable, since they generate the docs tables — and fails when a flag appears in no e2e test
+and in no exemption list with a recorded reason. This is the same forcing function as the `allRules`
+kitchen-sink coverage meta-test.
+
+**A runtime warning when an input selects nothing**, for the cases where selecting nothing is never
+legitimate:
+
+| input                                                               | warn?                   | condition                                                                                                        |
+| ------------------------------------------------------------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `--route` matches no route                                          | **yes**                 | only when the unfiltered route set is non-empty                                                                  |
+| a directive names an unknown rule id                                | **yes**                 | always — decision 5                                                                                              |
+| a `--rules`-selected rule whose fact source the run's scope skipped | **yes**                 | e.g. a component-scoped rule under `--route`, silent today                                                       |
+| `--rules`/`--ignore` unknown id                                     | already fatal           | no change                                                                                                        |
+| stale suppressions entry                                            | already ships           | no change                                                                                                        |
+| `overrides` glob matches nothing                                    | **yes, full runs only** | gated like stale-suppression reporting, since under `--route`/`--diff` most overrides legitimately match nothing |
+| a directive matches no finding                                      | **opt-in only**         | decision 6                                                                                                       |
+
+**And the rule that outlives this document**, recorded in AGENTS.md so it is read every session: a
+user-facing lever ships with (1) a kitchen-sink e2e case asserting an observable effect and (2) a
+runtime warning when it selects nothing on a full run.

--- a/docs/superpowers/specs/2026-08-17-route-inline-suppression.md
+++ b/docs/superpowers/specs/2026-08-17-route-inline-suppression.md
@@ -23,17 +23,25 @@ class. See "Why not per-family wiring".
 ### 1. Suppression is central, over `Result`s, keyed by `(location, line)`
 
 After `runRules`, every penalized result carrying a source `location` and a `line ≥ 1` is checked
-against a directive index and flipped to PASS if a directive on that file and line names its rule
-(or names nothing).
+against a directive index. A result whose file and line carry a directive naming its rule — or
+naming nothing — is **removed**, and a PASS for that rule and route is emitted **only when no
+penalized result for that pair survives**. Suppressing one of two surplus representatives leaves the
+other firing and no PASS, exactly as `fileRule` behaves for a partially-suppressed file.
 
 That makes the criterion and the implementation the same sentence, which is the whole point:
 **any rule that emits a line-anchored finding is covered by construction.** No per-rule list, no
 wiring step a new rule family can forget.
 
+**The emitted PASS is built, not converted.** Flipping a finding's `detection` in place would leave
+its defect `message`, its `line`, and any `fix` attached to a passing result — and `--verbose`
+prints a passed result's message, so a green ✓ would read "Multiple `<h1>` (2)". The PASS is
+constructed with the rule's pass label, the route, the file, and nothing else. That label is
+`fileRule`'s `spec.label` today and is not on the `Rule` interface, so `Rule` gains it (internal
+surface, no semver cost) and both paths emit identical PASS text rather than two dialects.
+
 `fileRule` keeps its own early filter — it must, because it decides PASS versus finding before
-emitting, and a file whose only finding is suppressed has to report a pass rather than nothing. The
-central pass is idempotent with respect to it: a result `fileRule` already suppressed never reaches
-it.
+emitting. The central pass is idempotent with respect to it: a result `fileRule` already suppressed
+never reaches it, and a `fileRule` PASS is not penalized so the central pass ignores it.
 
 ### Why not per-family wiring
 
@@ -52,6 +60,10 @@ A design for removing silent no-ops must not ship one.
 The union of every file this run parsed and collected directives from: component facts when they
 were collected, and the route composition's chain files and resolved local components always.
 
+**The composition does not collect directives today** — `parseFile` never calls
+`collectSuppressions`; only the component and Kit-module fact collectors do. Collecting them during
+composition and plumbing them to the central pass is new work, and this design's largest piece.
+
 The union matters because the two sources are not the same set under every invocation. `--route`
 skips component-fact collection while route-scoped rules still run — measured, all four a11y route
 rules fire under `--route "gallery/a11y/**"` — so an index built only from component facts would
@@ -65,9 +77,9 @@ the same bucket as one the rule skipped, and the category average deliberately e
 routes so an unchecked route cannot report a false 100.
 
 **This diverges from the suppressions file, and the divergence is now on the record.** An inline
-suppression keeps the key in the score as a PASS; the suppressions file drops the result after
-scoring, so a route whose only result it was leaves the average entirely. Two mechanisms, two score
-effects, for the identical finding. The inline behaviour is the defensible one and `fileRule` has
+suppression keeps the key in the score as a PASS; the suppressions file drops the result in
+`applyScope`, **before** scoring, so a route whose only result it was leaves the average entirely.
+Two mechanisms, two score effects, for the identical finding. The inline behaviour is the defensible one and `fileRule` has
 worked this way since it shipped, so the file-based mechanism is what would have to move — that is
 a separate decision, recorded here rather than silently inherited.
 
@@ -95,9 +107,11 @@ directive that matches no finding often is.
 The author fixed the code and left the comment; a rule is turned off in config; a `--route` run
 does not reach that file. All legitimate. Reporting them by default is how a warning gets muted.
 
-Unused-directive reporting is therefore opt-in — `--report-unused-directives`, following eslint's
-precedent — and for a line-anchored directive "used" is aggregated across every route before it is
-judged, since one directive can serve many routes.
+Unused-directive reporting is a **follow-up, not part of this design**. It would be opt-in when it
+lands (eslint's `--report-unused-directives` is the precedent), and "used" would have to be
+aggregated across every route before judging, since one directive can serve many routes. It is left
+out here deliberately: adding a flag is adding a lever, and a lever ships with the two guards this
+document's own Recurrence prevention section requires — which is scope this change does not need.
 
 ### 7. `--update-suppressions` interaction, pinned
 


### PR DESCRIPTION
First of the Phase C items, and the one I put first because it is the only place where a user does the work the tool documents and is **silently** ignored: `<!-- svelte-vitals-disable-next-line a11y/id-duplication -->` above a route-scoped finding does nothing, with no warning. A missed finding costs a defect; an escape hatch that fails without saying so costs trust.

The directive syntax is frozen surface at 1.0, so extending what it covers has to land before the freeze.

Design only — no code in this PR.

## What makes it tractable

Route-scoped findings already carry a real source location in static mode, measured on the kitchen-sink gallery:

```json
{ "id": "a11y/id-duplication", "location": "src/lib/a11y/DupId.svelte", "line": 3 }
```

So the directive's target is unambiguous: the file and line the finding already points at. This is wiring, not new semantics.

## The four decisions

**Which findings.** Any with a source location and a line — that is every route-scoped finding in static mode and none in rendered mode, so there is no per-rule list to keep in sync.

**Where the directives come from: the route composition, not `ctx.components`.** The obvious wiring breaks under `--route`, because component facts are not collected then while route-scoped rules still run — I measured that all four a11y route rules fire under `--route "gallery/a11y/**"`. A directive that works in a full run and silently stops working in a scoped one is the same failure this change exists to remove. The composition already reads every chain file and resolved component, so the directives ride along on `ResolvedA11y`.

**A suppressed finding becomes a PASS, not a silence** — matching `fileRule`, which filters before choosing PASS versus finding. The reason matters: a suppressed finding *was checked*. Making it vanish would put the route in the same bucket as one the rule skipped, and the category average deliberately excludes skipped routes so an unchecked route cannot report a false 100.

**A directive in a shared component silences that finding on every route it composes into.** Different from the suppressions file, whose key is per route. It is the right default — the author is annotating one piece of markup, not twenty routes — but it is a real difference and belongs in the rule docs rather than being discovered.

## Explicitly not in scope

Rendered mode (no files, no lines), route-naming directives (that is what the suppressions file and `overrides` are for), and extending this to `seo/single-h1` and other non-a11y route-scoped rules — the wiring generalises, but each rule's findings have to be checked to actually carry a file and line before that is claimed, so the docs must not imply it already works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance requiring user-facing controls to include end-to-end suppression coverage.
  * Documented route-scoped, line-anchored inline suppression behavior, including supported directives, warnings, PASS reporting, and update semantics.
  * Clarified handling for shared components, unknown rules, and unmatched suppression directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->