### PR TITLE
perf(core): memoize the rule-registry projection computeScore rebuilds per call

### DIFF
--- a/.changeset/score-registry-memo.md
+++ b/.changeset/score-registry-memo.md
@@ -1,0 +1,5 @@
+---
+'@svelte-vitals/core': patch
+---
+
+Memoize the rule-registry projection (`selectRules` → `buildInventory` / `ruleScopes`) that `computeScore` rebuilt on every call. Per-route scoring in the JSON report and the dashboard snapshot no longer pays a 105-rule filter and two Map builds per call; report output is byte-identical (verified against the kitchen-sink gallery). Measured on a synthetic 1,681-route result set: `buildJsonReport` median ~95 ms → ~18 ms.

--- a/.changeset/score-registry-memo.md
+++ b/.changeset/score-registry-memo.md
@@ -2,4 +2,4 @@
 '@svelte-vitals/core': patch
 ---
 
-Memoize the rule-registry projection (`selectRules` → `buildInventory` / `ruleScopes`) that `computeScore` rebuilt on every call. Per-route scoring in the JSON report and the dashboard snapshot no longer pays a 105-rule filter and two Map builds per call; report output is byte-identical (verified against the kitchen-sink gallery). Measured on a synthetic 1,681-route result set: `buildJsonReport` median ~95 ms → ~18 ms.
+Memoize the rule-registry projection (`selectRules` → `buildInventory` / `ruleScopes`) that `computeScore` rebuilt on every call. Per-route scoring in the JSON report and the dashboard snapshot no longer pays a 105-rule filter and two Map builds per call; report output is byte-identical (verified against the kitchen-sink gallery). Measured on a synthetic 1,681-route result set, `buildJsonReport` runs roughly 5× faster (tens of milliseconds saved per report; the absolute numbers depend on the machine).

