### PR TITLE
fix(core): lowercase tag names in collectAriaElements

### DIFF
--- a/.changeset/aria-elements-tag-lowercase.md
+++ b/.changeset/aria-elements-tag-lowercase.md
@@ -9,9 +9,12 @@ the tag as a component reference, so `<Div>` was never affected), but the collec
 `node.name` verbatim while `collectElements` already normalized with `.toLowerCase()`. The rules
 reading `ariaElements` were affected unevenly: `a11y/invalid-role`,
 `a11y/unknown-aria-attribute`, and `a11y/invalid-aria-value` never key off `e.tag` and were unaffected.
-`a11y/disallowed-aria-props` and `a11y/deprecated-aria` look up `HTML_SPEC.elements` by tag through
-`roleCandidates`, so a mixed-case tag missed the lookup and silently dropped every finding for that
-element. `a11y/required-aria-props`'s `HOST_SUPPLIED` table checks `e.tag`/`e.inputType`/`e.selectKind`
+`a11y/disallowed-aria-props` and `a11y/deprecated-aria` resolve an element's implicit role through
+`roleCandidates`, which looks up `HTML_SPEC.elements` by tag — on a mixed-case tag without an
+explicit `role` attribute that lookup missed, silently dropping the findings that depend on
+implicit-role resolution. Elements with an explicit role, and `deprecated-aria`'s
+globally-deprecated-attribute findings (`aria-grabbed` etc.), were unaffected.
+`a11y/required-aria-props`'s `HOST_SUPPLIED` table checks `e.tag`/`e.inputType`/`e.selectKind`
 to recognize a native control (a checkbox `<input>`, a combobox `<select>`) that already supplies a
 required prop natively — a mixed-case tag missed that recognition too, but in the other direction:
 the prop was wrongly reported missing on an element that already had it. Normalizing at collection

--- a/.changeset/aria-elements-tag-lowercase.md
+++ b/.changeset/aria-elements-tag-lowercase.md
@@ -1,0 +1,18 @@
+---
+'@svelte-vitals/core': patch
+---
+
+Lowercase tag names in `collectAriaElements`.
+
+Svelte accepts a mixed-case regular element (`<dIv>`; a leading capital instead makes Svelte treat
+the tag as a component reference, so `<Div>` was never affected), but the collector recorded
+`node.name` verbatim while `collectElements` already normalized with `.toLowerCase()`. Every rule
+reading `ariaElements` was affected, but not uniformly: `a11y/invalid-role`,
+`a11y/unknown-aria-attribute`, and `a11y/invalid-aria-value` never key off `e.tag` and were unaffected.
+`a11y/disallowed-aria-props` and `a11y/deprecated-aria` look up `HTML_SPEC.elements` by tag through
+`roleCandidates`, so a mixed-case tag missed the lookup and silently dropped every finding for that
+element. `a11y/required-aria-props`'s `HOST_SUPPLIED` table checks `e.tag`/`e.inputType`/`e.selectKind`
+to recognize a native control (a checkbox `<input>`, a combobox `<select>`) that already supplies a
+required prop natively — a mixed-case tag missed that recognition too, but in the other direction:
+the prop was wrongly reported missing on an element that already had it. Normalizing at collection
+fixes every consumer at once.

--- a/.changeset/aria-elements-tag-lowercase.md
+++ b/.changeset/aria-elements-tag-lowercase.md
@@ -6,8 +6,8 @@ Lowercase tag names in `collectAriaElements`.
 
 Svelte accepts a mixed-case regular element (`<dIv>`; a leading capital instead makes Svelte treat
 the tag as a component reference, so `<Div>` was never affected), but the collector recorded
-`node.name` verbatim while `collectElements` already normalized with `.toLowerCase()`. Every rule
-reading `ariaElements` was affected, but not uniformly: `a11y/invalid-role`,
+`node.name` verbatim while `collectElements` already normalized with `.toLowerCase()`. The rules
+reading `ariaElements` were affected unevenly: `a11y/invalid-role`,
 `a11y/unknown-aria-attribute`, and `a11y/invalid-aria-value` never key off `e.tag` and were unaffected.
 `a11y/disallowed-aria-props` and `a11y/deprecated-aria` look up `HTML_SPEC.elements` by tag through
 `roleCandidates`, so a mixed-case tag missed the lookup and silently dropped every finding for that

