### PR TITLE
feat(core): promote report rendering and gating to the stable entry

### DIFF
--- a/.changeset/olive-melons-wave.md
+++ b/.changeset/olive-melons-wave.md
@@ -1,0 +1,20 @@
+---
+'@svelte-vitals/core': minor
+---
+
+Promote report rendering and gating into the stable entry.
+
+`summarize`, `hasFailureAtOrAbove`, `formatGithubReport` and `formatMarkdownReport` are now exported
+from `@svelte-vitals/core` as well as `@svelte-vitals/core/internal`.
+
+The first-party GitHub Action draws an analysis onto three GitHub surfaces — diff annotations, the
+job summary, and a sticky PR comment — and gates its step on the result. `analyzeProject` and
+`applyScope` were already stable, so the analysis entry was covered while rendering and gating were
+not, and the Action's committed bundle depended on an entry that promises nothing across a patch.
+
+The promotion is a pure re-export. Every type these four reference — `Result`, `Config`, `Summary`,
+`Severity` — was already exported from the stable entry, so its type surface is unchanged.
+
+**What this freezes is each function's existence and signature, not the text it returns.** Markdown
+and workflow-command output stay human- and agent-readable: their prose, ordering and caps may
+change in any release. Call them to render; read `JsonReport` if you need to parse.

--- a/.changeset/olive-melons-wave.md
+++ b/.changeset/olive-melons-wave.md
@@ -18,3 +18,10 @@ The promotion is a pure re-export. Every type these four reference — `Result`,
 **What this freezes is each function's existence and signature, not the text it returns.** Markdown
 and workflow-command output stay human- and agent-readable: their prose, ordering and caps may
 change in any release. Call them to render; read `JsonReport` if you need to parse.
+
+One structural property is frozen alongside the signature, because asking "is there anything to
+show?" does not require parsing: **`formatGithubReport` returns the empty string when nothing is
+penalized**, so emitting its result unconditionally is safe.
+
+Both entries continue to export all four. Nothing is removed from `@svelte-vitals/core/internal`,
+so there is no migration deadline — moving an import is a free choice, not a deprecation.

--- a/docs/superpowers/specs/2026-08-16-v1-public-surface.md
+++ b/docs/superpowers/specs/2026-08-16-v1-public-surface.md
@@ -143,6 +143,18 @@ inventories, examined?`, closed over exactly `Summary`, `RuleEvidence`, `JsonIss
 - `defineConfig` and the config types it closes over: `Config`, `RuleSetting`, `RuleSettingObject`,
   `RuleOverride`, `RuleOptions`, `Severity`, `Category`, `CATEGORIES`, `TreatDynamicAs`.
 - `JsonReport` and the types it closes over (listed above).
+- **Added 2026-08-17**, by the promotion path this document describes rather than as a correction:
+  `summarize`, `hasFailureAtOrAbove`, `formatGithubReport`, `formatMarkdownReport`. The first-party
+  GitHub Action renders the analysis onto three GitHub surfaces and gates its step on the result —
+  so `analyzeProject` was stable while rendering and gating were not, and the Action's build
+  depended on `./internal`, which promises nothing across a patch. The promotion is a pure
+  re-export: every type these four reference (`Result`, `Config`, `Summary`, `Severity`) was
+  already exported here, so the type closure is unchanged — verified by the single-entry d.ts,
+  which still contains zero import statements.
+
+  **What is frozen is each function's existence and signature, not its output.** Markdown and
+  workflow-command text stay human/agent-readable per Report shapes above; a consumer calls these
+  to render and must not parse what comes back.
 
 Nothing else — and specifically **not** `Project`, `KitAlias`, or `Scope`: no frozen type reaches
 them, `Project` grows a field per project-scoped rule, and `Scope` belongs to `Rule`. They are

--- a/docs/superpowers/specs/2026-08-16-v1-public-surface.md
+++ b/docs/superpowers/specs/2026-08-16-v1-public-surface.md
@@ -50,6 +50,11 @@ the non-JSON `format*Report` functions, scoring functions) is **internal**. None
 any doc, and each can be promoted into `.` in a 1.x minor once a real consumer asks — promotion is
 additive, so nothing is lost by starting closed.
 
