### PR TITLE
docs: sync the ruleset's required checks when the test matrix changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,11 @@ install`/`ci upgrade` bundle into scaffolded workflows.
   `floor-smoke` still runs `pnpm install`/`pnpm build` on 24.16.0, so those
   stay floor-bound. Never pin the `test` matrix back to the floor, and never
   add a dev dependency to the smoke — it must stay Node-builtins-only. Design
-  doc: `docs/superpowers/specs/2026-07-31-floor-smoke-design.md`.
+  doc: `docs/superpowers/specs/2026-07-31-floor-smoke-design.md`. **Changing the
+  `test` matrix means updating the `main` ruleset's required status checks in the
+  same change** — they are matched by job name (`test (24)`), a stale name waits
+  forever as "Expected", and merges then only go through by admin bypass. Read them
+  with `gh api repos/oekazuma/svelte-vitals/rules/branches/main`.
 - **Vendored spec data is generated, never edited.** `packages/core/src/html-spec/generated.ts` (a
   projection of `@markuplint/html-spec`) and `packages/core/src/rules/seo/schema-vocabulary.generated.ts`
   (from `schema-dts`) are written by `pnpm --filter @svelte-vitals/core run gen:html-spec` /


### PR DESCRIPTION
The `main` ruleset's required status checks are matched by job name. #528 changed the `test` matrix from `22 / 24.16.0 / 26` to `24 / 26` and the ruleset kept the old names, so every PR since showed `test (22)` and `test (24.16.0)` as "Expected — Waiting for status to be reported" and merged only by admin bypass. The ruleset is fixed; this records the coupling in AGENTS.md next to the matrix rule so the next matrix change updates both.

Docs only, no changeset.