### PR TITLE
fix(core): guard HTML_SPEC lookups against Object.prototype keys

### DIFF
--- a/.changeset/html-spec-proto-key-guard.md
+++ b/.changeset/html-spec-proto-key-guard.md
@@ -1,0 +1,18 @@
+---
+'@svelte-vitals/core': patch
+---
+
+Guard HTML spec lookups against `Object.prototype` keys.
+
+`HTML_SPEC.elements` is `JSON.parse` output, so it inherits `Object.prototype`. A component
+containing an element like `<constructor>` — a legal, if unusual, tag name — indexed straight into
+`Object`'s own function instead of getting `undefined`, and the subsequent property access threw.
+`a11y/deprecated-attr` crashed outright; when a rule throws, the runner drops it from scoring
+silently rather than failing the run, so the finding loss was easy to miss. `a11y/deprecated-element`
+traversed the same unguarded lookup without crashing — its `.obsolete === true` check happened to
+read `undefined` off the `Object` function and land on a correct-by-accident `false`. `a11y/deprecated-aria`
+and `a11y/disallowed-aria-props` shared the same unguarded lookup pattern in `roleCandidates`, and the
+content-model checker and the attribute-name lookup each had one too — none of them crashed today, but
+all were one field access away from it. All lookups by an author-controlled tag or attribute name now
+check `Object.hasOwn` first, matching the existing convention this repo already uses elsewhere for
+attacker-shaped keys.