+> **Partly superseded 2026-08-17.** That mechanism was exercised: `formatGithubReport`,
+> `formatMarkdownReport`, `summarize` and `hasFailureAtOrAbove` are now in `.` — see the dated entry
+> under the `.` entry list below for who asked and what exactly the promotion freezes. The sentence
+> above stands for everything else it names.
+
 ## Frozen at 1.0
 
 ### `svelte-vitals` (CLI)

--- a/docs/superpowers/specs/2026-08-16-v1-public-surface.md
+++ b/docs/superpowers/specs/2026-08-16-v1-public-surface.md
@@ -156,6 +156,12 @@ inventories, examined?`, closed over exactly `Summary`, `RuleEvidence`, `JsonIss
   workflow-command text stay human/agent-readable per Report shapes above; a consumer calls these
   to render and must not parse what comes back.
 
+  One structural property is frozen with the signature: **`formatGithubReport` returns the empty
+  string when nothing is penalized.** "Is there anything to show?" is a question a caller asks
+  without parsing — the Action guards its `core.info` on exactly that — so it is a contract rather
+  than an accident. It already holds and is pinned by a test; stating it costs nothing and removes
+  a place where a caller would otherwise be relying on undefined behaviour.
+
 Nothing else — and specifically **not** `Project`, `KitAlias`, or `Scope`: no frozen type reaches
 them, `Project` grows a field per project-scoped rule, and `Scope` belongs to `Rule`. They are
 internal.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -13,10 +13,10 @@ This package is **mode-independent** and contains no I/O — it operates on a no
 
 ## Entry points
 
-| Entry                          | Contents                                                                                            | Stability                                                                     |
-| ------------------------------ | --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| `@svelte-vitals/core`          | `defineConfig` and the config types; the `JsonReport` types for reading a report                    | Follows semver.                                                               |
-| `@svelte-vitals/core/internal` | The engine, rules, fact collection, reporters, and scoring — what the CLI and the Vite plugin share | **No guarantee. Anything here may change in any release, including a patch.** |
+| Entry                          | Contents                                                                                                                                                                                              | Stability                                                                                                                         |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `@svelte-vitals/core`          | `defineConfig` and the config types; the `JsonReport` types for reading a report; `summarize`, `hasFailureAtOrAbove`, `formatGithubReport`, `formatMarkdownReport` for rendering one and gating on it | Follows semver. For the renderers, that covers the function — not the text it returns, which stays human-readable and may change. |
+| `@svelte-vitals/core/internal` | The engine, rules, fact collection, reporters, and scoring — what the CLI and the Vite plugin share                                                                                                   | **No guarantee. Anything here may change in any release, including a patch.**                                                     |
 
 Reach for `/internal` only if you accept pinning an exact version. If something there is what you
 actually need, open an issue — the point of the split is that promoting a name into the stable

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,5 +24,19 @@ export type {
 export { defineConfig, CATEGORIES } from './types.js';
 
 export type { Summary } from './summary.js';
+export { summarize, hasFailureAtOrAbove } from './summary.js';
+
+/**
+ * Rendering a report and gating on it. Promoted from `./internal` for the first-party GitHub
+ * Action, which draws the analysis onto three GitHub surfaces and decides its step's outcome — the
+ * analysis entry (`analyzeProject`) was stable while rendering and gating were not.
+ *
+ * What is frozen here is each function's **existence and signature**, not the text it produces:
+ * markdown and workflow-command output stay human/agent-readable, and their prose, ordering and
+ * caps may change in any release (`2026-08-16-v1-public-surface.md`). A consumer calls these to
+ * render; it must not parse what comes back — `JsonReport` is the shape for that.
+ */
+export { formatGithubReport } from './reporter/github.js';
+export { formatMarkdownReport } from './reporter/markdown.js';
 export type { JsonReport, RuleEvidence } from './reporter/json.js';
 export type { ScoreModel } from './scoring/score.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,10 @@ export { summarize, hasFailureAtOrAbove } from './summary.js';
  * markdown and workflow-command output stay human/agent-readable, and their prose, ordering and
  * caps may change in any release (`2026-08-16-v1-public-surface.md`). A consumer calls these to
  * render; it must not parse what comes back — `JsonReport` is the shape for that.
+ *
+ * One structural property is frozen alongside the signature, because "is there anything to show?"
+ * is a question a caller legitimately asks without parsing: **`formatGithubReport` returns the
+ * empty string when nothing is penalized.** Emitting its result unconditionally is therefore safe.
  */
 export { formatGithubReport } from './reporter/github.js';
 export { formatMarkdownReport } from './reporter/markdown.js';

--- a/packages/core/test/github-report.test.ts
+++ b/packages/core/test/github-report.test.ts
@@ -96,6 +96,9 @@ describe('formatGithubReport', () => {
         message: '<title>'
       }
     ];
+    // Frozen with the signature, not merely current behaviour: a caller may guard on the result's
+    // truthiness to decide whether to emit anything (the GitHub Action does).
     expect(formatGithubReport(passing, config)).toBe('');
+    expect(formatGithubReport([], config)).toBe('');
   });
 });


