### PR TITLE
fix(vite): surface analyzeProject warnings from the dev dashboard runner and pin crashed-rule reporting on the build path

### DIFF
--- a/.changeset/vite-surface-warnings.md
+++ b/.changeset/vite-surface-warnings.md
@@ -2,4 +2,4 @@
 '@svelte-vitals/vite': patch
 ---
 
-The dev dashboard's whole-project runner now forwards `analyzeProject`'s warnings (an `overrides` glob that matched nothing, an unknown inline-directive id, a file that could not be read or parsed, a rule that crashed and was skipped) to the terminal, the same way `vite build` already does. An unchanged warning set is not repeated on the next re-analysis. The build path's crashed-rule warning is now pinned by a test.
+The dev dashboard's whole-project runner now forwards `analyzeProject`'s warnings (for example an `overrides` glob that matched nothing, an unknown inline-directive id, a file that could not be read or parsed, a rule that crashed and was skipped, or a config-file validation notice) to the terminal, the same way `vite build` already does. An unchanged warning set is not repeated on the next re-analysis. Config-file warnings already printed when the file was loaded are not printed a second time by the runner. The build path's crashed-rule warning is now pinned by a test.

--- a/.changeset/vite-surface-warnings.md
+++ b/.changeset/vite-surface-warnings.md
@@ -1,0 +1,5 @@
+---
+'@svelte-vitals/vite': patch
+---
+
+The dev dashboard's whole-project runner now forwards `analyzeProject`'s warnings (an `overrides` glob that matched nothing, an unknown inline-directive id, a file that could not be read or parsed, a rule that crashed and was skipped) to the terminal, the same way `vite build` already does. An unchanged warning set is not repeated on the next re-analysis. The build path's crashed-rule warning is now pinned by a test.

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -274,6 +274,9 @@ export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin | Plugin
       // config-file values independently, since it calls analyzeProject (which loads
       // the config file itself).
       let config: Config;
+      // Config-file warnings already printed here for this edit — the runner below
+      // reloads the same config file itself and must not print them a second time.
+      let printedConfigWarnings = new Set<string>();
 
       // Guards a stale resolve from clobbering a newer one when two watcher-driven
       // calls overlap (the debounce below makes this rare but not impossible: a
@@ -289,6 +292,9 @@ export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin | Plugin
           const resolved = await resolveConfig(uiRoot, options);
           if (generation !== configGeneration) return;
           config = resolved.config;
+          // Replaced, not accumulated: an edit that fixes a warning must let a later,
+          // unrelated warning with the same text print again.
+          printedConfigWarnings = new Set(resolved.warnings);
           for (const w of resolved.warnings) warn(`svelte-vitals: ${w}`);
         } catch (err) {
           if (generation !== configGeneration) return;
@@ -327,8 +333,10 @@ export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin | Plugin
         onError: (err) =>
           warn(`svelte-vitals: dev analysis failed: ${err instanceof Error ? err.message : String(err)}`),
         // Same sink and prefix as the build path (closeBundle) so the two never read differently.
+        // The runner reloads the config file itself, so its warning set repeats whatever
+        // applyConfig already printed for this edit — skip those to avoid printing twice.
         onWarnings: (warnings) => {
-          for (const w of warnings) warn(`svelte-vitals: ${w}`);
+          for (const w of warnings) if (!printedConfigWarnings.has(w)) warn(`svelte-vitals: ${w}`);
         },
         onStatusChange: (analyzing) => store.setAnalyzing(analyzing)
       });

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -352,9 +352,13 @@ export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin | Plugin
         if (!isRelevant(file, uiRoot)) return;
         // The runner re-loads the config file itself (analyzeProject → loadConfigFile); the
         // dashboard's scoring config is resolved here, so it has to follow the same edit.
+        // Notifying the runner only after this resolve settles (applyConfig never rejects)
+        // keeps onWarnings' dedup order-independent — otherwise a runner run that finishes
+        // first would print a warning applyConfig's still-pending resolve then prints again.
         if (CONFIG_FILENAMES.includes(basename(file))) {
           clearTimeout(configTimer);
-          configTimer = setTimeout(() => void applyConfig(), 500);
+          configTimer = setTimeout(() => void applyConfig().then(() => runner.notifyChange(file)), 500);
+          return;
         }
         runner.notifyChange(file);
       });

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -326,6 +326,10 @@ export function svelteVitals(options: SvelteVitalsOptions = {}): Plugin | Plugin
         },
         onError: (err) =>
           warn(`svelte-vitals: dev analysis failed: ${err instanceof Error ? err.message : String(err)}`),
+        // Same sink and prefix as the build path (closeBundle) so the two never read differently.
+        onWarnings: (warnings) => {
+          for (const w of warnings) warn(`svelte-vitals: ${w}`);
+        },
         onStatusChange: (analyzing) => store.setAnalyzing(analyzing)
       });
       runner.start();

