### PR TITLE
refactor(cli): repaint animation frames in-house and drop log-update

### DIFF
--- a/.changeset/drop-log-update.md
+++ b/.changeset/drop-log-update.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': patch
+---
+
+Drop the `log-update` dependency. The spinner, greeting, and score animation now repaint through a small in-house frame writer that counts wrapped rows and clips to the terminal height the same way, so narrow- and short-terminal behaviour is unchanged while the CLI's install pulls in 16 fewer packages.

--- a/docs/superpowers/specs/2026-07-31-floor-smoke-design.md
+++ b/docs/superpowers/specs/2026-07-31-floor-smoke-design.md
@@ -30,12 +30,12 @@ nothing to do with that dependency.
 `jsdom@30` (PR #332) is the first dev dependency to cross the floor. Its only
 breaking change is the Node requirement:
 
-| Package                                                                                              | `engines.node`                         | On 22.13.0      |
-| ---------------------------------------------------------------------------------------------------- | -------------------------------------- | --------------- |
-| Runtime deps of the published packages (tinyglobby, mri, smol-toml, node-html-parser, log-update, …) | `>=12` – `>=22`                        | fine            |
-| vite 8 / oxlint / oxfmt                                                                              | `^20.19.0 \|\| >=22.12.0`              | fine by 0.01    |
-| vitest 4                                                                                             | `^20.0.0 \|\| ^22.0.0 \|\| >=24.0.0`   | fine            |
-| **jsdom 30**                                                                                         | `^22.22.2 \|\| ^24.15.0 \|\| >=26.0.0` | **unsatisfied** |
+| Package                                                                                  | `engines.node`                         | On 22.13.0      |
+| ---------------------------------------------------------------------------------------- | -------------------------------------- | --------------- |
+| Runtime deps of the published packages (tinyglobby, mri, smol-toml, node-html-parser, …) | `>=12` – `>=22`                        | fine            |
+| vite 8 / oxlint / oxfmt                                                                  | `^20.19.0 \|\| >=22.12.0`              | fine by 0.01    |
+| vitest 4                                                                                 | `^20.0.0 \|\| ^22.0.0 \|\| >=24.0.0`   | fine            |
+| **jsdom 30**                                                                             | `^22.22.2 \|\| ^24.15.0 \|\| >=26.0.0` | **unsatisfied** |
 
 CI is green only because pnpm's `engine-strict` is off by default (no `.npmrc` in
 this repo), so the mismatch is not even warned about — verified by grepping the

--- a/docs/superpowers/specs/2026-08-22-drop-log-update-design.md
+++ b/docs/superpowers/specs/2026-08-22-drop-log-update-design.md
@@ -1,0 +1,57 @@
+# Design: Drop `log-update`, repaint frames in-house
+
+`2026-07-10-cli-mascot-animation-design.md` ("Library decision") adopted `log-update` for one
+job: repaint the spinner / greeting / score-animation block without the hand-rolled `\x1b[nA`
+redraw corrupting when a line wraps on a narrow terminal. That job is now done by
+`packages/cli/src/frame-writer.ts`, and `log-update` leaves the CLI's runtime dependencies.
+
+## Why the library is no longer needed
+
+`log-update` is general: it hard-wraps arbitrary text with `wrap-ansi`, measures East Asian
+width with `string-width`, clips to terminal height, and diffs consecutive frames line by line.
+The CLI uses none of that generality:
+
+- **Every frame is authored, not user content.** The mascot (12 columns), the wave (24), the
+  confetti row (24), the speech bubble (message ≤ 26 chars, bordered) and the status line are
+  literal strings in `mascot.ts` / `pulse-animation.ts` / `speech-bubble.ts`. They are built
+  from ASCII, box-drawing and braille glyphs — all 1 column wide — and `mascot.ts` already
+  rejects fullwidth glyphs for that reason. So a line's rendered height is its code-point count
+  (ANSI stripped) divided by `stream.columns`, rounded up. That is the whole width model.
+- **Wrapping only happens in a narrow band.** The mascot is gated at 20 columns and the bubble
+  at 55; what can still wrap is the 24-column wave below 24 columns and the 15-column score
+  line below 15. Counting wrapped rows covers it; splitting the string (as `wrap-ansi` does)
+  was never observable.
+- **Height clipping is a few lines.** A frame taller than the viewport scrolls, and `\x1b[1A`
+  cannot climb past the top row, so the writer drops leading lines until the frame and its
+  trailing newline fit — the same rule `log-update` applied.
+
+The pnpm closure cost was 16 packages for that one primitive — the single largest
+non-parser subtree in `svelte-vitals`.
+
+## What frame-writer does
+
+`createFrameWriter(stream)` returns `render(frame)` / `render.clear()` / `render.done()`, the
+same three calls the three call sites already made. Each render erases the previous frame
+(`\x1b[2K` + `\x1b[1A\x1b[2K` × rendered rows + `\x1b[G`), writes the new one plus a trailing
+newline, and remembers the new row count; a frame identical to the last one at the same width
+is skipped, so the idle loop's repeated faces write nothing. Writes are wrapped in
+synchronized-output markers (`\x1b[?2026h/l`) on a TTY so the erase + repaint lands as one
+paint. The cursor is hidden on the first TTY render and restored by `clear()` and `done()`
+(the next render re-hides it), on `exit`, and on `SIGINT`/`SIGTERM`/`SIGQUIT`/`SIGHUP` (the
+handler re-raises the signal when no other listener owns it, so the exit status is unchanged).
+ANSI stripping for the width count reuses core's `terminalSafe`.
+
+## Known ceilings
+
+- **1-column glyphs are an invariant, not a convention.** `frame-writer.test.ts` runs every
+  animation frame and message through a fake stream and asserts they use only the authored
+  glyph families (ASCII, box drawing, braille, `·…●◡`); anything new fails the test until its
+  width is decided. Localized (CJK) mascot messages would need a width table — that is the
+  point at which a `string-width`-class dependency earns its way back. A partial width table
+  is not a safe middle ground: counting ZWJ/VS16 emoji sequences per scalar over-erases, which
+  walks the cursor past the frame into the user's earlier output.
+- **Ambiguous-width glyphs (`…`, `●`, `─`) count as 1**, the same default `string-width` uses,
+  so there is no behaviour change on terminals that render them wide.
+- **Changed frames repaint whole, no line diffing.** Identical frames are skipped and
+  synchronized output covers the rest on modern terminals; if flicker shows up somewhere,
+  diffing unchanged leading lines is the upgrade path.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -59,7 +59,6 @@
     "@gunshi/plugin-i18n": "catalog:",
     "@gunshi/plugin-suggestion": "catalog:",
     "gunshi": "catalog:",
