### PR TITLE
fix(cli): make boolean last-wins see every --flag=<value> token

### DIFF
--- a/.changeset/guard-args-last-wins.md
+++ b/.changeset/guard-args-last-wins.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': patch
+---
+
+Fix a boolean flag's last-wins resolution to see every `--flag=<value>` spelling, not just bare `--flag` and `--flag=false`. Previously `--flag=true --flag=false` left the flag on instead of turning it off, because the surviving `--flag=true` token reached the parser unnoticed.

--- a/packages/cli/src/gunshi/guard.ts
+++ b/packages/cli/src/gunshi/guard.ts
@@ -21,7 +21,12 @@ import { defineSuggestNames, levenshtein } from '@gunshi/plugin-suggestion';
 export interface GuardResult {
   /** Fatal `--<flag> requires a value.` messages; empty when nothing was rejected. */
   errors: string[];
-  /** `argv` with every `--<boolFlag>=false` token removed (equivalent to the flag never being passed). */
+  /**
+   * `argv` with boolean-flag tokens normalized for last-wins: if a `booleanFlag`'s last
+   * occurrence (any `--<flag>` or `--<flag>=<value>` spelling) is `=false`, every one of its
+   * tokens is removed (equivalent to the flag never being passed); otherwise only its `=false`
+   * tokens are removed, leaving the winning occurrence for gunshi to parse.
+   */
   argv: string[];
 }
 
@@ -46,17 +51,21 @@ export function guardArgs(argv: string[], valueFlags: readonly string[], boolean
 
   // Duplicate boolean tokens are last-wins under `node:util`'s parseArgs (overwrites on
   // repetition, then a final literal 'false' coerces to off) — so when a flag's LAST occurrence
-  // is `=false`, every token of that flag must go, not just the `=false` ones.
+  // is `=false`, every token of that flag must go, not just the `=false` ones. Every `--<flag>`
+  // spelling counts as an occurrence for "last", including `--<flag>=true` or any other explicit
+  // value — otherwise a surviving `=true` token between two off-decisions (or after the winning
+  // `=false`) reaches gunshi and re-ons the flag.
+  const isTokenOf = (flag: string, token: string) => token === `--${flag}` || token.startsWith(`--${flag}=`);
   const offFlags = new Set(
     booleanFlags.filter((flag) => {
       let lastToken: string | undefined;
-      for (const t of argv) if (t === `--${flag}` || t === `--${flag}=false`) lastToken = t;
+      for (const t of argv) if (isTokenOf(flag, t)) lastToken = t;
       return lastToken === `--${flag}=false`;
     })
   );
   const argvNormalized = argv.filter((token) => {
     for (const flag of booleanFlags) {
-      if (token === `--${flag}=false` || (offFlags.has(flag) && token === `--${flag}`)) return false;
+      if (offFlags.has(flag) ? isTokenOf(flag, token) : token === `--${flag}=false`) return false;
     }
     return true;
   });

--- a/packages/cli/test/gunshi-analyze.test.ts
+++ b/packages/cli/test/gunshi-analyze.test.ts
@@ -206,6 +206,32 @@ describe('--score --score=false: last-wins through the real dispatch path', () =
   });
 });
 