--- a/packages/core/src/scoring/score.ts
+++ b/packages/core/src/scoring/score.ts
@@ -42,7 +42,12 @@ export interface ScoreResult {
 
 export interface ScoreOptions {
   applyCriticalCap?: boolean;
-  /** The rules that ran. Defaults to the selected registry; supplied by tests and custom rule sets. */
+  /**
+   * The rules that ran. Defaults to the selected registry; supplied by tests and custom rule sets.
+   * Treated as immutable for as long as the same `config` object is in use: the registry projection
+   * is cached by the identity of this array and of `config`, so mutate neither in place — pass a
+   * new array or a new config instead.
+   */
   rules?: readonly Rule[];
 }
 
@@ -58,7 +63,8 @@ interface RegistryProjection {
 // Keyed on the `config` object's identity, then on the rules array's identity: every in-tree
 // caller passes the same `config` object for a whole run (`withFailedRulesOff` returns a fresh
 // object when it changes anything, the same one when it doesn't), and nothing mutates a Config
-// in place.
+// in place. Callers own that contract: a `config` or `options.rules` mutated in place after a call
+// will be scored against the stale projection.
 const projections = new WeakMap<Config, WeakMap<readonly Rule[], RegistryProjection>>();
 
 function projectRegistry(config: Config, rulesList: readonly Rule[]): RegistryProjection {

--- a/packages/core/src/scoring/score.ts
+++ b/packages/core/src/scoring/score.ts
@@ -50,17 +50,39 @@ function clamp(n: number): number {
   return Math.max(0, Math.min(100, n));
 }
 
+interface RegistryProjection {
+  inventory: Map<PairKey, number>;
+  pairOf: Map<string, PairKey>;
+}
+
+// Keyed on the `config` object's identity, then on the rules array's identity: every in-tree
+// caller passes the same `config` object for a whole run (`withFailedRulesOff` returns a fresh
+// object when it changes anything, the same one when it doesn't), and nothing mutates a Config
+// in place. `buildJsonReport` alone calls this ~7 times per route; the projection depends on
+// neither `results` nor `applyCriticalCap`, so a per-call rebuild was ~95% of report-building time.
+const projections = new WeakMap<Config, WeakMap<readonly Rule[], RegistryProjection>>();
+
+function projectRegistry(config: Config, rulesList: readonly Rule[]): RegistryProjection {
+  let byRules = projections.get(config);
+  if (!byRules) projections.set(config, (byRules = new WeakMap()));
+  let projection = byRules.get(rulesList);
+  if (!projection) {
+    // `selectRules` applied here, not just inside `buildInventory`, so `pairOf` and the inventory see
+    // the same filtered list — an injected rule that config turns `off` must vanish from both, not map
+    // to a pair in one and contribute nothing in the other.
+    const rules = selectRules([...rulesList], config);
+    projection = { inventory: buildInventory(config, rules), pairOf: ruleScopes(rules) };
+    byRules.set(rulesList, projection);
+  }
+  return projection;
+}
+
 /** Compute the headline score and its breakdown (design §12). */
 export function computeScore(results: Result[], config: Config, options: ScoreOptions = {}): ScoreResult {
   const routeResults = results.filter((r) => r.route !== undefined);
   const projectResults = results.filter((r) => r.route === undefined);
 
-  // `selectRules` applied here, not just inside `buildInventory`, so `pairOf` and the inventory see
-  // the same filtered list — an injected rule that config turns `off` must vanish from both, not map
-  // to a pair in one and contribute nothing in the other.
-  const rules = selectRules([...(options.rules ?? allRules)], config);
-  const inventory = buildInventory(config, rules);
-  const pairOf = ruleScopes(rules);
+  const { inventory, pairOf } = projectRegistry(config, options.rules ?? allRules);
 
   let anyCritical = false;
 

--- a/packages/core/src/scoring/score.ts
+++ b/packages/core/src/scoring/score.ts
@@ -58,8 +58,7 @@ interface RegistryProjection {
 // Keyed on the `config` object's identity, then on the rules array's identity: every in-tree
 // caller passes the same `config` object for a whole run (`withFailedRulesOff` returns a fresh
 // object when it changes anything, the same one when it doesn't), and nothing mutates a Config
-// in place. `buildJsonReport` alone calls this ~7 times per route; the projection depends on
-// neither `results` nor `applyCriticalCap`, so a per-call rebuild was ~95% of report-building time.
+// in place.
 const projections = new WeakMap<Config, WeakMap<readonly Rule[], RegistryProjection>>();
 
 function projectRegistry(config: Config, rulesList: readonly Rule[]): RegistryProjection {

--- a/packages/core/test/score.test.ts
+++ b/packages/core/test/score.test.ts
@@ -1,8 +1,9 @@
 // Scores are floored, not rounded (2026-07-31): a displayed 100 means the deduction was exactly zero.
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { defineConfig, type Result } from '../src/index.js';
 import { computeScore, withFailedRulesOff } from '../src/internal.js';
 import type { Rule } from '../src/rule.js';
+import * as inventory from '../src/scoring/inventory.js';
 import { buildInventory, DEDUCTION } from '../src/scoring/inventory.js';
 import { INVENTORY_FLOOR, scoresByCategory } from '../src/scoring/score.js';
 
@@ -19,6 +20,36 @@ const fail = (id: string, route: string, severity: 'critical' | 'warning' | 'inf
   detection: { presence: 'none', value: 'absent' },
   route,
   message: 'missing'
+});
+
+describe('computeScore memoizes the registry projection per config', () => {
+  it('builds the inventory once for repeated calls with the same config object', () => {
+    const spy = vi.spyOn(inventory, 'buildInventory');
+    try {
+      const config = defineConfig({});
+      const results: Result[] = [pass('seo/title-presence', '/a'), fail('seo/title-presence', '/b', 'critical')];
+      computeScore(results, config);
+      computeScore(results, config);
+      computeScore(results.slice(0, 1), config, { applyCriticalCap: false });
+      expect(spy).toHaveBeenCalledTimes(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('rebuilds for a different config object and for an explicit rules list', () => {
+    const spy = vi.spyOn(inventory, 'buildInventory');
+    try {
+      const a = defineConfig({});
+      const b = defineConfig({ rules: { 'seo/title-presence': 'off' } });
+      computeScore([], a);
+      computeScore([], b);
+      computeScore([], a, { rules: [] });
+      expect(spy).toHaveBeenCalledTimes(3);
+    } finally {
+      spy.mockRestore();
+    }
+  });
 });
 
 describe('computeScore (§12 worked example)', () => {


### PR DESCRIPTION
## Summary

`computeScore` rebuilt `selectRules(...)`, `buildInventory(...)` and `ruleScopes(...)` on every call, although all three depend only on `(config, options.rules)` and never on `results`. `buildJsonReport` calls `computeScore` about seven times per route (headline plus per-category), and `computeHealth` adds six more, so on a large project the rule-registry projection dominated report-building time.

The projection is now memoized in a `WeakMap` keyed on the `config` object's identity and then on the rules array's identity. Every in-tree caller passes one `config` object per run (`withFailedRulesOff` returns a fresh object when it changes anything and the same one otherwise), nothing mutates a `Config` in place, and a fresh `options.rules` array simply bypasses the cache. `WeakMap` means nothing is retained beyond the config's lifetime.

Score semantics are frozen and this changes no arithmetic: the kitchen-sink gallery's `--reporter json`, `--reporter console --no-color` and `--by-route` outputs are byte-identical before and after (verified with `cmp`).

## Measurement

Synthetic 1,681-route result set through `buildJsonReport`: roughly 5× faster (tens of milliseconds saved per report; absolute numbers depend on the machine). `pnpm bench` does not cover report building, so the probe script is the measurement.

## Tests

- New: the inventory is built once for repeated calls with the same config object; a different config object or an explicit rules list rebuilds. The first fails without the memo; keying on the rules list alone (ignoring config identity) fails the second plus two pre-existing scoring tests.
- Existing scoring/health/json-report suites and kitchen-sink e2e unchanged.

Verified: `pnpm build && pnpm typecheck && pnpm test && pnpm lint` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved scoring performance by reusing rule data during repeated calculations.
  * Faster per-route scoring in JSON reports and dashboard snapshots.
* **Bug Fixes**
  * Preserved report output exactly while optimizing score computation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->