-    "log-update": "catalog:",
     "magicast": "catalog:",
     "svelte": "catalog:",
     "tinyglobby": "catalog:"

--- a/packages/cli/src/frame-writer.ts
+++ b/packages/cli/src/frame-writer.ts
@@ -49,6 +49,7 @@ export function createFrameWriter(stream: NodeJS.WriteStream): FrameWriter {
   let rows = 0;
   let last = '';
   let lastColumns = 0;
+  let lastLimit = 0;
   const write = (out: string): void => {
     if (out === '') return;
     // Synchronized output: the terminal holds the erase + repaint until the sequence ends.
@@ -65,19 +66,26 @@ export function createFrameWriter(stream: NodeJS.WriteStream): FrameWriter {
   return Object.assign(
     (frame: string): void => {
       const columns = stream.columns || 80;
-      if (frame === last && columns === lastColumns) return;
+      const limit = (stream.rows || 24) - 1;
+      if (frame === last && columns === lastColumns && limit === lastLimit) return;
       const rowsOf = (line: string): number => Math.max(1, Math.ceil([...terminalSafe(line)].length / columns));
       const lines = frame.split('\n');
       let height = lines.reduce((n, line) => n + rowsOf(line), 0);
       // A frame taller than the viewport scrolls, and `\x1b[1A` cannot climb back past the top
-      // row — drop leading lines until the frame and its trailing newline fit.
-      const limit = (stream.rows || 24) - 1;
+      // row — drop leading lines until the frame and its trailing newline fit; if the last line
+      // alone still overflows, draw nothing rather than scroll.
       while (lines.length > 1 && height > limit) height -= rowsOf(lines.shift()!);
-      hideCursor(stream);
-      write(`${erase()}${lines.join('\n')}\n`);
-      rows = height;
+      if (height > limit) {
+        write(erase());
+        rows = 0;
+      } else {
+        hideCursor(stream);
+        write(`${erase()}${lines.join('\n')}\n`);
+        rows = height;
+      }
       last = frame;
       lastColumns = columns;
+      lastLimit = limit;
     },
     {
       clear(): void {

--- a/packages/cli/src/frame-writer.ts
+++ b/packages/cli/src/frame-writer.ts
@@ -1,0 +1,90 @@
+import { terminalSafe } from '@svelte-vitals/core/internal';
+
+/**
+ * In-place repaint for the CLI's multi-line frames (spinner, greeting, score animation).
+ * Frames are authored in 1-column glyphs — pinned by frame-writer.test.ts — so a line's rendered
+ * height is its ANSI-stripped code-point count over `stream.columns`, and the erase sequence
+ * steps back over exactly that many rows. Design record:
+ * docs/superpowers/specs/2026-08-22-drop-log-update-design.md.
+ */
+const HIDE_CURSOR = '\x1b[?25l';
+const SHOW_CURSOR = '\x1b[?25h';
+const EXIT_SIGNALS = ['SIGINT', 'SIGTERM', 'SIGQUIT', 'SIGHUP'] as const;
+
+export interface FrameWriter {
+  (frame: string): void;
+  /** Erases the current frame and restores the cursor; the next render starts fresh. */
+  clear(): void;
+  /** Leaves the current frame on screen and restores the cursor. */
+  done(): void;
+}
+
+let cursorHiddenOn: NodeJS.WriteStream | null = null;
+let exitHooksInstalled = false;
+
+function showCursor(): void {
+  if (!cursorHiddenOn) return;
+  cursorHiddenOn.write(SHOW_CURSOR);
+  cursorHiddenOn = null;
+}
+
+function hideCursor(stream: NodeJS.WriteStream): void {
+  if (cursorHiddenOn || !stream.isTTY) return;
+  cursorHiddenOn = stream;
+  stream.write(HIDE_CURSOR);
+  if (exitHooksInstalled) return;
+  exitHooksInstalled = true;
+  process.once('exit', showCursor);
+  // Signal death skips 'exit', so restore the cursor here and re-raise for the default exit
+  // status — unless something else (a prompt) has its own handler for the signal.
+  for (const signal of EXIT_SIGNALS) {
+    process.once(signal, () => {
+      showCursor();
+      if (process.listenerCount(signal) === 0) process.kill(process.pid, signal);
+    });
+  }
+}
+
+export function createFrameWriter(stream: NodeJS.WriteStream): FrameWriter {
+  let rows = 0;
+  let last = '';
+  let lastColumns = 0;
+  const write = (out: string): void => {
+    if (out === '') return;
+    // Synchronized output: the terminal holds the erase + repaint until the sequence ends.
+    stream.write(stream.isTTY ? `\x1b[?2026h${out}\x1b[?2026l` : out);
+  };
+  // After a render the cursor sits on the blank line below the frame: erase it, then step up
+  // through every rendered row, ending at column 0 of the frame's first row.
+  const erase = (): string => (rows === 0 ? '' : `\x1b[2K${'\x1b[1A\x1b[2K'.repeat(rows)}\x1b[G`);
+  const reset = (): void => {
+    rows = 0;
+    last = '';
+    showCursor();
+  };
+  return Object.assign(
+    (frame: string): void => {
+      const columns = stream.columns || 80;
+      if (frame === last && columns === lastColumns) return;
+      const rowsOf = (line: string): number => Math.max(1, Math.ceil([...terminalSafe(line)].length / columns));
+      const lines = frame.split('\n');
+      let height = lines.reduce((n, line) => n + rowsOf(line), 0);
+      // A frame taller than the viewport scrolls, and `\x1b[1A` cannot climb back past the top
+      // row — drop leading lines until the frame and its trailing newline fit.
+      const limit = (stream.rows || 24) - 1;
+      while (lines.length > 1 && height > limit) height -= rowsOf(lines.shift()!);
+      hideCursor(stream);
+      write(`${erase()}${lines.join('\n')}\n`);
+      rows = height;
+      last = frame;
+      lastColumns = columns;
+    },
+    {
+      clear(): void {
+        write(erase());
+        reset();
+      },
+      done: reset
+    }
+  );
+}

--- a/packages/cli/src/mascot.ts
+++ b/packages/cli/src/mascot.ts
@@ -1,4 +1,4 @@
-import { createLogUpdate } from 'log-update';
+import { createFrameWriter } from './frame-writer.js';
 
 export type MascotState = 'ecstatic' | 'happy' | 'content';
 
@@ -164,11 +164,9 @@ const PLAIN_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '�
 const PLAIN_TICK_MS = 80;
 
 /**
- * The analysis-phase progress indicator: a small idle-blink loop rendered via
- * `log-update` (chosen over a hand-rolled `\r`/`\x1b[nA` redraw specifically
- * because it correctly tracks wrapped/actual line count — see the design spec's
- * "Library decision"). No-op when `enabled` is false. `mascot: false` renders a
- * plain one-line braille spinner instead (`--no-animation`, narrow terminals).
+ * The analysis-phase progress indicator: a small idle-blink loop. No-op when `enabled` is
+ * false. `mascot: false` renders a plain one-line braille spinner instead (`--no-animation`,
+ * narrow terminals).
  */
 export function startMascotSpinner(
   text: string,
@@ -177,7 +175,7 @@ export function startMascotSpinner(
   if (!opts.enabled) return { stop() {} };
   const stream = opts.stream ?? process.stderr;
   const mascot = opts.mascot ?? true;
-  const render = createLogUpdate(stream);
+  const render = createFrameWriter(stream);
   let i = 0;
   const tick = (): void => {
     render(mascot ? `${renderMascotIdleFrame(i)}\n${text}` : `${PLAIN_FRAMES[i % PLAIN_FRAMES.length]} ${text}`);
@@ -190,9 +188,6 @@ export function startMascotSpinner(
     stop() {
       clearInterval(timer);
       render.clear();
-      // clear() erases but leaves the cursor hidden (only done() re-shows it) —
-      // without this, a --no-animation run keeps the cursor invisible until exit.
-      render.done();
     }
   };
 }

--- a/packages/cli/src/pulse-animation.ts
+++ b/packages/cli/src/pulse-animation.ts
@@ -1,6 +1,6 @@
 import { setTimeout as sleep } from 'node:timers/promises';
 import { scoreColor, type Palette } from '@svelte-vitals/core/internal';
-import { createLogUpdate } from 'log-update';
+import { createFrameWriter } from './frame-writer.js';
 import { colorEnabled } from './color.js';
 import { isAgentEnv, isCiEnv, type ReporterName } from './reporter-resolve.js';
 import {
@@ -51,16 +51,13 @@ interface ScoreAnimationOptions {
  * the score climbs (the wave drops away once it settles — see WAVE_FRAMES' doc comment),
  * plus — on a wide-enough terminal (`mascotFitsWidth`) — a mascot that watches neutrally
  * while the score counts up, then snaps to its reaction pose on the final frame, held
- * briefly, followed by a confetti bonus if the score is a perfect 100. Redraws via
- * `log-update` (see mascot.ts's `startMascotSpinner` doc comment for why: hand-rolled
- * `\x1b[nA` cursor math doesn't track wrapped lines, and this block is now up to 8 lines
- * tall with the mascot + confetti).
+ * briefly, followed by a confetti bonus if the score is a perfect 100.
  */
 export async function playScoreAnimation(opts: ScoreAnimationOptions): Promise<void> {
   const frameDelayMs = opts.frameDelayMs ?? FRAME_DELAY_MS;
   const holdMs = opts.frameDelayMs ?? REACTION_HOLD_MS;
   const confettiDelayMs = opts.frameDelayMs ?? CONFETTI_FRAME_DELAY_MS;
-  const render = createLogUpdate(opts.stream);
+  const render = createFrameWriter(opts.stream);
   const showMascot = mascotFitsWidth(opts.stream.columns);
   const state = mascotStateFor(opts.score);
   const reactionMessage =

--- a/packages/cli/src/speech-bubble.ts
+++ b/packages/cli/src/speech-bubble.ts
@@ -1,5 +1,5 @@
 import { setTimeout as sleep } from 'node:timers/promises';
-import { createLogUpdate } from 'log-update';
+import { createFrameWriter } from './frame-writer.js';
 import { renderMascotAnticipating, type MascotState } from './mascot.js';
 
 const MIN_BUBBLE_COLUMNS = 55;
@@ -77,9 +77,7 @@ const GREETING_HOLD_MS = 800;
 /**
  * Plays a one-shot greeting: the mascot's idle-open pose with a random greeting
  * message in a speech bubble, held for `holdMs`, then cleared — called once
- * before analysis starts (index.ts), never repeated within a single run. Uses
- * `log-update` for the same reason mascot.ts's `startMascotSpinner` and
- * pulse-animation.ts's `playScoreAnimation` do: accurate multi-line redraw/clear.
+ * before analysis starts (index.ts), never repeated within a single run.
  */
 export async function playMascotGreeting(opts: {
   enabled: boolean;
@@ -89,7 +87,7 @@ export async function playMascotGreeting(opts: {
 }): Promise<void> {
   if (!opts.enabled) return;
   const holdMs = opts.holdMs ?? GREETING_HOLD_MS;
-  const render = createLogUpdate(opts.stream);
+  const render = createFrameWriter(opts.stream);
   render(renderMascotWithSpeech(renderMascotAnticipating(), pickMessage(GREETING_MESSAGES)));
   if (holdMs > 0) await sleep(holdMs);
   render.clear();

--- a/packages/cli/test/dep-budget.test.ts
+++ b/packages/cli/test/dep-budget.test.ts
@@ -12,8 +12,8 @@ import { fileURLToPath } from 'node:url';
  */
 const BUDGET: Record<string, number> = {
   '@svelte-vitals/core': 21,
-  'svelte-vitals': 59,
-  '@svelte-vitals/vite': 71
+  'svelte-vitals': 43,
+  '@svelte-vitals/vite': 55
 };
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');

--- a/packages/cli/test/frame-writer.test.ts
+++ b/packages/cli/test/frame-writer.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { terminalSafe } from '@svelte-vitals/core/internal';
+import { createFrameWriter } from '../src/frame-writer.js';
+import { playScoreAnimation } from '../src/pulse-animation.js';
+import { GREETING_MESSAGES, REACTION_MESSAGES, playMascotGreeting } from '../src/speech-bubble.js';
+import { renderMascotIdleFrame, startMascotSpinner } from '../src/mascot.js';
+import { ansiPalette } from '../src/color.js';
+import { fakeStream } from './helpers/fake-stream.js';
+
+const erase = (rows: number) => `\x1b[2K${'\x1b[1A\x1b[2K'.repeat(rows)}\x1b[G`;
+
+describe('createFrameWriter', () => {
+  it('erases as many rows as the previous frame occupied, wrapped lines included', () => {
+    const { writes, stream } = fakeStream({ columns: 19 });
+    const render = createFrameWriter(stream);
+    const wave = `${'─'.repeat(24)}\nHealth: 10/100`; // 24 columns wrap to 2 rows at 19, plus 1
+    const settled = 'Health: 10/100';
+
+    render(wave);
+    render(settled);
+    render.clear();
+    render.clear();
+
+    expect(writes).toEqual([`${wave}\n`, `${erase(3)}${settled}\n`, erase(1)]);
+  });
+
+  it('skips a frame identical to the last one unless the width changed', () => {
+    const { writes, stream } = fakeStream({ columns: 19 });
+    const render = createFrameWriter(stream);
+    const wave = `${'─'.repeat(24)}\nHealth: 10/100`;
+
+    render(wave);
+    render(wave);
+    stream.columns = 80;
+    render(wave);
+    render.clear();
+    render(wave);
+
+    expect(writes).toEqual([`${wave}\n`, `${erase(3)}${wave}\n`, erase(2), `${wave}\n`]);
+  });
+
+  it('ignores ANSI sequences when measuring a line', () => {
+    const { writes, stream } = fakeStream({ columns: 10 });
+    const render = createFrameWriter(stream);
+
+    render(`\x1b[38;2;255;62;0m${'x'.repeat(10)}\x1b[0m`);
+    render.clear();
+
+    expect(writes[1]).toBe(erase(1));
+  });
+
+  it('drops leading lines when the frame would not fit the terminal height', () => {
+    const { writes, stream } = fakeStream({ rows: 4 });
+    const render = createFrameWriter(stream);
+
+    render('one\ntwo\nthree\nfour\nfive');
+    render.clear();
+
+    expect(writes).toEqual(['three\nfour\nfive\n', erase(3)]);
+  });
+
+  it('forgets the frame on done() without erasing it', () => {
+    const { writes, stream } = fakeStream();
+    const render = createFrameWriter(stream);
+
+    render('a');
+    render.done();
+    render('b');
+
+    expect(writes).toEqual(['a\n', 'b\n']);
+  });
+
+  // The row count assumes every glyph is 1 column wide, so the frames may only use the glyph
+  // families listed here; anything new (CJK, emoji, fullwidth) needs a width decision first.
+  it('every authored frame and message is 1-column glyphs only', async () => {
+    vi.useFakeTimers();
+    const { writes, stream } = fakeStream();
+    try {
+      for (const score of [82, 95, 100]) {
+        await playScoreAnimation({ score, palette: ansiPalette, stream, frameDelayMs: 0 });
+      }
+      await playMascotGreeting({ enabled: true, stream, holdMs: 0 });
+      const plain = startMascotSpinner('Analyzing…', { enabled: true, stream, mascot: false });
+      vi.advanceTimersByTime(80 * 10);
+      plain.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+    for (let i = 0; i < 24; i++) writes.push(renderMascotIdleFrame(i));
+    const text = terminalSafe([...writes, ...GREETING_MESSAGES, ...Object.values(REACTION_MESSAGES).flat()].join('\n'));
+
+    expect(text).toMatch(/^[\x20-\x7e\n·…─-╿●◡⠀-⣿]*$/u);
+  });
+});

--- a/packages/cli/test/frame-writer.test.ts
+++ b/packages/cli/test/frame-writer.test.ts
@@ -59,6 +59,27 @@ describe('createFrameWriter', () => {
     expect(writes).toEqual(['three\nfour\nfive\n', erase(3)]);
   });
 
+  it('draws nothing when even the last line overflows the viewport, and repaints once it fits', () => {
+    const { writes, stream } = fakeStream({ columns: 10, rows: 2 });
+    const render = createFrameWriter(stream);
+
+    render('Health: 82/100'); // 14 code points: 2 rows at 10 columns, 1 row available
+    stream.rows = 5;
+    render('Health: 82/100');
+
+    expect(writes).toEqual(['Health: 82/100\n']);
+  });
+
+  it('hides the cursor and brackets each TTY write in synchronized output until done()', () => {
+    const { writes, stream } = fakeStream({ isTTY: true });
+    const render = createFrameWriter(stream);
+
+    render('a');
+    render.done();
+
+    expect(writes).toEqual(['\x1b[?25l', '\x1b[?2026ha\n\x1b[?2026l', '\x1b[?25h']);
+  });
+
   it('forgets the frame on done() without erasing it', () => {
     const { writes, stream } = fakeStream();
     const render = createFrameWriter(stream);

--- a/packages/cli/test/helpers/fake-stream.ts
+++ b/packages/cli/test/helpers/fake-stream.ts
@@ -1,6 +1,6 @@
 /** A write-capturing stand-in for process.stdout/stderr; `columns`/`rows` stand in for the TTY size. */
-export function fakeStream(size: { columns?: number; rows?: number } = {}) {
+export function fakeStream(tty: { isTTY?: boolean; columns?: number; rows?: number } = {}) {
   const writes: string[] = [];
-  const stream = { write: (s: string) => writes.push(s), ...size } as unknown as NodeJS.WriteStream;
+  const stream = { write: (s: string) => writes.push(s), ...tty } as unknown as NodeJS.WriteStream;
   return { writes, stream };
 }

--- a/packages/cli/test/helpers/fake-stream.ts
+++ b/packages/cli/test/helpers/fake-stream.ts
@@ -1,0 +1,6 @@
+/** A write-capturing stand-in for process.stdout/stderr; `columns`/`rows` stand in for the TTY size. */
+export function fakeStream(size: { columns?: number; rows?: number } = {}) {
+  const writes: string[] = [];
+  const stream = { write: (s: string) => writes.push(s), ...size } as unknown as NodeJS.WriteStream;
+  return { writes, stream };
+}

--- a/packages/cli/test/mascot.test.ts
+++ b/packages/cli/test/mascot.test.ts
@@ -8,11 +8,7 @@ import {
   renderConfettiFrame,
   startMascotSpinner
 } from '../src/mascot.js';
-
-function fakeStream() {
-  const writes: string[] = [];
-  return { writes, stream: { write: (s: string) => writes.push(s) } as unknown as NodeJS.WriteStream };
-}
+import { fakeStream } from './helpers/fake-stream.js';
 
 describe('mascotStateFor', () => {
   it('is ecstatic at exactly 100', () => {

--- a/packages/cli/test/pulse-animation.test.ts
+++ b/packages/cli/test/pulse-animation.test.ts
@@ -2,11 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { scoreAnimationEnabled, playScoreAnimation } from '../src/pulse-animation.js';
 import { noColorPalette, ansiPalette } from '../src/color.js';
 import { REACTION_MESSAGES } from '../src/speech-bubble.js';
-
-function fakeStream() {
-  const writes: string[] = [];
-  return { writes, stream: { write: (s: string) => writes.push(s) } as unknown as NodeJS.WriteStream };
-}
+import { fakeStream } from './helpers/fake-stream.js';
 
 describe('scoreAnimationEnabled', () => {
   const base = {
@@ -82,20 +78,14 @@ describe('playScoreAnimation', () => {
   });
 
   it('omits the mascot entirely on a narrow terminal, still completing the wave/score reveal', async () => {
-    const { writes, stream } = fakeStream();
-    // 19, not 15: below MIN_MASCOT_COLUMNS (20) so the mascot is correctly omitted,
-    // but still wide enough that log-update doesn't hard-wrap the plain
-    // "Health: 82/100" score line (14 visible chars) itself, which would otherwise
-    // split the "82/100" substring this test asserts on across two physical lines.
-    Object.defineProperty(stream, 'columns', { value: 19 });
+    const { writes, stream } = fakeStream({ columns: 19 }); // below MIN_MASCOT_COLUMNS — mascot omitted
     await playScoreAnimation({ score: 82, palette: noColorPalette, stream, frameDelayMs: 0 });
     expect(writes[writes.length - 1]).toContain('82/100');
     expect(writes.join('')).not.toContain('╭'); // no mascot face art anywhere (the wave's own color isn't a reliable signal — it's colored too now)
   });
 
   it('colors the pulse wave dim orange while counting', async () => {
-    const { writes, stream } = fakeStream();
-    Object.defineProperty(stream, 'columns', { value: 19 }); // below MIN_MASCOT_COLUMNS — isolates the wave's own color from the mascot's
+    const { writes, stream } = fakeStream({ columns: 19 }); // below MIN_MASCOT_COLUMNS — isolates the wave's own color from the mascot's
     await playScoreAnimation({ score: 82, palette: ansiPalette, stream, frameDelayMs: 0 });
     const allWrites = writes.join('');
     expect(allWrites).toContain('\x1b[38;2;153;37;0m'); // dim orange, seen during at least one counting frame
@@ -137,8 +127,7 @@ describe('playScoreAnimation', () => {
   });
 
   it('omits the speech bubble (but keeps the mascot) when the terminal fits the mascot but not the bubble', async () => {
-    const { writes, stream } = fakeStream();
-    Object.defineProperty(stream, 'columns', { value: 45 }); // >= 20 (mascot) but < 55 (bubble)
+    const { writes, stream } = fakeStream({ columns: 45 }); // >= 20 (mascot) but < 55 (bubble)
     await playScoreAnimation({ score: 95, palette: ansiPalette, stream, frameDelayMs: 0 });
     const allWrites = writes.join('');
     expect(allWrites).toContain('\x1b[38;2;255;62;0m'); // mascot still present

--- a/packages/cli/test/speech-bubble.test.ts
+++ b/packages/cli/test/speech-bubble.test.ts
@@ -10,6 +10,7 @@ import {
   REACTION_MESSAGES
 } from '../src/speech-bubble.js';
 import { renderMascotReaction } from '../src/mascot.js';
+import { fakeStream } from './helpers/fake-stream.js';
 
 describe('renderSpeechBubble', () => {
   it('returns exactly 3 lines: top border, text, bottom border', () => {
@@ -108,11 +109,6 @@ describe('renderMascotWithSpeech', () => {
     expect(block).toContain('\x1b[38;2;255;62;0m'); // still the mascot, orange present
   });
 });
-
-function fakeStream() {
-  const writes: string[] = [];
-  return { writes, stream: { write: (s: string) => writes.push(s) } as unknown as NodeJS.WriteStream };
-}
 
 describe('playMascotGreeting', () => {
   it('writes nothing when disabled', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,9 +63,6 @@ catalogs:
     happy-dom:
       specifier: ^20.11.2
       version: 20.11.2
-    log-update:
-      specifier: ^8.0.0
-      version: 8.0.0
     magicast:
       specifier: ^0.5.4
       version: 0.5.4
@@ -215,9 +212,6 @@ importers:
       gunshi:
         specifier: 'catalog:'
         version: 0.37.1
-      log-update:
-        specifier: 'catalog:'
-        version: 8.0.0
       magicast:
         specifier: 'catalog:'
         version: 0.5.4
@@ -2788,10 +2782,6 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
-  ansi-styles@6.2.3:
-    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
-    engines: {node: '>=12'}
-
   ansis@4.3.1:
     resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
     engines: {node: '>=14'}
@@ -3050,10 +3040,6 @@ packages:
 
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
-
-  cli-cursor@5.0.0:
-    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
-    engines: {node: '>=18'}
 
   cli-highlight@2.1.11:
     resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
@@ -4090,10 +4076,6 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
-  is-fullwidth-code-point@5.1.0:
-    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
-    engines: {node: '>=18'}
-
   is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
     engines: {node: '>= 0.4'}
@@ -4469,10 +4451,6 @@ packages:
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
-  log-update@8.0.0:
-    resolution: {integrity: sha512-lddSgOt3bPASrylL54ZSpy8nBHns+vBVSoILlVOx+dei300pnLRN958rj/EdlVLKuWlSESU3qdnDZdAI7FXYGg==}
-    engines: {node: '>=22'}
-
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -4722,10 +4700,6 @@ packages:
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
-
-  mimic-function@5.0.1:
-    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
-    engines: {node: '>=18'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -4981,10 +4955,6 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
-
-  onetime@7.0.0:
-    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
-    engines: {node: '>=18'}
 
   oniguruma-parser@0.12.2:
     resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
@@ -5323,10 +5293,6 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
-  restore-cursor@5.1.0:
-    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
-    engines: {node: '>=18'}
-
   retext-latin@4.0.0:
     resolution: {integrity: sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==}
 
@@ -5539,10 +5505,6 @@ packages:
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
     engines: {node: '>=8'}
-
-  slice-ansi@9.0.0:
-    resolution: {integrity: sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==}
-    engines: {node: '>=22'}
 
   slugify@1.6.9:
     resolution: {integrity: sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==}
@@ -6254,10 +6216,6 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
-
-  wrap-ansi@10.0.0:
-    resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
-    engines: {node: '>=20'}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -8753,8 +8711,6 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
-  ansi-styles@6.2.3: {}
-
   ansis@4.3.1: {}
 
   any-promise@1.3.0: {}
@@ -9169,10 +9125,6 @@ snapshots:
       consola: 3.4.2
 
   cjs-module-lexer@1.4.3: {}
-
-  cli-cursor@5.0.0:
-    dependencies:
-      restore-cursor: 5.1.0
 
   cli-highlight@2.1.11:
     dependencies:
@@ -10432,10 +10384,6 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
-  is-fullwidth-code-point@5.1.0:
-    dependencies:
-      get-east-asian-width: 1.6.0
-
   is-generator-function@1.1.2:
     dependencies:
       call-bound: 1.0.4
@@ -10721,15 +10669,6 @@ snapshots:
   lodash.topath@4.5.2: {}
 
   lodash@4.18.1: {}
-
-  log-update@8.0.0:
-    dependencies:
-      ansi-escapes: 7.3.0
-      cli-cursor: 5.0.0
-      slice-ansi: 9.0.0
-      string-width: 8.2.1
-      strip-ansi: 7.2.0
-      wrap-ansi: 10.0.0
 
   longest-streak@3.1.0: {}
 
@@ -11257,8 +11196,6 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
-  mimic-function@5.0.1: {}
-
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.7
@@ -11395,10 +11332,6 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
-
-  onetime@7.0.0:
-    dependencies:
-      mimic-function: 5.0.1
 
   oniguruma-parser@0.12.2: {}
 
@@ -11810,11 +11743,6 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  restore-cursor@5.1.0:
-    dependencies:
-      onetime: 7.0.0
-      signal-exit: 4.1.0
-
   retext-latin@4.0.0:
     dependencies:
       '@types/nlcst': 2.0.3
@@ -12154,11 +12082,6 @@ snapshots:
   skin-tone@2.0.0:
     dependencies:
       unicode-emoji-modifier-base: 1.0.0
-
-  slice-ansi@9.0.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 5.1.0
 
   slugify@1.6.9: {}
 
@@ -12833,12 +12756,6 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-
-  wrap-ansi@10.0.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 8.2.1
-      strip-ansi: 7.2.0
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,7 +32,6 @@ catalog:
   '@gunshi/plugin-suggestion': 0.37.1
   gunshi: 0.37.1
   happy-dom: ^20.11.2
-  log-update: ^8.0.0
   magicast: ^0.5.4
   node-html-parser: ^9.0.1
   oxfmt: ^0.64.0


### PR DESCRIPTION
## Summary

- `log-update` was adopted (design `2026-07-10-cli-mascot-animation-design.md`, "Library decision") for one job: repaint the spinner / greeting / score block without a hand-rolled `\x1b[nA` redraw corrupting when a line wraps on a narrow terminal. That job is now `packages/cli/src/frame-writer.ts`: erase = `\x1b[2K` + `\x1b[1A\x1b[2K` × *rendered* rows, where a line's rows are its ANSI-stripped code-point count (core's `terminalSafe`) over `stream.columns`; frames taller than the viewport drop leading lines so they never scroll (log-update's rule); a frame identical to the last one at the same width is skipped; synchronized output (`?2026`) on a TTY; cursor hidden on first render and restored by `clear()`/`done()`, `exit`, and `SIGINT`/`SIGTERM`/`SIGQUIT`/`SIGHUP` (re-raised when no other listener owns the signal).
- This works because every frame is authored in 1-column glyphs with bounded widths (mascot 12, wave 24, confetti 24, bubble ≤ 30). `frame-writer.test.ts` pins that as an allowlist (ASCII, box drawing, braille, `·…●◡`) over every idle/plain/reaction frame and message, and pins the wrapped-row erase count, the identical-frame skip, the width-change repaint, and the height clip.
- Design record: `docs/superpowers/specs/2026-08-22-drop-log-update-design.md`.
- `clear()` now also restores the cursor, so `startMascotSpinner().stop()` is one call and its workaround comment is gone.
- Shared `test/helpers/fake-stream.ts` replaces the four per-file `fakeStream` copies.
- Production closure (`dep-budget.test.ts`): `svelte-vitals` 59 → **43**, `@svelte-vitals/vite` 71 → **55**; ceilings lowered to match. Patch changeset for `svelte-vitals`.

## Test plan

- [x] `pnpm test` — full suite incl. 6 frame-writer tests; `pnpm build` / `typecheck` / `lint` (0 warnings) / `smoke` / `e2e`
- [x] Built CLI under a real pty (clean env, 100×40): greeting 4-row / spinner 5-row / score 6-row erases, cursor hide/show balanced 3/3, sync markers 10/10
- [x] Same under a 5-row pane: every erase is 4 rows (clipped to rows−1), nothing scrolls into scrollback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved CLI spinners, greetings, and score animations with more reliable rendering across narrow or short terminals.
  - Animation frames now handle wrapped lines, terminal boundaries, ANSI styling, and duplicate updates more smoothly.
  - Cursor visibility and terminal cleanup are restored safely when animations finish or are interrupted.

- **Chores**
  - Reduced the CLI’s installed package footprint by removing an unused rendering dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->