### PR TITLE
test(cli): cap the production dependency closure of each published package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ install`/`ci upgrade` bundle into scaffolded workflows.
   number edit. The two regressions that counts cannot catch — a widened analysis, and lost
   parallelism — are measured manually with `pnpm bench` (never in CI).
 - **Dependency budget**: `packages/cli/test/dep-budget.test.ts` caps the production dependency
-  closure (unique `name@version` reachable through `dependencies`) of each published package at its
+  closure (unique `name@version` reachable through `dependencies` / `optionalDependencies`) of each published package at its
   measured size. Adding or bumping a runtime dependency means checking that test. Lowering a ceiling
   is welcome; raising one is a design decision needing a recorded reason in the PR, not a number edit.
 - **User-facing levers ship with two guards.** A lever is anything a user sets to change what the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,10 @@ install`/`ci upgrade` bundle into scaffolded workflows.
   budget is welcome; raising one is a design decision needing a recorded reason, not a
   number edit. The two regressions that counts cannot catch — a widened analysis, and lost
   parallelism — are measured manually with `pnpm bench` (never in CI).
+- **Dependency budget**: `packages/cli/test/dep-budget.test.ts` caps the production dependency
+  closure (unique `name@version` reachable through `dependencies`) of each published package at its
+  measured size. Adding or bumping a runtime dependency means checking that test. Lowering a ceiling
+  is welcome; raising one is a design decision needing a recorded reason in the PR, not a number edit.
 - **User-facing levers ship with two guards.** A lever is anything a user sets to change what the
   run does — a CLI flag, a config key, an inline directive, a suppressions entry, an override. Each
   needs (1) a case in the kitchen-sink e2e suite asserting an **observable effect** on the real

--- a/packages/cli/test/dep-budget.test.ts
+++ b/packages/cli/test/dep-budget.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, realpathSync, existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Production dependency closure allowed per published package — unique name@version pairs
+ * reachable through `dependencies` / `optionalDependencies`, the workspace siblings included.
+ * Each number is the measured status quo, not an ideal: `svelte` alone is ~20 of core's and
+ * is the parser, so it is the floor. Lowering a ceiling is welcome; RAISING one is a design
+ * decision that needs a recorded reason in the PR, not a number edit.
+ */
+const BUDGET: Record<string, number> = {
+  '@svelte-vitals/core': 21,
+  'svelte-vitals': 59,
+  '@svelte-vitals/vite': 71
+};
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const pkgDir: Record<string, string> = {
+  '@svelte-vitals/core': 'packages/core',
+  'svelte-vitals': 'packages/cli',
+  '@svelte-vitals/vite': 'packages/vite'
+};
+
+function readPkg(dir: string): {
+  name: string;
+  version: string;
+  dependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+} {
+  return JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'));
+}
+
+// Node resolution without the `exports` map: walk up from `from` for node_modules/<name>, then
+// realpath so pnpm's virtual-store layout (.pnpm/<name>@<ver>/node_modules/<name>) is where the
+// next hop's siblings live.
+function locate(name: string, from: string): string | null {
+  for (let dir = from; ; dir = dirname(dir)) {
+    const candidate = join(dir, 'node_modules', name);
+    if (existsSync(join(candidate, 'package.json'))) return realpathSync(candidate);
+    if (dir === dirname(dir)) return null;
+  }
+}
+
+function closure(dir: string): Set<string> {
+  const seen = new Set<string>();
+  const visit = (d: string): void => {
+    const pkg = readPkg(d);
+    for (const [name, range] of Object.entries({ ...pkg.dependencies, ...pkg.optionalDependencies })) {
+      const found = locate(name, d);
+      if (!found) {
+        if (pkg.optionalDependencies?.[name] === range) continue;
+        throw new Error(`${pkg.name}: dependency ${name} is not installed`);
+      }
+      const dep = readPkg(found);
+      const key = `${dep.name}@${dep.version}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      visit(found);
+    }
+  };
+  visit(dir);
+  return seen;
+}
+
+describe('production dependency budget', () => {
+  for (const [name, max] of Object.entries(BUDGET)) {
+    it(`${name} pulls in at most ${max} packages`, () => {
+      const deps = closure(join(root, pkgDir[name]!));
+      expect(deps.size, `${name} closure:\n${[...deps].sort().join('\n')}`).toBeLessThanOrEqual(max);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- New `packages/cli/test/dep-budget.test.ts`: walks each published package's `dependencies` / `optionalDependencies` through node resolution (realpath'd, so pnpm's virtual store is handled) and asserts the unique `name@version` closure stays at or under its measured size: core 21, cli 59, vite 71.
- Same contract as the I/O budget: lowering a ceiling is welcome, raising one is a design decision that needs a reason in the PR. Documented in AGENTS.md.
- No changeset: test + docs only.

The point is to stop the runtime tree from creeping before trying to shrink it — the follow-ups (happy-dom for the vite tests, dropping `log-update`) land against these numbers.

## Test plan

- [x] `pnpm --filter svelte-vitals exec vitest run test/dep-budget.test.ts` — 3 pass at the current closure
- [x] `pnpm --filter svelte-vitals typecheck`, `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)