--- a/packages/core/src/component-parse.ts
+++ b/packages/core/src/component-parse.ts
@@ -1230,12 +1230,16 @@ function collectAriaElements(node: Node, source: string, acc: AriaElementFact[])
       (a: Node) => a?.type === 'Attribute' && typeof a.name === 'string' && a.name.toLowerCase().startsWith('aria-')
     );
     if (roleAttr || ariaAttrs.length > 0) {
-      const inputType = node.name === 'input' ? attrText(node.attributes, 'type') : undefined;
-      const hasList = node.name === 'input' && findAttr(node.attributes, 'list') !== undefined;
-      const selectKind = node.name === 'select' ? selectNativeRole(node.attributes) : undefined;
+      // Tag names, like the attribute names above, keep their source spelling in the Svelte AST —
+      // normalize so spec lookups (HTML tag matching is case-insensitive) and the input/select
+      // special-casing don't silently miss a mixed-case tag like `<dIv>` or `<inPUT>`.
+      const tag = node.name.toLowerCase();
+      const inputType = tag === 'input' ? attrText(node.attributes, 'type') : undefined;
+      const hasList = tag === 'input' && findAttr(node.attributes, 'list') !== undefined;
+      const selectKind = tag === 'select' ? selectNativeRole(node.attributes) : undefined;
       const hasSpread = node.attributes.some((a: Node) => a?.type === 'SpreadAttribute');
       acc.push({
-        tag: node.name,
+        tag,
         line: lineOf(source, node.start),
         ...(roleAttr ? { role: classifyAttrValue(roleAttr.value) } : {}),
         ...(inputType !== undefined ? { inputType: inputType.toLowerCase() } : {}),

--- a/packages/core/test/a11y-role-table-rules.test.ts
+++ b/packages/core/test/a11y-role-table-rules.test.ts
@@ -79,6 +79,14 @@ describe('a11y/disallowed-aria-props', () => {
     expect(await disallowed('<label for="x" aria-label="close sidebar">x</label>')).toHaveLength(1);
   });
 
+  it('judges a mixed-case tag the same as its lowercase form', async () => {
+    // Svelte's AST keeps `<dIv>`'s source casing; the collector normalizes it so this HTML_SPEC
+    // lookup — keyed by lowercase tag — still finds the element instead of silently skipping it.
+    expect(await disallowed('<dIv aria-label="Breadcrumb">x</dIv>')).toEqual([
+      '`aria-label` is prohibited on <div> — its role does not take a name'
+    ]);
+  });
+
   it('reports an attribute the role does not own, with the role named', async () => {
     expect(await disallowed('<span aria-level="2">x</span>')).toEqual([
       '`aria-level` is not supported by role `generic`'

--- a/packages/core/test/component-parse.test.ts
+++ b/packages/core/test/component-parse.test.ts
@@ -1315,6 +1315,20 @@ describe('parseComponentFacts — ariaElements (a11y ARIA rules)', () => {
     const c = parseComponentFacts('<input type="CHECKBOX" role="switch" />', 'C.svelte');
     expect(c.ariaElements![0]!.inputType).toBe('checkbox');
   });
+  it('lowercases a mixed-case tag, including for the input/select special-casing', () => {
+    // Svelte accepts `<dIv>`/`<inPUT>` as ordinary HTML elements; the tag must be normalized like
+    // attribute names are, or spec lookups keyed by lowercase tag (role-candidates) and the
+    // input/select branches below silently miss it.
+    expect(parseComponentFacts('<dIv aria-label="x"></dIv>', 'C.svelte').ariaElements![0]!.tag).toBe('div');
+    // A leading capital makes Svelte treat the tag as a component, not an element — the mixed case
+    // has to start lowercase, and a void element without a closing tag needs the `/>` form.
+    const input = parseComponentFacts('<inPUT aria-label="x" type="TEXT" />', 'C.svelte').ariaElements![0]!;
+    expect(input.tag).toBe('input');
+    expect(input.inputType).toBe('text');
+    const select = parseComponentFacts('<sElect multiple aria-label="x"></sElect>', 'C.svelte').ariaElements![0]!;
+    expect(select.tag).toBe('select');
+    expect(select.selectKind).toBe('listbox');
+  });
   it('marks hasSpread when the element carries a spread attribute, but still collects it', () => {
     const c = parseComponentFacts('<div role="checkbox" {...attrs}></div>', 'C.svelte');
     expect(c.ariaElements).toEqual([{ tag: 'div', line: 1, role: { literal: 'checkbox' }, hasSpread: true, aria: [] }]);


### PR DESCRIPTION
## Summary

Follow-up to a Copilot review observation on #615, verified as pre-existing behavior. Svelte accepts mixed-case regular HTML elements whose first letter is lowercase (`<dIv>`, `<inPUT>`; a leading capital is a component reference instead), but `collectAriaElements` recorded `node.name` verbatim while its sibling `collectElements` already lowercases. Consequences, verified per rule:

- `a11y/disallowed-aria-props` and `a11y/deprecated-aria` (the two `roleCandidates` consumers) silently dropped every finding on a mixed-case element — the `HTML_SPEC.elements` lookup is keyed by lowercase tag
- `a11y/required-aria-props` fired spurious findings on legitimate hosts (`<inPUT type="checkbox" role="switch">` etc.): its `HOST_SUPPLIED` suppression gates on `e.tag === 'input'`/`'select'`, so a mixed-case tag could only under-suppress, never drop a finding — confirmed structurally and with five pre/post probes
- `invalid-role`, `unknown-aria-attribute`, `invalid-aria-value` never consult `e.tag` and were unaffected

The fix normalizes once at collection (`const tag = node.name.toLowerCase()`), also covering the `input`/`select` special-casing (`inputType`/`hasList`/`selectKind`), so every consumer is fixed at the root instead of patching the lookup site. SVG names are unaffected observably: the spec stores SVG under `svg:*` keys (zero bare keys carry an uppercase letter), so raw and lowercased mixed-case SVG names miss identically — pinned by the untouched full suite and kitchen-sink e2e.

## Tests

- Parse-level: `<dIv aria-label>` → `tag: 'div'`; `<inPUT type="TEXT">` → `tag: 'input'` + `inputType: 'text'`; `<sElect multiple>` → `selectKind: 'listbox'`
- Rule-level discriminator: `a11y/disallowed-aria-props` produces the identical full message for `<dIv aria-label>` as for `<div aria-label>`
- All red-verified against the unfixed code; full suite (core 1757 / cli 1267 / vite 258 / kitchen-sink 38), typecheck, lint green; no repo fixture contains a mixed-case tag, so no other suite shifts

Changeset: `@svelte-vitals/core` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accessibility rule handling for HTML elements written with mixed-case tags.
  - Correctly recognizes mixed-case inputs and selects, including their types and native roles.
  - Ensures ARIA validation produces consistent results regardless of tag capitalization.

- **Tests**
  - Added coverage for mixed-case elements and accessibility rule validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->