### PR TITLE
chore(renovate): keep lock file maintenance in one PR and automerge it

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,8 @@
   "minimumReleaseAge": "3 days",
   "labels": ["renovate"],
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": true,
+    "automerge": true
   },
   "rangeStrategy": "bump",
   "platformAutomerge": true,
@@ -21,8 +22,10 @@
       "enabled": false
     },
     {
+      "description": "matchUpdateTypes keeps this rule off the lockFileMaintenance update type — without it, the group rename splits lock file maintenance into a second, permanently-conflicting -catalog twin PR.",
       "groupName": "catalog",
-      "matchFileNames": ["pnpm-workspace.yaml"]
+      "matchFileNames": ["pnpm-workspace.yaml"],
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"]
     },
     {
       "groupName": "linters",


### PR DESCRIPTION
## Why

Two `lock file maintenance` PRs kept appearing every week (#577 and #521), and neither ever merged.

**The split**: the `catalog` packageRule matched only on `matchFileNames: ["pnpm-workspace.yaml"]`. With no `matchUpdateTypes` restriction it also matched the `lockFileMaintenance` update type (the catalog makes `pnpm-workspace.yaml` a package file), and the `groupName` rename split lock file maintenance onto a second `renovate/lock-file-maintenance-catalog` branch. The twins both rewrite `pnpm-lock.yaml`, so merging one conflicts the other, every week.

**The stranding**: `lockFileMaintenance` is not one of the automerged update types, and main's ruleset enforces strict up-to-date status checks — so the manual-merge PR was perpetually behind a fast-moving main.

## What

- Restrict the `catalog` rule to real version update types, so lock file maintenance stays in one PR (Renovate will autoclose #521).
- Automerge lock file maintenance like minor/patch: CI still gates it, and the Renovate app is already on the ruleset bypass list for exactly this purpose.

Note: `minimumReleaseAge` is not enforced on lockfile refreshes (the `renovate/stability-days` status is not a required check), so the freshness guard for transitive bumps is pnpm's supply-chain policy check in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)