### PR TITLE
fix(core): a11y/no-autofocus — SVG-namespace dialog/popover no longer exempts autofocus

### DIFF
--- a/packages/core/src/rules/a11y/no-autofocus.ts
+++ b/packages/core/src/rules/a11y/no-autofocus.ts
@@ -7,12 +7,14 @@ import { componentRule } from '../component-rule.js';
  * The popover check accepts the attribute in any form (bare, literal, expression): an expression
  * could resolve to a real popover value, and a generous carve-out trades a false negative for
  * never flagging the documented pattern (same trade as correctness/autoplay-muted's `muted`).
+ * Neither container form counts in the SVG namespace — the focusing steps are defined for the
+ * HTML `dialog` element and HTML elements with a `popover` attribute only; a `<dialog>` inside
+ * `<foreignObject>` is back in HTML and still counts.
  */
 function inShowTimeContainer(elements: ElementFact[], start: ElementFact): boolean {
   let e: ElementFact | undefined = start;
   while (e !== undefined) {
-    if (e.tag === 'dialog') return true;
-    if (e.attrs.some((a) => a.name === 'popover')) return true;
+    if (!e.inSvg && (e.tag === 'dialog' || e.attrs.some((a) => a.name === 'popover'))) return true;
     e = e.parent === undefined ? undefined : elements[e.parent];
   }
   return false;

--- a/packages/core/test/no-autofocus-rule.test.ts
+++ b/packages/core/test/no-autofocus-rule.test.ts
@@ -88,6 +88,19 @@ describe('a11y/no-autofocus', () => {
     expect(passed).toHaveLength(1);
   });
 
+  it('ignores a popover attribute on an SVG element — the focusing steps are HTML-only', async () => {
+    const { penalized } = await check('<svg popover="auto"><foreignObject><input autofocus /></foreignObject></svg>');
+    expect(penalized).toHaveLength(1);
+  });
+
+  it('honours a <dialog> inside <foreignObject> — its children are back in the HTML namespace', async () => {
+    const { penalized, passed } = await check(
+      '<svg><foreignObject><dialog><input autofocus /></dialog></foreignObject></svg>'
+    );
+    expect(penalized).toEqual([]);
+    expect(passed).toHaveLength(1);
+  });
+
   it('emits nothing for a component without autofocus', async () => {
     const { penalized, passed } = await check('<input />');
     expect(penalized).toEqual([]);


### PR DESCRIPTION
Restores a review fix that was lost from #598: the commit addressing the review comment (require `!e.inSvg` on the dialog/popover carve-out) was made and replied to on the PR, but the push silently failed to update the remote branch, so the squash merge only contains the first commit. This lands that fix on main unchanged.

## What

The show-time container check in `a11y/no-autofocus` now requires the element to be outside the SVG namespace: the HTML focusing steps are defined for the HTML `dialog` element and HTML elements with a `popover` attribute only, so `<svg popover><foreignObject><input autofocus /></foreignObject></svg>` no longer exempts the autofocus. A real `<dialog>` inside `<foreignObject>` is back in the HTML namespace and still counts. Two regression tests pin the boundary.

## Notes

No changeset: the rule shipped in #598 is still unreleased (no Version Packages since), so the pending minor changeset already covers the released behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autofocus validation for SVG content.
  * SVG elements named `dialog` or carrying a `popover` attribute are now handled correctly and no longer incorrectly affect autofocus warnings.
  * HTML dialogs embedded within SVG `foreignObject` elements continue to behave as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->