### PR TITLE
chore(renovate): hold lock file maintenance to minimumReleaseAge before automerging

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,10 @@
   "minimumReleaseAge": "3 days",
   "labels": ["renovate"],
   "lockFileMaintenance": {
+    "description": "platformAutomerge stays off here: a lockfile refresh pulls versions younger than minimumReleaseAge, and GitHub's auto-merge only waits for required checks — it would merge past the pending renovate/stability-days status. Renovate-side automerge waits for its own stability check, so the 3-day age holds.",
     "enabled": true,
-    "automerge": true
+    "automerge": true,
+    "platformAutomerge": false
   },
   "rangeStrategy": "bump",
   "platformAutomerge": true,


### PR DESCRIPTION
Follow-up to #578, closing the gap it left in the 3-day age guard.

## The gap

For regular updates, `minimumReleaseAge: 3 days` is enforced upstream: Renovate never proposes a version younger than that. A lockfile refresh is different — it takes the latest in-range versions, so younger releases do get in, and Renovate only expresses that as a pending `renovate/stability-days` status.

`platformAutomerge: true` delegates merging to GitHub's auto-merge, which waits for **required** checks only. `renovate/stability-days` is not (and should not be) required — a required check that never reports on human PRs would block every human PR. So after #578, GitHub could merge a lockfile refresh straight past the pending stability status.

## The fix

`platformAutomerge: false` on `lockFileMaintenance` only. Renovate then performs the merge itself, and Renovate-side automerge waits for its own checks — including stability — to go green. In practice: the Monday refresh sits until every dependency it pulled is at least 3 days old, then merges on a later Renovate run. Every other update type keeps the faster platform automerge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)