+// Truth table for every 2-token last-wins shape, run against a real project (unitEntryFixtureDir)
+// instead of an invalid dir: ProjectError fires before opts.score is ever read, so an invalid-dir
+// run can't distinguish --score being on from off (both hit the same "No SvelteKit project found"
+// path) — only a real analysis run makes the on/off difference (bare number vs. full report)
+// observable.
+describe('boolean last-wins truth table (--score): every =<value> spelling counts as an occurrence', () => {
+  it('--score=true --score=false: the trailing =false wins, off (full report, not a bare number)', async () => {
+    const { code, out } = await run([unitEntryFixtureDir, '--score=true', '--score=false']);
+    expect(code).toBe(1);
+    expect(out).not.toMatch(/^\d+$/);
+    expect(out.length).toBeGreaterThan(0);
+  });
+
+  it('--score=false --score=true: the trailing =true wins, on (a bare Health-score number)', async () => {
+    const { code, out } = await run([unitEntryFixtureDir, '--score=false', '--score=true']);
+    expect(code).toBe(1);
+    expect(out).toMatch(/^\d+$/);
+  });
+
+  it('--score=false --score: the trailing bare flag wins, on (a bare Health-score number)', async () => {
+    const { code, out } = await run([unitEntryFixtureDir, '--score=false', '--score']);
+    expect(code).toBe(1);
+    expect(out).toMatch(/^\d+$/);
+  });
+});
+
 describe('--help wins over a guard-detected error (help is checked before the guard fallback)', () => {
   it('--help --reporter= prints help and exits 0, exactly like today', async () => {
     const { code, out, err } = await run(['--help', '--reporter=']);

--- a/packages/cli/test/gunshi-guard.test.ts
+++ b/packages/cli/test/gunshi-guard.test.ts
@@ -72,6 +72,16 @@ describe('guardArgs: boolean --flag=false normalization', () => {
     const { argv } = guardArgs(['--json=false', '--json'], [], ['json']);
     expect(argv).toEqual(['--json']);
   });
+
+  it('a --<boolFlag>=true token counts as an occurrence too: a trailing =false still turns it off', () => {
+    const { argv } = guardArgs(['--json=true', '--json=false'], [], ['json']);
+    expect(argv).toEqual([]);
+  });
+
+  it('--<boolFlag>=false then =true: the trailing =true wins, flag stays on', () => {
+    const { argv } = guardArgs(['--json=false', '--json=true'], [], ['json']);
+    expect(argv).toEqual(['--json=true']);
+  });
 });
 
 describe('splitAtTerminator', () => {


### PR DESCRIPTION
## Summary

Boolean CLI flags follow a last-wins convention: a final `--flag=false` turns the flag off. `guardArgs` implements this by rewriting argv before gunshi parses (gunshi coerces any explicit value on a declared boolean to `true`). But its last-occurrence scan only recognized the `--flag` and `--flag=false` spellings, and its removal filter only stripped those two — so in `--score=true --score=false` the surviving `--score=true` token reached gunshi and turned the flag back on. Reproduced on the built binary: a bare score number instead of the full report.

The fix shares one predicate (`isTokenOf`: exact `--flag` or `--flag=` prefix) between the scan and the filter:

- every spelling counts as an occurrence for "last"
- a flag whose last occurrence is `--flag=false` has **all** of its tokens removed
- otherwise only its `=false` tokens are removed, leaving the winning occurrence for gunshi

Semantics are otherwise unchanged (only a literal trailing `=false` turns a flag off; verified cell-by-cell against the legacy `node:util` `parseArgs` path, including `--flag=`, `--flag=FALSE`, and 3-token mixes). The same `guardArgs` serves `install`/`explain`/`docs`/`ci`, so those flag lists inherit the fix.

## Tests

- Unit truth-table cells in `gunshi-guard.test.ts` (`=true …=false` → all tokens dropped; `=false …=true` → `=true` survives)
- Real-dispatch cells in `gunshi-analyze.test.ts` against a real fixture project, asserting the observable difference (bare Health-score number vs full report) — the originally sketched invalid-dir pattern was replaced because `ProjectError` fires before `--score` is ever read and cannot discriminate on/off
- Revert-verified: the two discriminating cells fail on the unfixed code; full suite (core/cli/vite/kitchen-sink), typecheck, lint all green

Changeset: `svelte-vitals` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed boolean command-line flags so the last occurrence consistently determines whether the flag is enabled or disabled.
  * Corrected handling for flags written with explicit values, including mixed `true` and `false` values.
  * Updated flag behavior documentation and added coverage for supported value combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->