--- a/packages/vite/src/ui/analysis.ts
+++ b/packages/vite/src/ui/analysis.ts
@@ -10,7 +10,7 @@ export type AnalyzeFn = (opts: {
   rules?: Record<string, RuleSetting>;
   failOn?: Severity;
   parseCache?: ParseCache;
-}) => Promise<{ results: Result[]; failedRuleIds?: string[] }>;
+}) => Promise<{ results: Result[]; failedRuleIds?: string[]; warnings?: string[] }>;
 
 export interface AnalysisRunnerOptions {
   /** Project root to analyze (passed as `cwd` to `analyzeProject`). */
@@ -24,6 +24,8 @@ export interface AnalysisRunnerOptions {
   /** `failedRuleIds` is `analyzeProject`'s crashed-rule ids — omitted when the injected `analyze` doesn't return them. Ids only, not a config: the base config (plugin-option weights/overrides included) must stay the caller's, never swapped for `analyzeProject`'s own. */
   onResults(results: Result[], failedRuleIds?: string[]): void;
   onError(err: unknown): void;
+  /** `analyzeProject`'s human-readable warnings (empty selections, unknown directive ids, skipped files, crashed rules). Called only when the set differs from the previous run's — a debounced re-run per save would otherwise repeat the same lines. */
+  onWarnings?(warnings: string[]): void;
   /** Called `true` right before a run starts its `analyze()` call and `false` once that run settles — including right before a coalesced follow-up starts again, so a rapid burst of changes may emit false-then-true between runs rather than staying true throughout. */
   onStatusChange?(analyzing: boolean): void;
   /** Debounce window for `notifyChange` (default: 500ms). */
@@ -52,13 +54,14 @@ export function createAnalysisRunner(opts: AnalysisRunnerOptions): AnalysisRunne
   let running = false;
   let pending = false;
   let timer: ReturnType<typeof setTimeout> | undefined;
+  let lastWarningsKey: string | undefined;
 
   async function runOnce(): Promise<void> {
     if (stopped) return;
     running = true;
     opts.onStatusChange?.(true);
     try {
-      const { results, failedRuleIds } = await analyze({
+      const result = await analyze({
         cwd: opts.root,
         treatDynamicAs: opts.treatDynamicAs,
         metaComponents: opts.metaComponents,
@@ -66,12 +69,17 @@ export function createAnalysisRunner(opts: AnalysisRunnerOptions): AnalysisRunne
         failOn: opts.failOn,
         parseCache
       });
+      const { results, failedRuleIds } = result;
       // Passing a 2nd arg only when defined keeps callers that ignore it (and tests
       // asserting exact call args) unaffected by this addition.
       if (!stopped) {
         if (failedRuleIds !== undefined) opts.onResults(results, failedRuleIds);
         else opts.onResults(results);
       }
+      const warnings = result.warnings ?? [];
+      const key = warnings.join('\n');
+      if (!stopped && warnings.length > 0 && key !== lastWarningsKey) opts.onWarnings?.(warnings);
+      lastWarningsKey = key;
     } catch (err) {
       if (!stopped) opts.onError(err);
     } finally {

--- a/packages/vite/test/analyze-rule-failure.test.ts
+++ b/packages/vite/test/analyze-rule-failure.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const THROWN = 'synthetic rule failure (test)\nsecond line must not be printed';
+
+vi.mock('@svelte-vitals/core/internal', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@svelte-vitals/core/internal')>();
+  const allRules = actual.allRules.map((rule) =>
+    rule.id === 'seo/title-presence'
+      ? {
+          ...rule,
+          check: async () => {
+            throw new Error(THROWN);
+          }
+        }
+      : rule
+  );
+  return { ...actual, allRules };
+});
+
+const { analyze } = await import('../src/analyze.js');
+
+describe('vite build path reports a crashed rule', () => {
+  let cwd: string;
+  let pages: string;
+  beforeAll(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'sv-rule-failure-'));
+    pages = join(cwd, '.svelte-kit/output/prerendered/pages');
+    await mkdir(pages, { recursive: true });
+    await writeFile(join(pages, 'index.html'), '<html lang="en"><head><title>Home</title></head><body></body></html>');
+  });
+  afterAll(async () => rm(cwd, { recursive: true, force: true }));
+
+  it('names the rule and only the first line of its message in warnings', async () => {
+    const r = await analyze(pages, cwd, { report: false });
+    expect(r.warnings).toContain('rule seo/title-presence failed and was skipped: synthetic rule failure (test)');
+    expect(r.warnings.some((w) => w.includes('second line'))).toBe(false);
+  });
+});

--- a/packages/vite/test/ui-analysis.test.ts
+++ b/packages/vite/test/ui-analysis.test.ts
@@ -71,6 +71,50 @@ describe('createAnalysisRunner', () => {
     expect(onResults).toHaveBeenCalledWith([]);
   });
 
+  it('forwards analyzeProject warnings through onWarnings', async () => {
+    const analyze = vi.fn<AnalyzeFn>(async () => ({ results: [], warnings: ['rule x failed and was skipped: boom'] }));
+    const onWarnings = vi.fn();
+    const runner = createAnalysisRunner({ root: '/proj', analyze, onResults: vi.fn(), onError: vi.fn(), onWarnings });
+    runner.start();
+    await vi.waitFor(() => expect(onWarnings).toHaveBeenCalledWith(['rule x failed and was skipped: boom']));
+  });
+
+  it('does not repeat an identical warning set on the next run, and sends a changed set', async () => {
+    let call = 0;
+    const analyze = vi.fn<AnalyzeFn>(async () => ({
+      results: [],
+      warnings: ++call <= 2 ? ['same'] : ['same', 'new']
+    }));
+    const onWarnings = vi.fn();
+    const runner = createAnalysisRunner({
+      root: '/proj',
+      analyze,
+      onResults: vi.fn(),
+      onError: vi.fn(),
+      onWarnings,
+      debounceMs: 10
+    });
+    runner.start();
+    await vi.waitFor(() => expect(analyze).toHaveBeenCalledTimes(1));
+    runner.notifyChange('/proj/src/a.svelte');
+    await vi.advanceTimersByTimeAsync(20);
+    await vi.waitFor(() => expect(analyze).toHaveBeenCalledTimes(2));
+    runner.notifyChange('/proj/src/b.svelte');
+    await vi.advanceTimersByTimeAsync(20);
+    await vi.waitFor(() => expect(analyze).toHaveBeenCalledTimes(3));
+    expect(onWarnings.mock.calls).toEqual([[['same']], [['same', 'new']]]);
+  });
+
+  it('still calls onResults with one argument when the analyzer returns no failedRuleIds', async () => {
+    // Guards the existing exact-args assertions above against the widened return type.
+    const analyze = vi.fn<AnalyzeFn>(async () => ({ results: [], warnings: [] }));
+    const onResults = vi.fn();
+    const runner = createAnalysisRunner({ root: '/proj', analyze, onResults, onError: vi.fn() });
+    runner.start();
+    await vi.waitFor(() => expect(onResults).toHaveBeenCalledTimes(1));
+    expect(onResults.mock.calls[0]).toEqual([[]]);
+  });
+
   it('coalesces N rapid notifyChange calls into a single debounced run', async () => {
     const analyze = vi.fn<AnalyzeFn>(async () => ({ results: [] }));
     const runner = createAnalysisRunner({

--- a/packages/vite/test/ui-plugin-config-file.test.ts
+++ b/packages/vite/test/ui-plugin-config-file.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { EventEmitter } from 'node:events';
@@ -142,6 +142,39 @@ describe('svelteVitals dev dashboard — svelte-vitals.config.* wiring', () => {
       try {
         await startUiServer(cwd);
         expect(warnSpy.mock.calls.some((args) => String(args[0]).includes('failOn'))).toBe(true);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it('does not print the same config-file warning twice (applyConfig + the runner both load it)', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'sv-ui-config-'));
+    try {
+      // The whole-project runner's analyzeProject only reaches (and warns about) the config
+      // file once detectProject recognizes cwd as a SvelteKit project — svelte.config.js plus
+      // an existing src/routes dir is the minimal shape that satisfies it without any pages.
+      await writeFile(join(cwd, 'svelte.config.js'), 'export default {};\n');
+      await mkdir(join(cwd, 'src/routes'), { recursive: true });
+      await writeFile(join(cwd, 'svelte-vitals.config.js'), `export default { failOn: 'nope' };\n`);
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const { call } = await startUiServer(cwd);
+        // Wait for the whole-project runner's first (fire-and-forget) run to finish, so its
+        // warnings — if any duplicate applyConfig's — have already reached console.warn.
+        await vi.waitFor(
+          () => {
+            const { res, body } = fakeRes();
+            call(req('GET', '/data.json'), res);
+            expect(JSON.parse(body()).analyzing).toBe(false);
+            expect(warnSpy.mock.calls.some((args) => String(args[0]).includes('failOn'))).toBe(true);
+          },
+          { timeout: 2000 }
+        );
+        const failOnWarnings = warnSpy.mock.calls.filter((args) => String(args[0]).includes('unknown failOn'));
+        expect(failOnWarnings).toHaveLength(1);
       } finally {
         warnSpy.mockRestore();
       }

--- a/packages/vite/test/ui-plugin.test.ts
+++ b/packages/vite/test/ui-plugin.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import { join } from 'node:path';
 import type { Plugin, ViteDevServer } from 'vite';
 
 type MiddlewareHandler = (req: IncomingMessage, res: ServerResponse, next: () => void) => void;
@@ -110,6 +111,37 @@ describe('svelteVitals({ ui })', () => {
     const irrelevantFile = `${root}/node_modules/foo/index.js`;
     watcherCallback!('change', irrelevantFile);
     expect(mockNotifyChange).not.toHaveBeenCalled();
+  });
+
+  it('notifies the runner of a config-file change only after the config has been re-resolved', async () => {
+    const plugins = svelteVitals({ ui: true }) as Plugin[];
+    const ui = plugins.find((p) => p.name === 'svelte-vitals:ui')!;
+    let watcherCallback: ((event: string, file: string) => void) | undefined;
+    const root = '/tmp/does-not-exist-svelte-vitals-ui-plugin-test';
+    const server = {
+      config: { root },
+      watcher: {
+        on: (_event: string, cb: (event: string, file: string) => void) => {
+          watcherCallback = cb;
+        }
+      },
+      middlewares: { use: (_path: string, _fn: MiddlewareHandler) => {} }
+    } as ViteDevServer;
+    const hook = typeof ui.configureServer === 'function' ? ui.configureServer : ui.configureServer!.handler;
+    await (hook as (s: ViteDevServer) => void | Promise<void>).call({}, server);
+
+    // A plain src/ file still notifies the runner synchronously (unchanged behavior).
+    const relevantFile = join(root, 'src/routes/+page.svelte');
+    watcherCallback!('change', relevantFile);
+    expect(mockNotifyChange).toHaveBeenCalledWith(relevantFile);
+    mockNotifyChange.mockClear();
+
+    // A config-file edit must wait for applyConfig's re-resolve (debounced 500ms) before
+    // notifying the runner — otherwise the runner's onWarnings dedup can race applyConfig.
+    const configFile = join(root, 'svelte-vitals.config.js');
+    watcherCallback!('change', configFile);
+    expect(mockNotifyChange).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(mockNotifyChange).toHaveBeenCalledWith(configFile), { timeout: 2000 });
   });
 
   it('configureServer wraps printUrls to also announce the dashboard URL', async () => {


### PR DESCRIPTION
> Stacked on #643 (`advisor/063-config-file-import-cache`): both change `configureServer` in `packages/vite/src/plugin.ts`. Merge #643 first, then retarget this PR to `main` (the diff shown here is against the 063 branch).

## Summary

- `analyzeProject` returns `warnings` (an `overrides` glob that matched nothing, an unknown inline-directive id, a file that could not be read or parsed, a crashed rule, config-file validation notices). The CLI prints them and `vite build` prints them, but the dev dashboard's whole-project runner dropped them at the type level: `AnalyzeFn` returned only `{ results, failedRuleIds }`. A crashed rule was silently scored out, an empty `overrides` glob was invisible.
- `AnalyzeFn` now carries `warnings?`, the runner has an `onWarnings` callback that fires only when the set differs from the previous run (a debounced re-run per save would otherwise repeat the same lines), and the plugin routes it through the same `terminalSafe` sink and `svelte-vitals: ` prefix as the build path. `onResults` keeps its one-argument form when the analyzer returns no `failedRuleIds`, so existing exact-args assertions hold.
- Config-file warnings are printed once: `applyConfig` (from #643) records what it printed for the current resolve and the runner skips those lines, since it reloads the same config file itself. Without this the `unknown failOn` line appeared twice at startup.
- The build path's crashed-rule warning (`rule X failed and was skipped: …`, first line only) was untested; a new test mocks one rule's `check` to throw and asserts the warning.

## Tests

- New: build-path crashed-rule warning (fails if the `formatFailedRuleWarning` push is removed); runner forwards warnings, dedupes an identical set and sends a changed one, keeps `onResults` one-arg; dashboard prints a config-file warning exactly once after the runner's first run (fails with 2 before the fix).
- Existing `ui-analysis.test.ts` exact-args assertions, `ui-plugin.test.ts`, `plugin-error.test.ts` and #643's config-file tests unchanged and green.

Verified: `pnpm build && pnpm typecheck && pnpm test && pnpm lint` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Development dashboard analysis warnings are now forwarded to the terminal, matching build behavior.
  - Repeated warnings are suppressed when unchanged or already displayed during configuration loading.
  - Warnings reappear when configuration changes resolve the issue.
  - Crashed analysis rules now report a concise warning without disrupting the build path.

- **Tests**
  - Added coverage for warning forwarding, deduplication, configuration warnings, and crashed rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->