### PR TITLE
ci: replace pnpm/action-setup + actions/setup-node with pnpm/setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,12 +64,9 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        # setup-node puts this Node on PATH and disables pnpm's devEngines shim,
-        # so scripts actually run under it rather than the pinned 24.16.0.
-        # These are the release lines the DEV toolchain supports — the published
-        # engines.node floor (24.16.0) is defended by the `floor-smoke` job instead.
-        # '24' is the latest 24.x (the current development line — devEngines pins 24.16.0);
-        # '26' is the latest of the Current line (active LTS from 2026-10) — early warning.
+        # Release lines the DEV toolchain supports; the published engines.node floor is
+        # defended by the `floor-smoke` job. setup-node disables pnpm's devEngines shim,
+        # so scripts run under the matrix Node rather than the pinned one.
         node-version: ['24', '26']
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -90,12 +87,8 @@ jobs:
         run: pnpm build
       - name: Run tests
         run: pnpm test
-      # Bare `node` is correct here — setup-node puts the matrix version on
-      # PATH, so the built dist runs under each supported line.
       - name: Run the floor smoke on the matrix Node
         run: node scripts/floor-smoke.js
-      # dist is already built by this point (restored from cache or built above) — the
-      # gate-flag E2E (Phase 0 of the gunshi migration) runs the same built bin.js.
       - name: Run the CLI gate-flag E2E
         run: pnpm e2e
 
@@ -107,12 +100,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      # 24.16.0 is the published packages' engines.node floor. This is the only job
-      # pinned to it: it runs the built dist under a bare `node`, so no dev
-      # dependency (vitest, happy-dom, ...) is held to the end-user's Node version.
-      # pnpm itself is not exempt, though: the pinned pnpm in the root
-      # `package.json` still runs `pnpm install`/`pnpm build` on this floor, so a
-      # future pnpm bump needs to stay runnable on 24.16.0 too.
+      # The only job pinned to the published engines.node floor: it runs the built
+      # dist under a bare `node`, so no dev dependency is held to the end-user's
+      # Node — only the build toolchain, which `pnpm build` still runs on it.
       - name: Setup Node.js and dependencies
         uses: ./.github/workflows/setup-node
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Setup Node.js and dependencies
         uses: ./.github/workflows/setup-node
         with:
-          node-version: ${{ matrix.node-version }}
+          runtime: node@${{ matrix.node-version }}
       - name: Restore package builds
         id: dist-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -106,7 +106,7 @@ jobs:
       - name: Setup Node.js and dependencies
         uses: ./.github/workflows/setup-node
         with:
-          node-version: '24.16.0'
+          runtime: node@24.16.0
       - name: Restore package builds
         id: dist-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,8 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        # setup-node rewrites devEngines.runtime.version to this,
-        # so pnpm's managed runtime (onFail: download) actually runs scripts under it.
+        # setup-node puts this Node on PATH and disables pnpm's devEngines shim,
+        # so scripts actually run under it rather than the pinned 24.16.0.
         # These are the release lines the DEV toolchain supports — the published
         # engines.node floor (24.16.0) is defended by the `floor-smoke` job instead.
         # '24' is the latest 24.x (the current development line — devEngines pins 24.16.0);
@@ -90,8 +90,8 @@ jobs:
         run: pnpm build
       - name: Run tests
         run: pnpm test
-      # Bare `node` is correct here — actions/setup-node puts the matrix
-      # version on PATH, so the built dist runs under each supported line.
+      # Bare `node` is correct here — setup-node puts the matrix version on
+      # PATH, so the built dist runs under each supported line.
       - name: Run the floor smoke on the matrix Node
         run: node scripts/floor-smoke.js
       # dist is already built by this point (restored from cache or built above) — the

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -27,7 +27,7 @@ jobs:
   ecosystem:
     runs-on: ubuntu-latest
     # A real run is under two minutes. This is a backstop sized above the script's own worst
-    # case — eight targets each hitting both per-target limits — so a bad week still ends with the
+    # case — every target hitting both per-target limits — so a bad week still ends with the
     # script's per-target report rather than a mid-run kill.
     timeout-minutes: 40
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,6 @@ jobs:
           persist-credentials: false
       - name: Setup Node.js and dependencies
         uses: ./.github/workflows/setup-node
