### PR TITLE
docs: record the measured C-6 decision in the v1 roadmap

### DIFF
--- a/docs/superpowers/specs/2026-08-16-v1-roadmap.md
+++ b/docs/superpowers/specs/2026-08-16-v1-roadmap.md
@@ -42,10 +42,15 @@ surface come first so everything downstream is measured against the final shape.
 
 Ordered so each step's schema/key decisions are settled before the next builds on them.
 
-6. **Pretender-style component mapping** — config declaring what an unresolvable component
-   renders as (`{ "Link": "a" }`). New config key → schema decision → belongs before the freeze.
-   Widens `no-missing-id-ref`'s closed world; the "better than file-scoped linters" claim
-   depends on this.
+6. **Pretender-style component mapping** — **decided against as designed (2026-08-21).** The
+   widening measurement (`2026-08-20-no-missing-id-ref-widening-measured.md`) put per-name
+   mapping at 8 of 286 unlockable routes, all in one app, while the component-heavy apps carry
+   191–313 distinct unresolvable names — a per-name config key is not a real user behavior at
+   that scale. The reach this item existed for ships instead as the opt-in
+   `a11y/unverified-id-ref` (`2026-08-21-unverified-id-ref-design.md`), so the "better than
+   file-scoped linters" claim rests on that rule plus the sibling's closed-world soundness. A
+   coarser-than-per-name mechanism would need a new design that engages the measured numbers;
+   no config key ships before then, and nothing here blocks the freeze.
 7. **Shell-id duplication** — merge `app.html` ids into the composed `ids` map. Requires the
    findingKey-for-out-of-route-location decision, which is exactly why it must precede the
    freeze.


### PR DESCRIPTION
## Summary

Roadmap item C-6 (pretender-style component mapping) still read as a pre-freeze schema decision the "better than file-scoped linters" claim depends on. That premise is now superseded by measurement: #550 put per-name mapping at 8 of 286 unlockable routes (component-heavy apps carry 191–313 distinct unresolvable names), and the reach shipped instead as the opt-in `a11y/unverified-id-ref` (#551). This updates the roadmap entry to record the decision — no config key ships without a new design that engages the measured numbers, and nothing in C-6 blocks the freeze.

Doc-only; no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the accessibility roadmap to document the decision not to introduce per-name component mappings or a new configuration option.
  * Documented measured coverage, unresolved names, and the opt-in `a11y/unverified-id-ref` rule as the current alternative.
  * Clarified that broader mechanisms require additional design work before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->