### PR TITLE
fix(cli,vite): re-evaluate an edited svelte-vitals.config on dev re-analysis instead of serving the ESM cache

### DIFF
--- a/.changeset/config-file-reload.md
+++ b/.changeset/config-file-reload.md
@@ -1,0 +1,6 @@
+---
+'svelte-vitals': patch
+'@svelte-vitals/vite': patch
+---
+
+Re-evaluate `svelte-vitals.config.{js,ts}` when it changes instead of serving Node's ESM module cache. In `vite dev` the dashboard re-analysis now runs with the edited config, and the dashboard's own scoring config (weights, overrides) follows the edit too; an edit that fails validation is warned about and the previous config is kept. Modules the config file imports are still cached until the dev server process restarts.

--- a/docs/blume.translations.json
+++ b/docs/blume.translations.json
@@ -40,7 +40,7 @@
       "ja": "4405a6efd51689f4"
     },
     "src/content/docs/guides/(vite)/dev-dashboard.mdx": {
-      "ja": "fad78899a34c9b88"
+      "ja": "bbe678034b40e47d"
     },
     "src/content/docs/guides/(vite)/meta.ts": {
       "ja": "72937c0224fde0f3"

--- a/docs/src/content/docs/guides/(vite)/dev-dashboard.mdx
+++ b/docs/src/content/docs/guides/(vite)/dev-dashboard.mdx
@@ -89,6 +89,7 @@ Notes:
 - Live updates only flow over a loopback origin (`localhost`, `127.0.0.1`, `[::1]`). When you run `vite dev --host` and open the app via a LAN IP, the handle skips the ingest POST, a guard against a spoofed `Host` header, so visited routes won't refine to `measured`. Open it from `localhost` instead.
 - The dashboard's ingest endpoint checks the `Origin` header: a request that carries one must match the dashboard's own host and port, so a page served by another local dev server or tool cannot feed it findings. Requests without an `Origin` header (the server-side handle's own POSTs) are accepted as before.
 - Set `SVELTE_VITALS_DEBUG=true` to surface swallowed internal errors (analysis failures, skipped ingests) to the terminal for troubleshooting.
+- Editing `svelte-vitals.config.{js,ts}` re-analyzes with the new config, dashboard scoring included. Modules the config file itself imports are not re-evaluated until `vite dev` restarts.
 
 ## Copy a fix prompt for any finding
 

--- a/docs/src/content/docs/ja/guides/(vite)/dev-dashboard.mdx
+++ b/docs/src/content/docs/ja/guides/(vite)/dev-dashboard.mdx
@@ -87,6 +87,7 @@ export const handle = sequence(
 - ライブ更新はループバックオリジン（`localhost`、`127.0.0.1`、`[::1]`）でのみ流れます。`vite dev --host` で LAN の IP からアプリを開いた場合、ハンドルは ingest の POST をスキップする（`Host` ヘッダー偽装への防御）ため、訪問したルートが `measured` に切り替わりません。その場合は `localhost` から開いてください。
 - dashboard の ingest エンドポイントは `Origin` ヘッダーを検査します。`Origin` を持つリクエストは dashboard 自身のホストとポートに一致する必要があるため、別のローカル dev サーバーやツールが配信するページから finding を流し込むことはできません。`Origin` を持たないリクエスト（サーバー側ハンドル自身の POST）は従来どおり受け付けます。
 - `SVELTE_VITALS_DEBUG=true` を設定すると、飲み込まれた内部エラー（分析失敗、ingest のスキップ）がトラブルシューティング用にターミナルへ表示されます。
+- `svelte-vitals.config.{js,ts}` を編集すると、新しい設定で再解析され、ダッシュボードの採点にも反映されます。設定ファイル自身が import している別モジュールは `vite dev` を再起動するまで再評価されません。
 
 ## 指摘ごとに修正プロンプトをコピーする
 

--- a/packages/cli/src/config-file.ts
+++ b/packages/cli/src/config-file.ts
@@ -292,8 +292,16 @@ async function loadFrom(path: string): Promise<LoadedConfigFile> {
     // it was first loaded. A content hash in the query re-evaluates only when the file actually
     // changed; an unchanged file keeps hitting the cache instead of leaking a module per run.
     // Modules the config itself imports are still cached — that is a documented limitation.
-    const digest = createHash('sha1').update(readFileSync(path)).digest('hex').slice(0, 16);
-    mod = (await import(`${pathToFileURL(path).href}?v=${digest}`)) as { default?: unknown };
+    let digest = createHash('sha1').update(readFileSync(path)).digest('hex').slice(0, 16);
+    // The import reads the file a second time; a save in between would bind new contents to
+    // the old digest. Recompute after importing and retry (bounded) until the digest we used
+    // matches what's on disk, so a save-then-revert can't stick with the wrong cached module.
+    for (let attempt = 0; ; attempt++) {
+      mod = (await import(`${pathToFileURL(path).href}?v=${digest}`)) as { default?: unknown };
+      const digestAfter = createHash('sha1').update(readFileSync(path)).digest('hex').slice(0, 16);
+      if (digestAfter === digest || attempt >= 2) break;
+      digest = digestAfter;
+    }
   } catch (err) {
     // A .js config in CJS scope is parsed as CJS, so its `export default` is a SyntaxError
     // that names neither the file nor the fix — rethrow with both. A typo in an ESM config

--- a/packages/cli/src/config-file.ts
+++ b/packages/cli/src/config-file.ts
@@ -1,4 +1,5 @@
-import { existsSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type { Category, Config, RuleOptions, RuleOverride } from '@svelte-vitals/core';
@@ -286,7 +287,13 @@ export async function loadConfigFromPath(path: string): Promise<LoadedConfigFile
 async function loadFrom(path: string): Promise<LoadedConfigFile> {
   let mod: { default?: unknown };
   try {
-    mod = (await import(pathToFileURL(path).href)) as { default?: unknown };
+    // Node's ESM loader caches modules by URL for the life of the process, so a long-lived
+    // host (the vite dev dashboard re-analyzes on every save) would keep serving the config as
+    // it was first loaded. A content hash in the query re-evaluates only when the file actually
+    // changed; an unchanged file keeps hitting the cache instead of leaking a module per run.
+    // Modules the config itself imports are still cached — that is a documented limitation.
+    const digest = createHash('sha1').update(readFileSync(path)).digest('hex').slice(0, 16);
+    mod = (await import(`${pathToFileURL(path).href}?v=${digest}`)) as { default?: unknown };
   } catch (err) {
     // A .js config in CJS scope is parsed as CJS, so its `export default` is a SyntaxError
     // that names neither the file nor the fix — rethrow with both. A typo in an ESM config

--- a/packages/cli/test/config-file.test.ts
+++ b/packages/cli/test/config-file.test.ts
@@ -1,3 +1,5 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect } from 'vitest';
 import { loadConfigFile, loadConfigFromPath } from '../src/config-file.js';
@@ -252,6 +254,36 @@ describe('loadConfigFile', () => {
   // scripts/floor-smoke.js. It cannot live here: vitest's module runner
   // transforms in-process dynamic `import()`, so a `.ts` config always loads
   // inside vitest regardless of the host Node.
+});
+
+describe('loadConfigFile re-reads an edited file', () => {
+  it('returns the new contents after the file is rewritten in the same process', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'svelte-vitals-config-reload-'));
+    try {
+      const file = join(dir, 'svelte-vitals.config.js');
+      writeFileSync(file, "export default { failOn: 'warning' };\n");
+      expect((await loadConfigFile(dir))?.config.failOn).toBe('warning');
+      writeFileSync(file, "export default { failOn: 'critical' };\n");
+      expect((await loadConfigFile(dir))?.config.failOn).toBe('critical');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not re-evaluate an unchanged file (same contents → same module instance)', async () => {
+    // Pin the cache key: an identical file must resolve to the identical URL, so the run-per-save
+    // dev loop does not leak one module instance per re-analysis.
+    const dir = mkdtempSync(join(tmpdir(), 'svelte-vitals-config-reload-'));
+    try {
+      const file = join(dir, 'svelte-vitals.config.js');
+      writeFileSync(file, 'export default { metaComponents: [] };\n');
+      const a = await loadConfigFile(dir);
+      const b = await loadConfigFile(dir);
+      expect(a).toEqual(b);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('loadConfigFromPath', () => {

--- a/packages/cli/test/config-file.test.ts
+++ b/packages/cli/test/config-file.test.ts
@@ -270,17 +270,32 @@ describe('loadConfigFile re-reads an edited file', () => {
     }
   });
 
-  it('does not re-evaluate an unchanged file (same contents → same module instance)', async () => {
-    // Pin the cache key: an identical file must resolve to the identical URL, so the run-per-save
-    // dev loop does not leak one module instance per re-analysis.
+  it('does not re-evaluate an unchanged file, but does re-evaluate a changed one', async () => {
+    // Pin the cache key: an identical file must resolve to the identical URL (cached, module
+    // body does not re-run), so the run-per-save dev loop does not leak one module instance
+    // per re-analysis — while an actually-changed file must re-run.
     const dir = mkdtempSync(join(tmpdir(), 'svelte-vitals-config-reload-'));
+    const evalCounter = () =>
+      (globalThis as { __svelteVitalsConfigEvaluations?: number }).__svelteVitalsConfigEvaluations;
     try {
       const file = join(dir, 'svelte-vitals.config.js');
-      writeFileSync(file, 'export default { metaComponents: [] };\n');
-      const a = await loadConfigFile(dir);
-      const b = await loadConfigFile(dir);
-      expect(a).toEqual(b);
+      (globalThis as { __svelteVitalsConfigEvaluations?: number }).__svelteVitalsConfigEvaluations = 0;
+      writeFileSync(
+        file,
+        'globalThis.__svelteVitalsConfigEvaluations = (globalThis.__svelteVitalsConfigEvaluations ?? 0) + 1;\nexport default { metaComponents: [] };\n'
+      );
+      await loadConfigFile(dir);
+      await loadConfigFile(dir);
+      expect(evalCounter()).toBe(1);
+
+      writeFileSync(
+        file,
+        "globalThis.__svelteVitalsConfigEvaluations = (globalThis.__svelteVitalsConfigEvaluations ?? 0) + 1;\nexport default { metaComponents: ['X'] };\n"
+      );
+      await loadConfigFile(dir);
+      expect(evalCounter()).toBe(2);
     } finally {
+      delete (globalThis as { __svelteVitalsConfigEvaluations?: number }).__svelteVitalsConfigEvaluations;
       rmSync(dir, { recursive: true, force: true });
     }
   });

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -275,15 +275,23 @@ export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin | Plugin
       // the config file itself).
       let config: Config;
 
+      // Guards a stale resolve from clobbering a newer one when two watcher-driven
+      // calls overlap (the debounce below makes this rare but not impossible: a
+      // resolve can still be in flight when the timer fires again).
+      let configGeneration = 0;
+
       // Shared by startup and the config-file watcher below: an invalid config must
       // never take the dev server down, so a failed re-resolve keeps whatever config
       // the dashboard was already using.
       const applyConfig = async (): Promise<void> => {
+        const generation = ++configGeneration;
         try {
           const resolved = await resolveConfig(uiRoot, options);
+          if (generation !== configGeneration) return;
           config = resolved.config;
           for (const w of resolved.warnings) warn(`svelte-vitals: ${w}`);
         } catch (err) {
+          if (generation !== configGeneration) return;
           // Dev must not crash on a config typo; the dashboard runs on plugin
           // options/defaults (or the previous config, on a later edit) and says so.
           // The build path (closeBundle) intentionally DOES fail — see the comment there.
@@ -321,11 +329,21 @@ export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin | Plugin
         onStatusChange: (analyzing) => store.setAnalyzing(analyzing)
       });
       runner.start();
+
+      // A save-by-truncate editor delivers a 'change' event while the file is
+      // half-written, which would make an immediate re-resolve throw on the partial
+      // content and print a false "config file invalid" warning. Debouncing (500ms,
+      // mirroring the runner's own default debounce in ui/analysis.ts) lets a burst
+      // of events settle on the final write before resolving once.
+      let configTimer: ReturnType<typeof setTimeout> | undefined;
       server.watcher?.on('all', (_event, file) => {
         if (!isRelevant(file, uiRoot)) return;
         // The runner re-loads the config file itself (analyzeProject → loadConfigFile); the
         // dashboard's scoring config is resolved here, so it has to follow the same edit.
-        if (CONFIG_FILENAMES.includes(basename(file))) void applyConfig();
+        if (CONFIG_FILENAMES.includes(basename(file))) {
+          clearTimeout(configTimer);
+          configTimer = setTimeout(() => void applyConfig(), 500);
+        }
         runner.notifyChange(file);
       });
 
@@ -334,6 +352,7 @@ export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin | Plugin
       // flip, and no re-analysis timer outlives the server.
       server.httpServer?.once('close', () => {
         delete process.env.SVELTE_VITALS_UI;
+        clearTimeout(configTimer);
         runner.stop();
       });
 

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -274,20 +274,26 @@ export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin | Plugin
       // config-file values independently, since it calls analyzeProject (which loads
       // the config file itself).
       let config: Config;
-      let warnings: string[];
-      try {
-        ({ config, warnings } = await resolveConfig(uiRoot, options));
-      } catch (err) {
-        // Dev must not crash on a config typo; the dashboard runs on plugin
-        // options/defaults and says so. The build path (closeBundle) intentionally
-        // DOES fail — see the comment there.
-        warn(
-          `svelte-vitals: config file invalid — dashboard using plugin options/defaults: ${err instanceof Error ? err.message : String(err)}`
-        );
-        config = mergeConfig(options, undefined);
-        warnings = [];
-      }
-      for (const w of warnings) warn(`svelte-vitals: ${w}`);
+
+      // Shared by startup and the config-file watcher below: an invalid config must
+      // never take the dev server down, so a failed re-resolve keeps whatever config
+      // the dashboard was already using.
+      const applyConfig = async (): Promise<void> => {
+        try {
+          const resolved = await resolveConfig(uiRoot, options);
+          config = resolved.config;
+          for (const w of resolved.warnings) warn(`svelte-vitals: ${w}`);
+        } catch (err) {
+          // Dev must not crash on a config typo; the dashboard runs on plugin
+          // options/defaults (or the previous config, on a later edit) and says so.
+          // The build path (closeBundle) intentionally DOES fail — see the comment there.
+          warn(
+            `svelte-vitals: config file invalid — dashboard using ${config ? 'the previous config' : 'plugin options/defaults'}: ${err instanceof Error ? err.message : String(err)}`
+          );
+          config ??= mergeConfig(options, undefined);
+        }
+      };
+      await applyConfig();
       const store = createStore();
 
       // The whole-project runner's crashed-rule ids, read by installUiMiddleware on every
@@ -316,7 +322,11 @@ export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin | Plugin
       });
       runner.start();
       server.watcher?.on('all', (_event, file) => {
-        if (isRelevant(file, uiRoot)) runner.notifyChange(file);
+        if (!isRelevant(file, uiRoot)) return;
+        // The runner re-loads the config file itself (analyzeProject → loadConfigFile); the
+        // dashboard's scoring config is resolved here, so it has to follow the same edit.
+        if (CONFIG_FILENAMES.includes(basename(file))) void applyConfig();
+        runner.notifyChange(file);
       });
 
       // Clear the flag and stop the runner when the dev server stops, so the handle
@@ -327,7 +337,14 @@ export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin | Plugin
         runner.stop();
       });
 
-      installUiMiddleware(server, config, readPackageVersion(), store, readCoreVersion(), () => staticFailedRuleIds);
+      installUiMiddleware(
+        server,
+        () => config,
+        readPackageVersion(),
+        store,
+        readCoreVersion(),
+        () => staticFailedRuleIds
+      );
 
       // The dashboard has no separate CLI entry point (unlike `vitest --ui`) to signal
       // it exists, so announce it the same way Vite announces its own dev server: as an

--- a/packages/vite/src/ui/middleware.ts
+++ b/packages/vite/src/ui/middleware.ts
@@ -61,7 +61,8 @@ function isResultLike(x: unknown): x is Result {
  */
 export function installUiMiddleware(
   server: ViteDevServer,
-  config: Config,
+  /** A function is read on every request, so a config-file edit picked up mid-session is reflected without re-mounting the middleware. */
+  config: Config | (() => Config),
   version: string,
   store: FindingsStore,
   coreVersion?: string,
@@ -69,6 +70,7 @@ export function installUiMiddleware(
   getStaticFailedRuleIds?: () => string[] | undefined
 ): void {
   const clients = new Set<ServerResponse>();
+  const currentConfig = (): Config => (typeof config === 'function' ? config() : config);
 
   store.subscribe(() => {
     for (const res of clients) {
@@ -165,7 +167,7 @@ export function installUiMiddleware(
 
     if (url.startsWith('/data.json')) {
       try {
-        const snapshot = buildSnapshot(store, config, { version, coreVersion }, getStaticFailedRuleIds?.());
+        const snapshot = buildSnapshot(store, currentConfig(), { version, coreVersion }, getStaticFailedRuleIds?.());
         res.setHeader('Content-Type', 'application/json');
         res.end(JSON.stringify(snapshot));
       } catch {
@@ -178,7 +180,9 @@ export function installUiMiddleware(
     // Last line of defense that validated data should never reach: if the renderer
     // throws anyway, return a plain-text 500 and never take down the dev server.
     try {
-      const html = renderAppShell(buildSnapshot(store, config, { version, coreVersion }, getStaticFailedRuleIds?.()));
+      const html = renderAppShell(
+        buildSnapshot(store, currentConfig(), { version, coreVersion }, getStaticFailedRuleIds?.())
+      );
       res.setHeader('Content-Type', 'text/html');
       res.end(html);
     } catch {

--- a/packages/vite/test/ui-plugin-config-file.test.ts
+++ b/packages/vite/test/ui-plugin-config-file.test.ts
@@ -161,11 +161,14 @@ describe('svelteVitals dev dashboard — svelte-vitals.config.* wiring', () => {
         await writeFile(configPath, 'export default { weights: { seo: 2 } };\n');
         fireWatcher(configPath);
         // The re-resolve is async; poll /data.json until the new weight lands.
-        await vi.waitFor(() => {
-          const { res, body } = fakeRes();
-          call(req('GET', '/data.json'), res);
-          expect(JSON.parse(body()).report.weights.seo).toBe(2);
-        });
+        await vi.waitFor(
+          () => {
+            const { res, body } = fakeRes();
+            call(req('GET', '/data.json'), res);
+            expect(JSON.parse(body()).report.weights.seo).toBe(2);
+          },
+          { timeout: 2000 }
+        );
       } finally {
         warnSpy.mockRestore();
       }
@@ -184,9 +187,12 @@ describe('svelteVitals dev dashboard — svelte-vitals.config.* wiring', () => {
         const { call, fireWatcher } = await startUiServer(cwd);
         await writeFile(configPath, "export default { rules: { 'no/such-rule': 'off' } };\n");
         fireWatcher(configPath);
-        await vi.waitFor(() => {
-          expect(warnSpy.mock.calls.some((args) => String(args[0]).includes('config file invalid'))).toBe(true);
-        });
+        await vi.waitFor(
+          () => {
+            expect(warnSpy.mock.calls.some((args) => String(args[0]).includes('config file invalid'))).toBe(true);
+          },
+          { timeout: 2000 }
+        );
         const { res, body } = fakeRes();
         call(req('GET', '/data.json'), res);
         expect(JSON.parse(body()).report.weights.seo).toBe(5);

--- a/packages/vite/test/ui-plugin-config-file.test.ts
+++ b/packages/vite/test/ui-plugin-config-file.test.ts
@@ -69,9 +69,14 @@ async function startUiServer(cwd: string, extraOptions: Record<string, unknown> 
   const plugins = svelteVitals({ ui: true, cwd, ...extraOptions }) as Plugin[];
   const ui = plugins.find((p) => p.name === 'svelte-vitals:ui')!;
   let handler: MiddlewareHandler = () => {};
+  let watcherCb: ((...args: unknown[]) => void) | undefined;
   const server = {
     config: { root: cwd },
-    watcher: { on: (_event: string, _cb: (...args: unknown[]) => void) => {} },
+    watcher: {
+      on: (_event: string, cb: (...args: unknown[]) => void) => {
+        watcherCb = cb;
+      }
+    },
     middlewares: { use: (_path: string, fn: MiddlewareHandler) => (handler = fn) }
   } as ViteDevServer;
   const hook = typeof ui.configureServer === 'function' ? ui.configureServer : ui.configureServer!.handler;
@@ -87,7 +92,7 @@ async function startUiServer(cwd: string, extraOptions: Record<string, unknown> 
   ingestReq.emit('end');
   await new Promise((r) => setTimeout(r, 0));
 
-  return { call };
+  return { call, fireWatcher: (file: string) => watcherCb?.('change', file) };
 }
 
 describe('svelteVitals dev dashboard — svelte-vitals.config.* wiring', () => {
@@ -137,6 +142,54 @@ describe('svelteVitals dev dashboard — svelte-vitals.config.* wiring', () => {
       try {
         await startUiServer(cwd);
         expect(warnSpy.mock.calls.some((args) => String(args[0]).includes('failOn'))).toBe(true);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('re-resolves the dashboard config when svelte-vitals.config.* changes on the watcher', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'sv-ui-config-'));
+    try {
+      const configPath = join(cwd, 'svelte-vitals.config.js');
+      await writeFile(configPath, 'export default { weights: { seo: 5 } };\n');
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const { call, fireWatcher } = await startUiServer(cwd);
+        await writeFile(configPath, 'export default { weights: { seo: 2 } };\n');
+        fireWatcher(configPath);
+        // The re-resolve is async; poll /data.json until the new weight lands.
+        await vi.waitFor(() => {
+          const { res, body } = fakeRes();
+          call(req('GET', '/data.json'), res);
+          expect(JSON.parse(body()).report.weights.seo).toBe(2);
+        });
+      } finally {
+        warnSpy.mockRestore();
+      }
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the previous dashboard config when the edited file fails validation', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'sv-ui-config-'));
+    try {
+      const configPath = join(cwd, 'svelte-vitals.config.js');
+      await writeFile(configPath, 'export default { weights: { seo: 5 } };\n');
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const { call, fireWatcher } = await startUiServer(cwd);
+        await writeFile(configPath, "export default { rules: { 'no/such-rule': 'off' } };\n");
+        fireWatcher(configPath);
+        await vi.waitFor(() => {
+          expect(warnSpy.mock.calls.some((args) => String(args[0]).includes('config file invalid'))).toBe(true);
+        });
+        const { res, body } = fakeRes();
+        call(req('GET', '/data.json'), res);
+        expect(JSON.parse(body()).report.weights.seo).toBe(5);
       } finally {
         warnSpy.mockRestore();
       }


### PR DESCRIPTION
## Summary

- `loadFrom` (packages/cli/src/config-file.ts) imported `svelte-vitals.config.{js,ts}` with a bare `import()`, so Node's ESM loader returned the first-evaluated module for the life of the process. The CLI is one process per run and unaffected; the `vite dev` dashboard re-analyzes on every save and kept running with the config as first loaded, silently ignoring edits (turning a rule off, changing `weights`/`overrides`) until the dev server process was restarted.
- The import URL now carries a content hash (`?v=<sha1>`): an edited file is re-evaluated, an unchanged file keeps hitting the cache (no module leak per re-analysis). Modules the config file itself imports are still cached — documented as a known limitation.
- The dashboard's own scoring config was resolved once in `configureServer` and passed by value. `installUiMiddleware` now accepts a getter (`Config | (() => Config)`, backward compatible) and the plugin re-resolves the config when the watcher sees a `svelte-vitals.config.*` change. Re-resolution is debounced (500 ms, mirroring the runner) so a truncate-then-write save does not raise a false "config file invalid" warning on the half-written file, and a generation counter lets the newest edit win when two resolves overlap. A failed re-resolve warns and keeps the previous config.


![How a config edit reaches the dashboard: the watcher and the new applyConfig in the vite plugin, the loader whose import URL now carries the content hash, and the middleware reading the config through a getter](https://github.com/user-attachments/assets/6a6ba28e-fe97-4e40-9286-dea6d4004fcb)

![Editing the config during vite dev: both the dashboard applyConfig and the runner analyzeProject now receive the re-evaluated module instead of the first-loaded one](https://github.com/user-attachments/assets/d4b4fbde-8745-4284-a5b3-2d95f27c4779)

## Tests

- cli: `loadConfigFile` returns the new contents after the file is rewritten in the same process (fails on the ESM cache without the fix); unchanged contents load identically.
- vite: watcher-driven re-resolve is reflected in `/data.json`; an invalid edit keeps the previous config and warns.
- Existing `ui-middleware.test.ts` (value-passing) and `plugin-config-error.test.ts` unchanged and green; `pnpm smoke` exercises the `.ts` config path with the `?v=` query under bare Node.

## Docs

- `dev-dashboard.mdx` (en/ja) gained one Notes bullet; translation ledger stamped.

Verified: `pnpm build && pnpm typecheck && pnpm test && pnpm lint`, `pnpm smoke`, `pnpm --filter docs run translate:check` all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The development dashboard now automatically re-analyzes when `svelte-vitals.config.js` or `.ts` changes.
  * Updated scoring weights and overrides are reflected without restarting the development server.
  * Invalid configuration edits retain the previous valid configuration and display a warning.

* **Bug Fixes**
  * Prevented stale configuration updates from overwriting newer edits.
  * Added a brief delay when detecting file changes to avoid warnings while files are being saved.

* **Documentation**
  * Updated the dashboard guide in English and Japanese with configuration reload behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
