### PR TITLE
fix(core): strip C1 control characters (U+0080-U+009F) in terminalSafe

### DIFF
--- a/.changeset/terminal-safe-c1-control-chars.md
+++ b/.changeset/terminal-safe-c1-control-chars.md
@@ -1,0 +1,14 @@
+---
+'@svelte-vitals/core': patch
+---
+
+Strip C1 control characters (U+0080–U+009F) in `terminalSafe`.
+
+The function already removed ESC-form (`\x1b[`/`\x1b]`) OSC/CSI sequences and C0 control
+bytes, but let C1 control bytes through untouched. C1 has single-codepoint equivalents for
+CSI (U+009B), OSC (U+009D), and ST (U+009C) that legacy or some configured terminals
+interpret the same as their two-byte ESC forms, so a repo path or route id containing one
+of these bytes could still smuggle a terminal-title rewrite or cursor/screen control
+sequence into a rendered report. `terminalSafe` now matches C1 CSI/OSC sequences (and OSC's
+C1 ST terminator) alongside their ESC-form counterparts, and the final control-byte sweep
+now also drops any other lone C1 byte.

--- a/packages/core/src/reporter/sanitize.ts
+++ b/packages/core/src/reporter/sanitize.ts
@@ -37,25 +37,28 @@ export function mdEscape(text: string): string {
 }
 
 /**
- * Strip ANSI/OSC escape sequences and C0 control characters (except `\n`/`\t`) from a
+ * Strip ANSI/OSC escape sequences and C0/C1 control characters (except `\n`/`\t`) from a
  * string before it reaches a terminal. POSIX file/route names can contain almost any
  * byte, so a hostile repo can smuggle a terminal-title rewrite, cursor move, or other
  * escape-sequence trick into what looks like plain report text.
  *
- * Only OSC and CSI sequences are pattern-matched and removed whole (payload included) —
- * those cover title-bar writes and cursor/screen control, the two classes with a real
- * blast radius. Any other `ESC` byte (rarer single/two-byte forms like reset or
- * save-cursor) falls through to the final C0 sweep below, which drops the lone `ESC`
- * but — deliberately, not swallowing an adjacent legitimate character — leaves whatever
- * printable byte follows it as stray text.
+ * OSC and CSI sequences are pattern-matched and removed whole (payload included) — those
+ * cover title-bar writes and cursor/screen control, the two classes with a real blast
+ * radius. Each is matched in both its two-byte `ESC` form and its single-codepoint C1
+ * form (U+009D OSC, U+009B CSI — C1 also interprets as `ESC ]`/`ESC [` on legacy/some
+ * configured terminals), and OSC's terminator likewise accepts either `ESC \` or the
+ * single-codepoint C1 ST (U+009C). Any other `ESC`/C1 byte (rarer single/two-byte forms
+ * like reset or save-cursor) falls through to the final control sweep below, which drops
+ * the lone control byte but — deliberately, not swallowing an adjacent legitimate
+ * character — leaves whatever printable byte follows it as stray text.
  * ponytail: doesn't special-case every Fe escape form; broaden the CSI/OSC patterns if a
  * concrete non-CSI/OSC sequence turns out to matter.
  */
-/* oxlint-disable no-control-regex -- deliberately matching C0/DEL/ESC control bytes to strip them */
+/* oxlint-disable no-control-regex -- deliberately matching C0/C1/DEL/ESC control bytes to strip them */
 export function terminalSafe(text: string): string {
   return text
-    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?/g, '') // OSC ... (BEL | ST)
-    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '') // CSI ... final byte
-    .replace(/[\x00-\x08\x0b-\x1f\x7f]/g, '');
+    .replace(/(?:\x1b\]|\x9d)[^\x07\x9c\x1b]*(?:\x07|\x9c|\x1b\\)?/g, '') // OSC ... (BEL | ST)
+    .replace(/(?:\x1b\[|\x9b)[0-?]*[ -/]*[@-~]/g, '') // CSI ... final byte
+    .replace(/[\x00-\x08\x0b-\x1f\x7f-\x9f]/g, '');
 }
 /* oxlint-enable no-control-regex */

