### PR TITLE
fix(core): guard the remaining Object.prototype-keyed lookups (JSON-LD @type, rule options, placement values)

### DIFF
--- a/.changeset/prototype-key-sweep.md
+++ b/.changeset/prototype-key-sweep.md
@@ -1,0 +1,5 @@
+---
+'@svelte-vitals/core': patch
+---
+
+Guard three remaining `Object.prototype`-keyed lookups. A page whose JSON-LD `@type` is a name like `constructor` no longer crashes `seo/json-ld-required-props` (a crashed rule drops out of scoring project-wide, raising Health); a rule option keyed by such a name is now rejected as `unknown option` instead of being accepted silently or reported with the wrong message; and `architecture/reserved-name-placement` no longer throws when a directory named like that is declared in only one of its placement maps.

--- a/packages/core/src/rule-options.ts
+++ b/packages/core/src/rule-options.ts
@@ -129,7 +129,8 @@ export function resolveRuleOptions(
   for (const layer of layers) {
     if (!layer) continue;
     for (const [key, value] of Object.entries(layer)) {
-      const s = spec[key];
+      // Same presence rule as `isMentionedAnywhere` above: an inherited member is not a declared option.
+      const s = Object.hasOwn(spec, key) ? spec[key] : undefined;
       if (!s) continue; // validation rejects unknown keys up front; ignore defensively
       if (s.kind === 'integer') out[key] = value;
       else if (s.kind === 'string-list') out[key] = [...(out[key] as string[]), ...(value as string[])];
@@ -183,7 +184,8 @@ export function validateRuleOptions(
   const isNonEmptyString = (v: unknown): boolean => typeof v === 'string' && v.length > 0;
 
   for (const [key, value] of Object.entries(options)) {
-    const s = spec[key];
+    // Same presence rule as `isMentionedAnywhere` above: an inherited member is not a declared option.
+    const s = Object.hasOwn(spec, key) ? spec[key] : undefined;
     if (!s) {
       errors.push(`${ruleId}: unknown option '${key}'. Known options: ${Object.keys(spec).join(', ')}.`);
       continue;

--- a/packages/core/src/rules/architecture/reserved-name-placement.ts
+++ b/packages/core/src/rules/architecture/reserved-name-placement.ts
@@ -147,15 +147,20 @@ export const architectureReservedNamePlacement: Rule = {
       const inAnyUnits = Object.hasOwn(anyUnits, name);
       if (!inPlacements && !inCapUnits && !inAnyUnits) continue;
 
+      // The presence flags above are `Object.hasOwn`; the value reads must be too, or a name like
+      // `constructor` declared in one map reads Object.prototype's function out of the other two.
+      const declaredValue = (map: typeof placements, present: boolean): string | undefined =>
+        present ? map[name] : undefined;
+
       // A value that splits to nothing ungoverns the NAME, in every map of this resolved option set.
       // Dropping only the empty value would shrink the union and turn a typo into false positives at
       // every position the emptied entry covered — the opposite direction from the sibling rule,
       // whose maps compete rather than union.
       const emptyValue = (present: boolean, value: string | undefined) => present && globsOf(value ?? '').length === 0;
       if (
-        emptyValue(inPlacements, placements[name]) ||
-        emptyValue(inCapUnits, capUnits[name]) ||
-        emptyValue(inAnyUnits, anyUnits[name])
+        emptyValue(inPlacements, declaredValue(placements, inPlacements)) ||
+        emptyValue(inCapUnits, declaredValue(capUnits, inCapUnits)) ||
+        emptyValue(inAnyUnits, declaredValue(anyUnits, inAnyUnits))
       ) {
         continue;
       }
@@ -178,9 +183,9 @@ export const architectureReservedNamePlacement: Rule = {
       // directory twice.
       const judged = new Set<string>();
       const resolvedValues: [MapName, string | undefined][] = [
-        ['placements', placements[name]],
-        ['capitalisedUnitPlacements', capUnits[name]],
-        ['anyCaseUnitPlacements', anyUnits[name]]
+        ['placements', declaredValue(placements, inPlacements)],
+        ['capitalisedUnitPlacements', declaredValue(capUnits, inCapUnits)],
+        ['anyCaseUnitPlacements', declaredValue(anyUnits, inAnyUnits)]
       ];
       for (const [map, value] of resolvedValues) {
         if (value === undefined) continue;
@@ -202,9 +207,17 @@ export const architectureReservedNamePlacement: Rule = {
       // Every map is consulted, not short-circuited on the first that permits the position: an
       // alternative left unread has still qualified this directory, and the classification below would
       // go on to blame an exclusion elsewhere in its glob for the silence.
-      const byPlacement = record('placements', placements[name], true);
-      const byCapUnit = record('capitalisedUnitPlacements', capUnits[name], isUnitDir(parent, filesIn));
-      const byAnyUnit = record('anyCaseUnitPlacements', anyUnits[name], isAnyCaseUnitDir(parent, filesIn));
+      const byPlacement = record('placements', declaredValue(placements, inPlacements), true);
+      const byCapUnit = record(
+        'capitalisedUnitPlacements',
+        declaredValue(capUnits, inCapUnits),
+        isUnitDir(parent, filesIn)
+      );
+      const byAnyUnit = record(
+        'anyCaseUnitPlacements',
+        declaredValue(anyUnits, inAnyUnits),
+        isAnyCaseUnitDir(parent, filesIn)
+      );
       if (byPlacement || byCapUnit || byAnyUnit) continue;
 
       const at = reportAt(dir, files);

--- a/packages/core/src/rules/seo/json-ld-required-props.ts
+++ b/packages/core/src/rules/seo/json-ld-required-props.ts
@@ -12,7 +12,9 @@ export const seoJsonLdRequiredProps = jsonldRule({
     let hasKnownType = false;
     for (const node of nodes) {
       for (const t of typeOf(node)) {
-        const required = REQUIRED_PROPS[t];
+        // `t` is the page's own @type string; an unguarded index would return Object.prototype members
+        // for names like `constructor` and crash the whole rule (a crashed rule drops out of scoring).
+        const required = Object.hasOwn(REQUIRED_PROPS, t) ? REQUIRED_PROPS[t] : undefined;
         if (!required) continue; // unknown/custom type, or a type Google requires nothing from → not flagged
         hasKnownType = true;
         const missing = missingRequiredProps(node, required);

--- a/packages/core/test/reserved-name-placement.test.ts
+++ b/packages/core/test/reserved-name-placement.test.ts
@@ -117,6 +117,11 @@ describe('architecture/reserved-name-placement', () => {
     expect(results.map((r) => r.route)).toEqual(['src/lib/Icons/parts', 'src/lib/formatDate/parts']);
   });
 
+  it('does not throw when a directory is named like an Object.prototype member and declared in only one map', async () => {
+    const tree = ['src/lib/Card/Card.svelte', 'src/lib/Card/constructor/a.svelte'];
+    await expect(run(tree, { capitalisedUnitPlacements: { constructor: 'src/lib/**' } })).resolves.toBeDefined();
+  });
+
   // Testing item 2
   it('is silent for an any-case name under both kinds of unit, in one run', async () => {
     const results = await run(UNIT_TREE, { anyCaseUnitPlacements: { tests: 'src/**' } });

--- a/packages/core/test/rule-options.test.ts
+++ b/packages/core/test/rule-options.test.ts
@@ -21,6 +21,12 @@ describe('resolveRuleOptions', () => {
   it('returns an empty object for a rule with no spec', () => {
     expect(resolveRuleOptions('r', undefined, defineConfig({}))).toEqual({});
   });
+  it('ignores an Object.prototype-named key in a layer instead of merging it in', () => {
+    // resolveRuleOptions trusts validation, but the defensive `if (!s) continue` must hold for these names too.
+    const config = defineConfig({ rules: { r: { options: { constructor: { z: 'y' } } } } });
+    const resolved = resolveRuleOptions('r', spec, config);
+    expect(Object.hasOwn(resolved, 'constructor')).toBe(false);
+  });
   it('replaces an integer from the global setting', () => {
     const config = defineConfig({ rules: { r: { options: { max: 10 } } } });
     expect(resolveRuleOptions('r', spec, config).max).toBe(10);
@@ -95,6 +101,13 @@ describe('validateRuleOptions', () => {
   });
   it('rejects an unknown option key', () => {
     expect(validateRuleOptions('r', spec, { maxx: 10 })[0]).toContain("unknown option 'maxx'");
+  });
+  it('rejects an Object.prototype-named option key as unknown, not as a wrong-typed option', () => {
+    for (const key of ['constructor', 'toString', 'hasOwnProperty']) {
+      const errors = validateRuleOptions('r', spec, { [key]: { a: 'b' } });
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain(`unknown option '${key}'`);
+    }
   });
   it('rejects options on a rule that declares none', () => {
     expect(validateRuleOptions('r', undefined, { max: 1 })[0]).toContain('takes no options');

--- a/packages/core/test/seo-jsonld-rules.test.ts
+++ b/packages/core/test/seo-jsonld-rules.test.ts
@@ -426,6 +426,23 @@ describe('seo/json-ld-deprecated-type-021', () => {
       await seoJsonLdRequiredProps.check(ctx(headWithJsonLd('{"@context":"https://schema.org","@type":"Person"}')))
     ).toHaveLength(0);
   });
+  it('seo/json-ld-required-props treats an Object.prototype-named @type as unknown instead of throwing', async () => {
+    for (const type of ['constructor', 'toString', 'valueOf', 'hasOwnProperty']) {
+      const rs = await seoJsonLdRequiredProps.check(
+        ctx(headWithJsonLd(`{"@context":"https://schema.org","@type":"${type}"}`))
+      );
+      expect(fails(rs)).toHaveLength(0);
+    }
+    // Same for the array form of @type.
+    const rs = await seoJsonLdRequiredProps.check(
+      ctx(
+        headWithJsonLd(
+          '{"@context":"https://schema.org","@type":["constructor","WebSite"],"name":"n","url":"https://e.com/"}'
+        )
+      )
+    );
+    expect(fails(rs)).toHaveLength(0);
+  });
   it('seo/json-ld-deprecated-type-021 skip parseable JSON-LD that seo/json-ld-validity deems invalid (missing @context/@type)', async () => {
     // Relative URL present, but no @context → seo/json-ld-validity owns the finding; seo/json-ld-relative-url stays silent (no misleading pass).
     expect(await seoJsonLdRelativeUrl.check(ctx(headWithJsonLd('{"@type":"Org","image":"/logo.png"}')))).toHaveLength(


### PR DESCRIPTION
## Summary

PR #615 guarded the `HTML_SPEC` lookups against `Object.prototype` keys. Three sites of the same class remained in core; this closes them with the same `Object.hasOwn` pattern.

- `seo/json-ld-required-props`: `REQUIRED_PROPS[t]` was indexed with the page's own `@type` string. A page declaring `"@type": "constructor"` (or `toString`, `valueOf`, `hasOwnProperty`) read `Object.prototype.constructor`, passed the `!required` check, and crashed in `missingRequiredProps`. `runRules` catches per rule, so the rule produced zero results project-wide and `withFailedRulesOff` removed its weight from the Health denominator, raising the score. Reproduced against the built dist before the fix.
- `rule-options.ts` (`validateRuleOptions` / `resolveRuleOptions`): `spec[key]` was indexed with config-file option keys. An option keyed by an inherited name was accepted silently instead of being rejected as `unknown option` (or reported with the wrong "must be an object" message), and merged as if it were a map option. Same presence rule as `isMentionedAnywhere` in the same file.
- `architecture/reserved-name-placement`: the presence checks were already `Object.hasOwn`, but the value reads (`placements[name]` etc.) were raw. A directory named `constructor` declared in only one of the three placement maps read `Object.prototype.constructor` from the other two and threw in `globsOf`. All nine reads now go through a guarded helper.

## Tests

One new test per site, each shown to fail on the pre-fix code (the JSON-LD case with the exact `reading 'filter'` crash, the placement case with the exact `value.split is not a function` crash). Kitchen-sink expectations unchanged.

Verified: `pnpm build && pnpm typecheck && pnpm test && pnpm lint` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes when JSON-LD types or directory names match built-in JavaScript property names.
  * Unknown rule option names are now correctly reported as unknown instead of being silently accepted or misclassified.
  * Prevented invalid inherited properties from affecting rule scoring and validation.
* **Tests**
  * Added coverage for prototype-named JSON-LD types, directory names, and rule options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->