### PR TITLE
fix(docs): use Lucide's accessibility icon on the rules index

### DIFF
--- a/docs/blume.translations.json
+++ b/docs/blume.translations.json
@@ -205,7 +205,7 @@
       "ja": "c4a63541169fdd34"
     },
     "src/content/docs/rules/index.mdx": {
-      "ja": "9da98d2b6bcb596c"
+      "ja": "1b678b664d91aae8"
     },
     "src/content/docs/rules/performance/font-preload-crossorigin.md": {
       "ja": "878aaf05f304ecc3"

--- a/docs/src/content/docs/ja/rules/index.mdx
+++ b/docs/src/content/docs/ja/rules/index.mdx
@@ -26,7 +26,7 @@ svelte-vitals が報告するルールをカテゴリ別にまとめました。
     コードの形と置き場所のサイン。コンポーネントの大きさ、props の数、そしてプロジェクトが宣言した import
     の境界を見ます。
   </Card>
-  <Card title="Accessibility" icon="universal-access" href="/ja/rules/a11y">
+  <Card title="Accessibility" icon="accessibility" href="/ja/rules/a11y">
     すべての人にとって使いやすいサイト。ARIA の妥当性、ランドマーク構造、アクセシブルネーム、セマンティック HTML
     を見ます。
   </Card>

--- a/docs/src/content/docs/rules/index.mdx
+++ b/docs/src/content/docs/rules/index.mdx
@@ -26,7 +26,7 @@ The severities below are the defaults — see [Configuration](/guides/configurat
     Component size, prop surface, and the import boundaries a project declares — signals that code is placed or shaped
     wrong.
   </Card>
-  <Card title="Accessibility" icon="universal-access" href="/rules/a11y">
+  <Card title="Accessibility" icon="accessibility" href="/rules/a11y">
     ARIA validity, landmark structure, accessible names, and semantic markup — what makes a site usable for everyone.
   </Card>
 </CardGroup>

--- a/packages/cli/scripts/rules-index.js
+++ b/packages/cli/scripts/rules-index.js
@@ -33,7 +33,9 @@ const CATEGORY_ICON = {
   correctness: 'circle-check',
   security: 'shield',
   architecture: 'layers',
-  a11y: 'universal-access'
+  // Lucide names only — the docs' icon set is @iconify-json/lucide, and an unknown
+  // name renders as no icon at all ('universal-access' is FontAwesome's name).
+  a11y: 'accessibility'
 };
 
 // The one place these blurbs live: core has no localized prose, and duplicating them


### PR DESCRIPTION
## Summary

The rules index pages (en/ja) showed no icon on the Accessibility card: the generator's `CATEGORY_ICON` used `universal-access`, which is FontAwesome's name — the docs' icon set is `@iconify-json/lucide`, where an unknown name renders as no icon at all. The other five categories already used valid Lucide names.

Switched to Lucide's `accessibility` (verified present in the installed icon set, `universal-access` verified absent), regenerated both index pages, re-stamped the pair, and left a comment in the generator pinning the Lucide-names-only constraint.

Doc-only; no changeset. rules-index drift test and docs-links green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)