--- a/packages/core/test/sanitize.test.ts
+++ b/packages/core/test/sanitize.test.ts
@@ -31,4 +31,30 @@ describe('terminalSafe', () => {
   it('leaves clean text untouched', () => {
     expect(terminalSafe('src/routes/blog/+page.svelte')).toBe('src/routes/blog/+page.svelte');
   });
+
+  it('strips a C1 CSI sequence (\\x9b) with its payload', () => {
+    expect(terminalSafe('a\x9b31mb')).toBe('ab');
+  });
+
+  it('strips a C1 OSC sequence (\\x9d) terminated by BEL', () => {
+    expect(terminalSafe('a\x9d0;evil\x07b')).toBe('ab');
+  });
+
+  it('strips a C1 OSC sequence (\\x9d) terminated by C1 ST (\\x9c)', () => {
+    expect(terminalSafe('a\x9d0;evil\x9cb')).toBe('ab');
+  });
+
+  it('strips a lone C1 byte that is not a CSI/OSC opener', () => {
+    expect(terminalSafe('a\x80b')).toBe('ab');
+  });
+
+  it('leaves ESC-form CSI/OSC sequences stripped as before (non-regression)', () => {
+    expect(terminalSafe('a\x1b[31mb')).toBe('ab');
+    expect(terminalSafe('a\x1b]0;evil\x07b')).toBe('ab');
+  });
+
+  it('leaves ordinary multibyte and Latin-1-range text untouched (non-regression)', () => {
+    expect(terminalSafe('こんにちは🎉café')).toBe('こんにちは🎉café');
+    expect(terminalSafe(' ¡é')).toBe(' ¡é');
+  });
 });


### PR DESCRIPTION
## Summary

`terminalSafe` stripped ESC-form OSC/CSI sequences and C0+DEL controls, but passed C1 controls (U+0080–U+009F) through — including the single-codepoint CSI (U+009B), OSC (U+009D), and ST (U+009C), which legacy and some configured terminals interpret exactly like `ESC[`/`ESC]` (CWE-150). Since the function's threat model is analyzed-repo strings reaching the terminal, the C1 spellings were a bypass of the ESC-form filter. Pre-existing since the sanitizer was introduced; surfaced by review on #617, which only applied the existing sanitizer at new sinks.

The fix mirrors the ESC forms:

- OSC and CSI are matched in both spellings (`(?:\x1b\]|\x9d)…`, `(?:\x1b\[|\x9b)…`), with OSC accepting BEL, `ESC \`, or the C1 ST terminator in either direction
- the final control sweep widens from `\x7f` to `\x7f-\x9f`, which makes the invariant structural: no C0 (except `\n`/`\t`), DEL, or C1 byte can survive, regardless of replace ordering — adversarial splice inputs (a stripped sequence concatenating two halves into a new opener) leave only inert printable residue

Unterminated C1 sequences follow the pre-existing, documented ESC-form policy (OSC swallows to end of string; a lone non-opener C1 byte is dropped without touching its neighbors). U+00A0 and everything above U+009F — Latin-1, CJK, astral emoji — are untouched; the non-`u` regex operates on code units and cannot reach surrogate pairs.

## Tests

New cases in `sanitize.test.ts` (red-verified against the unfixed code): C1 CSI with payload, C1 OSC terminated by BEL and by C1 ST, a lone non-opener C1 byte, plus non-regression pins for ESC-form stripping and multibyte/Latin-1 passthrough. Full suite (core 1766 / cli 1272 / vite 258 / kitchen-sink 38), typecheck, lint — all green; `frame-writer`'s width math over ESC-form SGR is unaffected.

Changeset: `@svelte-vitals/core` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal output sanitization by removing C1 control characters and their CSI/OSC escape sequences.
  * Preserved valid multibyte and Latin-1 text while filtering unsafe control codes.

* **Tests**
  * Added coverage for C1 control sequences, standalone control bytes, existing escape formats, and preserved text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->