-        with:
-          registry-url: 'https://registry.npmjs.org'
       - name: Build packages
         run: pnpm build
       - name: Create Release Pull Request or Publish to npm

--- a/.github/workflows/setup-node/action.yml
+++ b/.github/workflows/setup-node/action.yml
@@ -2,22 +2,21 @@ name: 'Setup Node.js and pnpm'
 description: 'Install pnpm and Node.js (from package.json devEngines unless overridden) and install dependencies'
 
 inputs:
-  node-version:
-    description: 'Optional Node.js version override (defaults to devEngines.runtime.version)'
+  runtime:
+    description: 'Optional runtime override such as node@24 (defaults to devEngines.runtime)'
     required: false
     default: ''
 
 runs:
   using: 'composite'
   steps:
-    # `node` without a version resolves to devEngines.runtime. Either way the action installs the
-    # Node it picked on PATH, disables pnpm's context-aware `node` shim and installs with
-    # `--no-runtime`, so a matrix job's scripts run under the version it asked for, not the
-    # manifest's pin. It installs only `node`, no `npm`: `check:publish`'s `attw --pack` shells
-    # out to `npm pack` and gets the runner image's npm.
+    # The action puts the Node it installed on PATH, disables pnpm's context-aware `node` shim
+    # and installs with `--no-runtime`, so a matrix job's scripts run under the version it asked
+    # for, not the manifest's pin. It installs only `node`, no `npm`: `check:publish`'s
+    # `attw --pack` shells out to `npm pack` and gets the runner image's npm.
     - name: Install pnpm, Node.js and dependencies
       uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
       with:
-        runtime: ${{ inputs.node-version != '' && format('node@{0}', inputs.node-version) || 'node' }}
+        runtime: ${{ inputs.runtime }}
         cache: true
         require-lockfile: true

--- a/.github/workflows/setup-node/action.yml
+++ b/.github/workflows/setup-node/action.yml
@@ -1,11 +1,7 @@
 name: 'Setup Node.js and pnpm'
-description: 'Install pnpm, set up Node.js using version from package.json devEngines, and install dependencies'
+description: 'Install pnpm and Node.js (from package.json devEngines unless overridden) and install dependencies'
 
 inputs:
-  registry-url:
-    description: 'Optional npm registry URL for publishing'
-    required: false
-    default: ''
   node-version:
     description: 'Optional Node.js version override (defaults to devEngines.runtime.version)'
     required: false
@@ -14,54 +10,14 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Get Node.js version from package.json
-      id: get-node-version
-      shell: bash
-      env:
-        NODE_VERSION_OVERRIDE: ${{ inputs.node-version }}
-      run: |
-        if [ -n "$NODE_VERSION_OVERRIDE" ]; then
-          echo "node-version=$NODE_VERSION_OVERRIDE" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-        NODE_VERSION=$(jq -r '.devEngines.runtime.version' package.json)
-        if [ -z "$NODE_VERSION" ] || [ "$NODE_VERSION" = "null" ]; then
-          echo "::error::Could not extract devEngines.runtime.version from package.json"
-          exit 1
-        fi
-        echo "node-version=${NODE_VERSION}" >> "$GITHUB_OUTPUT"
-
-    - name: Install pnpm
-      uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-
-    - name: Setup Node.js
-      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+    # `node` without a version resolves to devEngines.runtime. Either way the action installs the
+    # Node it picked on PATH, disables pnpm's context-aware `node` shim and installs with
+    # `--no-runtime`, so a matrix job's scripts run under the version it asked for, not the
+    # manifest's pin. It installs only `node`, no `npm`: `check:publish`'s `attw --pack` shells
+    # out to `npm pack` and gets the runner image's npm.
+    - name: Install pnpm, Node.js and dependencies
+      uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
       with:
-        node-version: ${{ steps.get-node-version.outputs.node-version }}
-        cache: 'pnpm'
-        registry-url: ${{ inputs.registry-url }}
-
-    - name: Install dependencies
-      shell: bash
-      run: pnpm install --frozen-lockfile
-
-    - name: Point devEngines at the matrix Node version
-      if: inputs.node-version != ''
-      shell: bash
-      env:
-        NODE_VERSION_OVERRIDE: ${{ inputs.node-version }}
-      run: |
-        # devEngines.runtime (onFail: download) makes pnpm run scripts under ITS version
-        # regardless of the runner's node — rewrite it so the matrix actually tests this version.
-        # Must run AFTER `pnpm install --frozen-lockfile`: pnpm records the runtime in
-        # pnpm-lock.yaml, so rewriting the manifest first fails the frozen-lockfile check.
-        jq --arg v "$NODE_VERSION_OVERRIDE" '.devEngines.runtime.version = $v' package.json > package.json.tmp
-        mv package.json.tmp package.json
-        # pnpm manages the devEngines runtime as a lockfile-recorded dependency: the first
-        # `pnpm run` after this rewrite auto-installs to fetch the new runtime, and CI's
-        # frozen-lockfile default would kill that install (the manifest no longer matches the
-        # lockfile's recorded runtime). Deps were already installed and frozen-verified above,
-        # so let that runtime-fetch install run unfrozen for the rest of this job.
-        # NB: this must live in pnpm-workspace.yaml — pnpm 11's internally spawned install
-        # ignores npm_config_* env overrides and .npmrc for this setting.
-        printf '\nfrozenLockfile: false\n' >> pnpm-workspace.yaml
+        runtime: ${{ inputs.node-version != '' && format('node@{0}', inputs.node-version) || 'node' }}
+        cache: true
+        require-lockfile: true


### PR DESCRIPTION
## Summary

Collapses the `setup-node` composite action to a single [`pnpm/setup@v2.1.0`](https://github.com/pnpm/setup) step (SHA-pinned), replacing `pnpm/action-setup` + `actions/setup-node`.

- `pnpm/setup` installs pnpm (from `packageManager`) and Node (from `devEngines.runtime`, or `runtime: node@<matrix>`) in one step. When it installs a runtime it exports `PNPM_CONFIG_GLOBAL_SHIMS={"node":false}` and runs `pnpm install --no-runtime`, so `pnpm run` uses the PATH Node instead of the manifest's pin. The jq `devEngines` rewrite and the `frozenLockfile: false` append are no longer needed and are removed.
- `cache: true` replaces `actions/setup-node`'s `cache: 'pnpm'`; `require-lockfile: true` replaces the explicit `--frozen-lockfile`.
- `registry-url` is dropped from the action and `release.yml`. No `NODE_AUTH_TOKEN` exists anywhere and changesets publishes through `pnpm publish` with OIDC, so the `.npmrc` `actions/setup-node` generated was never used.
- Two `ci.yml` comments describing the old mechanism are updated.

## Verification

- Fresh clone, `CI=true pnpm install --frozen-lockfile --no-runtime`, then `pnpm -w exec node --version` / `pnpm -r exec node --version` with the shim disabled: every package runs the PATH Node, not the `devEngines` pin, and `pnpm-lock.yaml` stays unchanged. This is the behaviour the matrix relies on.
- `pnpm lint`, `pnpm format`, YAML parse: pass.

## Things to watch on the first runs

- `pnpm runtime set` installs only `node`, not `npm`. `check:publish`'s `attw --pack` shells out to `npm pack`, which now resolves to the runner image's npm (ubuntu-24.04 ships npm 10.9.8, which supports Node 24/26). Noted in the action's comment; `pnpm pack --out` + `attw <tgz>` is a verified fallback if that ever breaks.
- Release job: should be unchanged (token-less OIDC already), but the next release run is the proof.
- First CI run is a one-time pnpm store cache miss (new cache key namespace).

No changeset: CI-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Standardized Node.js and pnpm setup across continuous integration and release workflows.
  - Simplified environment configuration and dependency installation using a shared setup process.
  - Enforced lockfile-based installations for more consistent build and release runs.
  - Updated workflow documentation to clarify which Node.js version is used when running scripts.
  - No end-user functionality or workflow behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->