### PR TITLE
chore: release all packages in lockstep via changesets fixed group

### DIFF
--- a/.changeset/align-package-versions.md
+++ b/.changeset/align-package-versions.md
@@ -1,0 +1,7 @@
+---
+'@svelte-vitals/core': patch
+'@svelte-vitals/vite': patch
+'svelte-vitals': patch
+---
+
+Release all packages in lockstep. `svelte-vitals`, `@svelte-vitals/core` and `@svelte-vitals/vite` now always share one version number; this release only aligns them.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@4.0.0/schema.json",
   "access": "public",
-  "baseBranch": "main"
+  "baseBranch": "main",
+  "fixed": [["svelte-vitals", "@svelte-vitals/core", "@svelte-vitals/vite"]]
 }


### PR DESCRIPTION
## Summary

Adds a Changesets \`fixed\` group covering \`svelte-vitals\`, \`@svelte-vitals/core\` and \`@svelte-vitals/vite\`, so the three published packages always share one version number.

Today they sit at 0.54.4 / 0.51.2 / 0.36.4, which makes it hard for users to tell which versions belong together. With \`fixed\`, any changeset bumps all three to the same version, including packages with no changes.

## Effects

- The first release after this lands takes the group's highest version (0.54.4) as its base, so core and vite jump to match.
- Internal \`workspace:^\` links are unaffected.
- Ships with a patch changeset so the alignment lands as its own release, with a CHANGELOG line explaining the version jump.

## Verification

Dry-run with a single \`svelte-vitals: patch\` changeset: \`changeset version\` bumped all three packages to 0.54.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Aligned release versions for the Svelte Vitals packages.
  - Configured the packages to be versioned and released together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->