--- a/packages/core/src/html-spec/content-model.ts
+++ b/packages/core/src/html-spec/content-model.ts
@@ -270,7 +270,10 @@ export function judgeContent(
   const child = els[childIdx]!;
   for (let i = ancestors.length - 1; i >= 0; i--) {
     const holder = els[ancestors[i]!]!;
-    const spec = HTML_SPEC.elements[holder.tag];
+    // JSON.parse output inherits Object.prototype, and holder.tag is an author-controlled tag
+    // name (e.g. `constructor`) — an unguarded index would return Object's function instead of
+    // undefined.
+    const spec = Object.hasOwn(HTML_SPEC.elements, holder.tag) ? HTML_SPEC.elements[holder.tag] : undefined;
     if (!spec?.contentModel) return undefined;
     const cm = spec.contentModel as { contents?: unknown; conditional?: { condition: string; contents: unknown }[] };
     if (cm.contents === true) return undefined;

--- a/packages/core/src/html-spec/index.ts
+++ b/packages/core/src/html-spec/index.ts
@@ -6,7 +6,10 @@ export { HTML_SPEC, HTML_SPEC_VERSION } from './generated.js';
 
 /** The HTML element's spec row; `undefined` for SVG (`svg:*`) and unknown names. */
 export function htmlElement(tag: string): HtmlElementSpec | undefined {
-  return HTML_SPEC.elements[tag.toLowerCase()];
+  const key = tag.toLowerCase();
+  // JSON.parse output inherits Object.prototype, and `constructor` is a legal author tag —
+  // an unguarded index would return Object's function instead of undefined.
+  return Object.hasOwn(HTML_SPEC.elements, key) ? HTML_SPEC.elements[key] : undefined;
 }
 
 /**
@@ -27,7 +30,11 @@ export function isObsoleteElement(tag: string): boolean {
  * and the per-element table is where the dataset's per-attribute status lives.
  */
 export function elementAttr(tag: string, name: string): HtmlAttrSpec | undefined {
-  return htmlElement(tag)?.attributes[name.toLowerCase()];
+  const attrs = htmlElement(tag)?.attributes;
+  if (!attrs) return undefined;
+  const key = name.toLowerCase();
+  // Same Object.prototype hazard as htmlElement, keyed by an author-controlled attribute name.
+  return Object.hasOwn(attrs, key) ? attrs[key] : undefined;
 }
 
 /**

--- a/packages/core/src/rules/a11y/role-candidates.ts
+++ b/packages/core/src/rules/a11y/role-candidates.ts
@@ -46,11 +46,14 @@ export function roleCandidates(e: AriaElementFact): RoleCandidates | undefined {
     return role ? { explicit: true, roles: [role], namingProhibited: false } : undefined;
   }
   if (e.hasSpread) return undefined;
-  const el = HTML_SPEC.elements[e.tag];
+  // JSON.parse output and object literals inherit Object.prototype, and e.tag is an author-
+  // controlled tag name (e.g. `constructor`) — an unguarded index would return Object's
+  // function instead of undefined.
+  const el = Object.hasOwn(HTML_SPEC.elements, e.tag) ? HTML_SPEC.elements[e.tag] : undefined;
   if (!el) return undefined;
   // An override replaces the element's ARIA facts wholesale — role, prohibition and conditions.
-  const aria: Pick<typeof el.aria, 'implicitRole' | 'namingProhibited' | 'conditions'> =
-    ELEMENT_FACT_OVERRIDES[e.tag] ?? el.aria;
+  const override = Object.hasOwn(ELEMENT_FACT_OVERRIDES, e.tag) ? ELEMENT_FACT_OVERRIDES[e.tag] : undefined;
+  const aria: Pick<typeof el.aria, 'implicitRole' | 'namingProhibited' | 'conditions'> = override ?? el.aria;
   const roles: (string | false)[] = [aria.implicitRole ?? false];
   for (const c of Object.values(aria.conditions ?? {})) {
     if ('implicitRole' in c) roles.push(c.implicitRole ?? false);

--- a/packages/core/test/a11y-spec-data-rules.test.ts
+++ b/packages/core/test/a11y-spec-data-rules.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { parseComponentFacts } from '../src/component-parse.js';
-import { a11yDeprecatedElement, a11yDeprecatedAttr } from '../src/internal.js';
+import {
+  a11yDeprecatedElement,
+  a11yDeprecatedAttr,
+  a11yDeprecatedAria,
+  a11yDisallowedAriaProps
+} from '../src/internal.js';
 import { defineConfig, defaultProject, type Result } from '../src/types.js';
 import type { RuleContext } from '../src/rule.js';
 
@@ -101,5 +106,19 @@ describe('a11y/deprecated-attr', () => {
   it('does not consult the global attribute groups', async () => {
     const out = await a11yDeprecatedAttr.check(ctx('<svg><use xlink:href="#i" /></svg><div xml:lang="en">t</div>'));
     expect(fails(out)).toEqual([]);
+  });
+});
+
+describe('an Object.prototype-inherited tag name (<constructor>) does not crash spec-data rules', () => {
+  const src = '<constructor data-x="1"></constructor>';
+
+  it('a11y/deprecated-attr treats it as an unknown element and finds nothing', async () => {
+    const out = await a11yDeprecatedAttr.check(ctx(src));
+    expect(fails(out)).toEqual([]);
+  });
+
+  it('a11y/deprecated-aria and a11y/disallowed-aria-props (roleCandidates consumers) find nothing', async () => {
+    expect(fails(await a11yDeprecatedAria.check(ctx(src)))).toEqual([]);
+    expect(fails(await a11yDisallowedAriaProps.check(ctx(src)))).toEqual([]);
   });
 });

--- a/packages/core/test/a11y-spec-data-rules.test.ts
+++ b/packages/core/test/a11y-spec-data-rules.test.ts
@@ -110,14 +110,15 @@ describe('a11y/deprecated-attr', () => {
 });
 
 describe('an Object.prototype-inherited tag name (<constructor>) does not crash spec-data rules', () => {
-  const src = '<constructor data-x="1"></constructor>';
-
   it('a11y/deprecated-attr treats it as an unknown element and finds nothing', async () => {
-    const out = await a11yDeprecatedAttr.check(ctx(src));
+    const out = await a11yDeprecatedAttr.check(ctx('<constructor data-x="1"></constructor>'));
     expect(fails(out)).toEqual([]);
   });
 
   it('a11y/deprecated-aria and a11y/disallowed-aria-props (roleCandidates consumers) find nothing', async () => {
+    // Needs an aria-* attribute (not just data-x) so parseComponentFacts records an ariaElements
+    // entry — that's what makes these rules actually reach roleCandidates for this tag.
+    const src = '<constructor data-x="1" aria-label="x"></constructor>';
     expect(fails(await a11yDeprecatedAria.check(ctx(src)))).toEqual([]);
     expect(fails(await a11yDisallowedAriaProps.check(ctx(src)))).toEqual([]);
   });

--- a/packages/core/test/html-spec.test.ts
+++ b/packages/core/test/html-spec.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { projectHtmlSpec, resolveHtmlSpec } from '../scripts/html-spec.js';
 import { HTML_SPEC, HTML_SPEC_VERSION } from '../src/html-spec/generated.js';
+import { elementAttr, htmlElement, isDeprecatedAttr } from '../src/html-spec/index.js';
 import { isKnownAriaAttribute, isKnownRole } from '../src/rules/a11y/aria-data.js';
 
 const REGENERATE = 'run `pnpm --filter @svelte-vitals/core run gen:html-spec`';
@@ -58,6 +59,22 @@ describe('html-spec: what the projection must and must not carry', () => {
       .find((l) => l.startsWith('Copyright'))!;
     expect(head.startsWith('/*!')).toBe(true);
     expect(head).toContain(copyright);
+  });
+});
+
+describe('html-spec: Object.prototype keys are not element data', () => {
+  it('treats Object.prototype-inherited tag names as unknown elements', () => {
+    expect(htmlElement('constructor')).toBeUndefined();
+    expect(htmlElement('toString')).toBeUndefined();
+    expect(htmlElement('valueOf')).toBeUndefined();
+  });
+
+  it('does not throw when checking a deprecated attribute on such a tag', () => {
+    expect(isDeprecatedAttr('constructor', 'data-x')).toBe(false);
+  });
+
+  it('treats an Object.prototype-inherited attribute name as an unknown attribute', () => {
+    expect(elementAttr('img', 'constructor')).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

`HTML_SPEC.elements` is `JSON.parse` output, so it inherits `Object.prototype`. Indexing it with the author-controlled tag name `constructor` returned `Object`'s own function (non-nullish, so `?.` did not short-circuit), and the next property access threw. Reproduced: a component containing `<constructor data-x="1">` crashed `a11y/deprecated-attr`'s `check()` with `TypeError: Cannot read properties of undefined (reading 'data-x')` — and a crashed rule is silently dropped from scoring by the failed-rule isolation, with the exit code unchanged, so a CI gate stays green while a scored rule disappears.

This applies the repo's existing convention for attacker-shaped keys (`Object.create(null)` in the rendered collector, the "never index by shell id" guard in route composition) to every author-reachable `HTML_SPEC` lookup:

- `htmlElement` and `elementAttr` (`packages/core/src/html-spec/index.ts`) — tag and attribute name lookups now check `Object.hasOwn` first; this fixes the `a11y/deprecated-attr` crash
- `roleCandidates` (`packages/core/src/rules/a11y/role-candidates.ts`) — the `HTML_SPEC.elements[e.tag]` and `ELEMENT_FACT_OVERRIDES[e.tag]` lookups (benign today, one field access away from the same failure)
- `judgeContent` (`packages/core/src/html-spec/content-model.ts`) — the ancestor-tag lookup (same hazard class)

`HTML_SPEC.aria.roles[role]` is deliberately left unguarded: `role` only arrives via `resolveRole` → aria-query's `Map.has`, or from spec data, so a prototype key cannot reach it.

## Tests

- Unit: `htmlElement('constructor'/'toString'/'valueOf')` → `undefined`, `isDeprecatedAttr('constructor','data-x')` → `false`, `elementAttr('img','constructor')` → `undefined` (all fail on the unguarded code)
- Rule-level regression: `<constructor data-x="1">` through `a11y/deprecated-attr` (crashed before this fix) and the `roleCandidates` consumers (`a11y/deprecated-aria`, `a11y/disallowed-aria-props`, non-regression pins)
- Full suite: build, typecheck, core 1760 tests, cli/vite/kitchen-sink suites, lint — all green; the guard widens the `undefined` range only, so no existing expectation changed

Changeset: `@svelte-vitals/core` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented inherited property names from being misinterpreted as valid HTML elements, attributes, or ARIA roles.
  * Improved handling of unusual or unknown markup names, preventing crashes and incorrect accessibility findings.
  * Ensured unsupported names are treated as unknown rather than matching built-in object properties.

* **Tests**
  * Added regression coverage for inherited names such as `constructor`, `toString`, and `valueOf`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->