### PR TITLE
docs(plans): record the 2026-09-03 deep audit and plans 062-068

### DIFF
--- a/plans/062-dev-ui-ingest-same-origin.md
+++ b/plans/062-dev-ui-ingest-same-origin.md
@@ -1,0 +1,344 @@
+# Plan 062: dev UI の `POST /ingest` を same-origin に限定し、body サイズに上限を設ける
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat 13aa7ad0..HEAD -- packages/vite/src/ui/middleware.ts packages/vite/src/loopback.ts packages/vite/test/ui-middleware.test.ts 'docs/src/content/docs/guides/(vite)/dev-dashboard.mdx' 'docs/src/content/docs/ja/guides/(vite)/dev-dashboard.mdx'`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+| Priority | Effort | Risk | Depends on | Category | Planned at                    |
+| -------- | ------ | ---- | ---------- | -------- | ----------------------------- |
+| P2       | S      | LOW  | none       | security | commit `13aa7ad0`, 2026-09-03 |
+
+## Why this matters
+
+`vite dev` 中に `/__svelte-vitals/ingest` へ POST された finding は、そのまま dashboard に表示され、各カードの「Copy AI prompt」経由でユーザーが**書き込み権限を持つコーディングエージェントに貼り付ける**テキストになる。現在のガードは「`Origin` ヘッダーがあり、かつそのホスト名が loopback でなければ拒否」であり、ホスト名しか見ていない。そのため `Host: localhost:5173` の dev サーバーに対し、`Origin: http://localhost:3000` を持つ別ポートのページ(他プロジェクトの dev サーバー、ローカルで動くツールの UI、そこに XSS があるページ)から `fetch(..., { method: 'POST', mode: 'no-cors' })` すれば、preflight なしで任意の finding を注入できる。注入された `recommendation` / `fix.description` / `fix.snippet` は型と形しか検証されない(Plan 058 が守るのは Markdown **構造**であって内容ではない)。
+
+前提条件は「開発者のブラウザ内に攻撃者が制御する loopback オリジンのページがある」ことなので影響は LOW〜MED だが、閉じるコストは数行である。送信側 `postIngest`(`hooks/handle.ts`)は Node の `fetch` を使い、**Node の fetch は `Origin` ヘッダーを送らない**(Node 24.18.1 で実測済み: `origin: null`)。dashboard 自身からの POST は same-origin。したがって「`Origin` が無い、または `Host` と完全一致(hostname:port)」に絞っても正規経路は一切壊れない。
+
+同じ経路の body は上限なしにメモリへ蓄積される(`chunks.push`)。same-origin 化で到達者はほぼ dashboard 自身に限られるが、防御の多層化として 4 MiB の上限を同時に入れる。根拠は 2026-09-03 の実測: built CLI で `examples/kitchen-sink`(欠陥ギャラリー、80 ルート・190 finding)を `--reporter json` で解析し、1 ルートあたりの ingest payload(`{route, results, failedRuleIds}` 相当)に換算した最大が 25 finding で約 14 KB、JSON レポート全体でも約 130 KB だった。4 MiB は最大ルートの約 300 倍にあたる。
+
+## Current state
+
+- `packages/vite/src/ui/middleware.ts` — dev UI のミドルウェア。HEAD の実コード(89-130 行、抜粋):
+
+  ```ts
+  server.middlewares.use('/__svelte-vitals', (req: IncomingMessage, res: ServerResponse) => {
+    const url = req.url ?? '/';
+
+    // Same boundary as the sending side's postIngest (hooks/handle.ts): the dev UI is
+    // loopback-only. Cross-site form POSTs carry an Origin header (same-origin GET
+    // navigations don't), so rejecting only "Origin present AND non-loopback" never
+    // breaks legitimate use. Host validation mitigates DNS rebinding (LAN use via
+    // --host is already blocked on the sending side too).
+    const origin = req.headers.origin;
+    const host = req.headers.host;
+    if (
+      (typeof origin === 'string' && !isLoopbackOrigin(origin)) ||
+      host === undefined ||
+      !isLoopbackOrigin(`http://${host}`)
+    ) {
+      // drain any unread body so the client reliably receives the 403 (unread data kills the socket)
+      req.resume();
+      res.statusCode = 403;
+      res.end('svelte-vitals dev UI is only available from localhost');
+      return;
+    }
+
+    if (req.method === 'POST' && url.startsWith('/ingest')) {
+      // Collect raw Buffers and decode once: per-chunk toString() would corrupt a
+      // multibyte char split across a chunk boundary, dropping that route's findings.
+      const chunks: Buffer[] = [];
+      req.on('data', (c: Buffer) => chunks.push(c));
+      req.on('end', () => {
+        try {
+          const { route, results, failedRuleIds } = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+          if (typeof route === 'string' && Array.isArray(results)) {
+            const failedIds = Array.isArray(failedRuleIds) ? failedRuleIds.filter((id) => typeof id === 'string') : [];
+            store.set(route, results.filter(isResultLike), failedIds);
+          }
+        } catch {
+          // ignore malformed ingest payloads — dev tooling must not crash the dev server
+        }
+        res.statusCode = 204;
+        res.end();
+      });
+      return;
+    }
+  ```
+
+- `packages/vite/src/loopback.ts` — 送信側・受信側で共有する loopback 判定(全文):
+
+  ```ts
+  /** Only the local dev server hosts the ingest endpoint, so never POST off-box. */
+  export function isLoopbackOrigin(origin: string): boolean {
+    try {
+      const host = new URL(origin).hostname;
+      // WHATWG URL keeps the brackets on IPv6 hostnames ('[::1]'); a bare '::1' never parses.
+      return host === 'localhost' || host === '127.0.0.1' || host === '[::1]';
+    } catch {
+      return false;
+    }
+  }
+  ```
+
+- `packages/vite/src/hooks/handle.ts:42-66` — 送信側 `postIngest`。`fetch(\`${origin}/__svelte-vitals/ingest\`, { method: 'POST', headers: { 'content-type': 'application/json' }, body })`。`origin`は`event.url.origin`(=ページ要求の `Host`由来)で、dashboard と同じ vite サーバーを指す。Node の`fetch`(undici)は `Origin` ヘッダーを付けない。
+
+- `packages/vite/test/ui-middleware.test.ts` — 既存テスト。`setup()` がミドルウェアのハンドラを捕まえ、`postReq(url, headers)` / `getReq(url, headers)` が `EventEmitter` ベースの疑似 `IncomingMessage`(`method`/`url`/`headers`/`resume`)を作り、`res()` が疑似 `ServerResponse` を作る。body は `ireq.emit('data', Buffer)` → `ireq.emit('end')` で流す。Origin 関連の既存ケース(206-234 行):
+
+  ```ts
+  it('rejects a cross-site ingest POST carrying a non-loopback Origin', async () => {
+    const { call } = setup();
+    const ir = res();
+    const ireq = postReq('/ingest', { host: 'localhost:5173', origin: 'https://evil.example' });
+    call(ireq, ir);
+    expect(ir.statusCode).toBe(403); // rejected before the body is even read
+    ireq.emit('data', Buffer.from(ingestBody));
+    ireq.emit('end');
+    await new Promise((r) => setTimeout(r, 0));
+    const gr = res();
+    call(getReq('/'), gr);
+    expect(gr.statusCode).not.toBe(403);
+    expect(gr.chunks.join('')).not.toContain('seo/title-presence');
+  });
+
+  it('accepts an ingest POST without an Origin header (server-side postIngest behavior)', async () => {
+    const { call } = setup();
+    const ir = res();
+    const ireq = postReq('/ingest', { host: 'localhost:5173' }); // node fetch sends no Origin
+    call(ireq, ir);
+    ireq.emit('data', Buffer.from(ingestBody));
+    ireq.emit('end');
+    await new Promise((r) => setTimeout(r, 0));
+    expect(ir.statusCode).toBe(204);
+    const gr = res();
+    call(getReq('/'), gr);
+    expect(gr.chunks.join('')).toContain('seo/title-presence'); // stored and rendered
+  });
+  ```
+
+  **別ポートの loopback Origin を拒否するケースは存在しない**(このギャップが本計画の対象)。
+
+- ユーザー向け docs — `docs/src/content/docs/guides/(vite)/dev-dashboard.mdx:89`(en)と `docs/src/content/docs/ja/guides/(vite)/dev-dashboard.mdx:87`(ja)の "Notes" 箇条書きに、境界の説明がある:
+
+  > - Live updates only flow over a loopback origin (`localhost`, `127.0.0.1`, `[::1]`). When you run `vite dev --host` and open the app via a LAN IP, the handle skips the ingest POST, a guard against a spoofed `Host` header, so visited routes won't refine to `measured`. Open it from `localhost` instead.
+
+  > - ライブ更新はループバックオリジン（`localhost`、`127.0.0.1`、`[::1]`）でのみ流れます。`vite dev --host` で LAN の IP からアプリを開いた場合、…
+
+  AGENTS.md の規約: en を編集したら ja も同時に更新し、`pnpm --filter docs run translate:stamp <en-file>` で台帳(`docs/blume.translations.json`)に記録する。CI の `docs` ジョブ(`translate:check`)が未記録の en 変更を落とす。**ja を実際に更新せずに stamp してはならない。**
+
+- 設計上の注意点(実装判断の根拠として固定):
+  - 比較は `new URL(origin).host`(hostname と port)対 `new URL(\`http://${req.headers.host}\`).host`(Host 側も URL パーサに通し、既定ポートの省略と大文字小文字を正規化する)。**scheme は比較しない** — Vite を `server.https`で動かすと`Origin`は`https://localhost:5173`、`Host` は `localhost:5173` のままで、scheme まで比べると正規の dashboard からの POST を落とす。
+  - `Origin: null`(sandboxed iframe、`file://` ページ — `--reporter html` の静的レポートを含む)は `new URL('null')` が throw するので現状でも 403。そのままにし、テストで固定する。
+  - 既存の loopback Host チェックと DNS rebinding 防御は**そのまま残す**。same-origin 判定は Host が loopback であることの上に重ねる。
+  - `Content-Type` は見ない(現状どおり)。`no-cors` の simple request は `text/plain` で来るので、Content-Type で絞っても防御にならず、判定は Origin で行う。
+  - リポジトリ規約: コードコメントは英語。非自明な WHY のみ書く。
+
+## Commands you will need
+
+| Purpose    | Command                                                    | Expected on success |
+| ---------- | ---------------------------------------------------------- | ------------------- |
+| Install    | `pnpm install`                                             | exit 0              |
+| Build      | `pnpm build`                                               | exit 0              |
+| Vite tests | `pnpm build && pnpm --filter @svelte-vitals/vite run test` | all pass            |
+| Docs gate  | `pnpm --filter docs run translate:check`                   | exit 0              |
+| Full       | `pnpm build && pnpm typecheck && pnpm test && pnpm lint`   | 全て exit 0         |
+
+vite パッケージのテストは `@svelte-vitals/core` / `svelte-vitals` の**ビルド済み dist** を import するため、テスト前に必ず `pnpm build` を通すこと。
+
+## Scope
+
+**In scope**(変更してよいファイルはこれだけ):
+
+- `packages/vite/src/loopback.ts`(`isSameOrigin` を追加)
+- `packages/vite/src/ui/middleware.ts`(ガード条件・コメント・body 上限)
+- `packages/vite/test/ui-middleware.test.ts`(テスト追加)
+- `packages/vite/test/loopback.test.ts`(新規)
+- `docs/src/content/docs/guides/(vite)/dev-dashboard.mdx` と `docs/src/content/docs/ja/guides/(vite)/dev-dashboard.mdx`(Notes に 1 文追加)
+- `docs/blume.translations.json`(`translate:stamp` が更新する — 手で編集しない)
+- `.changeset/`(新規 changeset 1 件)
+
+**Out of scope**(触らない):
+
+- `packages/vite/src/hooks/handle.ts` — 送信側は変更不要(Node fetch は Origin を送らない。もし送っていたら STOP 条件)。
+- `packages/vite/src/ui/snapshot.ts` / `store.ts` / `packages/core/src/reporter/app-shell.ts` — 表示側の無害化(058 で済み)。
+- `examples/kitchen-sink` — ユーザーが設定する「lever」ではないので kitchen-sink の e2e ガード(AGENTS.md)は不要。
+- `GET /`・`/events`・`/data.json` の応答形式・CORS ヘッダーの追加。
+
+## Git workflow
+
+- Branch: `advisor/062-dev-ui-ingest-same-origin`
+- Conventional commits、例: `fix(vite): accept dev UI ingest only from the dashboard's own origin and cap the body`
+- push / PR 作成はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: `isSameOrigin` を loopback.ts に追加し、単体テストを書く
+
+`packages/vite/src/loopback.ts` に追加:
+
+```ts
+/**
+ * Whether `origin` (an Origin header value) names exactly the server this request reached —
+ * `host` is the Host header, `hostname[:port]`. The scheme is deliberately ignored: under
+ * `server.https` the Origin is https while the Host header is unchanged. Both sides go
+ * through the URL parser so a default port (`localhost:80`) and hostname case compare equal.
+ */
+export function isSameOrigin(origin: string, host: string): boolean {
+  try {
+    return new URL(origin).host === new URL(`http://${host}`).host;
+  } catch {
+    return false;
+  }
+}
+```
+
+`packages/vite/test/loopback.test.ts` を新規作成(vitest、`describe`/`it`/`expect`。既存テストの import スタイルに合わせる):
+
+| ケース                                         | 期待    |
+| ---------------------------------------------- | ------- |
+| `('http://localhost:5173', 'localhost:5173')`  | `true`  |
+| `('https://localhost:5173', 'localhost:5173')` | `true`  |
+| `('http://[::1]:5173', '[::1]:5173')`          | `true`  |
+| `('http://localhost', 'localhost:80')`         | `true`  |
+| `('http://LOCALHOST:5173', 'localhost:5173')`  | `true`  |
+| `('http://localhost:3000', 'localhost:5173')`  | `false` |
+| `('http://127.0.0.1:5173', 'localhost:5173')`  | `false` |
+| `('null', 'localhost:5173')`                   | `false` |
+
+**Verify**: `pnpm build && pnpm --filter @svelte-vitals/vite run test` → 新ファイルの 8 ケース含め all pass
+
+### Step 2: 失敗するミドルウェアテストを先に追加する(TDD red)
+
+`packages/vite/test/ui-middleware.test.ts` に、既存の `rejects a cross-site ingest POST carrying a non-loopback Origin` をコピーして次を追加する(store が変化しないことの確認まで同じ形で):
+
+1. `rejects an ingest POST from another loopback port (cross-origin on localhost)` — `postReq('/ingest', { host: 'localhost:5173', origin: 'http://localhost:3000' })` → `403`、その後の `GET /` に `seo/title-presence` が現れない。
+2. `accepts an ingest POST from the dashboard's own origin` — `origin: 'http://localhost:5173'` → `204`、`GET /` に反映。
+3. `accepts a same-host https Origin (server.https)` — `origin: 'https://localhost:5173'` → `204`。
+4. `rejects Origin: null` — `origin: 'null'` → `403`(現状でも通るはずのケースを固定する)。
+5. `rejects an ingest body over the size cap and stores nothing` — `Buffer.alloc(4 * 1024 * 1024 + 1, 0x20)` を 1 回または複数回 `emit('data')` してから `emit('end')` → `413`、`GET /` に `seo/title-presence` が現れない。
+
+**Verify**: `pnpm build && pnpm --filter @svelte-vitals/vite run test` → ケース 1 と 5 が **fail**、2〜4 は pass(4 は既存挙動で pass する)
+
+### Step 3: ミドルウェアのガードを same-origin 化し、body 上限を入れる
+
+`packages/vite/src/ui/middleware.ts`:
+
+1. import に `isSameOrigin` を追加(`'../loopback.js'`)。
+2. ファイル先頭の定数に `const INGEST_BODY_LIMIT = 4 * 1024 * 1024;` を追加し、英語コメントで「same-origin にしても dashboard 自身の XSS からの巨大 POST は残るので、メモリ蓄積に上限を置く。kitchen-sink の最大ルート(25 finding)で約 14 KB」と WHY を 1〜2 行で書く。
+3. ガード条件を次の形に置き換え、直上のコメントも書き直す(「Origin present AND non-loopback を拒否」の説明は誤りになるので残さない):
+
+   ```ts
+   // Loopback Host defeats DNS rebinding; on top of that, a request carrying an Origin must come
+   // from this very server (host:port). The handle's server-side fetch sends no Origin, and the
+   // dashboard's own fetches are same-origin, so nothing legitimate is lost — while a page on any
+   // other localhost port (another dev server, a local tool UI) can no longer POST findings in.
+   const origin = req.headers.origin;
+   const host = req.headers.host;
+   if (
+     host === undefined ||
+     !isLoopbackOrigin(`http://${host}`) ||
+     (typeof origin === 'string' && !isSameOrigin(origin, host))
+   ) {
+   ```
+
+   403 の本文・`req.resume()` はそのまま。
+
+4. `POST /ingest` 分岐に上限を入れる。`chunks` の合計バイト数を数え、超えたら以後のチャンクを捨て、`end` で `413` を返して parse も `store.set` もしない:
+
+   ```ts
+   const chunks: Buffer[] = [];
+   let received = 0;
+   req.on('data', (c: Buffer) => {
+     received += c.length;
+     if (received <= INGEST_BODY_LIMIT) chunks.push(c);
+   });
+   req.on('end', () => {
+     if (received > INGEST_BODY_LIMIT) {
+       res.statusCode = 413;
+       res.end();
+       return;
+     }
+     try { ... 既存どおり ... } catch { ... }
+     res.statusCode = 204;
+     res.end();
+   });
+   ```
+
+   `req.destroy()` は使わない — テストの疑似 `IncomingMessage` は `resume` しか持たず、実サーバーでも 413 を返し切る方が挙動が読みやすい。
+
+**Verify**: `pnpm build && pnpm --filter @svelte-vitals/vite run test` → Step 2 の 5 ケース含め all pass。特に既存の `accepts an ingest POST without an Origin header` と `rejects a dashboard GET with a non-loopback Host (DNS rebinding)` が無変更で pass すること。
+
+### Step 4: docs(en/ja)に境界の 1 文を追加し、台帳に stamp する
+
+`docs/src/content/docs/guides/(vite)/dev-dashboard.mdx` の "Live updates only flow over a loopback origin …" の箇条書きの**直後**に 1 項目追加:
+
+```md
+- The dashboard's ingest endpoint accepts POSTs only from the dashboard's own origin (same host and port) or from the server-side handle, so a page served by another local dev server or tool cannot feed it findings.
+```
+
+`docs/src/content/docs/ja/guides/(vite)/dev-dashboard.mdx` の対応する箇条書きの直後には、次の 1 項目を追加する。
+
+```md
+- dashboard の ingest エンドポイントは、dashboard 自身のオリジン（同じホストとポート）またはサーバー側ハンドルからの POST だけを受け付けます。別のローカル dev サーバーやツールが配信するページから finding を流し込むことはできません。
+```
+
+両方を編集し終えたら、次のコマンドで台帳に記録する。
+
+```bash
+pnpm --filter docs run translate:stamp 'src/content/docs/guides/(vite)/dev-dashboard.mdx'
+```
+
+**Verify**: `pnpm --filter docs run translate:check` → exit 0。`git diff --stat docs/blume.translations.json` → 変更が 1 エントリ(dev-dashboard.mdx)のみ。
+
+### Step 5: changeset を書き、最終検証
+
+`pnpm changeset` で `@svelte-vitals/vite` **patch**(英語)。内容例:
+
+> The dev dashboard's `/__svelte-vitals/ingest` endpoint now accepts POSTs only from the dashboard's own origin (same host and port) or from the server-side handle, and answers 413 to bodies over 4 MiB. Previously a page served from any other localhost port could inject findings — including fix snippets that reach "Copy AI prompt" — into the dashboard.
+
+**Verify**: `pnpm build && pnpm typecheck && pnpm test && pnpm lint` → 全て exit 0
+
+## Test plan
+
+- Step 1 の `loopback.test.ts`(8 ケース)— `isSameOrigin` の port/scheme/IPv6/既定ポート/大文字小文字/不正値の意味論を固定。
+- Step 2 の 5 ケース — 別ポート拒否(本命)、same-origin 受理、https 受理、`Origin: null` 拒否、413。
+- 既存ケースが回帰検出を担う: `accepts an ingest POST without an Origin header`(送信側の実挙動)、`rejects a cross-site ingest POST carrying a non-loopback Origin`、`rejects a dashboard GET with a non-loopback Host`、multibyte 分割 body。
+- 手本: `packages/vite/test/ui-middleware.test.ts:206-234`(構造をそのままコピーして origin と期待値だけ変える)。
+
+## Done criteria
+
+- [ ] `Origin: http://localhost:3000` + `Host: localhost:5173` の `POST /ingest` が 403 で、store が変化しないことをテストが証明している
+- [ ] `Origin` なし / same-origin(http, https)の `POST /ingest` が 204 で反映されることをテストが証明している
+- [ ] 4 MiB 超の body が 413 で、store が変化しないことをテストが証明している
+- [ ] `grep -n "Origin present AND non-loopback" packages/vite/src/ui/middleware.ts` → 0 件(古い説明コメントが消えている)
+- [ ] en/ja の dev-dashboard.mdx の両方に新しい箇条書きがあり、`pnpm --filter docs run translate:check` が exit 0
+- [ ] `pnpm build && pnpm typecheck && pnpm test && pnpm lint` 全て exit 0
+- [ ] `git status` で in-scope 外の変更ゼロ
+- [ ] changeset(`@svelte-vitals/vite` patch、英語)が存在する
+- [ ] `plans/README.md` の 062 行を更新済み
+
+## STOP conditions
+
+Stop and report back (do not improvise) if:
+
+- "Current state" の `middleware.ts` 抜粋・既存テスト抜粋と実コードが不一致。
+- Step 3 の変更後に既存の `accepts an ingest POST without an Origin header` が fail する、または `packages/vite/test/ui-ingest.test.ts` / `ui-integration.test.ts` が fail する — 送信側が Origin を付けている可能性があり、`hooks/handle.ts` は out of scope なので報告。
+- Vite 本体が `/__svelte-vitals` に届く前に同等の Origin 検証を行っていて、テストの前提(ハンドラに Origin 付き要求が届く)が成り立たないと判明した場合。
+- `translate:stamp` が dev-dashboard.mdx 以外の台帳エントリも書き換える(台帳を丸ごと再生成してはならない)。
+- ja ページに en の "Live updates only flow over a loopback origin" に対応する箇条書きが見つからない(挿入位置を推測せず報告)。
+
+## Maintenance notes
+
+- `/__svelte-vitals` 配下に新しいルートを足すとき、このガードは自動的にかかる(ミドルウェア先頭で一括判定)。ルート個別の緩和は作らないこと。
+- 将来 dev UI を LAN 公開(`--host`)で使いたい要望が来たら、緩める箇所は **3 つ同時**: ここの loopback Host チェック、same-origin 判定、送信側 `postIngest` の loopback 判定。片方だけ緩めると live 更新が黙って止まる(Plan 006 の Maintenance notes と同じ注意)。docs の 2 つの箇条書き(en/ja)も追随させる。
+- レビュー観点: ガード条件が「Host が loopback」**かつ**「Origin があるなら Host と一致」の 2 段になっているか。`isLoopbackOrigin(origin)` を残して same-origin を省く戻し方は、本計画が閉じるギャップをそのまま再導入する。
+- 上限 `INGEST_BODY_LIMIT` を上げる場合は、実際に超えた route の finding 数と payload サイズを changeset に記録すること(値の根拠が kitchen-sink 実測の約 14 KB/ルート(2026-09-03)であるため)。

--- a/plans/062-dev-ui-ingest-same-origin.md
+++ b/plans/062-dev-ui-ingest-same-origin.md
@@ -90,7 +90,7 @@
   }
   ```
 
-- `packages/vite/src/hooks/handle.ts:42-66` — 送信側 `postIngest`。`fetch(\`${origin}/__svelte-vitals/ingest\`, { method: 'POST', headers: { 'content-type': 'application/json' }, body })`。`origin`は`event.url.origin`(=ページ要求の `Host`由来)で、dashboard と同じ vite サーバーを指す。Node の`fetch`(undici)は `Origin` ヘッダーを付けない。
+- `packages/vite/src/hooks/handle.ts:42-66` — 送信側 `postIngest`。``fetch(`${origin}/__svelte-vitals/ingest`, { method: 'POST', headers: { 'content-type': 'application/json' }, body })``。`origin`は`event.url.origin`(=ページ要求の `Host`由来)で、dashboard と同じ vite サーバーを指す。Node の`fetch`(undici)は `Origin` ヘッダーを付けない。
 
 - `packages/vite/test/ui-middleware.test.ts` — 既存テスト。`setup()` がミドルウェアのハンドラを捕まえ、`postReq(url, headers)` / `getReq(url, headers)` が `EventEmitter` ベースの疑似 `IncomingMessage`(`method`/`url`/`headers`/`resume`)を作り、`res()` が疑似 `ServerResponse` を作る。body は `ireq.emit('data', Buffer)` → `ireq.emit('end')` で流す。Origin 関連の既存ケース(206-234 行):
 
@@ -130,13 +130,12 @@
 - ユーザー向け docs — `docs/src/content/docs/guides/(vite)/dev-dashboard.mdx:89`(en)と `docs/src/content/docs/ja/guides/(vite)/dev-dashboard.mdx:87`(ja)の "Notes" 箇条書きに、境界の説明がある:
 
   > - Live updates only flow over a loopback origin (`localhost`, `127.0.0.1`, `[::1]`). When you run `vite dev --host` and open the app via a LAN IP, the handle skips the ingest POST, a guard against a spoofed `Host` header, so visited routes won't refine to `measured`. Open it from `localhost` instead.
-
   > - ライブ更新はループバックオリジン（`localhost`、`127.0.0.1`、`[::1]`）でのみ流れます。`vite dev --host` で LAN の IP からアプリを開いた場合、…
 
   AGENTS.md の規約: en を編集したら ja も同時に更新し、`pnpm --filter docs run translate:stamp <en-file>` で台帳(`docs/blume.translations.json`)に記録する。CI の `docs` ジョブ(`translate:check`)が未記録の en 変更を落とす。**ja を実際に更新せずに stamp してはならない。**
 
 - 設計上の注意点(実装判断の根拠として固定):
-  - 比較は `new URL(origin).host`(hostname と port)対 `new URL(\`http://${req.headers.host}\`).host`(Host 側も URL パーサに通し、既定ポートの省略と大文字小文字を正規化する)。**scheme は比較しない** — Vite を `server.https`で動かすと`Origin`は`https://localhost:5173`、`Host` は `localhost:5173` のままで、scheme まで比べると正規の dashboard からの POST を落とす。
+  - 比較は `new URL(origin).host`(hostname と port)対 ``new URL(`http://${req.headers.host}`).host``(Host 側も URL パーサに通し、既定ポートの省略と大文字小文字を正規化する)。**scheme は比較しない** — Vite を `server.https`で動かすと`Origin`は`https://localhost:5173`、`Host` は `localhost:5173` のままで、scheme まで比べると正規の dashboard からの POST を落とす。
   - `Origin: null`(sandboxed iframe、`file://` ページ — `--reporter html` の静的レポートを含む)は `new URL('null')` が throw するので現状でも 403。そのままにし、テストで固定する。
   - 既存の loopback Host チェックと DNS rebinding 防御は**そのまま残す**。same-origin 判定は Host が loopback であることの上に重ねる。
   - `Content-Type` は見ない(現状どおり)。`no-cors` の simple request は `text/plain` で来るので、Content-Type で絞っても防御にならず、判定は Origin で行う。

--- a/plans/063-config-file-import-cache.md
+++ b/plans/063-config-file-import-cache.md
@@ -1,0 +1,407 @@
+# Plan 063: config ファイルの `import()` をキャッシュバストし、dev dashboard が編集後の config を読むようにする
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat d3828d9e..HEAD -- packages/cli/src/config-file.ts packages/cli/src/index.ts packages/vite/src/plugin.ts packages/vite/src/ui/middleware.ts packages/vite/src/ui/analysis.ts packages/cli/test/config-file.test.ts packages/vite/test/ui-plugin-config-file.test.ts packages/vite/test/ui-middleware.test.ts`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+| Priority | Effort | Risk | Depends on | Category    | Planned at                                                                 |
+| -------- | ------ | ---- | ---------- | ----------- | -------------------------------------------------------------------------- |
+| P1       | S      | MED  | none       | correctness | commit `13aa7ad0` (= `origin/main` `d3828d9e` の 3 コミット前)、2026-09-03 |
+
+この計画は `origin/main`(`d3828d9e`)を起点に書いている。監査時のローカル HEAD `13aa7ad0` は 3 コミット遅れているが、本計画が触るファイルはその 3 コミットで変わっていない(`packages/vite/src/ui/middleware.ts` だけは #640 で変わったので、抜粋は `origin/main` 版から取っている)。ブランチは `origin/main` から切ること。
+
+## Why this matters
+
+`svelte-vitals.config.{js,ts}` は `packages/cli/src/config-file.ts` の `loadFrom` が **素の `import()`** で読む。Node の ESM ローダーはモジュールキャッシュを URL でキーにするので、同じプロセス内で同じファイルを 2 回 `import()` すると、2 回目は**最初に評価したモジュールオブジェクト**が返る。ファイルが書き換わっていても再評価されない。
+
+CLI は 1 プロセス 1 解析なので無害。壊れるのは長寿命プロセスである **vite dev の dashboard** で、ここでは次の順に事が進む。
+
+1. `packages/vite/src/plugin.ts` の watcher は `svelte-vitals.config.*` の変更を「再解析トリガー」として登録している(`CONFIG_BASENAMES` に `CONFIG_FILENAMES` を展開、`isRelevant` が真を返す)。設計書 `docs/superpowers/specs/2026-07-08-dev-dashboard-whole-project-design.md` 73-74 行もそれを明記している。
+2. トリガーされた `createAnalysisRunner` は `analyzeProject({ cwd, … })` を呼び、`analyzeProject` は毎回 `loadConfigFile(cwd)` を呼ぶ(`packages/cli/src/index.ts:292-297`)。
+3. しかし `loadFrom` の `import()` はキャッシュ済みモジュールを返すので、**再解析は初回ロード時の config で走る**。スピナーは回り、findings は描き直されるが、`rules: { 'seo/title-presence': 'off' }` を足しても消えない。警告も「再起動が必要」というヒントも出ない。
+
+さらに別レイヤーとして、dashboard の採点・描画に使う `config` は `configureServer` で一度だけ `resolveConfig` され(`plugin.ts:275-290`)、`installUiMiddleware(server, config, …)` に**値で**渡される。runner 側の config を直しても、`weights` や `overrides` を編集した結果は `/data.json` の Health に反映されない。
+
+Vite の dev サーバー再起動(vite.config 変更時など)は同一 Node プロセス内で行われ、ESM モジュールキャッシュは消えない。直るのは `vite dev` プロセスを止めて起動し直したときだけである。
+
+実測(2026-09-03、Node 24.18.1 と vitest 4.1.11 の両方): `writeFileSync(f, 'export default 1')` → `import(url)` → `writeFileSync(f, 'export default 2')` → `import(url)` は **1, 1** を返し、`import(url + '?v=2')` は **2** を返す。つまり URL にクエリを付けることで再評価でき、かつ vitest の in-process テストでもこの挙動は再現する(下の Step 2 の red が成立する根拠)。
+
+## Current state
+
+- `packages/cli/src/config-file.ts:286-290`(`loadFrom`、抜粋):
+
+  ```ts
+  /** Import one known-present config file and validate it. Shared by discovery and `--config`. */
+  async function loadFrom(path: string): Promise<LoadedConfigFile> {
+    let mod: { default?: unknown };
+    try {
+      mod = (await import(pathToFileURL(path).href)) as { default?: unknown };
+    } catch (err) {
+  ```
+
+  同ファイルの import 行(1-10 行付近)には `existsSync` を含む `node:fs` の import と `pathToFileURL` の `node:url` の import がある。`node:crypto` はまだ import していない。
+
+- `packages/cli/src/index.ts:288-298`(`analyzeProject` の冒頭): `opts.loadedConfig` が無ければ `opts.configPath` または `loadConfigFile(cwd)` を毎回呼ぶ。ここは変更しない。
+
+- `packages/vite/src/plugin.ts:30-42`(watcher の対象): `CONFIG_BASENAMES` に `...CONFIG_FILENAMES` を展開。`isRelevant(file, root)`(`plugin.ts:54-61`)は `CONFIG_BASENAMES.has(basename(file))` で真を返す。
+
+- `packages/vite/src/plugin.ts:268-333`(`configureServer`、抜粋):
+
+  ```ts
+  async configureServer(server: ViteDevServer) {
+    process.env.SVELTE_VITALS_UI = '1';
+    const uiRoot = options.cwd ?? server.config.root;
+
+    // This `config` drives the dashboard's rendering/scoring (installUiMiddleware →
+    // buildSnapshot → buildJsonReport) — the whole-project `runner` below gets its
+    // config-file values independently, since it calls analyzeProject (which loads
+    // the config file itself).
+    let config: Config;
+    let warnings: string[];
+    try {
+      ({ config, warnings } = await resolveConfig(uiRoot, options));
+    } catch (err) {
+      warn(`svelte-vitals: config file invalid — dashboard using plugin options/defaults: ${…}`);
+      config = mergeConfig(options, undefined);
+      warnings = [];
+    }
+    for (const w of warnings) warn(`svelte-vitals: ${w}`);
+    const store = createStore();
+    let staticFailedRuleIds: string[] = [];
+    const runner = createAnalysisRunner({ root: uiRoot, …, onResults: (results, failedRuleIds) => { store.setStatic(results); staticFailedRuleIds = failedRuleIds ?? []; }, … });
+    runner.start();
+    server.watcher?.on('all', (_event, file) => {
+      if (isRelevant(file, uiRoot)) runner.notifyChange(file);
+    });
+    server.httpServer?.once('close', () => { delete process.env.SVELTE_VITALS_UI; runner.stop(); });
+
+    installUiMiddleware(server, config, readPackageVersion(), store, readCoreVersion(), () => staticFailedRuleIds);
+  ```
+
+  `staticFailedRuleIds` は「リクエストごとに読む getter」として渡している(コメントに理由あり)。`config` は値で渡している。
+
+- `packages/vite/src/ui/middleware.ts`(**`origin/main` 版**、62-70 行と 168 / 181 行):
+
+  ```ts
+  export function installUiMiddleware(
+    server: ViteDevServer,
+    config: Config,
+    version: string,
+    store: FindingsStore,
+    coreVersion?: string,
+    /** Reads the whole-project runner's current crashed-rule ids; called per request … */
+    getStaticFailedRuleIds?: () => string[] | undefined
+  ): void {
+  ```
+
+  `config` の使用箇所は 2 つだけ: `/data.json` の `buildSnapshot(store, config, …)`(168 行)と、dashboard HTML の `renderAppShell(buildSnapshot(store, config, …))`(181 行)。
+
+- `packages/vite/src/analyze.ts:65-72`(`resolveConfig`): `loadConfigFile(cwd)` → `mergeConfig(options, loaded?.config)`。再解決に再利用できる。
+
+- 既存テスト:
+  - `packages/cli/test/config-file.test.ts` — `fixture(name)` で `test/fixtures/config-file-*` を読む形式。`loadConfigFile` / `loadConfigFromPath` を直接呼ぶ。
+  - `packages/vite/test/ui-plugin-config-file.test.ts` — `startUiServer(cwd, extraOptions)` が一時ディレクトリに `svelte-vitals.config.js` を置いて `configureServer` を呼び、`/ingest` で seo finding を 1 件流し込んでから `GET /data.json` の `report.weights.seo` を読む。`server.watcher.on` はダミー(`(_event, _cb) => {}`)。
+  - `packages/vite/test/ui-middleware.test.ts` — `installUiMiddleware` を直接呼ぶ。`config` を値で渡している。
+
+- 設計上の注意(実装判断の根拠として固定):
+  - キャッシュキーは**ファイル内容のハッシュ**にする。mtime は同一秒内の連続編集を取りこぼし(FS によっては 1〜2 秒粒度)、単調カウンタは変更のない再解析(src の保存ごとに走る)のたびにモジュールを 1 つずつ漏らす。内容ハッシュなら「変わっていなければ同じ URL → キャッシュヒット、変わっていれば新 URL → 再評価」になり、リークは実際の編集回数に比例するだけで済む。config ファイルは数 KB なので読み取りコストは無視できる。
+  - config ファイルが `import` する**別のローカルモジュール**(共有の rules 定義など)はこの計画では再評価されない。既知の制限として docs に書く(Step 5)。
+  - `installUiMiddleware` のシグネチャは `config: Config | (() => Config)` に**広げる**(getter を受け付ける)。既存の値渡しテストはそのまま通る。
+  - dashboard の config 再解決で `resolveConfig` が throw したら(config に typo)、`configureServer` 起動時と同じく `warn` して**直前の config を維持**する。dev は落とさない。
+  - `SvelteKit handle`(`packages/vite/src/hooks/handle.ts`)が受け取る `config` はプラグインオプションだけから作られ、config ファイルを読まないので本計画の対象外。
+  - リポジトリ規約: コードコメントは英語、非自明な WHY のみ。
+
+## Commands you will need
+
+| Purpose    | Command                                                    | Expected on success |
+| ---------- | ---------------------------------------------------------- | ------------------- |
+| Install    | `pnpm install`                                             | exit 0              |
+| Build      | `pnpm build`                                               | exit 0              |
+| CLI tests  | `pnpm build && pnpm --filter svelte-vitals run test`       | all pass            |
+| Vite tests | `pnpm build && pnpm --filter @svelte-vitals/vite run test` | all pass            |
+| Docs gate  | `pnpm --filter docs run translate:check`                   | exit 0              |
+| Full       | `pnpm build && pnpm typecheck && pnpm test && pnpm lint`   | 全て exit 0         |
+
+cli / vite パッケージのテストは `@svelte-vitals/core`(と vite は `svelte-vitals`)の**ビルド済み dist** を import するため、テスト前に必ず `pnpm build` を通すこと。
+
+## Scope
+
+**In scope**(変更してよいファイルはこれだけ):
+
+- `packages/cli/src/config-file.ts`(`loadFrom` のキャッシュバスト)
+- `packages/cli/test/config-file.test.ts`(テスト追加)
+- `packages/vite/src/ui/middleware.ts`(`config` 引数を getter 対応に)
+- `packages/vite/src/plugin.ts`(config ファイル変更時に dashboard config を再解決)
+- `packages/vite/test/ui-plugin-config-file.test.ts`(テスト追加)
+- `docs/src/content/docs/guides/(vite)/dev-dashboard.mdx` と `docs/src/content/docs/ja/guides/(vite)/dev-dashboard.mdx`(Notes に 1 文)
+- `docs/blume.translations.json`(`translate:stamp` が更新する。手で編集しない)
+- `.changeset/`(新規 changeset 1 件、`svelte-vitals` と `@svelte-vitals/vite` の patch)
+
+**Out of scope**(触らない):
+
+- `packages/cli/src/index.ts` — `analyzeProject` の config 読み込み順序は変えない。
+- `packages/vite/src/ui/analysis.ts` — runner は `analyzeProject` を呼ぶだけで、キャッシュバストはローダー側で効く。
+- `packages/vite/src/hooks/handle.ts` — 上記のとおり config ファイルを読まない。
+- `packages/vite/src/analyze.ts`(build モード)— 1 プロセス 1 解析。
+- config が import する別モジュールの再評価(既知の制限として文書化のみ)。
+- `packages/vite/test/ui-middleware.test.ts` — 変更不要(値渡しのまま通る)。通らなくなったら STOP。
+
+## Git workflow
+
+- Branch: `advisor/063-config-file-import-cache`(`origin/main` から)
+- Conventional commits、例: `fix(cli,vite): re-evaluate an edited svelte-vitals.config on dev re-analysis instead of serving the ESM cache`
+- push / PR 作成はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: ローダー側の失敗するテストを先に書く(TDD red)
+
+`packages/cli/test/config-file.test.ts` に新しい `describe('loadConfigFile re-reads an edited file', …)` を追加する。既存の fixture 方式ではなく一時ディレクトリを使う(ファイルを書き換えるため):
+
+```ts
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+it('returns the new contents after the file is rewritten in the same process', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'svelte-vitals-config-reload-'));
+  try {
+    const file = join(dir, 'svelte-vitals.config.js');
+    writeFileSync(file, "export default { failOn: 'warning' };\n");
+    expect((await loadConfigFile(dir))?.config.failOn).toBe('warning');
+    writeFileSync(file, "export default { failOn: 'critical' };\n");
+    expect((await loadConfigFile(dir))?.config.failOn).toBe('critical');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+it('does not re-evaluate an unchanged file (same contents → same module instance)', async () => {
+  // Pin the cache key: an identical file must resolve to the identical URL, so the run-per-save
+  // dev loop does not leak one module instance per re-analysis.
+  const dir = mkdtempSync(join(tmpdir(), 'svelte-vitals-config-reload-'));
+  try {
+    const file = join(dir, 'svelte-vitals.config.js');
+    writeFileSync(file, 'export default { metaComponents: [] };\n');
+    const a = await loadConfigFile(dir);
+    const b = await loadConfigFile(dir);
+    expect(a).toEqual(b);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+```
+
+2 つ目のケースは「同一内容ならキャッシュヒット」を直接は観測できない(モジュールの同一性は `loadFrom` の外に出ない)。**このケースは緑のまま**でよく、目的は挙動の固定である。同一性を確かめたければ Step 3 で `loadFrom` に渡す URL をログする一時デバッグを入れ、終わったら消す。
+
+**Verify**: `pnpm build && pnpm --filter svelte-vitals run test -- config-file` → 1 つ目のケースが **fail**(2 回目の `failOn` が `'warning'` のまま)。2 つ目は pass。
+
+### Step 2: `loadFrom` に内容ハッシュのクエリを付ける
+
+`packages/cli/src/config-file.ts`:
+
+1. import に `createHash` を追加: `import { createHash } from 'node:crypto';`。`node:fs` の import に `readFileSync` を追加。
+2. `loadFrom` の `import()` 行を置き換える:
+
+   ```ts
+   // Node's ESM loader caches modules by URL for the life of the process, so a long-lived
+   // host (the vite dev dashboard re-analyzes on every save) would keep serving the config as
+   // it was first loaded. A content hash in the query re-evaluates only when the file actually
+   // changed; an unchanged file keeps hitting the cache instead of leaking a module per run.
+   // Modules the config itself imports are still cached — that is a documented limitation.
+   const digest = createHash('sha1').update(readFileSync(path)).digest('hex').slice(0, 16);
+   mod = (await import(`${pathToFileURL(path).href}?v=${digest}`)) as { default?: unknown };
+   ```
+
+   `readFileSync` が throw した場合(読めない)は従来 `import()` が投げていたのと同じ catch に入る。catch 内の `err instanceof SyntaxError` 分岐は変えない。
+
+**Verify**: `pnpm build && pnpm --filter svelte-vitals run test -- config-file` → all pass(Step 1 のケースが green に転じる)。続けて `pnpm --filter svelte-vitals run test` 全体と `pnpm smoke`(floor-smoke の `.ts` config ケースは `.ts` に `?v=` を付けても Node のネイティブ型ストリップが効くことの確認になる)→ all pass。
+
+### Step 3: dashboard 側の失敗するテストを書く(TDD red)
+
+`packages/vite/test/ui-plugin-config-file.test.ts` の `startUiServer` を、watcher コールバックを捕まえられるように拡張する。既存の呼び出しを壊さないよう、戻り値に `fireWatcher(file)` を**追加**する。
+
+```ts
+let watcherCb: ((event: string, file: string) => void) | undefined;
+const server = {
+  config: { root: cwd },
+  watcher: { on: (_event: string, cb: (...args: unknown[]) => void) => { watcherCb = cb as typeof watcherCb; } },
+  middlewares: { use: (_path: string, fn: MiddlewareHandler) => (handler = fn) }
+} as ViteDevServer;
+…
+return { call, fireWatcher: (file: string) => watcherCb?.('change', file) };
+```
+
+このテストファイルは `createAnalysisRunner` をモックしていない(実 runner が `analyzeProject` を一時ディレクトリに対して走らせる)。既存ケースがそれで通っているので、そのままでよい。
+
+新ケースを追加:
+
+```ts
+it('re-resolves the dashboard config when svelte-vitals.config.* changes on the watcher', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'sv-ui-config-'));
+  try {
+    const configPath = join(cwd, 'svelte-vitals.config.js');
+    await writeFile(configPath, 'export default { weights: { seo: 5 } };\n');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { call, fireWatcher } = await startUiServer(cwd);
+      await writeFile(configPath, 'export default { weights: { seo: 2 } };\n');
+      fireWatcher(configPath);
+      // The re-resolve is async; poll /data.json until the new weight lands.
+      await vi.waitFor(() => {
+        const { res, body } = fakeRes();
+        call(req('GET', '/data.json'), res);
+        expect(JSON.parse(body()).report.weights.seo).toBe(2);
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+
+it('keeps the previous dashboard config when the edited file fails validation', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'sv-ui-config-'));
+  try {
+    const configPath = join(cwd, 'svelte-vitals.config.js');
+    await writeFile(configPath, 'export default { weights: { seo: 5 } };\n');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { call, fireWatcher } = await startUiServer(cwd);
+      await writeFile(configPath, "export default { rules: { 'no/such-rule': 'off' } };\n");
+      fireWatcher(configPath);
+      await vi.waitFor(() => {
+        expect(warnSpy.mock.calls.some((args) => String(args[0]).includes('config file invalid'))).toBe(true);
+      });
+      const { res, body } = fakeRes();
+      call(req('GET', '/data.json'), res);
+      expect(JSON.parse(body()).report.weights.seo).toBe(5);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  } finally {
+    await rm(cwd, { recursive: true, force: true });
+  }
+});
+```
+
+**Verify**: `pnpm build && pnpm --filter @svelte-vitals/vite run test -- ui-plugin-config-file` → 1 つ目が **fail**(`seo` が 5 のまま、`waitFor` タイムアウト)、2 つ目は現状の挙動と一致するので pass するはずだが、`warn` が呼ばれないので **fail** する(現状は再解決自体をしない)。両方 fail が期待値。
+
+### Step 4: middleware を getter 対応にし、plugin で config を再解決する
+
+1. `packages/vite/src/ui/middleware.ts`(origin/main 版):
+
+   - シグネチャを `config: Config | (() => Config)` に変える。JSDoc に「関数を渡すとリクエストごとに読む(config ファイルの編集を反映するため)」と 1 行。
+   - 関数冒頭に `const currentConfig = (): Config => (typeof config === 'function' ? config() : config);` を置き、168 行と 181 行の `buildSnapshot(store, config, …)` を `buildSnapshot(store, currentConfig(), …)` に変える。
+
+2. `packages/vite/src/plugin.ts` の `configureServer`:
+
+   - `let config: Config;` はそのまま。config 解決の try/catch を関数に括り出す(起動時と watcher 時で共有):
+
+     ```ts
+     // Shared by startup and the watcher: an invalid config must never take the dev server
+     // down, so a failed re-resolve keeps whatever config the dashboard was already using.
+     const applyConfig = async (): Promise<void> => {
+       try {
+         const resolved = await resolveConfig(uiRoot, options);
+         config = resolved.config;
+         for (const w of resolved.warnings) warn(`svelte-vitals: ${w}`);
+       } catch (err) {
+         warn(
+           `svelte-vitals: config file invalid — dashboard using ${config ? 'the previous config' : 'plugin options/defaults'}: ${err instanceof Error ? err.message : String(err)}`
+         );
+         config ??= mergeConfig(options, undefined);
+       }
+     };
+     await applyConfig();
+     ```
+
+     既存の警告文 `config file invalid — dashboard using plugin options/defaults` を含むテスト(`plugin-config-error.test.ts` / `ui-plugin-config-file.test.ts` の "logs a non-fatal config-file warning")が文字列一致で見ている場合があるので、起動時のメッセージは**従来どおり** `plugin options/defaults` を含める(上の三項がそれを保証する)。
+
+   - watcher の登録を変える:
+
+     ```ts
+     server.watcher?.on('all', (_event, file) => {
+       if (!isRelevant(file, uiRoot)) return;
+       // The runner re-loads the config file itself (analyzeProject → loadConfigFile); the
+       // dashboard's scoring config is resolved here, so it has to follow the same edit.
+       if (CONFIG_FILENAMES.includes(basename(file))) void applyConfig();
+       runner.notifyChange(file);
+     });
+     ```
+
+     `CONFIG_FILENAMES` は既に `plugin.ts` が import している(`CONFIG_BASENAMES` の構築に使用)。`basename` も import 済み。
+
+   - `installUiMiddleware(server, () => config, …)` と getter で渡す。
+
+**Verify**: `pnpm build && pnpm typecheck && pnpm --filter @svelte-vitals/vite run test` → all pass(Step 3 の 2 ケース含む)。`ui-middleware.test.ts` は無変更で pass すること。
+
+### Step 5: docs(en/ja)に既知の制限を 1 文追加し、台帳に stamp する
+
+`docs/src/content/docs/guides/(vite)/dev-dashboard.mdx` の "Notes" 箇条書き(既存の loopback の項の近く)に追加:
+
+> - Editing `svelte-vitals.config.{js,ts}` re-analyzes with the new config, dashboard scoring included. Modules the config file itself imports are not re-evaluated until `vite dev` restarts.
+
+ja 版 `docs/src/content/docs/ja/guides/(vite)/dev-dashboard.mdx` の同じ位置には次の 1 文を入れる。
+
+> - `svelte-vitals.config.{js,ts}` を編集すると、新しい設定で再解析され、ダッシュボードの採点にも反映されます。設定ファイル自身が import している別モジュールは `vite dev` を再起動するまで再評価されません。
+
+その後 `pnpm --filter docs run translate:stamp "docs/src/content/docs/guides/(vite)/dev-dashboard.mdx"` を実行し、`docs/blume.translations.json` の差分が 1 エントリだけであることを `git diff --stat docs/blume.translations.json` で確認する。
+
+**Verify**: `pnpm --filter docs run translate:check` → exit 0。`pnpm lint`(textlint 含む)→ exit 0。
+
+### Step 6: changeset を書き、最終検証
+
+`.changeset/` に新規ファイル(名前は任意の kebab-case、例 `config-file-reload.md`):
+
+```md
+---
+'svelte-vitals': patch
+'@svelte-vitals/vite': patch
+---
+
+Re-evaluate `svelte-vitals.config.{js,ts}` when it changes instead of serving Node's ESM module cache. In `vite dev` the dashboard re-analysis now runs with the edited config, and the dashboard's own scoring config (weights, overrides) follows the edit too; an edit that fails validation is warned about and the previous config is kept. Modules the config file imports are still cached until the dev server process restarts.
+```
+
+**Verify**: `pnpm build && pnpm typecheck && pnpm test && pnpm lint` → 全て exit 0。`pnpm smoke` → exit 0。
+
+## Test plan
+
+- 新規(cli): `config-file.test.ts` の再読込ケース、同一内容ケース。
+- 新規(vite): `ui-plugin-config-file.test.ts` の watcher 経由の再解決ケース、無効 config で前回 config 維持ケース。
+- 既存: `ui-middleware.test.ts`(値渡し)、`plugin-config-error.test.ts`、`floor-smoke` の `.ts` config ケースが無変更で通ること。
+- 判別性: Step 2 と Step 4 の変更をそれぞれ `git stash` で外すと、対応する新ケースだけが赤になることを一度確認する(レビューで問われる)。
+
+## Done criteria
+
+- [ ] `pnpm build && pnpm typecheck && pnpm test && pnpm lint` が全て exit 0
+- [ ] `pnpm smoke` が exit 0
+- [ ] `pnpm --filter docs run translate:check` が exit 0
+- [ ] `grep -n "?v=" packages/cli/src/config-file.ts` が 1 行ヒット
+- [ ] `grep -n "() => config" packages/vite/src/plugin.ts` が 1 行ヒット
+- [ ] changeset が `svelte-vitals` と `@svelte-vitals/vite` の両方を patch で含む
+- [ ] `plans/README.md` の 063 行を更新済み
+
+## Maintenance notes
+
+- 将来 config ローダーを別の仕組み(bundler 経由、`jiti` など)に置き換える場合、キャッシュキーの契約(「内容が同じなら同じ、違えば違う」)を保存すること。`config-file.test.ts` の再読込ケースがそれを守る。
+- `installUiMiddleware` の `config` に関数を渡すのは plugin.ts だけ。値渡しの呼び出しを増やしても壊れないが、config を差し替えたい新しい呼び出し側は getter を渡す。
+- `applyConfig` が起動時と watcher 時で同じ関数になったので、警告文を変えるときは両方のテストの文字列一致を見る。
+
+## STOP conditions
+
+- Drift check でいずれかの in-scope ファイルが変わっており、抜粋と一致しない。
+- Step 1 の再読込ケースが**修正前から green** になる(vitest のモジュールキャッシュ挙動が変わった)。その場合は計画の前提が崩れているので報告する。
+- Step 2 の後で `pnpm smoke` の `.ts` config ケースが落ちる(`?v=` 付き `file:` URL で型ストリップが効かない Node がある)。
+- `ui-middleware.test.ts` が Step 4 の後で落ちる(シグネチャ拡張が後方互換でなくなっている)。
+- `resolveConfig` が `plugin.ts` から到達できない(`analyze.ts` の export が変わった)。

--- a/plans/064-prototype-key-sweep.md
+++ b/plans/064-prototype-key-sweep.md
@@ -271,7 +271,7 @@ Guard three remaining `Object.prototype`-keyed lookups. A page whose JSON-LD `@t
 - [ ] `pnpm build && pnpm typecheck && pnpm test && pnpm lint` が全て exit 0
 - [ ] `grep -n "Object.hasOwn(REQUIRED_PROPS" packages/core/src/rules/seo/json-ld-required-props.ts` が 1 行ヒット
 - [ ] `grep -c "Object.hasOwn(spec, key)" packages/core/src/rule-options.ts` が `2`
-- [ ] `grep -nE "(placements|capUnits|anyUnits)\[name\]" packages/core/src/rules/architecture/reserved-name-placement.ts` のヒットが `declaredValue` ヘルパ内の 1 行だけ
+- [ ] `grep -nE "(placements|capUnits|anyUnits)\[name\]" packages/core/src/rules/architecture/reserved-name-placement.ts` のヒットが 0 行(ヘルパは引数名 `map` で読むので名前付き map の生索引は残らない)。`grep -c "\[name\]"` は `1`(`declaredValue` ヘルパ内)
 - [ ] changeset に `__proto__` / `prototype pollution` の語が**含まれない**
 - [ ] `plans/README.md` の 064 行を更新済み(260828-REV-01 を「064 で対応」に書き換え)
 

--- a/plans/064-prototype-key-sweep.md
+++ b/plans/064-prototype-key-sweep.md
@@ -1,0 +1,289 @@
+# Plan 064: core の `Object.prototype` キー索引の残り 3 サイトをふさぐ(JSON-LD `@type` でルール脱落、rule options の無言受理、placement 値読み)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat d3828d9e..HEAD -- packages/core/src/rules/seo/json-ld-required-props.ts packages/core/src/rules/seo/jsonld-engine.ts packages/core/src/rule-options.ts packages/core/src/rules/architecture/reserved-name-placement.ts packages/core/test/seo-jsonld-rules.test.ts packages/core/test/rule-options.test.ts packages/core/test/reserved-name-placement.test.ts packages/core/test/html-spec.test.ts`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+| Priority | Effort | Risk | Depends on | Category    | Planned at                                                                   |
+| -------- | ------ | ---- | ---------- | ----------- | ---------------------------------------------------------------------------- |
+| P1       | S      | LOW  | none       | correctness | commit `13aa7ad0`(= `origin/main` `d3828d9e` と同内容のファイル)、2026-09-03 |
+
+## Why this matters
+
+PR #615(計画 055)は `HTML_SPEC` の索引を `Object.hasOwn` で守った。同じクラスのハザードが core にあと 3 サイト残っており、うち 1 つは**解析対象のページ内容**から到達できる。
+
+1. **`seo/json-ld-required-props` がプロジェクト全体で脱落し、スコアが上がる。** `REQUIRED_PROPS[t]` の `t` はページの JSON-LD の `@type` 文字列そのもの。`"@type": "constructor"`(または `toString` / `valueOf` / `hasOwnProperty`)があると `Object.prototype.constructor`(関数)が返り、`!required` を素通りして `missingRequiredProps` の `row.all` が `undefined` になり `.filter` で throw する。`runRules` はルール単位で catch するので、**そのルールは当該ルートだけでなく全ルートで結果ゼロ**になり、`withFailedRulesOff` が重みを分母から外して **Health が上がる**。監査時に built `dist` で再現済み(`failedRules: [{ id: 'seo/json-ld-required-props', message: 'Cannot read properties of undefined (reading \'filter\')' }]`)。
+2. **rule options の unknown-key 検証に穴がある。** `validateRuleOptions` と `resolveRuleOptions` の `spec[key]` は config ファイル由来のキーで索引する。`options: { constructor: { a: 'b' } }` のように `Object.prototype` のメンバー名をキーにすると `!s` が偽になり、`unknown option` エラーが出ないまま無言で受理され(検証)、あるいは map 型としてマージされる(解決)。AGENTS.md が「typo で config が無言で inert になるのを防ぐ」と定義した境界の穴。値がオブジェクトでない場合は `x.constructor must be an object of string → non-empty string` という**誤ったメッセージ**になる。同ファイルの `isMentionedAnywhere`(90-98 行)は同じ理由で `Object.hasOwn` を使っており、そのポリシーを未適用の 2 サイトに広げるだけ。
+3. **`architecture/reserved-name-placement` の値読みが未ガード。** 055 のレビュー副産物(README の 260828-REV-01)として記録済みで未着手。存在チェック(145-147 行)は `Object.hasOwn` だが、その後の値読み `placements[name]` / `capUnits[name]` / `anyUnits[name]`(181-183 行、205-207 行)は生索引。`capitalisedUnitPlacements: { constructor: 'src/lib/**' }` だけを宣言したプロジェクトに `constructor` という名前のディレクトリがあると、`placements['constructor']` が `Object.prototype.constructor` を返し `globsOf(Function)` → `splitNames` で throw。監査時に再現済み(`value.split is not a function or its return value is not iterable`)。
+
+3 つとも修正は `Object.hasOwn` ガード 1 行ずつ。テストは #615 が `packages/core/test/html-spec.test.ts:65-78` に置いた形式に倣う。
+
+**changeset で主張してよいこと・いけないこと**(レビューで REJECT される主張を避ける): 1 は「ページ内容から到達可能なクラッシュ、ルール脱落、スコア上振れ」まで言ってよい。2 は「`constructor` 等の名前のオプションキーが無言で受理される、または誤ったメッセージになる」までであり、**`__proto__` によるプロトタイプ汚染は主張しない**。config は JS/TS モジュールとして評価されるので、オブジェクトリテラルの `__proto__:` は prototype をセットするだけで `Object.entries` のキーには現れない(到達不能)。3 は「特定の名前のディレクトリと片側だけの placement 設定の組み合わせでルールがクラッシュする」まで。
+
+## Current state
+
+- `packages/core/src/rules/seo/json-ld-required-props.ts:11-24`(全文の要部):
+
+  ```ts
+  problem: (nodes) => {
+    let hasKnownType = false;
+    for (const node of nodes) {
+      for (const t of typeOf(node)) {
+        const required = REQUIRED_PROPS[t];
+        if (!required) continue; // unknown/custom type, or a type Google requires nothing from → not flagged
+        hasKnownType = true;
+        const missing = missingRequiredProps(node, required);
+        if (missing.length > 0) return `${t} JSON-LD is missing required ${missing.join(', ')}`;
+      }
+    }
+    // No known types found → no signal (rule is not applicable)
+    return hasKnownType ? undefined : false;
+  };
+  ```
+
+- `packages/core/src/rules/seo/jsonld-engine.ts:196-210` — `REQUIRED_PROPS: RequiredPropsByType`(open index signature、7 エントリの通常オブジェクト)。`:218-224` の `missingRequiredProps(node, row)` は `Array.isArray(row) ? row : row.all` を `.filter` する。`typeOf(node)`(`:34-39`)は `@type` の文字列または文字列配列をそのまま返す。
+
+- `packages/core/src/rule-options.ts:131-137`(`resolveRuleOptions` のマージループ):
+
+  ```ts
+  for (const [key, value] of Object.entries(layer)) {
+    const s = spec[key];
+    if (!s) continue; // validation rejects unknown keys up front; ignore defensively
+    if (s.kind === 'integer') out[key] = value;
+    else if (s.kind === 'string-list') out[key] = [...(out[key] as string[]), ...(value as string[])];
+    else out[key] = { ...(out[key] as Record<string, string>), ...(value as Record<string, string>) };
+  }
+  ```
+
+  `:185-190`(`validateRuleOptions`):
+
+  ```ts
+  for (const [key, value] of Object.entries(options)) {
+    const s = spec[key];
+    if (!s) {
+      errors.push(`${ruleId}: unknown option '${key}'. Known options: ${Object.keys(spec).join(', ')}.`);
+      continue;
+    }
+  ```
+
+  `:90-98` の `isMentionedAnywhere` は `Object.hasOwn(config.rules, ruleId)` を使い、その理由を 6 行のコメントで説明している(「open-ended record への presence check はこのリポジトリでは `Object.hasOwn`」)。
+
+- `packages/core/src/rules/architecture/reserved-name-placement.ts:144-147`(存在チェック、ガード済み)と `:179-183` / `:205-207`(値読み、未ガード):
+
+  ```ts
+  const name = baseName(dir);
+  const inPlacements = Object.hasOwn(placements, name);
+  const inCapUnits = Object.hasOwn(capUnits, name);
+  const inAnyUnits = Object.hasOwn(anyUnits, name);
+  if (!inPlacements && !inCapUnits && !inAnyUnits) continue;
+  …
+  const resolvedValues: [MapName, string | undefined][] = [
+    ['placements', placements[name]],
+    ['capitalisedUnitPlacements', capUnits[name]],
+    ['anyCaseUnitPlacements', anyUnits[name]]
+  ];
+  …
+  const byPlacement = record('placements', placements[name], true);
+  const byCapUnit = record('capitalisedUnitPlacements', capUnits[name], isUnitDir(parent, filesIn));
+  const byAnyUnit = record('anyCaseUnitPlacements', anyUnits[name], isAnyCaseUnitDir(parent, filesIn));
+  ```
+
+  `:156-158` の `emptyValue(inPlacements, placements[name])` は `present &&` で短絡するので安全。`resolvedValues` と `record` は `value === undefined` で continue / return するが、`Object.prototype.constructor` は `undefined` ではない。
+
+- 既存テストの形式:
+  - `packages/core/test/html-spec.test.ts:65-78` — `describe('html-spec: Object.prototype keys are not element data', …)`、`htmlElement('constructor')` が `undefined` になることを pin。
+  - `packages/core/test/seo-jsonld-rules.test.ts:1-22` — `headWithJsonLd(raw)` で `ResolvedHead` を作り、`ctx(head)` で `RuleContext` を作り、`fails(await rule.check(ctx(...)))` で penalized な結果を数える。`seo/json-ld-required-props` のケースは 316 行から。
+  - `packages/core/test/rule-options.test.ts:92-97` — `validateRuleOptions('r', spec, { maxx: 10 })[0]` が `unknown option 'maxx'` を含むことを確認。`describe('resolveRuleOptions')` は 13 行から。
+  - `packages/core/test/reserved-name-placement.test.ts` — ルールを `RuleContext` で直接呼ぶ形式。既存ケースを 1 つコピーして fixture(ディレクトリ名と config)を差し替える。
+
+- リポジトリ規約: `Object.hasOwn(obj, key) ? obj[key] : undefined` の形(`role-candidates.ts:52` と同型)。コードコメントは英語、非自明な WHY のみ。
+
+## Commands you will need
+
+| Purpose    | Command                                                  | Expected on success |
+| ---------- | -------------------------------------------------------- | ------------------- |
+| Install    | `pnpm install`                                           | exit 0              |
+| Core tests | `pnpm --filter @svelte-vitals/core run test`             | all pass            |
+| Full       | `pnpm build && pnpm typecheck && pnpm test && pnpm lint` | 全て exit 0         |
+
+core のテストは dist に依存しないので、Step 1〜4 は `pnpm --filter @svelte-vitals/core run test` だけで回せる。
+
+## Scope
+
+**In scope**(変更してよいファイルはこれだけ):
+
+- `packages/core/src/rules/seo/json-ld-required-props.ts`
+- `packages/core/src/rule-options.ts`
+- `packages/core/src/rules/architecture/reserved-name-placement.ts`
+- `packages/core/test/seo-jsonld-rules.test.ts`
+- `packages/core/test/rule-options.test.ts`
+- `packages/core/test/reserved-name-placement.test.ts`
+- `.changeset/`(新規 changeset 1 件、`@svelte-vitals/core` の patch)
+
+**Out of scope**(触らない):
+
+- `packages/core/src/rules/seo/jsonld-engine.ts` — `missingRequiredProps` に shape チェックを足すのは二重防御で、呼び出し側を直せば不要。
+- `packages/cli/src/pkg-json.ts` の `hasDep`(全呼び出しがリテラル、到達不能)。
+- `html-spec/` / `role-candidates.ts` / `casing.ts` / `heavy-import.ts` / `reserved-directory-names.ts` — 監査でガード済みと確認。
+- ルール docs(en/ja)— 挙動の変化は「クラッシュ → 未知の型として無視」なので、docs の記述(unknown type は flag しない)はそのまま正しい。
+
+## Git workflow
+
+- Branch: `advisor/064-prototype-key-sweep`(`origin/main` から)
+- Conventional commits、例: `fix(core): guard the remaining Object.prototype-keyed lookups (JSON-LD @type, rule options, placement values)`
+- push / PR 作成はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: JSON-LD の失敗するテストを先に書く(TDD red)
+
+`packages/core/test/seo-jsonld-rules.test.ts` の `seo/json-ld-required-props` の describe(316 行付近)に追加する。
+
+```ts
+it('seo/json-ld-required-props treats an Object.prototype-named @type as unknown instead of throwing', async () => {
+  for (const type of ['constructor', 'toString', 'valueOf', 'hasOwnProperty']) {
+    const rs = await seoJsonLdRequiredProps.check(
+      ctx(headWithJsonLd(`{"@context":"https://schema.org","@type":"${type}"}`))
+    );
+    expect(fails(rs)).toHaveLength(0);
+  }
+  // Same for the array form of @type.
+  const rs = await seoJsonLdRequiredProps.check(
+    ctx(
+      headWithJsonLd(
+        '{"@context":"https://schema.org","@type":["constructor","WebSite"],"name":"n","url":"https://e.com/"}'
+      )
+    )
+  );
+  expect(fails(rs)).toHaveLength(0);
+});
+```
+
+`check` が throw する現状では `await` で reject し、テストは fail する。
+
+**Verify**: `pnpm --filter @svelte-vitals/core run test -- seo-jsonld-rules` → 新ケースが **fail**(`Cannot read properties of undefined (reading 'filter')`)。
+
+### Step 2: `REQUIRED_PROPS[t]` をガードする
+
+`packages/core/src/rules/seo/json-ld-required-props.ts:15` を置き換える。
+
+```ts
+// `t` is the page's own @type string; an unguarded index would return Object.prototype members
+// for names like `constructor` and crash the whole rule (a crashed rule drops out of scoring).
+const required = Object.hasOwn(REQUIRED_PROPS, t) ? REQUIRED_PROPS[t] : undefined;
+```
+
+**Verify**: `pnpm --filter @svelte-vitals/core run test -- seo-jsonld-rules` → all pass。
+
+### Step 3: rule options の失敗するテストを書き、ガードする(red → green)
+
+`packages/core/test/rule-options.test.ts` の `describe('validateRuleOptions')`(92 行〜)に追加する。
+
+```ts
+it('rejects an Object.prototype-named option key as unknown, not as a wrong-typed option', () => {
+  for (const key of ['constructor', 'toString', 'hasOwnProperty']) {
+    const errors = validateRuleOptions('r', spec, { [key]: { a: 'b' } });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain(`unknown option '${key}'`);
+  }
+});
+```
+
+`describe('resolveRuleOptions')`(13 行〜)に、既存ケースの `spec` / `config` の作り方に合わせて追加する。
+
+```ts
+it('ignores an Object.prototype-named key in a layer instead of merging it in', () => {
+  // resolveRuleOptions trusts validation, but the defensive `if (!s) continue` must hold for these names too.
+  const resolved =
+    resolveRuleOptions(/* same arguments the neighbouring cases use, with a layer { constructor: { z: 'y' } } */);
+  expect(Object.hasOwn(resolved, 'constructor')).toBe(false);
+});
+```
+
+引数の形は同じ describe 内の既存ケース(`resolveRuleOptions(ruleId, spec, config, compiledOverrides?)` 等)をそのままコピーして、layer にだけ `constructor` キーを足す。
+
+**Verify(red)**: `pnpm --filter @svelte-vitals/core run test -- rule-options` → 2 ケースが **fail**(validate 側は `errors` が空、resolve 側は `constructor` が own property になる)。
+
+`packages/core/src/rule-options.ts` の 2 箇所(`:132` と `:186`)を置き換える。
+
+```ts
+// Same presence rule as `isMentionedAnywhere` above: an inherited member is not a declared option.
+const s = Object.hasOwn(spec, key) ? spec[key] : undefined;
+```
+
+**Verify(green)**: `pnpm --filter @svelte-vitals/core run test -- rule-options` → all pass。
+
+### Step 4: reserved-name-placement の失敗するテストを書き、ガードする(red → green)
+
+`packages/core/test/reserved-name-placement.test.ts` に、既存ケースのうち「`capitalisedUnitPlacements` を使うケース」を 1 つコピーし、次の形にする。
+
+- config: `capitalisedUnitPlacements: { constructor: '<既存ケースと同じ glob>' }` のみ(`placements` と `anyCaseUnitPlacements` は宣言しない)。
+- sourceFiles: 既存ケースのディレクトリ名を `constructor` に置き換える(例 `src/lib/constructor/index.ts`)。
+- 期待: `check` が **resolve する**(throw しない)。findings の有無は問わない。`await expect(rule.check(ctx)).resolves.toBeDefined()` で十分。
+
+**Verify(red)**: `pnpm --filter @svelte-vitals/core run test -- reserved-name-placement` → 新ケースが **fail**(`value.split is not a function …`)。
+
+`packages/core/src/rules/architecture/reserved-name-placement.ts` の値読み 9 箇所(`:156-158`、`:181-183`、`:205-207`)を、存在フラグで守った読み方に変える。144-147 行の直後にヘルパを置く(名前は `Object.prototype` のメンバー名と被らないものにする。`valueOf` は不可)。
+
+```ts
+// The presence flags above are `Object.hasOwn`; the value reads must be too, or a name like
+// `constructor` declared in one map reads Object.prototype's function out of the other two.
+const declaredValue = (map: Record<string, string>, present: boolean): string | undefined =>
+  present ? map[name] : undefined;
+```
+
+そして `placements[name]` → `declaredValue(placements, inPlacements)`、`capUnits[name]` → `declaredValue(capUnits, inCapUnits)`、`anyUnits[name]` → `declaredValue(anyUnits, inAnyUnits)` に、9 箇所すべてを置き換える(`:156-158` の `emptyValue(...)` 呼び出しは `present &&` で短絡しているので現状でも安全だが、生索引を 1 か所も残さないために同じ形に揃える。挙動は変わらない)。`placements` 等の実際の型名はファイル冒頭の宣言を確認して合わせること。
+
+**Verify(green)**: `pnpm --filter @svelte-vitals/core run test -- reserved-name-placement` → all pass。
+
+### Step 5: changeset を書き、最終検証
+
+`.changeset/` に新規ファイル(例 `prototype-key-sweep.md`)。
+
+```md
+---
+'@svelte-vitals/core': patch
+---
+
+Guard three remaining `Object.prototype`-keyed lookups. A page whose JSON-LD `@type` is a name like `constructor` no longer crashes `seo/json-ld-required-props` (a crashed rule drops out of scoring project-wide, raising Health); a rule option keyed by such a name is now rejected as `unknown option` instead of being accepted silently or reported with the wrong message; and `architecture/reserved-name-placement` no longer throws when a directory named like that is declared in only one of its placement maps.
+```
+
+**Verify**: `pnpm build && pnpm typecheck && pnpm test && pnpm lint` → 全て exit 0。
+
+## Test plan
+
+- 新規 3 ケース(Step 1 / 3 / 4)。それぞれ対応する 1 行を revert すると赤に戻ることを一度確認する(判別性)。
+- 既存の `seo-jsonld-rules` / `rule-options` / `reserved-name-placement` / `html-spec` のケースが無変更で通ること。
+- kitchen-sink の e2e(`pnpm test` に含まれる)が期待件数のまま通ること。3 サイトとも「クラッシュ → 未検出」への変化なので既存の期待件数は動かないはず。動いたら STOP。
+
+## Done criteria
+
+- [ ] `pnpm build && pnpm typecheck && pnpm test && pnpm lint` が全て exit 0
+- [ ] `grep -n "Object.hasOwn(REQUIRED_PROPS" packages/core/src/rules/seo/json-ld-required-props.ts` が 1 行ヒット
+- [ ] `grep -c "Object.hasOwn(spec, key)" packages/core/src/rule-options.ts` が `2`
+- [ ] `grep -nE "(placements|capUnits|anyUnits)\[name\]" packages/core/src/rules/architecture/reserved-name-placement.ts` のヒットが `declaredValue` ヘルパ内の 1 行だけ
+- [ ] changeset に `__proto__` / `prototype pollution` の語が**含まれない**
+- [ ] `plans/README.md` の 064 行を更新済み(260828-REV-01 を「064 で対応」に書き換え)
+
+## Maintenance notes
+
+- 「ソース由来の文字列で `Record<string, …>` を索引する」箇所を新たに書くときは `Object.hasOwn` ガードが規約。`isMentionedAnywhere`(`rule-options.ts:90-98`)のコメントが正典。
+- `REQUIRED_PROPS` を `Map` に変えれば構造的に解決するが、`RequiredPropsByType` 型は `jsonld-engine.ts` の export であり他の JSON-LD ルールからも参照されるので、この計画では触らない。
+- Svelte 5.57 自身にも `<constructor>` タグで throw する同型の穴がある(`svelte/src/html-tree-validation.js:68`)。`collectComponentFacts` が catch して `parseFailed` にするので svelte-vitals 側は安全。upstream 報告の候補として README に記録済み。
+
+## STOP conditions
+
+- Drift check でいずれかの in-scope ファイルが変わっており、抜粋と一致しない。
+- Step 1 のテストが修正前に**通る**(既にガードされている、または `typeOf` が変わった)。
+- Step 4 で `reserved-name-placement.ts` の値読みが 9 箇所以外にもある(grep で確認して差分があれば報告)。
+- kitchen-sink の期待件数が動く。

--- a/plans/065-sink-sanitizer-gaps.md
+++ b/plans/065-sink-sanitizer-gaps.md
@@ -1,0 +1,272 @@
+# Plan 065: 解析対象由来の文字列が素通りする 2 つの出力シンクを塞ぐ(`@clack/prompts` の `terminalSafe` 未適用、SARIF `artifactLocation.uri` の未エンコード)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat d3828d9e..HEAD -- packages/cli/src/install/cli.ts packages/cli/src/gunshi/analyze.ts packages/core/src/reporter/sarif.ts packages/cli/test/install/cli.test.ts packages/core/test/sarif-report.test.ts`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+| Priority | Effort | Risk | Depends on | Category | Planned at                                                                   |
+| -------- | ------ | ---- | ---------- | -------- | ---------------------------------------------------------------------------- |
+| P1       | S      | LOW  | none       | security | commit `13aa7ad0`(= `origin/main` `d3828d9e` と同内容のファイル)、2026-09-03 |
+
+## Why this matters
+
+2 つとも「解析対象リポジトリ由来の文字列を、そのシンクの文法で無害化せずに出力している」クラスで、同クラスは PR #617 / #618 / #623 で他のシンクについて閉じてきた。残っているのがこの 2 つ。
+
+### A. `@clack/prompts` の対話プロンプト
+
+CLI の端末出力は `terminalSafe`(`packages/core/src/reporter/sanitize.ts`、C0/C1/OSC/CSI を剥がす)を境界にしている。`cli-io.ts:17`、`bin.ts:16`、`install/cli.ts:26-27`(`log` / `errorLog`)、`frame-writer.ts:71` などが全てラップ済み。**例外が `@clack/prompts` に渡す文字列**で、次の 3 サイトが未適用である。
+
+1. `packages/cli/src/install/cli.ts:54` の `selectAppPrompt` — `options: apps.map((a) => ({ value: a, label: a }))`。`apps` は `discoverApps` がファイルシステムから拾った**ディレクトリ名そのまま**。
+2. `packages/cli/src/install/cli.ts:80` の `confirm` — `message: \`Apply this plan?\n${planText}\``。`planText`は`install/index.ts`の`rowLine`が`r.path` と(manual 行では)`r.snippet` を連結したもの。
+3. `packages/cli/src/gunshi/analyze.ts:27` の `selectApp` — 1 と同じ `selectAppPrompt` を、`install` ではない通常解析の monorepo ピッカーで呼ぶ。
+
+POSIX のディレクトリ名はほぼ任意のバイトを許すので、エスケープシーケンスを含む名前のディレクトリを持つリポジトリで `svelte-vitals`(monorepo)や `svelte-vitals install` を対話実行すると、端末タイトルの書き換え・カーソル移動・「yes」と答えようとしているプロンプト文の上書きがそのまま起きる。1 は `selectAppPrompt` の中で一度サニタイズすれば 3 も直る。**`value` はサニタイズしない**(選択結果として返す実パスが化けるため)。`label` と `message` だけを対象にする。
+
+### B. SARIF の `artifactLocation.uri`
+
+`packages/core/src/reporter/sarif.ts:58` は `artifactLocation: { uri: r.location }` と生のパスを入れる。SARIF 2.1.0 の `uri` は URI reference なので、`#` はフラグメント、`%` はパーセントエスケープとして解釈され、空白や非 ASCII(日本語のファイル名はこのプロジェクトが他所で明示的に扱っている)は不正になる。GitHub code scanning はアラートを誤ったファイルに付けるか、アップロードを拒否する。どちらも**静かに finding が security タブから消える**失敗になる。他のレポーターは自分の文法で `location` を無害化している(`github.ts:28` の `escapeProp`、`markdown.ts:118` の `escapeCell`)ので、SARIF だけが例外。
+
+`partialFingerprints`(`sarif.ts:51`)には**触らない**。その文字列の形式を変えると GitHub 上で既存ユーザー全員のアラート同一性がリセットされる。
+
+## Current state
+
+- `packages/cli/src/install/cli.ts:1-6`(import): `import * as p from '@clack/prompts';` と `import { terminalSafe } from '@svelte-vitals/core/internal';` が既にある。
+
+- `packages/cli/src/install/cli.ts:49-56`:
+
+  ```ts
+  /** Single-select app picker via @clack/prompts — shared with bin.ts's monorepo analyzer picker. Returns null when cancelled. */
+  export async function selectAppPrompt(apps: string[], message: string): Promise<string | null> {
+    const res = await p.select({
+      message,
+      options: apps.map((a) => ({ value: a, label: a })),
+      initialValue: apps[0]
+    });
+    return p.isCancel(res) ? null : (res as string);
+  }
+  ```
+
+- `packages/cli/src/install/cli.ts:77-82`:
+
+  ```ts
+  confirm: async (planText: string) => {
+    const res = await p.confirm({ message: `Apply this plan?\n${planText}` });
+    return p.isCancel(res) ? false : Boolean(res);
+  };
+  ```
+
+- `packages/cli/src/gunshi/analyze.ts:25-28`: `selectApp(apps)` → `selectAppPrompt(apps, 'Multiple SvelteKit apps found — which one should svelte-vitals analyze?')`。`message` は定数。
+
+- `packages/cli/test/install/cli.test.ts:18-45` — `realIO().log / errorLog` が `console.log` / `console.error` を `vi.spyOn` して、`'a\x1b]0;evil\x07b'` が `'ab'` になることと `\n` / `\t` が保存されることを pin している。`@clack/prompts` のモックはこのファイルにはない(`vi.mock('@clack/prompts', …)` を新設する)。
+
+- `packages/core/src/reporter/sarif.ts:45-62`:
+
+  ```ts
+  const result: SarifResult = {
+    ruleId: r.id,
+    ruleIndex: ruleIndex.get(r.id)!,
+    level: severityToSarifLevel(effectiveSeverity(r, config)),
+    message: { text: messageText(r) },
+    partialFingerprints: {
+      'svelteVitals/v1': `${r.id}:${r.route ?? 'project'}${r.line !== undefined ? `:${r.location ?? ''}:${r.line}` : ''}`
+    }
+  };
+  if (r.location) {
+    result.locations = [
+      {
+        physicalLocation: {
+          artifactLocation: { uri: r.location },
+          ...(r.line !== undefined ? { region: { startLine: r.line } } : {})
+        }
+      }
+    ];
+  ```
+
+- `packages/core/test/sarif-report.test.ts:68-72` — `uri` が `'src/routes/none/+page.svelte'` であることを assert(エンコード不要な文字だけ)。`results` フィクスチャは 7-20 行。
+
+- `terminalSafe` の性質(`packages/core/test/sanitize.test.ts` で pin 済み): `\n` と `\t` は保存、ESC / C1 / OSC / CSI は除去。
+
+## Commands you will need
+
+| Purpose    | Command                                                  | Expected on success |
+| ---------- | -------------------------------------------------------- | ------------------- |
+| Install    | `pnpm install`                                           | exit 0              |
+| Core tests | `pnpm --filter @svelte-vitals/core run test`             | all pass            |
+| CLI tests  | `pnpm build && pnpm --filter svelte-vitals run test`     | all pass            |
+| Full       | `pnpm build && pnpm typecheck && pnpm test && pnpm lint` | 全て exit 0         |
+
+## Scope
+
+**In scope**(変更してよいファイルはこれだけ):
+
+- `packages/cli/src/install/cli.ts`(`selectAppPrompt` の `label`、`confirm` の `message`)
+- `packages/cli/test/install/prompts.test.ts`(新規。`@clack/prompts` のモジュールモックを他のケースから隔離するため)
+- `packages/core/src/reporter/sarif.ts`(`uri` のエンコード)
+- `packages/core/test/sarif-report.test.ts`(テスト追加)
+- `.changeset/`(新規 changeset 1 件、`svelte-vitals` と `@svelte-vitals/core` の patch)
+
+**Out of scope**(触らない):
+
+- `packages/cli/src/gunshi/analyze.ts` — `selectAppPrompt` 内で直るので変更不要。
+- `partialFingerprints` の形式。
+- `packages/core/src/reporter/agent.ts:55` の固定フェンス(既知、現状到達不能)。
+- `@clack/prompts` の `groupMultiselect`(`install/cli.ts:60-75`)— `label` / `hint` は svelte-vitals 自身の定数(`SelectableOption`)なので対象外。
+
+## Git workflow
+
+- Branch: `advisor/065-sink-sanitizer-gaps`(`origin/main` から)
+- Conventional commits、例: `fix(cli,core): sanitize prompt labels with terminalSafe and URI-encode SARIF artifact locations`
+- push / PR 作成はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: プロンプト側の失敗するテストを書く(TDD red)
+
+`@clack/prompts` のモジュールレベルのモックは同じファイルの全ケースに効くので、`install/cli.test.ts`(`runInstallCliGunshi` を実行するケースを含む)には足さず、**新規ファイル** `packages/cli/test/install/prompts.test.ts` を作る。先頭でモックを宣言する(vitest はモックを hoist する)。
+
+```ts
+const { selectSpy, confirmSpy } = vi.hoisted(() => ({
+  selectSpy: vi.fn(async (opts: { options: { value: string; label: string }[] }) => opts.options[0]!.value),
+  confirmSpy: vi.fn(async () => true)
+}));
+vi.mock('@clack/prompts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@clack/prompts')>();
+  return { ...actual, select: selectSpy, confirm: confirmSpy, isCancel: () => false };
+});
+```
+
+`import { selectAppPrompt, clackPrompts } from '../../src/install/cli.js';` を置き、describe を書く。
+
+```ts
+describe('clack prompt strings are terminalSafe', () => {
+  const escaped = 'apps/\x1b]0;evil\x07web';
+
+  it('selectAppPrompt sanitizes labels but returns the raw directory name as the value', async () => {
+    const picked = await selectAppPrompt([escaped, 'apps/api'], 'pick');
+    const opts = selectSpy.mock.calls[0]![0].options;
+    expect(opts[0]!.label).toBe('apps/web');
+    expect(opts[0]!.value).toBe(escaped);
+    expect(picked).toBe(escaped);
+  });
+
+  it('confirm sanitizes the plan text and keeps its newlines', async () => {
+    await clackPrompts().confirm('row 1\n' + escaped + '\nrow 3');
+    const message = (confirmSpy.mock.calls[0]![0] as { message: string }).message;
+    expect(message).toBe('Apply this plan?\nrow 1\napps/web\nrow 3');
+  });
+});
+```
+
+**Verify**: `pnpm build && pnpm --filter svelte-vitals run test -- install/prompts` → 2 ケースが **fail**(`label` と `message` にエスケープが残る)。`install/cli.test.ts` の既存ケースは無変更で pass。
+
+### Step 2: `label` と `message` を `terminalSafe` でラップする
+
+`packages/cli/src/install/cli.ts` の 2 箇所を変える。
+
+```ts
+// `apps` are directory names straight off the filesystem: sanitize what clack renders, never
+// the `value` — that is the path the caller goes on to use.
+options: apps.map((a) => ({ value: a, label: terminalSafe(a) })),
+```
+
+```ts
+// planText carries analyzed-repo paths and manual-row snippets; same boundary as log/errorLog above.
+const res = await p.confirm({ message: `Apply this plan?\n${terminalSafe(planText)}` });
+```
+
+**Verify**: `pnpm build && pnpm --filter svelte-vitals run test` → all pass。
+
+### Step 3: SARIF 側の失敗するテストを書く(TDD red)
+
+`packages/core/test/sarif-report.test.ts` に追加する。既存の `results` フィクスチャの 1 件目をコピーして `location` を差し替えたローカル配列を使う。
+
+```ts
+it('URI-encodes artifactLocation.uri per path segment, keeping the separators', () => {
+  const tricky: Result[] = [{ ...results[0]!, location: 'src/routes/a b/#tag/100%/ページ/+page.svelte' }];
+  const run = JSON.parse(formatSarifReport(tricky, config, { version: '0.0.0' })).runs[0];
+  expect(run.results[0].locations[0].physicalLocation.artifactLocation.uri).toBe(
+    'src/routes/a%20b/%23tag/100%25/%E3%83%9A%E3%83%BC%E3%82%B8/+page.svelte'
+  );
+  // The fingerprint keeps the raw path: changing its format would reset alert identity on GitHub.
+  expect(run.results[0].partialFingerprints['svelteVitals/v1']).toBe('seo/title-presence:/none');
+});
+```
+
+`results[0]` に `line` があるかを確認し、ある場合はフィンガープリントの期待値を既存の 76 行のケースに合わせる(`line` があれば `:${location}:${line}` が付く。**生の `location`** のまま)。
+
+**Verify**: `pnpm --filter @svelte-vitals/core run test -- sarif-report` → 新ケースが **fail**(`uri` が生のまま)。
+
+### Step 4: `uri` をセグメントごとにエンコードする
+
+`packages/core/src/reporter/sarif.ts` にヘルパを足し、58 行で使う。
+
+```ts
+/**
+ * SARIF `artifactLocation.uri` is a URI reference: `#`, `?`, `%`, spaces and non-ASCII in a raw
+ * path would be read as fragment/query/escape/invalid and mis-attribute (or drop) the alert in
+ * code scanning. `encodeURI` keeps `/` and `+` (both legal in a path, and `+page.svelte` is every
+ * SvelteKit route) but leaves `#` and `?` alone, so those two are encoded explicitly.
+ */
+function toArtifactUri(location: string): string {
+  return encodeURI(location).replace(/#/g, '%23').replace(/\?/g, '%3F');
+}
+```
+
+```ts
+artifactLocation: { uri: toArtifactUri(r.location) },
+```
+
+`encodeURIComponent` を使わないのは、`+` を `%2B` にすると全 SvelteKit ユーザーの SARIF 出力が変わり、`%2B` を decode しない consumer で誤帰属するため。監査時の実測(Node 24): 上の関数は `src/routes/a b/#tag/100%/ページ/+page.svelte` を Step 3 の期待値どおりに変換し、`src/routes/none/+page.svelte` は**そのまま**返す。
+
+**Verify**: `pnpm --filter @svelte-vitals/core run test -- sarif-report` → all pass(68-72 行の既存ケース `src/routes/none/+page.svelte` は無変更のまま通る)。
+
+### Step 5: changeset を書き、最終検証
+
+`.changeset/` に新規ファイル(例 `sink-sanitizer-gaps.md`)。
+
+```md
+---
+'svelte-vitals': patch
+'@svelte-vitals/core': patch
+---
+
+Sanitize the two remaining output sinks that carried analyzed-repo strings raw. The interactive app picker and the install plan confirmation now pass directory names and plan text through `terminalSafe` before `@clack/prompts` renders them (the selected value is still the raw path). The SARIF reporter now URI-encodes `artifactLocation.uri`, so a path with `#`, `?`, `%`, spaces or non-ASCII characters attaches the alert to the right file in code scanning; plain ASCII paths such as `src/routes/+page.svelte` are unchanged. `partialFingerprints` are unchanged, so existing alert identities are preserved.
+```
+
+**Verify**: `pnpm build && pnpm typecheck && pnpm test && pnpm lint` → 全て exit 0。
+
+## Test plan
+
+- 新規: プロンプト 2 ケース(`label` は無害化・`value` は生のまま、`message` は無害化かつ改行保持)、SARIF 1 ケース(エンコード + フィンガープリント不変)。
+- 既存: `sarif-report.test.ts` の `uri` 期待値(`src/routes/none/+page.svelte`)は無変更で通ること。
+- 判別性: Step 2 / Step 4 をそれぞれ revert して対応ケースだけが赤になることを確認する。
+
+## Done criteria
+
+- [ ] `pnpm build && pnpm typecheck && pnpm test && pnpm lint` が全て exit 0
+- [ ] `grep -c "terminalSafe(" packages/cli/src/install/cli.ts` が `6`(既存 4: log / errorLog / runCommand の 2 つ、追加 2: label / planText)
+- [ ] `grep -n "toArtifactUri" packages/core/src/reporter/sarif.ts` が定義 1 + 使用 1 の 2 行
+- [ ] `git diff origin/main -- packages/core/src/reporter/sarif.ts | grep partialFingerprints` が空(フィンガープリント行に差分なし)
+- [ ] `plans/README.md` の 065 行を更新済み
+
+## Maintenance notes
+
+- `@clack/prompts` に渡す文字列を新たに増やすときは、解析対象由来かどうかを見て `terminalSafe` を通す。`value` はサニタイズしない。
+- SARIF の `uri` は ASCII の通常パスでは変わらない。`#` / `?` / `%` / 空白 / 非 ASCII を含むパスだけがエンコードされる。`encodeURIComponent` に変えると `+page.svelte` が全ルートで `%2Bpage.svelte` になるので、変えない。
+- `partialFingerprints` の形式は互換性の契約。変えるときは新しいキー(`svelteVitals/v2`)を**追加**し、v1 を残す。
+
+## STOP conditions
+
+- Drift check でいずれかの in-scope ファイルが変わっており、抜粋と一致しない。
+- `@clack/prompts` のモックで `select` / `confirm` が呼ばれない(clack の API 形が変わっている)。
+- SARIF の既存テストで `uri` 以外の期待値が動く。

--- a/plans/065-sink-sanitizer-gaps.md
+++ b/plans/065-sink-sanitizer-gaps.md
@@ -27,7 +27,7 @@
 CLI の端末出力は `terminalSafe`(`packages/core/src/reporter/sanitize.ts`、C0/C1/OSC/CSI を剥がす)を境界にしている。`cli-io.ts:17`、`bin.ts:16`、`install/cli.ts:26-27`(`log` / `errorLog`)、`frame-writer.ts:71` などが全てラップ済み。**例外が `@clack/prompts` に渡す文字列**で、次の 3 サイトが未適用である。
 
 1. `packages/cli/src/install/cli.ts:54` の `selectAppPrompt` — `options: apps.map((a) => ({ value: a, label: a }))`。`apps` は `discoverApps` がファイルシステムから拾った**ディレクトリ名そのまま**。
-2. `packages/cli/src/install/cli.ts:80` の `confirm` — `message: \`Apply this plan?\n${planText}\``。`planText`は`install/index.ts`の`rowLine`が`r.path` と(manual 行では)`r.snippet` を連結したもの。
+2. `packages/cli/src/install/cli.ts:80` の `confirm` — ``message: `Apply this plan?\n${planText}` ``。`planText`は`install/index.ts`の`rowLine`が`r.path` と(manual 行では)`r.snippet` を連結したもの。
 3. `packages/cli/src/gunshi/analyze.ts:27` の `selectApp` — 1 と同じ `selectAppPrompt` を、`install` ではない通常解析の monorepo ピッカーで呼ぶ。
 
 POSIX のディレクトリ名はほぼ任意のバイトを許すので、エスケープシーケンスを含む名前のディレクトリを持つリポジトリで `svelte-vitals`(monorepo)や `svelte-vitals install` を対話実行すると、端末タイトルの書き換え・カーソル移動・「yes」と答えようとしているプロンプト文の上書きがそのまま起きる。1 は `selectAppPrompt` の中で一度サニタイズすれば 3 も直る。**`value` はサニタイズしない**(選択結果として返す実パスが化けるため)。`label` と `message` だけを対象にする。

--- a/plans/066-score-registry-memo.md
+++ b/plans/066-score-registry-memo.md
@@ -1,0 +1,276 @@
+# Plan 066: `computeScore` のレジストリ射影(selectRules / buildInventory / ruleScopes)を config 単位でメモ化する
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat d3828d9e..HEAD -- packages/core/src/scoring/score.ts packages/core/src/scoring/inventory.ts packages/core/src/config-apply.ts packages/core/src/reporter/json.ts packages/core/test/score.test.ts packages/core/test/health.test.ts`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+| Priority | Effort | Risk | Depends on | Category    | Planned at                                                                   |
+| -------- | ------ | ---- | ---------- | ----------- | ---------------------------------------------------------------------------- |
+| P2       | S      | LOW  | none       | performance | commit `13aa7ad0`(= `origin/main` `d3828d9e` と同内容のファイル)、2026-09-03 |
+
+## Why this matters
+
+`computeScore(results, config, options)` は呼ばれるたびに `selectRules([...allRules], config)`(105 ルールのフィルタ)、`buildInventory(config, rules)`、`ruleScopes(rules)`(各 105 エントリの Map)を**作り直す**。この 3 つは `results` に依存せず、`(config, options.rules)` だけの関数である。
+
+呼び出し回数は多い。`buildJsonReport`(`reporter/json.ts`)はルートごとに `computeScore` を 1 回と `scoresByCategory`(カテゴリ数ぶん、最大 6 回)を呼ぶので、R ルートで約 7R 回。加えて `computeHealth` が 6 回。CLI の既定経路(`packages/cli/src/index.ts`)は `computeHealth` を最大 3 回(アニメーション、console レポーター内、`--min-health`)呼ぶ。
+
+監査時の実測(2026-09-03、既存の `packages/core/dist` に対する read-only プローブ、Node 24): 1,681 ルート / 30,258 結果の合成データで `buildJsonReport` は **189.5 ms**、うち **180.1 ms** が 11,767 回の `computeScore` 呼び出し(1 件の結果配列に対するもの)で、1 回あたり約 15 µs。つまりレポート構築時間の約 95% が結果と無関係なセットアップ。bench 設計書(`2026-08-17-bench-gated-decisions.md`)が引く shadcn-svelte docs(1,681 ルート、1,225 ms end-to-end)ではレポート構築が全体の約 15% にあたり、そのほとんどがこれ。dev dashboard は `/data.json` リクエストごとに同じコストを払う。
+
+スコアの意味論は凍結されている(`2026-08-16-score-semantics-freeze.md`)。この計画は**算術を一切変えず**、純粋関数の結果をキャッシュするだけ。したがって done criteria は「kitchen-sink の `--reporter json` 出力がバイト単位で同一」である。
+
+`pnpm bench` は `analyzeProject()` を計測し、レポート構築は含まない(設計書自身が「what this does not measure」に挙げている)。よって計測は本計画の Step 4 のプローブスクリプトで行う。
+
+## Current state
+
+- `packages/core/src/scoring/score.ts:1-7`(import)と `:53-63`(`computeScore` 冒頭):
+
+  ```ts
+  import { selectRules } from '../config-apply.js';
+  import { allRules } from '../rules/index.js';
+  import { buildInventory, ruleScopes, DEDUCTION, type PairKey } from './inventory.js';
+  …
+  export function computeScore(results: Result[], config: Config, options: ScoreOptions = {}): ScoreResult {
+    const routeResults = results.filter((r) => r.route !== undefined);
+    const projectResults = results.filter((r) => r.route === undefined);
+
+    // `selectRules` applied here, not just inside `buildInventory`, so `pairOf` and the inventory see
+    // the same filtered list — an injected rule that config turns `off` must vanish from both, not map
+    // to a pair in one and contribute nothing in the other.
+    const rules = selectRules([...(options.rules ?? allRules)], config);
+    const inventory = buildInventory(config, rules);
+    const pairOf = ruleScopes(rules);
+  ```
+
+  以降(`:65-141`)は `inventory` と `pairOf` を読むだけで、どちらも変更しない(`inventory.get(p)`、`pairOf.get(r.id)`)。
+
+- `packages/core/src/scoring/score.ts:41-45`(`ScoreOptions`): `applyCriticalCap?: boolean` と `rules?: readonly Rule[]`。`rules` は「テストとカスタムルールセット」用。
+- `packages/core/src/scoring/score.ts:144-153`(`scoresByCategory`): カテゴリごとに `computeScore(rs, config, options)`。`:165-166`(`computeHealth`): `scoresByCategory(results, config)`。
+- `packages/core/src/scoring/inventory.ts:24-45` — `buildInventory(config, rules = selectRules(allRules, config))` と `ruleScopes(rules)`。どちらも新しい Map を返す純粋関数。
+- `packages/core/src/config-apply.ts:30-32`(`selectRules`)は `rules.filter(...)`。`:41-49`(`withFailedRulesOff`)は `failedRuleIds.length === 0` なら **同じ `config` オブジェクトを返し**、そうでなければ**新しいオブジェクト**を返す。`Config` を in-place で mutate する箇所は監査時の grep(`config\.\w+ =` / `config\.rules\[`)でゼロ。
+- `packages/core/src/reporter/json.ts:92`(`computeHealth`)、`:114`(ルートごと `computeScore`)、`:118`(ルートごと `scoresByCategory`)。
+- `packages/core/test/score.test.ts` — `describe('computeScore (§12 worked example)')` は `defineConfig({})` と手組みの `Result[]` で `computeScore` を直接呼ぶ。`:193` の `describe('scoresByCategory — scoring options')` が `options` を渡す形。
+- `packages/core/test/health.test.ts` — `computeHealth(results, defineConfig({ weights }))` の形。
+- kitchen-sink の e2e(`examples/kitchen-sink/test/e2e-static.test.ts:41`)は `execFileSync(process.execPath, [bin, appDir, '--reporter', 'json'])` で built CLI を走らせる。同じコマンドをバイト比較に使う。
+
+## Commands you will need
+
+| Purpose       | Command                                                                                 | Expected on success                              |
+| ------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Install       | `pnpm install`                                                                          | exit 0                                           |
+| Build         | `pnpm build`                                                                            | exit 0                                           |
+| Core tests    | `pnpm --filter @svelte-vitals/core run test`                                            | all pass                                         |
+| JSON snapshot | `node packages/cli/dist/bin.js examples/kitchen-sink --reporter json > <file>; echo $?` | exit 1(gallery は finding あり)、ファイルに JSON |
+| Full          | `pnpm build && pnpm typecheck && pnpm test && pnpm lint`                                | 全て exit 0                                      |
+
+## Scope
+
+**In scope**(変更してよいファイルはこれだけ):
+
+- `packages/core/src/scoring/score.ts`(メモ化)
+- `packages/core/test/score.test.ts`(呼び出し回数のテスト)
+- `.changeset/`(新規 changeset 1 件、`@svelte-vitals/core` の patch)
+- 一時ファイル: 計測プローブは scratchpad か `/tmp` に置き、**コミットしない**。
+
+**Out of scope**(触らない):
+
+- `inventory.ts` / `config-apply.ts` — シグネチャも中身も変えない。
+- `reporter/json.ts` / `reporter/console.ts` / `packages/cli/src/index.ts` の `computeHealth` 呼び出し回数の削減(3 回 → 1 回)。メモ化が効けば各回のコストは結果走査だけになり、hoist は別の小さな計画で足りる。
+- vite dashboard の `buildSnapshot` メモ化(README の 260903-PERF-03)。
+- スコア算術・`INVENTORY_FLOOR`・`CRITICAL_CAP`。凍結済み。
+
+## Git workflow
+
+- Branch: `advisor/066-score-registry-memo`(`origin/main` から)
+- Conventional commits、例: `perf(core): memoize the rule-registry projection computeScore rebuilds per call`
+- push / PR 作成はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: 変更前の JSON スナップショットを取る
+
+```bash
+pnpm build
+node packages/cli/dist/bin.js examples/kitchen-sink --reporter json > /tmp/sv-066-before.json; echo "exit $?"
+```
+
+exit は 1(gallery は finding を持つ)で正常。ファイルが空でないことを `wc -c` で確認。
+
+### Step 2: 呼び出し回数を数える失敗するテストを書く(TDD red)
+
+`packages/core/test/score.test.ts` に追加する。`vi.mock` でモジュール全体を差し替えると `score.ts` の import 解決が絡むので、**`inventory.ts` の `buildInventory` を spy** する。
+
+```ts
+import { vi } from 'vitest';
+import * as inventory from '../src/scoring/inventory.js';
+
+describe('computeScore memoizes the registry projection per config', () => {
+  it('builds the inventory once for repeated calls with the same config object', () => {
+    const spy = vi.spyOn(inventory, 'buildInventory');
+    try {
+      const config = defineConfig({});
+      const results: Result[] = [/* copy the small worked-example set used above */];
+      computeScore(results, config);
+      computeScore(results, config);
+      computeScore(results.slice(0, 1), config, { applyCriticalCap: false });
+      expect(spy).toHaveBeenCalledTimes(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('rebuilds for a different config object and for an explicit rules list', () => {
+    const spy = vi.spyOn(inventory, 'buildInventory');
+    try {
+      const a = defineConfig({});
+      const b = defineConfig({ rules: { 'seo/title-presence': 'off' } });
+      computeScore([], a);
+      computeScore([], b);
+      computeScore([], a, { rules: [] });
+      expect(spy).toHaveBeenCalledTimes(3);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+```
+
+ESM の名前空間 import に対する `vi.spyOn` は、`score.ts` が `import { buildInventory } from './inventory.js'` で**ライブバインディング**を使っているので効く(vitest はモジュールを変換してエクスポートを getter にする)。効かない場合(呼び出し回数が常に 0)は STOP。
+
+**Verify**: `pnpm --filter @svelte-vitals/core run test -- score` → 1 つ目が **fail**(3 回呼ばれる)。2 つ目は 3 回で pass(現状も毎回作るため)。
+
+### Step 3: `WeakMap` でメモ化する
+
+`packages/core/src/scoring/score.ts` の `computeScore` 直前に追加し、冒頭の 3 行を置き換える。
+
+```ts
+interface RegistryProjection {
+  inventory: Map<PairKey, number>;
+  pairOf: Map<string, PairKey>;
+}
+
+// Keyed on the `config` object's identity, then on the rules array's identity: every in-tree
+// caller passes the same `config` object for a whole run (`withFailedRulesOff` returns a fresh
+// object when it changes anything, the same one when it doesn't), and nothing mutates a Config
+// in place. `buildJsonReport` alone calls this ~7 times per route; the projection depends on
+// neither `results` nor `applyCriticalCap`, so a per-call rebuild was ~95% of report-building time.
+const projections = new WeakMap<Config, WeakMap<readonly Rule[], RegistryProjection>>();
+
+function projectRegistry(config: Config, rulesList: readonly Rule[]): RegistryProjection {
+  let byRules = projections.get(config);
+  if (!byRules) projections.set(config, (byRules = new WeakMap()));
+  let projection = byRules.get(rulesList);
+  if (!projection) {
+    // `selectRules` applied here, not just inside `buildInventory`, so `pairOf` and the inventory see
+    // the same filtered list — an injected rule that config turns `off` must vanish from both, not map
+    // to a pair in one and contribute nothing in the other.
+    const rules = selectRules([...rulesList], config);
+    projection = { inventory: buildInventory(config, rules), pairOf: ruleScopes(rules) };
+    byRules.set(rulesList, projection);
+  }
+  return projection;
+}
+```
+
+```ts
+export function computeScore(results: Result[], config: Config, options: ScoreOptions = {}): ScoreResult {
+  const routeResults = results.filter((r) => r.route !== undefined);
+  const projectResults = results.filter((r) => r.route === undefined);
+  const { inventory, pairOf } = projectRegistry(config, options.rules ?? allRules);
+```
+
+`allRules` はモジュール定数なので、`options.rules` 省略時のキーは常に同じ配列オブジェクト。`Rule` 型の import が `score.ts` に既にあることを確認する(`:2` に `import type { Rule }` あり)。
+
+**Verify**: `pnpm --filter @svelte-vitals/core run test` → all pass(Step 2 の両ケース含む)。`pnpm typecheck` → exit 0。
+
+### Step 4: バイト同一性と効果を計測する
+
+```bash
+pnpm build
+node packages/cli/dist/bin.js examples/kitchen-sink --reporter json > /tmp/sv-066-after.json
+cmp /tmp/sv-066-before.json /tmp/sv-066-after.json && echo IDENTICAL
+```
+
+`IDENTICAL` が出ること。出なければ STOP(`version` フィールド以外の差分はスコア意味論の変化を意味する。`version` が変わっている場合は同じビルドで before を取り直す)。
+
+効果の計測(scratchpad に置く一時スクリプト、コミットしない):
+
+```js
+// /tmp/sv-066-probe.mjs — run with: node /tmp/sv-066-probe.mjs
+import { buildJsonReport } from '<repo>/packages/core/dist/internal.js';
+import { defineConfig } from '<repo>/packages/core/dist/index.js';
+const config = defineConfig({});
+const results = [];
+for (let i = 0; i < 1681; i++) {
+  for (let j = 0; j < 18; j++) {
+    results.push({
+      id: 'seo/title-presence',
+      category: 'seo',
+      severity: 'critical',
+      route: `/r${i}`,
+      detection: { presence: j % 3 ? 'own' : 'none', value: j % 3 ? 'static' : 'absent' },
+      message: 'm'
+    });
+  }
+}
+const t0 = performance.now();
+buildJsonReport(results, config, { version: '0' });
+console.log('buildJsonReport ms:', (performance.now() - t0).toFixed(1));
+```
+
+`buildJsonReport` の export 名と引数は `packages/core/src/reporter/json.ts` の実際のシグネチャに合わせる(`formatJsonReport` が文字列版、`buildJsonReport` がオブジェクト版)。変更前(`git stash`)と変更後で 3 回ずつ走らせ、中央値を changeset と PR に記録する。監査時の数字(180 ms → 数 ms 台)と桁が合わなければ STOP。
+
+### Step 5: changeset を書き、最終検証
+
+`.changeset/` に新規ファイル(例 `score-registry-memo.md`)。
+
+```md
+---
+'@svelte-vitals/core': patch
+---
+
+Memoize the rule-registry projection (`selectRules` → `buildInventory` / `ruleScopes`) that `computeScore` rebuilt on every call. Per-route scoring in the JSON report and the dashboard snapshot no longer pays a 105-rule filter and two Map builds per call; report output is byte-identical (verified against the kitchen-sink gallery). Measured: <before> ms → <after> ms for `buildJsonReport` over a synthetic 1,681-route result set.
+```
+
+`<before>` / `<after>` は Step 4 の中央値で埋める。
+
+**Verify**: `pnpm build && pnpm typecheck && pnpm test && pnpm lint` → 全て exit 0。
+
+## Test plan
+
+- 新規: 呼び出し回数 2 ケース(同一 config で 1 回、別 config / 別 rules で作り直す)。
+- 既存: `score.test.ts` / `health.test.ts` / `json-report.test.ts` / kitchen-sink e2e が無変更で通ること。
+- バイト同一性(Step 4)。
+- 判別性: Step 3 を revert すると Step 2 の 1 つ目が赤に戻る。
+
+## Done criteria
+
+- [ ] `pnpm build && pnpm typecheck && pnpm test && pnpm lint` が全て exit 0
+- [ ] `cmp` による before/after JSON のバイト同一性を確認済み(PR 本文に記載)
+- [ ] `grep -n "new WeakMap<Config" packages/core/src/scoring/score.ts` が 1 行ヒット
+- [ ] `grep -rn "config\.\(rules\|weights\|treatDynamicAs\|failOn\|overrides\) = " packages/core/src packages/cli/src packages/vite/src` が空(Config の in-place 変更なし)
+- [ ] changeset に before / after の ms を記載
+- [ ] `plans/README.md` の 066 行を更新済み
+
+## Maintenance notes
+
+- キャッシュキーはオブジェクト同一性。将来 `Config` を in-place で変更するコードを書くと、古い射影が返る。上の grep を CI に入れるほどではないが、レビューで見る。
+- `withFailedRulesOff` が新しいオブジェクトを返す設計(`config-apply.ts:41-49`)がこのメモ化の前提。同関数を「同じオブジェクトを変更して返す」形に変えてはならない。
+- `WeakMap` なので config オブジェクトが GC されれば射影も消える。長寿命プロセス(dev dashboard)でも config は 1 つなのでリークしない。
+
+## STOP conditions
+
+- Drift check でいずれかの in-scope ファイルが変わっており、抜粋と一致しない。
+- Step 2 の spy が `buildInventory` の呼び出しを捕まえない(常に 0 回)。
+- Step 4 で before / after の JSON が一致しない(`version` 以外)。
+- Step 4 の効果が監査時の桁(2 桁 ms 以上の削減)と合わない。
+- `Config` を in-place で変更する箇所が grep で見つかる。

--- a/plans/067-vite-surface-analysis-warnings.md
+++ b/plans/067-vite-surface-analysis-warnings.md
@@ -91,7 +91,7 @@ build 経路(`vite build`)は逆に、警告を `warn()` に流している(`ana
 - 設計上の注意(実装判断の根拠として固定):
   - `AnalyzeFn` の戻り値に `warnings?: string[]` を**追加**し、runner は `onWarnings?(warnings: string[])` を**新設**して流す。`onResults` の引数は変えない(厳密 assert のテストを守る)。
   - runner は前回流した警告集合と同一なら**再送しない**(debounce された再解析は保存のたびに走るので、同じ 3 行が毎回 `console.warn` に出るのは騒音)。集合比較は `warnings.join('\n')` の文字列比較で足りる。
-  - `plugin.ts` 側は `onWarnings` を `warn()` に `svelte-vitals: ` 接頭辞付きで流す(build 経路の `:242` と同じ形)。
+  - `plugin.ts` 側は `onWarnings` を `warn()` に流す。各行の先頭に `svelte-vitals:` と空白を付ける(build 経路の `:242` と同じ形)。
   - dashboard の HTML に警告を描画するのは本計画の対象外(`AppSnapshot` の型変更と app-shell の描画が要り、M になる)。
   - リポジトリ規約: コードコメントは英語、非自明な WHY のみ。
 
@@ -113,7 +113,7 @@ vite のテストは `svelte-vitals` と `@svelte-vitals/core` の built dist �
 - `packages/vite/src/ui/analysis.ts`(`AnalyzeFn` の戻り値型、`onWarnings`、重複抑制)
 - `packages/vite/src/plugin.ts`(`onWarnings` の配線。063 が変えた箇所の周辺だが、runner 生成部だけ)
 - `packages/vite/test/ui-analysis.test.ts`(テスト追加)
-- `packages/vite/test/analyze.test.ts`(build 経路のクラッシュ報告テスト追加)
+- `packages/vite/test/analyze-rule-failure.test.ts`(新規。build 経路のクラッシュ報告テスト。`analyze.test.ts` にモジュールレベルの `vi.mock` を足すと他ケースに効くので別ファイル)
 - `packages/vite/test/ui-plugin.test.ts`(`onWarnings` の配線テスト追加、任意)
 - `.changeset/`(新規 changeset 1 件、`@svelte-vitals/vite` の patch)
 

--- a/plans/067-vite-surface-analysis-warnings.md
+++ b/plans/067-vite-surface-analysis-warnings.md
@@ -1,0 +1,318 @@
+# Plan 067: vite プラグインで解析の警告(クラッシュしたルール、空の選択、読めないファイル)を dashboard でも表面化し、build 経路のクラッシュ報告をテストで固定する
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat d3828d9e..HEAD -- packages/vite/src/ui/analysis.ts packages/vite/src/plugin.ts packages/vite/src/analyze.ts packages/vite/test/ui-analysis.test.ts packages/vite/test/analyze.test.ts packages/vite/test/ui-plugin.test.ts packages/cli/src/index.ts`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+| Priority | Effort | Risk | Depends on                                          | Category                    | Planned at                                                                   |
+| -------- | ------ | ---- | --------------------------------------------------- | --------------------------- | ---------------------------------------------------------------------------- |
+| P2       | S      | LOW  | 063 と同じ `plugin.ts` を触るので、063 の後に直列で | correctness / test-coverage | commit `13aa7ad0`(= `origin/main` `d3828d9e` と同内容のファイル)、2026-09-03 |
+
+## Why this matters
+
+`analyzeProject`(`packages/cli/src/index.ts`)は結果と一緒に `warnings: string[]` を返す。中身は、`--route` や overrides の glob が何にもマッチしなかった通知(`emptySelections`。`collect-all.ts` のコメントが「#510 が隠れていた原因」と書くクラス)、未知の inline directive id、バージョン床、読めなかった / パースできなかったファイル(`skippedFileWarnings`)、そして**クラッシュしたルール**の人間向けメッセージ(`rule X failed and was skipped: …`)である。CLI はこれを stderr に出す。
+
+vite の dev dashboard は同じ `analyzeProject` を呼びながら、**warnings を構造的に捨てている**。`packages/vite/src/ui/analysis.ts` の `AnalyzeFn` の戻り値型が `{ results, failedRuleIds? }` で `warnings` を持たず、`onResults(results, failedRuleIds)` が唯一の出口。`plugin.ts` の `onResults` は store に書くだけで、プラグインが持つ `warn()` シンク(config 読み込み失敗には使っている)には流れない。結果として、overrides の `files` glob が空振りしていても、コンポーネントが読めなくても、ルールがクラッシュしていても、dashboard の利用者には何も見えない。クラッシュしたルールは `withFailedRulesOff` で採点から外れる(正しい)が、「どのルールが、なぜ」がどこにも出ない。
+
+build 経路(`vite build`)は逆に、警告を `warn()` に流している(`analyze.ts:126` → `plugin.ts:242`)。しかし**クラッシュしたルールの警告が出ることを確かめるテストがない**。CLI 側には `packages/cli/test/rule-failure-isolation.test.ts:52-58` が正確な stderr 行を pin しており、dev handle 側には `dev-handle.test.ts:192-214` が id の転送を pin しているが、build 経路だけが空白。#632 で 3 つのパイプラインを `runAnalysis` に統合した根拠は「3 つが同じ振る舞いをする」ことなので、その 1 辺を固定する。
+
+## Current state
+
+- `packages/vite/src/ui/analysis.ts:5-13`(`AnalyzeFn`):
+
+  ```ts
+  /** The subset of `analyzeProject` (from `svelte-vitals`) the runner needs. Injectable for tests. */
+  export type AnalyzeFn = (opts: {
+    cwd: string;
+    treatDynamicAs?: TreatDynamicAs;
+    metaComponents?: string[];
+    rules?: Record<string, RuleSetting>;
+    failOn?: Severity;
+    parseCache?: ParseCache;
+  }) => Promise<{ results: Result[]; failedRuleIds?: string[] }>;
+  ```
+
+  `:24-30`(`AnalysisRunnerOptions` の callback 群):
+
+  ```ts
+  onResults(results: Result[], failedRuleIds?: string[]): void;
+  onError(err: unknown): void;
+  onStatusChange?(analyzing: boolean): void;
+  ```
+
+  `:55-80`(`runOnce`): `const { results, failedRuleIds } = await analyze({...})` → `if (!stopped) { if (failedRuleIds !== undefined) opts.onResults(results, failedRuleIds); else opts.onResults(results); }`。コメントが「第 2 引数は定義されているときだけ渡す(呼び出し引数を厳密に assert するテストを壊さないため)」と書いている。
+
+- `packages/cli/src/index.ts:355-366`(`analyzeProject` の return): `warnings: [...warnings, ...skippedFileWarnings([...components, ...kitModules]), ...failedRuleWarnings(failedRules)]`。`AnalyzeResult.warnings` の JSDoc は `:219`。
+
+- `packages/vite/src/plugin.ts:46-47`: `const warn = (line: string): void => console.warn(terminalSafe(line));`。`:299-316`(runner 生成、063 適用後も同じ形):
+
+  ```ts
+  const runner = createAnalysisRunner({
+    root: uiRoot,
+    treatDynamicAs: options.treatDynamicAs,
+    metaComponents: options.metaComponents,
+    rules: options.rules,
+    failOn: options.failOn,
+    onResults: (results, failedRuleIds) => {
+      store.setStatic(results);
+      staticFailedRuleIds = failedRuleIds ?? [];
+    },
+    onError: (err) => warn(`svelte-vitals: dev analysis failed: ${err instanceof Error ? err.message : String(err)}`),
+    onStatusChange: (analyzing) => store.setAnalyzing(analyzing)
+  });
+  ```
+
+- `packages/vite/src/analyze.ts:120-126`(build 経路の警告組み立て):
+
+  ```ts
+  warnings.push(...skippedFileWarnings([...components, ...kitModules]));
+  warnings.push(...unknownDirectiveIds(directives, allRules));
+  for (const f of failedRules) warnings.push(formatFailedRuleWarning(f));
+  ```
+
+  `packages/vite/src/plugin.ts:242`: `for (const w of result.warnings) warn(\`svelte-vitals: ${w}\`);`。`formatFailedRuleWarning`(`packages/core/src/config-apply.ts:53-55`)は `rule ${id} failed and was skipped: ${message の 1 行目}` を返す。
+
+- 既存テスト:
+  - `packages/vite/test/ui-analysis.test.ts:36-50` — `vi.fn<AnalyzeFn>(async () => ({ results: [...] }))` を注入し、`onResults` の呼び出し引数を `toHaveBeenCalledWith([R('seo/title-presence')])` で**厳密に** assert している(第 2 引数を渡すと壊れるので、runner は `failedRuleIds` 未定義時に 1 引数で呼ぶ)。`vi.useFakeTimers()` を使う。
+  - `packages/vite/test/analyze.test.ts:250-260` — `r.warnings` に config-file の警告が入ることを assert(`makeProject(configSource)` が一時プロジェクトを作る)。`:262-270` は `a11y/unverified-id-ref` の inert 通知。
+  - `packages/vite/test/ui-plugin.test.ts:1-18` — `vi.mock('../src/ui/analysis.js', () => ({ createAnalysisRunner: () => ({ start, notifyChange: mockNotifyChange, stop }) }))` で runner をスタブ。
+  - `packages/cli/test/rule-failure-isolation.test.ts:13-25` — `vi.mock('@svelte-vitals/core/internal', importOriginal)` で `allRules` のうち `seo/title-presence` の `check` を throw する版に差し替える。build 経路のテストはこのモック手法をそのまま使う。
+
+- 設計上の注意(実装判断の根拠として固定):
+  - `AnalyzeFn` の戻り値に `warnings?: string[]` を**追加**し、runner は `onWarnings?(warnings: string[])` を**新設**して流す。`onResults` の引数は変えない(厳密 assert のテストを守る)。
+  - runner は前回流した警告集合と同一なら**再送しない**(debounce された再解析は保存のたびに走るので、同じ 3 行が毎回 `console.warn` に出るのは騒音)。集合比較は `warnings.join('\n')` の文字列比較で足りる。
+  - `plugin.ts` 側は `onWarnings` を `warn()` に `svelte-vitals: ` 接頭辞付きで流す(build 経路の `:242` と同じ形)。
+  - dashboard の HTML に警告を描画するのは本計画の対象外(`AppSnapshot` の型変更と app-shell の描画が要り、M になる)。
+  - リポジトリ規約: コードコメントは英語、非自明な WHY のみ。
+
+## Commands you will need
+
+| Purpose    | Command                                                    | Expected on success |
+| ---------- | ---------------------------------------------------------- | ------------------- |
+| Install    | `pnpm install`                                             | exit 0              |
+| Build      | `pnpm build`                                               | exit 0              |
+| Vite tests | `pnpm build && pnpm --filter @svelte-vitals/vite run test` | all pass            |
+| Full       | `pnpm build && pnpm typecheck && pnpm test && pnpm lint`   | 全て exit 0         |
+
+vite のテストは `svelte-vitals` と `@svelte-vitals/core` の built dist を import するので、テスト前に `pnpm build`。
+
+## Scope
+
+**In scope**(変更してよいファイルはこれだけ):
+
+- `packages/vite/src/ui/analysis.ts`(`AnalyzeFn` の戻り値型、`onWarnings`、重複抑制)
+- `packages/vite/src/plugin.ts`(`onWarnings` の配線。063 が変えた箇所の周辺だが、runner 生成部だけ)
+- `packages/vite/test/ui-analysis.test.ts`(テスト追加)
+- `packages/vite/test/analyze.test.ts`(build 経路のクラッシュ報告テスト追加)
+- `packages/vite/test/ui-plugin.test.ts`(`onWarnings` の配線テスト追加、任意)
+- `.changeset/`(新規 changeset 1 件、`@svelte-vitals/vite` の patch)
+
+**Out of scope**(触らない):
+
+- `packages/cli/src/index.ts` — `warnings` は既に返している。
+- `packages/vite/src/analyze.ts`(build 経路)— 既に警告を返している。テストを足すだけ。
+- `packages/vite/src/ui/snapshot.ts` / `store.ts` / `packages/core/src/reporter/app-shell.ts` — dashboard HTML への描画は別計画。
+- `packages/vite/src/hooks/handle.ts` — per-request の経路は `SVELTE_VITALS_DEBUG` ゲートで警告する設計(計画 068 の対象)。
+
+## Git workflow
+
+- Branch: `advisor/067-vite-surface-analysis-warnings`(063 のマージ後に `origin/main` から。063 が未マージなら 063 のブランチを base にスタックし、README にその旨を書く)
+- Conventional commits、例: `fix(vite): surface analyzeProject warnings from the dev dashboard runner and pin crashed-rule reporting on the build path`
+- push / PR 作成はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: build 経路のクラッシュ報告テストを書く(現状で green のはず)
+
+`packages/vite/test/analyze.test.ts` は `analyze` を直接呼ぶ。`rule-failure-isolation.test.ts` と同じ `vi.mock('@svelte-vitals/core/internal', …)` を**このファイルの先頭で**行うと他の全ケースに影響するので、新しいファイル `packages/vite/test/analyze-rule-failure.test.ts` を作る。
+
+```ts
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const THROWN = 'synthetic rule failure (test)\nsecond line must not be printed';
+
+vi.mock('@svelte-vitals/core/internal', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@svelte-vitals/core/internal')>();
+  const allRules = actual.allRules.map((rule) =>
+    rule.id === 'seo/title-presence'
+      ? {
+          ...rule,
+          check: async () => {
+            throw new Error(THROWN);
+          }
+        }
+      : rule
+  );
+  return { ...actual, allRules };
+});
+
+const { analyze } = await import('../src/analyze.js');
+
+describe('vite build path reports a crashed rule', () => {
+  let cwd: string;
+  let pages: string;
+  beforeAll(async () => {
+    cwd = await mkdtemp(join(tmpdir(), 'sv-rule-failure-'));
+    pages = join(cwd, '.svelte-kit/output/prerendered/pages');
+    await mkdir(pages, { recursive: true });
+    await writeFile(join(pages, 'index.html'), '<html lang="en"><head><title>Home</title></head><body></body></html>');
+  });
+  afterAll(async () => rm(cwd, { recursive: true, force: true }));
+
+  it('names the rule and only the first line of its message in warnings', async () => {
+    const r = await analyze(pages, cwd, { report: false });
+    expect(r.warnings).toContain('rule seo/title-presence failed and was skipped: synthetic rule failure (test)');
+    expect(r.warnings.some((w) => w.includes('second line'))).toBe(false);
+  });
+});
+```
+
+`analyze` が `@svelte-vitals/core/internal` の `allRules` を top-level import で束縛しているかを確認する(`packages/vite/src/analyze.ts:1-20`)。`runAnalysis` に渡す `rules` が `selectRules(allRules, config)` 由来ならこのモックが効く。効かない(警告が出ない)場合は、`svelte-vitals` 側の再エクスポートを経由している可能性があるので STOP。
+
+**Verify**: `pnpm build && pnpm --filter @svelte-vitals/vite run test -- analyze-rule-failure` → pass(現状の挙動を固定)。fail するならそれ自体が発見なので STOP して報告。
+
+### Step 2: runner の失敗するテストを書く(TDD red)
+
+`packages/vite/test/ui-analysis.test.ts` の `describe('createAnalysisRunner')` に追加する。
+
+```ts
+it('forwards analyzeProject warnings through onWarnings', async () => {
+  const analyze = vi.fn<AnalyzeFn>(async () => ({ results: [], warnings: ['rule x failed and was skipped: boom'] }));
+  const onWarnings = vi.fn();
+  const runner = createAnalysisRunner({ root: '/proj', analyze, onResults: vi.fn(), onError: vi.fn(), onWarnings });
+  runner.start();
+  await vi.waitFor(() => expect(onWarnings).toHaveBeenCalledWith(['rule x failed and was skipped: boom']));
+});
+
+it('does not repeat an identical warning set on the next run, and sends a changed set', async () => {
+  let call = 0;
+  const analyze = vi.fn<AnalyzeFn>(async () => ({
+    results: [],
+    warnings: ++call <= 2 ? ['same'] : ['same', 'new']
+  }));
+  const onWarnings = vi.fn();
+  const runner = createAnalysisRunner({
+    root: '/proj',
+    analyze,
+    onResults: vi.fn(),
+    onError: vi.fn(),
+    onWarnings,
+    debounceMs: 10
+  });
+  runner.start();
+  await vi.waitFor(() => expect(analyze).toHaveBeenCalledTimes(1));
+  runner.notifyChange('/proj/src/a.svelte');
+  await vi.advanceTimersByTimeAsync(20);
+  await vi.waitFor(() => expect(analyze).toHaveBeenCalledTimes(2));
+  runner.notifyChange('/proj/src/b.svelte');
+  await vi.advanceTimersByTimeAsync(20);
+  await vi.waitFor(() => expect(analyze).toHaveBeenCalledTimes(3));
+  expect(onWarnings.mock.calls).toEqual([[['same']], [['same', 'new']]]);
+});
+
+it('still calls onResults with one argument when the analyzer returns no failedRuleIds', async () => {
+  // Guards the existing exact-args assertions above against the widened return type.
+  const analyze = vi.fn<AnalyzeFn>(async () => ({ results: [], warnings: [] }));
+  const onResults = vi.fn();
+  const runner = createAnalysisRunner({ root: '/proj', analyze, onResults, onError: vi.fn() });
+  runner.start();
+  await vi.waitFor(() => expect(onResults).toHaveBeenCalledTimes(1));
+  expect(onResults.mock.calls[0]).toEqual([[]]);
+});
+```
+
+このファイルは `vi.useFakeTimers()` を `beforeEach` で使う。`debounceMs` と `advanceTimersByTimeAsync` の組み合わせは同ファイルの既存の debounce ケースに合わせる(既存ケースを読んで同じ待ち方にする)。
+
+**Verify**: `pnpm build && pnpm --filter @svelte-vitals/vite run test -- ui-analysis` → 1 つ目と 2 つ目が **fail**(型エラーまたは `onWarnings` 未呼び出し)、3 つ目は pass。`pnpm typecheck` は `warnings` が `AnalyzeFn` の戻り値型にないため**失敗する**のが期待値。
+
+### Step 3: runner に `onWarnings` と重複抑制を実装する
+
+`packages/vite/src/ui/analysis.ts`:
+
+1. `AnalyzeFn` の戻り値を `Promise<{ results: Result[]; failedRuleIds?: string[]; warnings?: string[] }>` に広げる。
+2. `AnalysisRunnerOptions` に追加する。
+
+   ```ts
+   /** `analyzeProject`'s human-readable warnings (empty selections, unknown directive ids, skipped files, crashed rules). Called only when the set differs from the previous run's — a debounced re-run per save would otherwise repeat the same lines. */
+   onWarnings?(warnings: string[]): void;
+   ```
+
+3. `createAnalysisRunner` に `let lastWarningsKey: string | undefined;` を持たせ、`runOnce` の `onResults` 呼び出しの直後に流す。
+
+   ```ts
+   const warnings = result.warnings ?? [];
+   const key = warnings.join('\n');
+   if (warnings.length > 0 && key !== lastWarningsKey) opts.onWarnings?.(warnings);
+   lastWarningsKey = key;
+   ```
+
+   `runOnce` の分割代入は `const result = await analyze({...}); const { results, failedRuleIds } = result;` の形に直す。
+
+**Verify**: `pnpm build && pnpm typecheck && pnpm --filter @svelte-vitals/vite run test -- ui-analysis` → all pass。
+
+### Step 4: plugin で `onWarnings` を `warn()` に配線する
+
+`packages/vite/src/plugin.ts` の `createAnalysisRunner({...})` に追加する。
+
+```ts
+// Same sink and prefix as the build path (closeBundle) so the two never read differently.
+onWarnings: (warnings) => {
+  for (const w of warnings) warn(`svelte-vitals: ${w}`);
+},
+```
+
+任意で `packages/vite/test/ui-plugin.test.ts` に「`createAnalysisRunner` に `onWarnings` が渡される」ことを確認するケースを足す(同ファイルのモックは runner のオプションを捨てているので、モックファクトリで受け取ったオプションを `vi.hoisted` の変数に保存する形に拡張する)。省略可。
+
+**Verify**: `pnpm build && pnpm typecheck && pnpm --filter @svelte-vitals/vite run test` → all pass。手動確認(任意): `examples/kitchen-sink` で `pnpm dev` を起動し、`svelte-vitals.config.js` に `overrides: [{ files: 'src/nope/**', rules: { seo: 'off' } }]` を足して保存すると、ターミナルに `svelte-vitals: overrides[0].files 'src/nope/**' matched no files` 相当の行が 1 回だけ出ること。
+
+### Step 5: changeset を書き、最終検証
+
+`.changeset/` に新規ファイル(例 `vite-surface-warnings.md`)。
+
+```md
+---
+'@svelte-vitals/vite': patch
+---
+
+The dev dashboard's whole-project runner now forwards `analyzeProject`'s warnings (an `overrides` glob that matched nothing, an unknown inline-directive id, a file that could not be read or parsed, a rule that crashed and was skipped) to the terminal, the same way `vite build` already does. An unchanged warning set is not repeated on the next re-analysis. The build path's crashed-rule warning is now pinned by a test.
+```
+
+**Verify**: `pnpm build && pnpm typecheck && pnpm test && pnpm lint` → 全て exit 0。
+
+## Test plan
+
+- 新規: build 経路のクラッシュ報告(1 ケース、現状 green)、runner の `onWarnings` 転送 / 重複抑制 / `onResults` 引数不変(3 ケース)。
+- 既存: `ui-analysis.test.ts` の厳密引数 assert、`ui-plugin.test.ts`、`plugin-error.test.ts` が無変更で通ること。
+- 判別性: Step 3 を revert すると Step 2 の 2 ケースが赤に戻る。
+
+## Done criteria
+
+- [ ] `pnpm build && pnpm typecheck && pnpm test && pnpm lint` が全て exit 0
+- [ ] `grep -n "onWarnings" packages/vite/src/ui/analysis.ts packages/vite/src/plugin.ts` がそれぞれ 1 行以上ヒット
+- [ ] `packages/vite/test/analyze-rule-failure.test.ts` が存在し pass
+- [ ] `plans/README.md` の 067 行を更新済み(260903-BUG-03 と 260903-TEST-04 の両方を閉じる)
+
+## Maintenance notes
+
+- 警告を dashboard HTML に描画したくなったら、`onWarnings` の配列を store に載せて `AppSnapshot` に `warnings` を足すのが最短(app-shell の描画と `sanitizeReport` 相当のエスケープが要る)。
+- `analyzeProject` の `warnings` に新しい種類を足すと、CLI・build・dashboard の 3 経路に自動で出る。出したくない種類があるなら `analyzeProject` 側で分けること。
+
+## STOP conditions
+
+- Drift check でいずれかの in-scope ファイルが変わっており、抜粋と一致しない(063 未マージなら 063 適用後の `plugin.ts` と照合する)。
+- Step 1 のテストが fail する(build 経路がクラッシュを報告していない)。
+- Step 2 の `onResults` 引数不変ケースが Step 3 の後で fail する。
+- `analyze.ts` の `allRules` が `@svelte-vitals/core/internal` 以外から来ていてモックが効かない。

--- a/plans/068-dev-handle-ingest-signature.md
+++ b/plans/068-dev-handle-ingest-signature.md
@@ -1,0 +1,303 @@
+# Plan 068: dev handle の ingest 署名を POST 成功後に記録し、同一ルートの POST を直列化する(初回失敗でルートが `static` に固定される問題)
+
+> **Executor instructions**: Follow this plan step by step. Run every
+> verification command and confirm the expected result before moving to the
+> next step. If anything in the "STOP conditions" section occurs, stop and
+> report — do not improvise. When done, update the status row for this plan
+> in `plans/README.md` — unless a reviewer dispatched you and told you they
+> maintain the index.
+>
+> **Drift check (run first)**: `git diff --stat d3828d9e..HEAD -- packages/vite/src/hooks/handle.ts packages/vite/test/dev-handle.test.ts`
+> If any in-scope file changed since this plan was written, compare the
+> "Current state" excerpts against the live code before proceeding; on a
+> mismatch, treat it as a STOP condition.
+
+## Status
+
+| Priority | Effort | Risk | Depends on | Category    | Planned at                                                                   |
+| -------- | ------ | ---- | ---------- | ----------- | ---------------------------------------------------------------------------- |
+| P2       | S      | LOW  | none       | correctness | commit `13aa7ad0`(= `origin/main` `d3828d9e` と同内容のファイル)、2026-09-03 |
+
+## Why this matters
+
+`svelteVitalsHandle`(`packages/vite/src/hooks/handle.ts`)は dev でページを描画するたびに、そのルートの rendered HTML を解析して dashboard の `/ingest` に POST する。同じ finding が続く再描画で POST を繰り返さないよう、ルートごとに「最後に送った finding の署名」を `lastSignature` に持ち、同じなら return する。
+
+問題は順序で、`lastSignature.set(route, signature)` が **POST を試みる前**に実行される(`handle.ts:117` → `:119`)。しかも `postIngest` は `fetch` を `catch {}` で握りつぶし、`res.ok` も見ない(`:55-65`)。したがって最初の ingest が届かなかった場合(dev サーバー再起動直後で middleware がまだ載っていない、#640 以降の same-origin ゲートに引っかかる 403、一時的なソケットエラー、500)、署名は「送った」として残り、以後そのルートを何度描画しても `:116` の early return で **二度と POST されない**。dashboard 上ではそのルートが `static` バッジのまま固定され、ユーザーには理由が見えない。dev サーバーを止めて起動し直すまで直らない。
+
+もう 1 点、`postIngest` も `analyzeAndIngest` も `void` で投げっぱなし(`:119`、`:167`)なので、同じルートの 2 回の描画は 2 つの順序保証のない in-flight POST になる。受け側の `store.set(route, …)`(`packages/vite/src/ui/store.ts:92-100`)は last-write-wins の置換なので、編集 → 描画 → 編集 → 描画の連打で**古いほうの結果が後から着いて残る**ことがある。
+
+修正はどちらも `analyzeAndIngest` の中で閉じる。`postIngest` が成功したかを返し、成功したときだけ署名を記録する。ルートごとに Promise の尾を持って POST を直列化する。
+
+## Current state
+
+- `packages/vite/src/hooks/handle.ts:44-66`(`postIngest`):
+
+  ```ts
+  async function postIngest(origin: string, route: string, results: Result[], failedRuleIds: string[]): Promise<void> {
+    // `origin` comes from the request (Host header), so a spoofed Host must not
+    // redirect this server-side POST to an arbitrary external host.
+    if (!isLoopbackOrigin(origin)) {
+      // Accessing the app over LAN/--host yields a non-loopback origin, so the live
+      // UI silently stops updating — surface why when debugging is enabled.
+      if (globalThis.process?.env?.SVELTE_VITALS_DEBUG) {
+        warn(
+          `svelte-vitals: live UI ingest skipped for non-loopback origin ${origin} — open the dashboard via localhost`
+        );
+      }
+      return;
+    }
+    try {
+      await fetch(`${origin}/__svelte-vitals/ingest`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        // failedRuleIds is always sent, empty array included, so a route that recovers from
+        // a previously-crashing rule clears its stale entry on the receiving store.
+        body: JSON.stringify({ route, results, failedRuleIds })
+      });
+    } catch {
+      // dev tooling must never break a request — swallow ingest failures
+    }
+  }
+  ```
+
+- `packages/vite/src/hooks/handle.ts:68-76`(`analyzeAndIngest` のシグネチャ)と `:111-127`(署名と POST):
+
+  ```ts
+  async function analyzeAndIngest(
+    html: string,
+    route: string,
+    origin: string,
+    rules: Rule[],
+    config: Config,
+    lastSignature: Map<string, string>
+  ): Promise<void> {
+    try {
+      …
+      const signature = `${findingSignature(results, config)}|failed:${[...failedRuleIds].sort().join(',')}`;
+      if (lastSignature.get(route) === signature) return;
+      lastSignature.set(route, signature);
+
+      if (globalThis.process?.env?.SVELTE_VITALS_UI) void postIngest(origin, route, results, failedRuleIds);
+    } catch (err) {
+      // Dev tooling must never break the request: swallow any parse/rule error.
+      // Set SVELTE_VITALS_DEBUG to surface tool-internal errors while debugging.
+      if (globalThis.process?.env?.SVELTE_VITALS_DEBUG) {
+        warn(`svelte-vitals: dev analysis failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+  }
+  ```
+
+- `packages/vite/src/hooks/handle.ts:152-153`: `const lastSignature = new Map<string, string>();` を `svelteVitalsHandle` のクロージャで 1 つ持つ。`:158-169`(`transformPageChunk`): `done && event.route.id != null` のとき `void analyzeAndIngest(buffer, event.route.id, event.url.origin, rules, config, lastSignature)`。コメントに「観測専用、レスポンスをブロックしない、`analyzeAndIngest` は自分で例外を握るので floating promise は reject しない」とある。**この契約は保つ。**
+
+- `packages/vite/test/dev-handle.test.ts`:
+  - `:64-72`(`setup()`): `process.env.SVELTE_VITALS_UI = '1'` を立て、`fetch` を `vi.fn(async () => ({ ok: true }) as Response)` でスタブし `vi.stubGlobal('fetch', fetchMock)`。
+  - `:31` の `flush = () => new Promise((resolve) => setTimeout(resolve, 0))` で fire-and-forget を 1 マクロタスクぶん待つ。
+  - `:143-151`: 「同じ finding の再訪問は 1 回だけ POST」を `fetchMock` の呼び出し回数で pin。
+  - `:192-214`: `vi.doMock('@svelte-vitals/core/internal', …)` で `runAnalysis` を差し替えて `failedRuleIds` の転送を pin。
+
+- 設計上の注意(実装判断の根拠として固定):
+  - `postIngest` は `Promise<boolean>` を返す。`fetch` が resolve し `res.ok` なら `true`。throw、`!res.ok`、非 loopback で skip した場合は `false`。**`false` のときは署名を記録しない**ので、次の描画で再送される。
+  - 非 loopback(`--host` で LAN 経由)は毎回 skip されるが、署名を記録しないぶん毎回 `analyze` が走る。これは現状(署名を記録して 2 回目以降は解析だけ走る)と解析コストは同じで、POST が 1 回も出ないのも同じ。挙動差なし。
+  - 直列化は `Map<string, Promise<void>>` をルート単位で持ち、`analyzeAndIngest` の POST 部分を `tail = tail.then(() => send())` で繋ぐ。解析(`runAnalysis`)自体は直列化しない(重い処理を待ち行列にする理由がない)。署名の比較と記録は POST の成功後に行うので、直列化された POST の中で「送る直前に署名を再確認」する必要はない(同じ署名の 2 つ目は送信前の `lastSignature.get(route) === signature` で落ちる。1 つ目がまだ in-flight で署名未記録なら 2 つ目も送られるが、同内容の POST が 2 回になるだけで無害)。
+  - `lastSignature` Map の型は変えず、`inflight: Map<string, Promise<void>>` を `svelteVitalsHandle` のクロージャに**追加**して引数で渡す。
+  - `SVELTE_VITALS_DEBUG` 時は失敗した POST を `warn` する(現状の非 loopback と同じ表面)。
+  - リポジトリ規約: コードコメントは英語、非自明な WHY のみ。
+
+## Commands you will need
+
+| Purpose    | Command                                                    | Expected on success |
+| ---------- | ---------------------------------------------------------- | ------------------- |
+| Install    | `pnpm install`                                             | exit 0              |
+| Build      | `pnpm build`                                               | exit 0              |
+| Vite tests | `pnpm build && pnpm --filter @svelte-vitals/vite run test` | all pass            |
+| Full       | `pnpm build && pnpm typecheck && pnpm test && pnpm lint`   | 全て exit 0         |
+
+## Scope
+
+**In scope**(変更してよいファイルはこれだけ):
+
+- `packages/vite/src/hooks/handle.ts`
+- `packages/vite/test/dev-handle.test.ts`
+- `.changeset/`(新規 changeset 1 件、`@svelte-vitals/vite` の patch)
+
+**Out of scope**(触らない):
+
+- `packages/vite/src/ui/middleware.ts` / `store.ts` — 受け側の置換セマンティクスは正しい。送り側で順序を保証する。
+- `packages/vite/src/loopback.ts`。
+- dashboard に「ingest が失敗している」ことを描画する UI。
+- `findingSignature` の形式。
+
+## Git workflow
+
+- Branch: `advisor/068-dev-handle-ingest-signature`(`origin/main` から)
+- Conventional commits、例: `fix(vite): record a route's ingest signature only after the POST succeeds and serialize POSTs per route`
+- push / PR 作成はオペレーターの指示があるまで行わない。
+
+## Steps
+
+### Step 1: 失敗するテストを書く(TDD red)
+
+`packages/vite/test/dev-handle.test.ts` に追加する。`setup()` は `fetch` を成功固定でスタブするので、失敗させたいケースでは `fetchMock.mockImplementationOnce(...)` で上書きする。
+
+```ts
+it('retries the ingest on the next render when the first POST failed (non-ok response)', async () => {
+  const fetchMock = setup();
+  fetchMock.mockImplementationOnce(async () => ({ ok: false, status: 403 }) as Response);
+  const handle = svelteVitalsHandle();
+  await handle({ event: fakeEvent('/none', '/none'), resolve: resolveWith([PAGE_NO_TITLE]) });
+  await flush();
+  await handle({ event: fakeEvent('/none', '/none'), resolve: resolveWith([PAGE_NO_TITLE]) });
+  await flush();
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+});
+
+it('retries the ingest on the next render when the first POST threw', async () => {
+  const fetchMock = setup();
+  fetchMock.mockImplementationOnce(async () => {
+    throw new Error('ECONNREFUSED');
+  });
+  const handle = svelteVitalsHandle();
+  await handle({ event: fakeEvent('/none', '/none'), resolve: resolveWith([PAGE_NO_TITLE]) });
+  await flush();
+  await handle({ event: fakeEvent('/none', '/none'), resolve: resolveWith([PAGE_NO_TITLE]) });
+  await flush();
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+});
+
+it('after a successful POST the same findings are still deduplicated', async () => {
+  const fetchMock = setup();
+  fetchMock.mockImplementationOnce(async () => ({ ok: false, status: 500 }) as Response);
+  const handle = svelteVitalsHandle();
+  for (let i = 0; i < 3; i++) {
+    await handle({ event: fakeEvent('/none', '/none'), resolve: resolveWith([PAGE_NO_TITLE]) });
+    await flush();
+  }
+  // 1st fails → 2nd succeeds → 3rd is deduplicated.
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+});
+
+it('sends POSTs for the same route in render order even when an earlier one is slow', async () => {
+  const fetchMock = setup();
+  const bodies: string[] = [];
+  let releaseFirst!: () => void;
+  fetchMock.mockImplementationOnce(async (_url, init) => {
+    bodies.push(String(init?.body));
+    await new Promise<void>((r) => (releaseFirst = r));
+    return { ok: true } as Response;
+  });
+  fetchMock.mockImplementation(async (_url, init) => {
+    bodies.push(String(init?.body));
+    return { ok: true } as Response;
+  });
+  const handle = svelteVitalsHandle();
+  await handle({ event: fakeEvent('/none', '/none'), resolve: resolveWith([PAGE_NO_TITLE]) });
+  await flush();
+  await handle({ event: fakeEvent('/none', '/none'), resolve: resolveWith([PAGE_TWO_H1]) });
+  await flush();
+  // The second POST must not have been issued while the first is still in flight.
+  expect(bodies).toHaveLength(1);
+  releaseFirst();
+  await flush();
+  await flush();
+  expect(bodies).toHaveLength(2);
+  expect(JSON.parse(bodies[0]!).results.some((r: Result) => r.id === 'seo/title-presence')).toBe(true);
+  expect(JSON.parse(bodies[1]!).results.some((r: Result) => r.id === 'seo/single-h1')).toBe(true);
+});
+```
+
+`PAGE_TWO_H1` の finding が `seo/single-h1` であることは同ファイルの既存ケース(`:47-50` のコメント)に依拠する。id が違えば既存ケースで使われている id に合わせる。
+
+**Verify**: `pnpm build && pnpm --filter @svelte-vitals/vite run test -- dev-handle` → 新 4 ケースのうち、1〜3 が **fail**(2 回目の POST が出ない / 回数が 1)、4 が **fail**(`bodies` が先に 2 になる)。既存ケースは pass。
+
+### Step 2: `postIngest` を成功可否を返す形にし、署名記録を成功後に移し、ルート単位で直列化する
+
+`packages/vite/src/hooks/handle.ts`:
+
+1. `postIngest` を `Promise<boolean>` にする。
+
+   ```ts
+   /** True only when the dashboard acknowledged the POST — the caller records the route's signature on that, so a lost ingest is retried on the next render instead of pinning the route to `static`. */
+   async function postIngest(origin: string, route: string, results: Result[], failedRuleIds: string[]): Promise<boolean> {
+     if (!isLoopbackOrigin(origin)) {
+       … (unchanged debug warn)
+       return false;
+     }
+     try {
+       const res = await fetch(`${origin}/__svelte-vitals/ingest`, { … unchanged … });
+       if (!res.ok && globalThis.process?.env?.SVELTE_VITALS_DEBUG) {
+         warn(`svelte-vitals: live UI ingest for ${route} rejected with HTTP ${res.status}`);
+       }
+       return res.ok;
+     } catch (err) {
+       // dev tooling must never break a request — swallow ingest failures
+       if (globalThis.process?.env?.SVELTE_VITALS_DEBUG) {
+         warn(`svelte-vitals: live UI ingest for ${route} failed: ${err instanceof Error ? err.message : String(err)}`);
+       }
+       return false;
+     }
+   }
+   ```
+
+2. `analyzeAndIngest` に `inflight: Map<string, Promise<void>>` 引数を足し、署名ブロックを置き換える。
+
+   ```ts
+   const signature = `${findingSignature(results, config)}|failed:${[...failedRuleIds].sort().join(',')}`;
+   if (lastSignature.get(route) === signature) return;
+
+   if (!globalThis.process?.env?.SVELTE_VITALS_UI) return;
+   // Per-route FIFO: two renders of one route are two unordered fetches otherwise, and the
+   // store replaces last-write-wins, so an older payload could land last. The signature is
+   // recorded only after the dashboard acknowledged the POST.
+   const previous = inflight.get(route) ?? Promise.resolve();
+   const next = previous.then(async () => {
+     if (await postIngest(origin, route, results, failedRuleIds)) lastSignature.set(route, signature);
+   });
+   inflight.set(route, next);
+   await next;
+   if (inflight.get(route) === next) inflight.delete(route);
+   ```
+
+   `await next` は `analyzeAndIngest` 自身が `void` で呼ばれているのでレスポンスをブロックしない。`postIngest` は throw しないので `next` は reject しない。
+
+3. `svelteVitalsHandle` に `const inflight = new Map<string, Promise<void>>();` を `lastSignature` の隣に足し、`analyzeAndIngest(..., lastSignature, inflight)` で渡す。
+
+**Verify**: `pnpm build && pnpm typecheck && pnpm --filter @svelte-vitals/vite run test` → all pass(Step 1 の 4 ケース含む。既存の `dedups` ケースと `failedRuleIds` 転送ケースが無変更で通ること)。
+
+### Step 3: changeset を書き、最終検証
+
+`.changeset/` に新規ファイル(例 `dev-handle-ingest-retry.md`)。
+
+```md
+---
+'@svelte-vitals/vite': patch
+---
+
+`svelteVitalsHandle` now records a route's ingest signature only after the dashboard acknowledged the POST, so a route whose first ingest was lost (dev server restarting, a rejected origin, a transient socket error) is retried on its next render instead of staying `static` for the rest of the session. POSTs for the same route are sent in render order, so a slow earlier ingest can no longer overwrite a newer one. With `SVELTE_VITALS_DEBUG` set, a rejected or failed ingest is logged.
+```
+
+**Verify**: `pnpm build && pnpm typecheck && pnpm test && pnpm lint` → 全て exit 0。
+
+## Test plan
+
+- 新規 4 ケース(非 ok で再送、throw で再送、成功後は重複除去、同一ルートの順序保証)。
+- 既存: `dedups` / `failedRuleIds` 転送 / pass-through(非 dev)ケースが無変更で通ること。
+- 判別性: Step 2 の「署名を成功後に記録」だけを revert すると 1〜3 が赤、「直列化」だけを revert すると 4 が赤になることを確認する。
+
+## Done criteria
+
+- [ ] `pnpm build && pnpm typecheck && pnpm test && pnpm lint` が全て exit 0
+- [ ] `grep -n "Promise<boolean>" packages/vite/src/hooks/handle.ts` が 1 行ヒット
+- [ ] `grep -n "lastSignature.set" packages/vite/src/hooks/handle.ts` のヒットが `postIngest` の成功分岐の 1 行だけ
+- [ ] `plans/README.md` の 068 行を更新済み
+
+## Maintenance notes
+
+- `inflight` の Promise 尾はルート数ぶんしか増えず、完了後に自分を削除する。SSR ルート id は有限なので無限に育たない(unmatched request は `event.route.id == null` で最初から対象外)。
+- ingest の受け側(`middleware.ts`)がステータスコードを変えたら、`res.ok` の判定はそのまま追従する。204 以外の 2xx を返しても成功扱い。
+
+## STOP conditions
+
+- Drift check でいずれかの in-scope ファイルが変わっており、抜粋と一致しない。
+- Step 1 の既存 `dedups` ケースが Step 2 の後で fail する(署名記録のタイミングが `flush` 1 回では足りない)。その場合は `flush` を 2 回に増やして通るかを確認し、通るならテスト側を直す。通らなければ報告。
+- `transformPageChunk` の契約(レスポンスをブロックしない)を守れない変更が必要になった場合。

--- a/plans/README.md
+++ b/plans/README.md
@@ -228,7 +228,7 @@ improve スキルによる監査(2026-07-05、commit `1f6f233` 時点)から生�
 - **260828-BUG-04** gunshi 系 6 closure の exit code 初期値 0 → 2 への防御的変更(現 HEAD で到達不能と検証済み、latent)(S)。
 - **260828-BUG-05** `permitted-contents` の KNOWN_TAGS が `svg:` prefix 剥がしで SVG 専用 60 名を HTML 既知タグ扱い(`<div><g>` に info 発火。measured spec の「unknown は無判定」方針と矛盾)(S)。
 - **260828-BUG-06** `loadSuppressions` の catch-all を ENOENT 限定に(EACCES が「ファイルなし」に化ける。安全側の failure だが診断が紛らわしい)(S)。
-- **260828-REV-01(055 レビュー副産物)** `reserved-name-placement.ts:181-183/205-207` の `capUnits[name]`/`anyUnits[name]` が hasOwn なしの config キー索引 — `constructor` という名のディレクトリ+片側 map の config エントリで Object 関数が `globsOf` に流れる(S)。
+- **260828-REV-01(055 レビュー副産物)** **→ 2026-09-03 の計画 064 に収容(未変化で再現済み)。** `reserved-name-placement.ts:181-183/205-207` の `capUnits[name]`/`anyUnits[name]` が hasOwn なしの config キー索引 — `constructor` という名のディレクトリ+片側 map の config エントリで Object 関数が `globsOf` に流れる(S)。
 - **260828-REV-02(058 レビュー副産物)** `reporter/agent.ts:55` の `fix.snippet` フェンスが固定 ``` — dashboard 側で直したのと同クラス。全ルールの snippet がリテラル著述の現在は latent(S)。
 - **260828-REV-03(056 レビュー副産物)** 短縮形 `-h --help=false` が last-wins 非対応(base から同挙動の既知ギャップ。気にする人が出たら、の優先度)(S)。
 - **260828-REV-04(PR #615 の Copilot 指摘、pre-existing と実測確認済み)** `collectAriaElements` がタグを小文字化せず記録(`collectElements` は小文字化する)ため、`<dIv>` のような mixed-case タグで `roleCandidates` が undefined になり role 依存の a11y 判定が静かにスキップされる(latent FN)。根治は role-candidates 側の lowercase ではなく collection 側(`component-parse.ts` の `collectAriaElements`)で `collectElements` と同様に小文字化 — 全 consumer が一度に直る。mixed-case 回帰テスト付きで(S)。監査時の「collectAriaElements SVG/case gap(latent)」の具体的帰結。**済み([PR #621](https://github.com/oekazuma/svelte-vitals/pull/621) — collection 側で小文字化。敵対的レビュー 1 巡: required-aria-props は「欠落」ではなく「過検出が直る」方向のみと executor が反証し reviewer が撤回)**
@@ -265,7 +265,116 @@ improve スキルによる監査(2026-07-05、commit `1f6f233` 時点)から生�
 - **2608-DIR-05(minHealth の config キー非対称)** HEAD 再確認 — `failOn` は config キー(config-file.ts の KNOWN_TOP_LEVEL_KEYS)なのに `minHealth` は CLI フラグのみのまま。flag-beats-config の優先順位を決める設計ノート 1 枚(S)。
 - 2608-DIR-04(agent skill 世代ズレ警告)は状況変化なし。v1 Phase E(タグ付け)は意図的保留のまま — 本監査からの提案はしない。
 
+## 2026-09-03 security 監査(commit `13aa7ad0`)
+
+`/improve security` による security カテゴリ限定の監査(standard、サブエージェントなし — 親が全対象コードを直接実読)。対象: vite dev UI(middleware / loopback / handle / snapshot / store)、CLI の shell-out・`import()`・ファイル書き込み経路(changed-files / baseline / config-file / install / ci / suppressions)、core の 6 レポーター(HTML / agent / markdown / github / sarif / json)とサニタイザ、own workflows と scaffold される workflow、ecosystem-smoke、pnpm / Renovate の supply-chain 設定、`pnpm audit --prod`。所見は 1 件だけ計画化し、それ以外は棄却理由を下に記録した。番号は 062 から: 060 / 061 はブランチ名(`advisor/060-aria-elements-lowercase` → PR #621、`advisor/061-terminal-safe-c1` → PR #623)として使用済みで、計画ファイル自体は plans/ に残っていない。
+
+| Plan | Title                                                                                                                               | Priority | Effort | Depends on | Status                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------------- | -------- | ------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 062  | dev UI の `POST /ingest` を same-origin(host:port 一致)に限定し、body を 4 MiB で 413 にする(loopback なら別ポートでも通る現状の穴) | P2       | S      | —          | DONE(2026-09-03 Sonnet executor、逸脱なし → レビュー(Fable)APPROVE[done criteria を worktree で全件再実行、main の middleware.ts に差し替える mutation check で新テスト 2 件だけが fail することを確認]。ブランチ `advisor/062-dev-ui-ingest-same-origin`、commit `26d4f766`。worktree `.claude/worktrees/agent-a835ee474b2dfd072`。[PR #640](https://github.com/oekazuma/svelte-vitals/pull/640) 作成済み。CodeRabbit 指摘 3 件[isSameOrigin の既定ポートがスキームをまたいで衝突(https://localhost が localhost:80 に一致・:443 明示が不一致)/413 が end まで返らない/docs と changeset が「Origin なし=ハンドルのみ」と過大主張]は全て妥当と検証し、REVISE 1 回で commit `4616b976`[hostname+実効ポート比較、socket.encrypted で Host 側の既定ポートを解決、cap 超過時に即 413+destroy、文言修正]→ 再レビュー APPROVE) |
+
+### 2026-09-03 監査で棄却・検証済みの所見(再監査防止)
+
+- `git` への引数注入(`packages/cli/src/baseline.ts:41` の `worktree add … <ref>`、`changed-files.ts:39` の `--merge-base <base>`)。ref は CLI 起動者自身の `--baseline` / `--diff` から来る。scaffold される workflow は `origin/${{ github.base_ref }}` と接頭辞付きで渡す。境界を越えていないので計画化しない。
+- `pnpm audit --prod`。30 件(high 17)は全て `docs>blume` 配下の devDependency 経路のみで、公開 3 パッケージからの到達経路はゼロ(advisory ごとの paths を機械照合)。2026-08-28 の 260828-DEPS-04(docs の devDependencies 化)が未着手のままノイズとして残っている — メンテナー直接作業が最安、という前回の結論を維持。
+- agent レポーターの固定フェンス(`packages/core/src/reporter/agent.ts:55` は `fenceFor` 相当なしで ``` を使う)。全 7 ルールの `fix.snippet` を実読し、いずれも定数文字列で解析対象由来の文字列を含まない。dashboard 側(058)と非対称だが、現状では到達不能。snippet に解析対象の値を埋め込むルールを足す時に初めて必要になる。
+- agent レポーター / AI prompt への意味的 prompt injection(`<dt>` テキスト、`hreflang` 値、`$state` 名などの引用が message に入る)。構造面(改行・リンク・フェンス)は `mdEscape` / `mdSafe` で無害化済みで、`agent-report.test.ts:129` に敵対値のテストもある。意味面は「自分のリポジトリの文字列を自分のエージェントに渡す」経路であり、linter→agent フィード一般に内在する。計画化しない。
+- dashboard の CSP 不在。描画は全て `textContent` / `setAttribute` / エスケープ済み埋め込み JSON 経由で、`docsUrl` は `safeHref` 済み。inline script のハッシュ計算は core の `node:` 禁止(runtime-agnostic)に抵触し、生成器+ドリフトテストを足すコストに見合わない。
+- own workflows / scaffold / supply-chain。SHA ピン、`persist-credentials: false`、最小 `permissions`、`pull_request_target` 不使用、`--frozen-lockfile`、`minimumReleaseAge`(pnpm 3 日 / Renovate 3 days)、`allowBuilds` 許可リスト、OIDC provenance — 全て HEAD で維持。所見なし。
+- ecosystem-smoke の untrusted clone。`execFileSync` 配列形、config ファイル除去(`import()` RCE 経路の遮断)、realpath による封じ込め、`contents: read` のみ — 2026-08-28 の検証結果を再確認、変化なし。
+- CLI の shell-out。`execFileSync` / `spawnSync` の配列形のみ(`shell: true` は win32 の install 経路だけで、引数は定数)。`import()` は config ファイル(設計どおり)と自身のモジュールのみ。
+- HTML レポート / dashboard の XSS。`embedJson`(`<` / U+2028 / U+2029 エスケープ)、`escapeHtml`、`safeHref`、`h()` の `textContent` 経由 — 実読で穴なし。
+- 委託済み秘密情報。`.env` なし、トークン形パターンの grep 0 件、npm publish は OIDC。
+
+### 本監査でカバーしていない領域(明示)
+
+- 別リポジトリの `oekazuma/svelte-vitals-action`(scaffold が呼ぶ側)。
+- `rules/security/*` の検出器そのものの妥当性(ルールの偽陰性・偽陽性は security 監査ではなく rule validity review の領域)。
+- ルールの正規表現に対する ReDoS(敵対的ソースでの CI 遅延)。PR 側が任意コードを走らせられる CI では境界にならないと判断し、計測していない。
+- Windows 挙動(引き続き macOS 上のみ)。
+
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJECTED (with one-line rationale)
+
+## 2026-09-03 deep 監査(commit `13aa7ad0`、計画は `origin/main` `d3828d9e` 起点)
+
+/improve deep による全リポジトリ監査(9 カテゴリ、8 並列サブエージェント + direction は親が直接)。前回 deep 監査(2026-08-28、`690dd5e4`)から 36 コミット / 113 ファイル。監査は #630/#632/#633 のリファクタ(runAnalysis 統合、module-ast 抽出)と tinyglobby → `node:fs` glob 置換に重み付けした。計画対象の所見は全件、親が引用元コードを実読し、うち BUG-01(ESM キャッシュ)は Node と vitest の両方で、TEST-01(読めないディレクトリ)は実 FS で再現した。ユーザー非対話セッションのため、スキルの既定に従い leverage 上位 6 件を計画化した。監査時のローカル HEAD `13aa7ad0` は `origin/main` より 3 コミット遅れ(#640/#641/#642)。作業ツリーを変えない方針で pull せず、計画の drift check は `d3828d9e` 起点で書いてある。
+
+| Plan | Title                                                                                                                                                                                  | Priority | Effort | Depends on            | Status                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------ | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 063  | config ファイルの `import()` をキャッシュバストし、dev dashboard が編集後の config を読む(ESM モジュールキャッシュ。dashboard 側の config も getter 化)(260903-BUG-01)                 | P1       | S      | —                     | DONE(2026-09-03 Sonnet executor → 敵対的レビュー(Fable)APPROVE[done criteria 全件再実行、mutation で新テストだけが赤になることを確認、内容ハッシュのキー契約を dist プローブで実証]→ should-fix 1 件[watcher 直後の即時 re-resolve が truncate+write 保存で偽の invalid 警告]を debounce 500 ms + 世代カウンタで修正 → 再レビュー APPROVE → [PR #643](https://github.com/oekazuma/svelte-vitals/pull/643)。ブランチ `advisor/063-config-file-import-cache`、commit `982baca9`)                                                                                                                           |
+| 064  | core の `Object.prototype` キー索引の残り 3 サイト(JSON-LD `@type` でルール脱落+スコア上振れ / rule options の無言受理 / placement 値読み。260828-REV-01 を収容)(260903-CORRECT-01/02) | P1       | S      | —                     | DONE(2026-09-03 Sonnet executor、逸脱なし → 敵対的レビュー(Fable)一発 APPROVE[3 サイト個別の mutation で対応テストだけが赤、`__proto__` は computed key 経由で到達可能だが修正後は unknown option として拒否されることを実証]→ [PR #644](https://github.com/oekazuma/svelte-vitals/pull/644)。ブランチ `advisor/064-prototype-key-sweep`、commit `fb6ea829`。レビュー nit: placement テストは `toEqual([])` にすれば更に強い)                                                                                                                                                                            |
+| 065  | 解析対象由来の文字列が素通りする 2 シンク(`@clack/prompts` の `terminalSafe` 未適用 3 サイト / SARIF `artifactLocation.uri` 未エンコード。fingerprint は不変)(260903-SEC-02/03)        | P1       | S      | —                     | DONE(2026-09-03 Sonnet executor[worktree 間で共有される `git stash` の衝突を踏んだが復旧、以後 stash 禁止]→ 敵対的レビュー(Fable)APPROVE[mutation で対応テストだけが赤、clack の `label` は描画専用と dist 実読で確認]→ should-fix 1 件[`encodeURI` が `[slug]` を `%5Bslug%5D` にする点が未固定]をテスト+changeset で固定 → [PR #645](https://github.com/oekazuma/svelte-vitals/pull/645)。ブランチ `advisor/065-sink-sanitizer-gaps`、commit `565e70b5`)                                                                                                                                               |
+| 066  | `computeScore` のレジストリ射影を config 単位でメモ化(レポート構築の約 95% が結果非依存のセットアップ。JSON バイト同一が done 条件)(260903-PERF-01)                                    | P2       | S      | —                     | DONE(2026-09-03 Sonnet executor[065 との共有 stash 衝突から dangling commit 経由で自力復旧、以後 cp 方式]→ 敵対的レビュー(Fable)APPROVE[json / console / --by-route の 3 形式でバイト同一を再確認、config 同一性を無視する誤メモ化は既存テスト 2 件も落とすことを実証、全 caller の config 不変性を列挙]→ nit 2 件[changeset の絶対 ms を比率表現に、コメントの動機文を削除]反映 → [PR #646](https://github.com/oekazuma/svelte-vitals/pull/646)。ブランチ `advisor/066-score-registry-memo`、commit `134388bb`)                                                                                         |
+| 067  | vite dashboard runner が `analyzeProject` の warnings を捨てている問題+build 経路のクラッシュ報告テスト(260903-BUG-03/TEST-04)                                                         | P2       | S      | 063(同じ `plugin.ts`) | DONE(2026-09-03 Sonnet executor → 敵対的レビュー(Fable)REJECT 1 回[config ファイル警告が applyConfig と runner の両方から出て起動時に二重印字。計画のスコープ外だった applyConfig の warn ループを親が許可]→ printed-Set で runner 側を抑制+1 回だけ印字を assert するテスト追加 → 再レビュー APPROVE[3 フェーズの実キャプチャで各行 1 回を確認]→ [PR #647](https://github.com/oekazuma/svelte-vitals/pull/647)。#643 マージ後(2026-09-04)に `git rebase --onto origin/main 982baca9` で main に載せ替え、base を main へ変更。ブランチ `advisor/067-vite-surface-analysis-warnings`、commit `408450bb`) |
+| 068  | dev handle の ingest 署名を POST 成功後に記録し、同一ルートの POST を直列化(初回失敗で `static` 固定)(260903-BUG-02)                                                                   | P2       | S      | —                     | DONE(2026-09-03 Sonnet executor → 敵対的レビュー(Fable)APPROVE + should-fix 2 件[「最後に ack された署名」で dedup すると A→B(in-flight)→A の再描画が 1 往復ぶん古いまま残る/inflight の掃除が finally でない]→ queued-signature 方式に変更+finally+interleave テスト → 再レビュー APPROVE + should-fix 2 件[changeset の機構文言が旧版のまま/失敗分岐の `=== signature` ガードを pin するテストなし]→ 反映 → [PR #648](https://github.com/oekazuma/svelte-vitals/pull/648)。ブランチ `advisor/068-dev-handle-ingest-signature`、commit `f7abd829`)                                                      |
+
+### 2026-09-03 の依存メモ
+
+- 063 → 067 は同じ `packages/vite/src/plugin.ts` の `configureServer` を触るので直列(067 は 063 の後、または 063 ブランチにスタック)。
+- 064 / 065 / 066 / 068 は互いに独立で並行可。064 と 066 は core の別ファイル、065 は cli+core の別ファイル、068 は vite の `hooks/handle.ts` のみ。
+
+### メンテナーが直接やるのが最安の 8 件(計画化しない)
+
+- 260903-DX-01(`.github/workflows/ci.yml:92`): test ジョブは dist キャッシュを復元した直後に `pnpm test`(= `pnpm build && pnpm -r test`)で無条件に再ビルドする。CI ログ(run 33726697506)でキャッシュヒット直後に 3 パッケージの tsdown が走るのを確認。`pnpm -r test` に変えればキャッシュが効く。root の `test` スクリプトは計画 048 の理由で build 先行のまま残す。
+- 260903-DX-05: `tsup` 言及 4 箇所(`packages/cli/src/version.ts:4,25`、`gunshi/registry.ts:3` の「tsup.config.ts」は存在しないファイル名、`packages/vite/src/version.ts:22`)。ツールは tsdown。
+- 260903-DOCS-01/02/03(`packages/core/README.md`): 8 行目「zero runtime dependencies」は誤り(`aria-query` と `svelte`、dep-budget 上限 21)。18 行目の stable 表に `CATEGORIES` 値 export と `Summary` / `RuleEvidence` / `ScoreModel` 型がない。`summary.ts:29` の `summarize` だけ JSDoc がない(effective severity で集計する非自明さを 1 行)。
+- 260903-DX-03: `NO_COLOR` / `FORCE_COLOR`(`packages/cli/src/color.ts:30-32`)が docs のどこにもない。`guides/(setup)/cli.md` の env 節に en/ja+stamp。
+- 260903-DEBT-04: `NAMING_ATTRS` が core 内で 2 つの意味(`a11y.ts:152` は landmark 用 2 属性、`rules/a11y/accessible-name.ts:6` はローカルの 3 属性、`component-parse.ts:1273` はインライン 3 属性)。前者を `LANDMARK_NAMING_ATTRS` に改名し、後者 2 つを 1 つの export に。
+- 260903-DX-02: PR #577(lock file maintenance)が `renovate/stability-days` pending で 10 日間ブロック(15 回 CI 再実行)。`renovate.json:7` のコメント「3-day age holds」と観測が矛盾。`pnpm-workspace.yaml` の `minimumReleaseAge` が resolve 時点で効いているので Renovate 側の gate は二重の可能性。設定判断はメンテナー。
+- 260903-DEPS-03: `magicast ^0.5.4` は published CLI の**ランタイム** 0.x 依存だが、`renovate.json` の minor automerge 例外は gunshi だけ。同じ 1 ルールを足す。
+- 260903-DEPS-01: TypeScript 7(PR #181、2026-07-11 から open、15 回 CI 失敗)のブロッカーは `examples/kitchen-sink` の `svelte-check` ガードだけ(TS6 の npm alias + `--tsgo` で解ける)。ただし core/cli/vite が TS7 で typecheck を通るかは kitchen-sink で止まるため未検証。判断はメンテナー。
+
+### 2026-09-03 監査で検出したが計画化しなかった主な所見(次回選定の候補、leverage 順)
+
+- 260903-TEST-01: `fs.glob` は読めないディレクトリを無警告で飛ばす(実 FS で再現)。`component.ts:364-386` は read/parse 失敗しか警告せず、列挙されなかったファイルは「無かった」ことになり正常スコアが出る。`runtime.ts:41-52` の EMFILE 事例と同クラス。まず `glob.test.ts` に `chmod 000` ケース(root と Windows では skip)、次に skipped-directory を warnings に流す(S + S–M)。
+- 260903-TEST-02 / DEBT-02: `packages/vite/src/glob.ts` はテストゼロ。cli 版とシグネチャが既に乖離(cli は `string[]` + `exclude`)。cli の 4 ケースをミラーし、共通本体の byte 同一性を pin する(S)。
+- 260903-TEST-03: `module-ast.ts`(20 export、#633 で新設)に直接テストなし(`grep module-ast packages/*/test` = 0)。同時期の `a11y.ts` / `head.ts` / `runAnalysis` にはある。scope/binding 4 関数の characterization テスト先行(M)。
+- 260903-TEST-05: `memory-runtime.ts:21-23` は `cwd` を捨て、ディレクトリを表現できないので `Runtime.glob` の 2 不変条件を反証できない。両アダプタで走る conformance テーブル(S、14 テストファイルが consumer)。
+- 260903-TEST-07: `--weights` / `--treat-dynamic-as` は parse と core の両端にテストがあるが `run()` で結線を assert するテストがない(S)。
+- 260903-TEST-08: `gunshi-docs-parity` の 4 セルが 130 行の docs 本文をスナップショットに埋め込み(dispatch 形状だけを assert する形に)(S)。
+- 260903-DEBT-01: `2026-08-16-v1-public-surface.md:262-291` が指定する `public-surface.json` + closure テストが**存在しない**(decision drift)。`json.ts:21` の `JsonIssue` は推論型のまま frozen `JsonReport` に含まれる(M)。
+- 260903-DEBT-03 / PERF-05: `component-parse.ts` に `CHILD_NODE_KEYS` walker skeleton が 23 個(cli `parse.ts` に 5 個)、`parseComponentFacts` は fragment を 17 回無条件+最大 13 回条件付きで走査。bench 設計書 §2 の「seven-walk」は実数の 2.4〜4.3 倍の過小(doc 訂正 S、`walkTemplate` 抽出 + 3 クラスタ分割は L)。
+- 260903-PERF-02: 1 回の CLI 実行で glob パターン 10 個 = 10 回のフル走査。`cli/glob.ts:13` は既に `string[]` を受けるが `Runtime.glob`(`runtime.ts:29`)が単一パターン。kitchen-sink 実測 17.1 ms → 5.2 ms。io-budget の「each pattern once」不変条件の書き換えが要る(M)。
+- 260903-PERF-03: dashboard の `buildSnapshot` が `/data.json` ごとに `buildJsonReport` を再構築。`store.sequence()` がサーバー側で未使用(S。066 の後が自然)。
+- 260903-PERF-04: `walkEstree` が `walkEvalScope` に委譲し、ノードごとに `scopeIntroducedNames` の `Set` を捨てている(kitchen-sink で 1 パスあたり 554 回、11 パス)。scope なしの再帰に分離(S、`pnpm bench` で確認)。
+- 260903-DEBT-05: #632 後も `mergeConfig`(vite `analyze.ts:44-55` vs cli `index.ts:300-313`)と post-analysis 警告の尾(`analyze.ts:124-126` vs `index.ts:330,359`)は 2 コピー(M)。
+- 260903-DEBT-06: vite `analyze.ts:128` の `score`(`computeScore` の combined、Health と一致しない)は plugin が読まない。`summary` は `failed` 判定で使用中なので削るのは `score` だけ(S)。
+- 260903-BUG-04: `install/index.ts:520-524` で `@svelte-vitals/vite` の自動インストール失敗が `errorLog` のみで exit 0。設計書 2026-07-04 は「warning 以上の recovery は non-goal」で、exit code は未規定。exit 2 にするか「best-effort、exit 0」と明文化するかはメンテナー判断(S)。
+- 260903-BUG-05: `baseline.ts:68-71` の catch が worktree 登録を prune せずに tmp を消す(`git worktree list` に prunable が残る)(S)。
+- 260903-DOCS-04: `2026-07-31-floor-smoke-design.md:35` の依存表が tinyglobby / mri / smol-toml を挙げる(3 つとも消滅)。AGENTS.md が現行として引いているので snapshot 注記か更新(S)。
+- 260903-DOCS-05: kitchen-sink README の route→rule 表に `a11y/unverified-id-ref` がない(105 中 104。ドリフトガードなし)(S)。
+- 260903-DX-04: gen 系スクリプト 7 本に umbrella がなく、AGENTS.md の 3 節に散在。`gen:all` + 1 表(S)。
+- 260903-DEPS-02: vite の dep 閉包 12/12 の内訳に `entities@4` と `entities@8`(node-html-parser 経由、upstream の問題)。override は dom-serializer を壊すので**やらない**。`max: 12` に注記のみ。
+- 260903-REV-01(監査副産物): `core/component.ts:366` のコメント「picomatch-style matching」は tinyglobby 時代の記述(現在は `node:fs` glob)。`2026-08-16-v1-public-surface.md:197` が `APP_STYLE` を vite の consumer として挙げるが `internal.ts` は export していない。どちらも 1 行。
+
+### 2026-09-03 監査で棄却・検証済みの所見(再監査防止)
+
+- TEST-06(`flag-coverage.test.ts` が help スナップショットで満たされる)は**誤り**。同テストは `.test.ts` しか読まない(`:20-26`)。「parse テストで名前が挙がるだけで通る」点はテストのヘッダと AGENTS.md が明記済みの by-design。棄却。
+- 前回 backlog の訂正: CATEGORIES は 3 重複ではなく 2 重複(`types.ts:144`、`resolve-args.ts:9`)。`internal.ts` の未消費 12 型は e9fd01ee の方針(「seam を越える shape は consumer が名指ししなくても残す」)どおりで所見ではない。
+- `isClassicScriptType`(#630)の空白のみ `type` の扱いが変わった件は WHATWG「prepare the script element」に照らして新挙動が正(リテラル空のみ classic)。drift ではない。
+- glob 置換(tinyglobby → `node:fs`)の意味論: `**` の 0 セグメント、brace の空代替、dot 除外、ディレクトリ除外、symlink ファイル追従(6f5419c0 の決定)、`exclude` の枝刈り、順序(全 consumer が sort)を全て probe し、乖離なし。
+- module-ast(#633)の 19 関数は 690dd5e4 の本体と byte 同一(`guardTerminates` だけ未ガード読みを**修正**)。`runAnalysis`(#632)の補正順序は旧 2 パイプラインと同一。landmark policy(#630)は #619/#621 の修正を含んで両 provider と一致。
+- パーサの fuzz(snippet / `{@render}` / `{@attach}` / `bind:` / `<svelte:element>` / `<svelte:boundary>` / TS generics / `$props.id()` / ネスト each 分割代入)で throw なし。Object.prototype ハザードの残り(html-spec / role-candidates / casing / heavy-import / reserved-directory-names / examinedCounts / aria-query)は全てガード済みと確認。正規表現の破滅的バックトラックなし。
+- セキュリティ(2026-09-03 security 監査の続き): 新 glob の path escape なし(全パターンがリテラル)、install scaffolder は解析対象の文字列を生成物に埋め込まない、`pkg-json.ts` の `JSON.parse` は安全、reporters の残りサニタイザ正常、post-#640 の `isSameOrigin` / 413 は健全、`scripts/` は無変更、fixture に prompt-injection 内容なし、`pnpm audit --prod` は published 3 パッケージ到達 0 件。
+- deps: catalog 迂回 0、engines 整合、tinyglobby 完全除去、全ランタイム依存に import サイトあり、廃止予定 API なし、typecheck / lint pass、vitest 設定にハックなし、cli の throw メッセージ 25 件は全て locator 付き。
+- docs: 監査範囲で `docs/src/content/docs/` の変更ゼロ、translations 台帳完全、CHANGELOG の主張 3 件を実装照合済み、`packages/cli/docs` の flag / path 全存在、cli-reference テストは en/ja 両方をカバー、AGENTS.md の path 20 件 / script 全件 / CI 5 job / 「3 箇所登録」主張は全て正。
+- Svelte 5.57 自身に `<constructor>` タグで throw する同型の穴(`html-tree-validation.js:68`)。`collectComponentFacts` が catch して `parseFailed` にするので svelte-vitals 側は安全。upstream 報告候補。
+
+### 本監査でカバーしていない領域(明示)
+
+- Windows 挙動(引き続き macOS のみ。`glob.ts:27` の separator 正規化も未検証)。
+- ルール docs の prose 層(#619/#621 の語彙で targeted grep のみ。全 210 ページの通読はしていない)。
+- `html-spec/content-model.ts` のセレクタエンジン(`matchHas` の subtree walk の複合コストは未定量化)。
+- `kit-module-parse.ts`(886 行)自身のパス数と fact 単位の意味論。`component-parse.ts` の ~30 collector の「throw しないが誤る」出力。
+- SvelteKit handle hook が受け取る config の staleness(config ファイルを読まないので 063 の対象外と判断したが、プラグインオプション変更時の挙動は見ていない)。
+- core/cli/vite が TypeScript 7 で typecheck を通るか(kitchen-sink で止まるため)。
+- Vite plugin API の 8→9 readiness(`ssr` 系のみ grep)。
+
+### 2026-09-03 方向性所見(計画化せず記録)
+
+- vite プラグインの build ゲート(`failOn`)は `svelte-vitals-suppressions.json` を読まない。設計書 `2026-07-13-suppressions-file-design.md:53` が「vite integration は v1 では CLI only」と明記した deferral だが、PR #211 で config ファイルが vite に配線された今、CLI で受け入れた finding が `vite build` では落ちる非対称がユーザーに見える。`applyScope` 相当を `analyze.ts` に足す設計 1 枚(S–M)。
+- dev dashboard はクラッシュしたルールの id を一切表示しない(`snapshot.ts:41-42` で採点補正のみ)。067 でターミナルには出るようになるが、dashboard 本体に出すかは `AppSnapshot` の型を広げる設計判断(M)。
+- 前回からの継続: 旧 i18n スパイクの Superseded 明記、examined counts の console footer、`minHealth` の config キー非対称。いずれも状況変化なし。v1 Phase E は意図的保留のまま(本監査からの提案はしない)。
 
 ## Dependency notes
 


### PR DESCRIPTION
Records the 2026-09-03 `/improve deep` audit in `plans/README.md` and adds the plan files it produced.

- Plan 062 (dev UI ingest same-origin, shipped in #640) was written in the previous session and never committed.
- Plans 063–068 are the six findings selected from the audit; all six shipped (#643, #644, #645, #646, #647, #648). Each README row records the executor/review rounds and the PR.
- The README section also lists the maintainer-direct items, the backlog with leverage order, the rejected findings, what the audit did not cover, and the direction notes.

Docs-only: `plans/` is not part of any published package or the docs site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added implementation plans covering dev dashboard security, configuration refresh, prototype-key handling, output sanitization, score computation performance, warning visibility, and ingest reliability.
  * Documented testing strategies, verification steps, scope boundaries, completion criteria, and maintenance guidance for each planned change.
  * Updated the plans index with audit findings, coverage references, statuses, and review details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->