### PR TITLE
fix(cli): sanitize subcommand stderr and the last-resort catch with terminalSafe

### DIFF
--- a/.changeset/terminal-safe-io-factories.md
+++ b/.changeset/terminal-safe-io-factories.md
@@ -1,0 +1,5 @@
+---
+'svelte-vitals': patch
+---
+
+Sanitize terminal escape sequences from analyzed-repo strings that reach the terminal outside the analyze report: every subcommand's stderr (`consoleIO.errorLog`), the `install` command's stdout/stderr and its `runCommand` failure messages, and the CLI's last-resort error path. The `analyze` command's own stdout is unchanged — its console reporter already sanitizes tainted substrings at interpolation points and still emits its own deliberate ANSI color codes.

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { terminalSafe } from '@svelte-vitals/core/internal';
 import { runCli } from './cli.js';
 
 /** Thin entry point: `runCli` does the full dispatch and never exits the process itself — see `CliResult.exit` for why the two mechanics below still have to differ per path. */
@@ -12,6 +13,6 @@ async function main(): Promise<void> {
 }
 
 main().catch((err: unknown) => {
-  console.error(`svelte-vitals: ${err instanceof Error ? err.message : String(err)}`);
+  console.error(terminalSafe(`svelte-vitals: ${err instanceof Error ? err.message : String(err)}`));
   process.exit(2);
 });

--- a/packages/cli/src/cli-io.ts
+++ b/packages/cli/src/cli-io.ts
@@ -1,3 +1,5 @@
+import { terminalSafe } from '@svelte-vitals/core/internal';
+
 /** Output sink for the read-only subcommands. Narrower than `InstallIO` — no filesystem access. */
 export interface CliIO {
   log(line: string): void;
@@ -5,6 +7,12 @@ export interface CliIO {
 }
 
 export const consoleIO: CliIO = {
+  // log carries the console reporter's own ANSI-styled report (e.g. formatConsoleReport); that
+  // reporter already sanitizes tainted analyzed-repo substrings at interpolation points
+  // (reporter/console.ts), so wrapping the whole sink here would strip its deliberate SGR color
+  // codes along with them.
   log: (line) => console.log(line),
-  errorLog: (line) => console.error(line)
+  // errorLog carries analyzed-repo strings (fs error messages, paths) with no deliberate
+  // styling — same threat model as reporter/sanitize.ts.
+  errorLog: (line) => console.error(terminalSafe(line))
 };

--- a/packages/cli/src/install/cli.ts
+++ b/packages/cli/src/install/cli.ts
@@ -2,6 +2,7 @@ import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import * as p from '@clack/prompts';
+import { terminalSafe } from '@svelte-vitals/core/internal';
 import type { InstallIO, InstallPrompts, SelectableOption, TargetId } from './index.js';
 
 export function realIO(): InstallIO {
@@ -22,8 +23,8 @@ export function realIO(): InstallIO {
     // clack reads from stdin and renders to stdout, so both must be interactive —
     // a piped/redirected stdin would leave the prompt hanging for input that never comes.
     isTTY: Boolean(process.stdin.isTTY) && Boolean(process.stdout.isTTY),
-    log: (line) => console.log(line),
-    errorLog: (line) => console.error(line),
+    log: (line) => console.log(terminalSafe(line)),
+    errorLog: (line) => console.error(terminalSafe(line)),
     runCommand: (command, args, cwd) => {
       const result = spawnSync(command, args, {
         cwd,
@@ -32,11 +33,13 @@ export function realIO(): InstallIO {
         timeout: 120_000
       });
       if (result.error) {
-        console.error(`svelte-vitals: ${command} failed to start: ${result.error.message}`);
+        console.error(terminalSafe(`svelte-vitals: ${command} failed to start: ${result.error.message}`));
         return 1;
       }
       if (result.signal) {
-        console.error(`svelte-vitals: ${command} was terminated (${result.signal}) — it may have timed out.`);
+        console.error(
+          terminalSafe(`svelte-vitals: ${command} was terminated (${result.signal}) — it may have timed out.`)
+        );
         return 1;
       }
       return result.status ?? 1;

--- a/packages/cli/test/cli-io.test.ts
+++ b/packages/cli/test/cli-io.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { consoleIO } from '../src/cli-io.js';
+
+const oscTitleRewrite = 'a\x1b]0;evil\x07b';
+
+describe('consoleIO', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('strips terminal escape sequences from errorLog() before they reach console.error', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    consoleIO.errorLog(oscTitleRewrite);
+    expect(spy).toHaveBeenCalledWith('ab');
+  });
+
+  it('preserves newlines and tabs in errorLog()', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    consoleIO.errorLog('a\nb\tc');
+    expect(spy).toHaveBeenCalledWith('a\nb\tc');
+  });
+
+  // log() carries the console reporter's own ANSI-styled report — it must stay unsanitized so
+  // deliberate SGR color codes reach the terminal (unit-level pin; the reporter's own tests cover
+  // the full styled-report dispatch path).
+  it('passes deliberate ANSI color codes through log() unmodified', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const styled = '\x1b[31mred\x1b[39m';
+    consoleIO.log(styled);
+    expect(spy).toHaveBeenCalledWith(styled);
+  });
+});

--- a/packages/cli/test/install/cli.test.ts
+++ b/packages/cli/test/install/cli.test.ts
@@ -15,6 +15,35 @@ describe('realIO().readFile', () => {
   });
 });
 
