### PR TITLE
fix(docs): person-standing icon for the a11y rules category

### DIFF
--- a/docs/blume.translations.json
+++ b/docs/blume.translations.json
@@ -205,7 +205,7 @@
       "ja": "c4a63541169fdd34"
     },
     "src/content/docs/rules/index.mdx": {
-      "ja": "1b678b664d91aae8"
+      "ja": "cd843ffb60cf1c73"
     },
     "src/content/docs/rules/performance/font-preload-crossorigin.md": {
       "ja": "878aaf05f304ecc3"

--- a/docs/src/content/docs/ja/rules/index.mdx
+++ b/docs/src/content/docs/ja/rules/index.mdx
@@ -26,7 +26,7 @@ svelte-vitals が報告するルールをカテゴリ別にまとめました。
     コードの形と置き場所のサイン。コンポーネントの大きさ、props の数、そしてプロジェクトが宣言した import
     の境界を見ます。
   </Card>
-  <Card title="Accessibility" icon="accessibility" href="/ja/rules/a11y">
+  <Card title="Accessibility" icon="person-standing" href="/ja/rules/a11y">
     すべての人にとって使いやすいサイト。ARIA の妥当性、ランドマーク構造、アクセシブルネーム、セマンティック HTML
     を見ます。
   </Card>

--- a/docs/src/content/docs/rules/index.mdx
+++ b/docs/src/content/docs/rules/index.mdx
@@ -26,7 +26,7 @@ The severities below are the defaults — see [Configuration](/guides/configurat
     Component size, prop surface, and the import boundaries a project declares — signals that code is placed or shaped
     wrong.
   </Card>
-  <Card title="Accessibility" icon="accessibility" href="/rules/a11y">
+  <Card title="Accessibility" icon="person-standing" href="/rules/a11y">
     ARIA validity, landmark structure, accessible names, and semantic markup — what makes a site usable for everyone.
   </Card>
 </CardGroup>

--- a/packages/cli/scripts/rules-index.js
+++ b/packages/cli/scripts/rules-index.js
@@ -34,8 +34,9 @@ const CATEGORY_ICON = {
   security: 'shield',
   architecture: 'layers',
   // Lucide names only — the docs' icon set is @iconify-json/lucide, and an unknown
-  // name renders as no icon at all ('universal-access' is FontAwesome's name).
-  a11y: 'accessibility'
+  // name renders as no icon at all. 'person-standing' (arms-out figure) over Lucide's
+  // 'accessibility' (a wheelchair glyph): the category is for everyone, not one disability.
+  a11y: 'person-standing'
 };
 
 // The one place these blurbs live: core has no localized prose, and duplicating them


### PR DESCRIPTION
## Summary

Follow-up to #558: Lucide's `accessibility` renders a wheelchair glyph, which reads as one disability rather than the category's for-everyone scope. Switched to `person-standing` (the arms-out figure — the closest Lucide equivalent to the universal-access mark), regenerated both index pages, re-stamped the pair, and updated the generator comment recording the choice.

Doc-only; no changeset. Drift test and translate:check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)