### PR DESCRIPTION
Requested by the [svelte-vitals-action](https://github.com/oekazuma/svelte-vitals-action) side, routed here directly instead of as an issue. `summarize`, `hasFailureAtOrAbove`, `formatGithubReport` and `formatMarkdownReport` move into `@svelte-vitals/core`'s stable entry.

This is the promotion path [#501](https://github.com/oekazuma/svelte-vitals-action/pull/501)'s design describes, taken for the first time: *"each can be promoted into `.` in a 1.x minor once a real consumer asks — promotion is additive, so nothing is lost by starting closed."*

## Why these four

The Action is not a CLI wrapper. It renders an analysis onto three GitHub surfaces — diff annotations, the job summary, a sticky PR comment — and gates its step on the result. `analyzeProject` and `applyScope` were already stable, so **the analysis entry was covered while rendering and gating were not**, and the Action's committed `dist/` depended on an entry that promises nothing across a patch. Its 0.42.0 → 0.44.0 Renovate PR failed on typecheck, which caught it that time.

## Verified before agreeing

The claim that this costs nothing checks out against the current build, not the 0.44.0 signatures quoted in the request:

```ts
formatGithubReport(results: Result[], config: Config): string
formatMarkdownReport(results: Result[], config: Config, meta: { version: string }): string
summarize(results: Result[], config: Config): Summary
hasFailureAtOrAbove(summary: Summary, min: Severity): boolean
```

`Result`, `Config`, `Summary` and `Severity` are **already** exported from the stable entry, so this is a pure re-export and the type surface does not widen. The type-closure invariant holds — a single-entry `tsup --dts-only` build of `src/index.ts` still emits **zero import statements**, and its declared set is the previous closure plus exactly these four names.

`pnpm check:publish`: 🟢 for both entries on node16-ESM and bundler.

## The distinction that had to be stated

The freeze design says the markdown and workflow-command reporters are *"human/agent-readable output, not schemas: their prose, ordering, and caps may change in any release."* Promoting them does not contradict that, but only if the difference is explicit:

**What is frozen is each function's existence and signature — not the text it returns.** A consumer calls them to render; `JsonReport` remains the shape to parse. That sentence is now in the export's own doc comment, the public-surface design, the package README's entry-point table, and the changeset.

## Recorded in the design, not silently

`2026-08-16-v1-public-surface.md` gains a dated entry under the `.` list explaining who asked and why, rather than the four names simply appearing — the promotion mechanism was exercised, nothing was refuted.

`pnpm build`, `pnpm typecheck`, `pnpm test`, `pnpm lint`, `pnpm check:publish` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stable public exports for summarizing results, evaluating failure thresholds, and generating GitHub or Markdown reports.
  * These functions retain stable signatures and referenced types.

* **Documentation**
  * Updated package documentation to list the new public exports.
  * Clarified that generated report text and ordering may change over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->