+describe('realIO().log / errorLog', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const oscTitleRewrite = 'a\x1b]0;evil\x07b';
+
+  it('strips terminal escape sequences from log() before they reach console.log', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    realIO().log(oscTitleRewrite);
+    expect(spy).toHaveBeenCalledWith('ab');
+  });
+
+  it('strips terminal escape sequences from errorLog() before they reach console.error', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    realIO().errorLog(oscTitleRewrite);
+    expect(spy).toHaveBeenCalledWith('ab');
+  });
+
+  it('preserves newlines and tabs', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    realIO().log('a\nb\tc');
+    realIO().errorLog('a\nb\tc');
+    expect(logSpy).toHaveBeenCalledWith('a\nb\tc');
+    expect(errorSpy).toHaveBeenCalledWith('a\nb\tc');
+  });
+});
+
 describe('realIO().isTTY', () => {
   it('is false when stdin is not a TTY even if stdout is (piped stdin would hang a prompt)', () => {
     const stdin = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');


### PR DESCRIPTION
## Summary

Strings from the analyzed repository (paths, directory names, filesystem error messages) can carry ANSI/OSC terminal escape sequences. The console reporter and `run()`'s stderr were hardened earlier, but three sinks stayed raw — reachable by simply running `svelte-vitals install` in a cloned repo, no analysis or config execution required:

- `consoleIO.errorLog` (`packages/cli/src/cli-io.ts`) — the default stderr sink for every subcommand's diagnostics; now wrapped in `terminalSafe`. `consoleIO.log` deliberately stays raw: it carries the console reporter's own ANSI-styled report (which sanitizes analyzed-repo substrings at interpolation points), and wrapping it strips all report coloring — caught by adversarial review and pinned with a passthrough test so it cannot regress silently again
- `realIO()` (`packages/cli/src/install/cli.ts`) — `log`/`errorLog` plus the two `runCommand` failure messages (fs error messages embed paths verbatim); the `stdio: 'inherit'` child output is the user's own package manager and is not (and cannot be) sanitized here
- `bin.ts`'s last-resort catch

Verified end-to-end: `explain` with an OSC title-rewrite payload in argv prints its diagnostic with the payload stripped (0 ESC bytes on stderr), and a `FORCE_COLOR=1` analyze run still emits its 74 ESC-bearing report lines, byte-for-byte matching the pre-change baseline.

## Tests

- `cli-io.test.ts` (new): `errorLog` strips an OSC title-rewrite sequence and preserves `\n`/`\t`; `log` passes `\x1b[31mred\x1b[39m` through unmodified (the anti-regression pin for report coloring)
- `install/cli.test.ts`: same stripping + preservation assertions against the real `realIO()` factory
- Full suite (core 1755 / cli 1273 / vite 258 / kitchen-sink 38), typecheck, lint — all green

Changeset: `svelte-vitals` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Sanitized terminal escape sequences in CLI error output and installation messages to prevent unsafe terminal behavior.
  * Preserved intended formatting such as newlines, tabs, and deliberate color output where appropriate.

* **Bug Fixes**
  * Improved sanitization for fatal CLI errors and command execution failures.

* **Tests**
  * Added coverage verifying safe terminal output across CLI and installation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->