### PR TITLE
fix(cli,vite): resolve landmark role token lists with resolveRole, not the first token

### DIFF
--- a/.changeset/landmark-resolve-role.md
+++ b/.changeset/landmark-resolve-role.md
@@ -1,0 +1,7 @@
+---
+'@svelte-vitals/core': patch
+'svelte-vitals': patch
+'@svelte-vitals/vite': patch
+---
+
+Landmark collection now resolves ARIA fallback role lists (`role="section main"`) the way user agents do — the first token naming a concrete role — instead of taking the first token unconditionally. A list whose first token is abstract or unrecognized (`role="section main"`) now resolves to `main` in both the source and rendered providers, matching browser behavior, so `a11y/duplicate-landmark` and `a11y/top-level-landmark` no longer miss or misreport landmarks introduced through such lists.

--- a/packages/cli/src/providers/source/parse.ts
+++ b/packages/cli/src/providers/source/parse.ts
@@ -16,7 +16,8 @@ import {
   decodeFragmentId,
   splitTokens,
   LANDMARK_ROLES,
-  IDREF_ATTRS
+  IDREF_ATTRS,
+  resolveRole
 } from '@svelte-vitals/core/internal';
 import { collectImports, type ImportMap } from './imports.js';
 
@@ -421,9 +422,9 @@ function collectA11y(fragment: AST.Fragment, source: string): ParsedA11y {
     // are filtered out internally, so this widening cast is safe.
     const attrs = node.attributes as AST.Attribute[];
     const roleAttr = findAttr(attrs, 'role');
-    // ARIA fallback role lists (role="switch checkbox") resolve to the first supported token; a
-    // non-literal or non-landmark role suppresses the tag mapping rather than falling through to it.
-    const role = roleAttr ? splitTokens(attrTextOf(roleAttr))[0] : undefined;
+    // ARIA fallback role lists resolve to the first token naming a concrete role (resolveRole); a
+    // role attribute, resolved or not, suppresses the tag mapping rather than falling through to it.
+    const role = roleAttr ? resolveRole(splitTokens(attrTextOf(roleAttr))) : undefined;
     let landmark = roleAttr ? (role && LANDMARK_ROLES.has(role) ? role : undefined) : LANDMARK_TAGS.get(node.name);
     if (!roleAttr && node.name === 'aside') {
       landmark = ctx.asideDemoting === 0 || hasAccessibleName(attrs) ? 'complementary' : undefined;

--- a/packages/cli/test/parse-file.test.ts
+++ b/packages/cli/test/parse-file.test.ts
@@ -100,6 +100,11 @@ describe('parseFile — a11y occurrences', () => {
     ]);
   });
 
+  it('resolves an ARIA fallback role list to the first concrete role, not the first token', () => {
+    const parsed = parseIt('<div role="section main" /><div role="button main" />');
+    expect(parsed.a11y.nodes).toEqual([expect.objectContaining({ kind: 'landmark', key: 'main' })]);
+  });
+
   it('emits an empty key for expression ids and tokenizes aria idref lists', () => {
     const parsed = parseIt('<div id={x} aria-labelledby="a b" aria-controls="c" /><a href="#top" /><a href="#" />');
     expect(parsed.a11y.nodes.map((n) => ({ kind: n.kind, key: n.key, attr: n.attr }))).toEqual([

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -23,6 +23,7 @@ export {
   LANDMARK_ROLES,
   IDREF_ATTRS
 } from './a11y.js';
+export { resolveRole } from './rules/a11y/aria-data.js';
 export type {
   EachBlockFact,
   EffectFact,

--- a/packages/vite/src/providers/rendered/parse-html.ts
+++ b/packages/vite/src/providers/rendered/parse-html.ts
@@ -7,7 +7,8 @@ import {
   isTopFragment,
   stripTextDirective,
   LANDMARK_ROLES,
-  IDREF_ATTRS
+  IDREF_ATTRS,
+  resolveRole
 } from '@svelte-vitals/core/internal';
 
 function attrValue(v: string | undefined): Value {
@@ -104,9 +105,10 @@ function collectA11y(root: HTMLElement): CollectedA11y {
     const roleAttr = el.getAttribute('role');
     // A literal role, present or not, decides landmark-ness outright — it suppresses the tag
     // mapping rather than falling through to it (mirrors the source provider's parse.ts).
+    // ARIA fallback role lists resolve to the first token naming a concrete role (resolveRole).
     let landmark: string | undefined;
     if (roleAttr !== undefined) {
-      const role = splitTokens(roleAttr)[0];
+      const role = resolveRole(splitTokens(roleAttr));
       landmark = role && LANDMARK_ROLES.has(role) ? role : undefined;
     } else if (tag === 'main') {
       landmark = 'main';

--- a/packages/vite/test/parse-html.test.ts
+++ b/packages/vite/test/parse-html.test.ts
@@ -309,6 +309,11 @@ describe('parse-html: a11y capture (rendered landmark/id parity)', () => {
     expect(landmarks).toContain('complementary');
   });
 
+  it('resolves an ARIA fallback role list to the first concrete role, not the first token', () => {
+    const { landmarks } = parseHtmlHead(doc('<div role="section main"></div><div role="button main"></div>'));
+    expect(landmarks).toEqual(['main']);
+  });
+
   it('reports nesting when a landmark sits inside another landmark', () => {
     const { nestedLandmarks } = parseHtmlHead(doc('<main><div role="complementary"></div></main>'));
     expect(nestedLandmarks).toContainEqual({ kind: 'complementary', within: 'main' });


### PR DESCRIPTION
## Summary

ARIA role attributes allow fallback lists (`role="section main"`); user agents apply the first token naming a concrete (non-abstract, known) role. The repo's a11y rule-validity review adopted exactly this rule and unified the role rules on the shared `resolveRole` helper — but landmark collection in both providers still took `splitTokens(...)[0]` unconditionally. A list whose first token is abstract or unknown (`role="section main"` resolves to `main` in a browser) was invisible as a landmark, so `a11y/duplicate-landmark` and `a11y/top-level-landmark` silently missed landmarks introduced through such lists, in both static and rendered mode.

Changes:

- `packages/core/src/internal.ts` — export `resolveRole` (internal surface only; the semver-stable `index.ts` is untouched)
- `packages/cli/src/providers/source/parse.ts` and `packages/vite/src/providers/rendered/parse-html.ts` — `resolveRole(splitTokens(...))` instead of the first token; role-attribute presence still suppresses the tag mapping, so `role="button main"` (resolves to `button`, concrete non-landmark) is correctly not a landmark

Behavior changes only for lists whose first token is not a concrete role — verified edge-by-edge (empty/whitespace/unknown/abstract-alone/mixed-case all identical to before), and the only other first-token role read left in the repo is inside `invalid-role`'s message for an already-unresolvable value, which is correct in context.

## Tests

- One exact-array case per provider: `<div role="section main"> <div role="button main">` yields exactly one landmark (`main`) — the array shape pins both the positive and the negative; mutation-tested (reverting the two src hunks fails exactly these two tests)
- kitchen-sink e2e unchanged (`expected-findings.json` no diff), full suite (core 1755 / cli 1268 / vite 259 / kitchen-sink 38), `pnpm e2e`, typecheck, lint — all green

Changeset: `@svelte-vitals/core` + `svelte-vitals` + `@svelte-vitals/vite` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accessibility landmark detection for elements with ARIA fallback role lists.
  - Landmark roles now resolve to the first recognized concrete role, even when earlier roles are abstract or unsupported.
  - Prevented missed or incorrectly reported landmarks in accessibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->